### PR TITLE
Add GCS Handler. 

### DIFF
--- a/mindtrace/storage/mindtrace/storage/__init__.py
+++ b/mindtrace/storage/mindtrace/storage/__init__.py
@@ -1,0 +1,3 @@
+from mindtrace.storage.gcs import GCSStorageHandler
+
+__all__ = ["GCSStorageHandler"]

--- a/mindtrace/storage/mindtrace/storage/base.py
+++ b/mindtrace/storage/mindtrace/storage/base.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+from mindtrace.core import MindtraceABC
+
+
+class StorageHandler(MindtraceABC, ABC):
+    """Abstract interface all storage providers must implement."""
+
+    # CRUD ------------------------------------------------------------------
+    @abstractmethod
+    def upload(
+        self,
+        local_path: str,
+        remote_path: str,
+        metadata: Optional[Dict[str, str]] = None,
+    ) -> str: ...
+
+    @abstractmethod
+    def download(self, remote_path: str, local_path: str) -> None: ...
+
+    @abstractmethod
+    def delete(self, remote_path: str) -> None: ...
+
+    # Introspection ---------------------------------------------------------
+    @abstractmethod
+    def list_objects(
+        self,
+        *,
+        prefix: str = "",
+        max_results: Optional[int] = None,
+    ) -> List[str]: ...
+
+    @abstractmethod
+    def exists(self, remote_path: str) -> bool: ...
+
+    @abstractmethod
+    def get_presigned_url(
+        self,
+        remote_path: str,
+        *,
+        expiration_minutes: int = 60,
+        method: str = "GET",
+    ) -> str: ...
+
+    @abstractmethod
+    def get_object_metadata(self, remote_path: str) -> Dict[str, Any]: ...

--- a/mindtrace/storage/mindtrace/storage/gcs.py
+++ b/mindtrace/storage/mindtrace/storage/gcs.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+from typing import Any, Dict, List, Optional
+
+from google.api_core import exceptions as gexc
+from google.cloud import storage
+from google.oauth2 import service_account
+
+from .base import StorageHandler
+
+
+class GCSStorageHandler(StorageHandler):
+    """A thin wrapper around ``google-cloud-storage`` APIs."""
+
+    def __init__(
+        self,
+        bucket_name: str,
+        *,
+        project_id: Optional[str] = None,
+        credentials_path: Optional[str] = None,
+        create_if_missing: bool = False,
+        location: str = "US",
+        storage_class: str = "STANDARD",
+    ) -> None:
+        # Credentials -------------------------------------------------------
+        creds = None
+        if credentials_path:
+            if not os.path.exists(credentials_path):
+                raise FileNotFoundError(credentials_path)
+            creds = service_account.Credentials.from_service_account_file(
+                credentials_path
+            )
+
+        # Client ------------------------------------------------------------
+        self.client: storage.Client = storage.Client(
+            project=project_id, credentials=creds
+        )
+        self.bucket_name = bucket_name
+        self._ensure_bucket(create_if_missing, location, storage_class)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_bucket(self, create: bool, location: str, storage_class: str) -> None:
+        bucket = self.client.bucket(self.bucket_name)
+        if bucket.exists(self.client):
+            return
+        if not create:
+            raise gexc.NotFound(f"Bucket {self.bucket_name!r} not found")
+        bucket.location = location
+        bucket.storage_class = storage_class
+        bucket.create()
+
+    def _bucket(self) -> storage.Bucket:  # thread‑safe fresh bucket obj
+        return self.client.bucket(self.bucket_name)
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+    def upload(
+        self,
+        local_path: str,
+        remote_path: str,
+        metadata: Optional[Dict[str, str]] = None,
+    ) -> str:
+        blob = self._bucket().blob(remote_path)
+        if metadata:
+            blob.metadata = metadata
+        blob.upload_from_filename(local_path)
+        return f"gs://{self.bucket_name}/{remote_path}"
+
+    def download(self, remote_path: str, local_path: str) -> None:
+        blob = self._bucket().blob(remote_path)
+        os.makedirs(os.path.dirname(local_path) or ".", exist_ok=True)
+        blob.download_to_filename(local_path)
+
+    def delete(self, remote_path: str) -> None:
+        try:
+            self._bucket().blob(remote_path).delete(if_generation_match=None)
+        except gexc.NotFound:
+            pass  # idempotent delete
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+    def list_objects(
+        self,
+        *,
+        prefix: str = "",
+        max_results: Optional[int] = None,
+    ) -> List[str]:
+        return [
+            b.name
+            for b in self.client.list_blobs(
+                self.bucket_name, prefix=prefix, max_results=max_results
+            )
+        ]
+
+    def exists(self, remote_path: str) -> bool:
+        return self._bucket().blob(remote_path).exists(self.client)
+
+    def get_presigned_url(
+        self,
+        remote_path: str,
+        *,
+        expiration_minutes: int = 60,
+        method: str = "GET",
+    ) -> str:
+        blob = self._bucket().blob(remote_path)
+        return blob.generate_signed_url(
+            expiration=timedelta(minutes=expiration_minutes),
+            method=method,
+            version="v4",
+        )
+
+    def get_object_metadata(self, remote_path: str) -> Dict[str, Any]:
+        blob = self._bucket().blob(remote_path)
+        blob.reload()
+        return {
+            "name": blob.name,
+            "size": blob.size,
+            "content_type": blob.content_type,
+            "created": blob.time_created.isoformat() if blob.time_created else None,
+            "updated": blob.updated.isoformat() if blob.updated else None,
+            "metadata": dict(blob.metadata or {}),
+        }

