### PR TITLE
Add mindtrace.core README

### DIFF
--- a/mindtrace/core/README.md
+++ b/mindtrace/core/README.md
@@ -144,7 +144,7 @@ class MyListener:
     def y_updated(...): ...
 ```
 
-Listeners may subscribe to any class that has been decorated with the `ObservaleContext` decorator, listening to any of the listed `vars` in the decorator.
+Listeners may subscribe to any class that has been decorated with the `ObservableContext` decorator, listening to any of the listed `vars` in the decorator.
 
 ```python
 from mindtrace.core import ObservableContext


### PR DESCRIPTION
This PR is an addendum to #15, implements and closes #40 and builds upon #38, which should be merged in first.

# Mindtrace Core Readme

This PR adds a readme to the `mindrace.core` module, in response to comments in #15. The readme is essentially the Observables PR wrapped into a Readme, and can be extended as reviewers care during this PR.