--- a/mindtrace/storage/pyproject.toml
+++ b/mindtrace/storage/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "mindtrace-storage"
+version = "0.1.0"
+dependencies = [
+    "google-cloud-storage",
+]
+
+[tool.setuptools]
+packages = ["mindtrace.storage"]
+
+[tool.setuptools.package-dir]
+"" = "."
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "mindtrace-apps>=0.1.0",
   "mindtrace-ui>=0.1.0",
   "mindtrace-datalake>=0.1.0",
+  "mindtrace-storage>=0.1.0",
 ]
 
 [tool.uv]
@@ -38,6 +39,7 @@ mindtrace-automation = { workspace = true }
 mindtrace-registry = { workspace = true }
 mindtrace-ui = { workspace = true }
 mindtrace-datalake = { workspace = true }
+mindtrace-storage = { workspace = true }
 
 [tool.uv.workspace]
 members = [
@@ -53,6 +55,7 @@ members = [
   "mindtrace/registry",
   "mindtrace/ui",
   "mindtrace/datalake",
+  "mindtrace/storage",
 ]
 
 [tool.ds.scripts]

--- a/tests/unit/mindtrace/storage/test_gcs_handler.py
+++ b/tests/unit/mindtrace/storage/test_gcs_handler.py
@@ -1,0 +1,120 @@
+# tests/test_gcs_handler.py
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.api_core.exceptions import NotFound
+
+from mindtrace.storage import GCSStorageHandler
+
+
+def _prepare_client(mock_client_cls, *, bucket_exists: bool = True):
+    """Return (client, bucket, blob) all fully stubbed."""
+    mock_client = MagicMock(name="storage.Client")
+    mock_client_cls.return_value = mock_client
+
+    mock_bucket = MagicMock(name="Bucket")
+    mock_client.bucket.return_value = mock_bucket
+    mock_bucket.exists.return_value = bucket_exists
+
+    mock_blob = MagicMock(name="Blob")
+    mock_bucket.blob.return_value = mock_blob
+
+    return mock_client, mock_bucket, mock_blob
+
+
+# ---------------------------------------------------------------------------
+# Constructor behaviour
+# ---------------------------------------------------------------------------
+
+
+@patch("mindtrace.storage.gcs.storage.Client")
+def test_ctor_creates_bucket_when_missing(mock_client_cls):
+    _, bucket, _ = _prepare_client(mock_client_cls, bucket_exists=False)
+
+    handler = GCSStorageHandler("new-bucket", create_if_missing=True)  # noqa: F841
+    bucket.create.assert_called_once()  # bucket auto-created
+
+
+@patch("mindtrace.storage.gcs.storage.Client")
+def test_ctor_errors_when_bucket_missing_and_create_false(mock_client_cls):
+    _prepare_client(mock_client_cls, bucket_exists=False)
+
+    with pytest.raises(NotFound):
+        GCSStorageHandler("missing-bucket")  # create_if_missing defaults to False
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+@patch("mindtrace.storage.gcs.storage.Client")
+def test_upload_returns_gs_uri_and_calls_api(mock_client_cls, tmp_path):
+    _, bucket, blob = _prepare_client(mock_client_cls)
+    local_file = tmp_path / "file.txt"
+    local_file.write_text("dummy")
+
+    h = GCSStorageHandler("my-bucket")
+    uri = h.upload(str(local_file), "remote/path.txt", metadata={"foo": "bar"})
+
+    assert uri == "gs://my-bucket/remote/path.txt"
+    blob.upload_from_filename.assert_called_once_with(str(local_file))
+    assert blob.metadata == {"foo": "bar"}
+
+
+@patch("mindtrace.storage.gcs.storage.Client")
+def test_download_creates_parent_dirs_and_invokes_api(mock_client_cls, tmp_path):
+    _, bucket, blob = _prepare_client(mock_client_cls)
+    dest = tmp_path / "nested/dir/out.bin"
+
+    GCSStorageHandler("b").download("remote/blob.bin", dest.as_posix())
+    blob.download_to_filename.assert_called_once_with(dest.as_posix())
+    # Parent directory must now exist
+    assert dest.parent.exists()
+
+
+@patch("mindtrace.storage.gcs.storage.Client")
+def test_delete_is_idempotent(mock_client_cls):
+    _, bucket, blob = _prepare_client(mock_client_cls)
+    blob.delete.side_effect = NotFound("not there")
+
+    GCSStorageHandler("bucket").delete("ghost.txt")  # should not raise
+    blob.delete.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Introspection
+# ---------------------------------------------------------------------------
+
+
+@patch("mindtrace.storage.gcs.storage.Client")
+def test_exists_delegates_to_blob(mock_client_cls):
+    _, bucket, blob = _prepare_client(mock_client_cls)
+    blob.exists.side_effect = (True, False)  # yes then no
+
+    h = GCSStorageHandler("bucket")
+    assert h.exists("foo") is True
+    assert h.exists("foo") is False
+
+
+@patch("mindtrace.storage.gcs.storage.Client")
+def test_signed_url_and_metadata(mock_client_cls):
+    _, bucket, blob = _prepare_client(mock_client_cls)
+    blob.generate_signed_url.return_value = "https://signed"
+    blob.time_created = datetime(2025, 1, 1)
+    blob.updated = datetime(2025, 1, 2)
+    blob.content_type = "text/plain"
+    blob.size = 42
+    blob.metadata = {"x": "y"}
+
+    h = GCSStorageHandler("b")
+    assert h.get_presigned_url("obj") == "https://signed"
+    meta = h.get_object_metadata("obj")
+
+    assert meta["name"] == blob.name
+    assert meta["size"] == 42
+    assert meta["content_type"] == "text/plain"
+    assert meta["created"] == "2025-01-01T00:00:00"
+    assert meta["updated"] == "2025-01-02T00:00:00"
+    assert meta["metadata"] == {"x": "y"}


### PR DESCRIPTION
Implements GCS Handler of [related issue](https://github.com/Mindtrace/mindtrace/issues/34). 
It's a facade of underlying google sdk, so if we ever need any other provider(s3, azure), we can create those easily following the same base class. I've initially created a factory class for it, but decided against it:
1- We don't have many objects,  

I've created a new submodule for it since it didn't feel like it didn't feel like a core feature or belonged to any other submodules. But there wont be 30 storage handlers, so a single submodule for it is too generous. maybe we have a cloud submodule, that primarily holds handlers that talk to cloud sdks, be it file storages or anything other service we might be using in the future. 