### PR TITLE
Initial ConnectionManager Generator

### DIFF
--- a/mindtrace/core/mindtrace/core/__init__.py
+++ b/mindtrace/core/mindtrace/core/__init__.py
@@ -1,8 +1,9 @@
-from mindtrace.core.utils import check_libs, ifnone, first_not_none
+from mindtrace.core.utils import check_libs, ifnone, first_not_none, ifnone_url, named_lambda
 from mindtrace.core.utils.dynamic import instantiate_target, get_class
+from mindtrace.core.utils.timers import Timer, TimerCollection, Timeout
 from mindtrace.core.config import Config
 from mindtrace.core.base import Mindtrace, MindtraceABC, MindtraceMeta
-from mindtrace.core.logging.logger import setup_logger
+from mindtrace.core.logging.logger import setup_logger, default_logger
 
 setup_logger()  # Initialize the default logger
 
@@ -15,13 +16,19 @@ __all__ = [
     "check_libs",
     "ContextListener", 
     "Config",
+    "default_logger",
     "EventBus", 
     "first_not_none", 
     "get_class",
     "ifnone", 
+    "ifnone_url",
     "instantiate_target",
     "Mindtrace", 
     "MindtraceABC", 
     "MindtraceMeta",
+    "named_lambda",
     "ObservableContext",
+    "Timer",
+    "TimerCollection",
+    "Timeout",
 ]

--- a/mindtrace/core/mindtrace/core/__init__.py
+++ b/mindtrace/core/mindtrace/core/__init__.py
@@ -4,6 +4,7 @@ from mindtrace.core.utils.timers import Timer, TimerCollection, Timeout
 from mindtrace.core.config import Config
 from mindtrace.core.base import Mindtrace, MindtraceABC, MindtraceMeta
 from mindtrace.core.logging.logger import setup_logger
+from mindtrace.core.types.task_schema import TaskSchema
 
 setup_logger()  # Initialize the default logger
 
@@ -27,6 +28,7 @@ __all__ = [
     "MindtraceMeta",
     "named_lambda",
     "ObservableContext",
+    "TaskSchema",
     "Timer",
     "TimerCollection",
     "Timeout",

--- a/mindtrace/core/mindtrace/core/__init__.py
+++ b/mindtrace/core/mindtrace/core/__init__.py
@@ -3,7 +3,7 @@ from mindtrace.core.utils.dynamic import instantiate_target, get_class
 from mindtrace.core.utils.timers import Timer, TimerCollection, Timeout
 from mindtrace.core.config import Config
 from mindtrace.core.base import Mindtrace, MindtraceABC, MindtraceMeta
-from mindtrace.core.logging.logger import setup_logger, default_logger
+from mindtrace.core.logging.logger import setup_logger
 
 setup_logger()  # Initialize the default logger
 
@@ -16,7 +16,6 @@ __all__ = [
     "check_libs",
     "ContextListener", 
     "Config",
-    "default_logger",
     "EventBus", 
     "first_not_none", 
     "get_class",

--- a/mindtrace/core/mindtrace/core/base/__init__.py
+++ b/mindtrace/core/mindtrace/core/base/__init__.py
@@ -1,1 +1,7 @@
-from mindtrace.core.base.mindtrace_base import Mindtrace, MindtraceABC
+from mindtrace.core.base.mindtrace_base import Mindtrace, MindtraceABC, MindtraceMeta
+
+__all__ = [
+    "Mindtrace",
+    "MindtraceABC",
+    "MindtraceMeta",
+]

--- a/mindtrace/core/mindtrace/core/base/mindtrace_base.py
+++ b/mindtrace/core/mindtrace/core/base/mindtrace_base.py
@@ -85,18 +85,43 @@ class Mindtrace(metaclass=MindtraceMeta):
     def __init__(
         self,
         suppress: bool = False,
-        **logger_kwargs
+        **kwargs
     ):
         """
         Initialize the Mindtrace object.
 
         Args:
             suppress (bool): Whether to suppress exceptions in context manager use.
-            **logger_kwargs: Keyword arguments passed to `get_logger`.
-                e.g., propagate=True, file_level=logging.INFO
+            **kwargs: Additional keyword arguments. Logger-related kwargs are passed to `get_logger`.
+                Valid logger kwargs: log_dir, logger_level, stream_level, file_level, 
+                file_mode, propagate, max_bytes, backup_count
         """
+        # Initialize parent classes first (cooperative inheritance)
+        try:
+            super().__init__(**kwargs)
+        except TypeError as e:
+            # If parent classes don't accept some kwargs, try without logger-specific ones
+            logger_param_names = {
+                'log_dir', 'logger_level', 'stream_level', 'file_level', 
+                'file_mode', 'propagate', 'max_bytes', 'backup_count'
+            }
+            remaining_kwargs = {k: v for k, v in kwargs.items() if k not in logger_param_names}
+            try:
+                super().__init__(**remaining_kwargs)
+            except TypeError:
+                # If that still fails, try with no kwargs
+                super().__init__()
+        
+        # Set Mindtrace-specific attributes
         self.suppress = suppress        
 
+        # Filter logger-specific kwargs for logger setup
+        logger_param_names = {
+            'log_dir', 'logger_level', 'stream_level', 'file_level', 
+            'file_mode', 'propagate', 'max_bytes', 'backup_count'
+        }
+        logger_kwargs = {k: v for k, v in kwargs.items() if k in logger_param_names}
+        
         # Set up the logger
         self.logger = get_logger(self.unique_name, **logger_kwargs)
 

--- a/mindtrace/core/mindtrace/core/base/mindtrace_base.py
+++ b/mindtrace/core/mindtrace/core/base/mindtrace_base.py
@@ -6,7 +6,6 @@ import traceback
 import inspect
 from typing import Callable, Optional, Union
 
-
 from mindtrace.core.config import Config
 from mindtrace.core.logging.logger import get_logger
 from mindtrace.core.utils import ifnone
@@ -81,6 +80,8 @@ class Mindtrace(metaclass=MindtraceMeta):
     which ensures consistent logging behavior across all method types.
     """
 
+    config = Config()
+
     def __init__(
         self,
         suppress: bool = False,
@@ -95,7 +96,6 @@ class Mindtrace(metaclass=MindtraceMeta):
                 e.g., propagate=True, file_level=logging.INFO
         """
         self.suppress = suppress        
-        self.config = Config()
 
         # Set up the logger
         self.logger = get_logger(self.unique_name, **logger_kwargs)

--- a/mindtrace/core/mindtrace/core/config/config.py
+++ b/mindtrace/core/mindtrace/core/config/config.py
@@ -5,10 +5,15 @@ class Config(dict):
         default_config = {
             "MINDTRACE_TEMP_DIR": "~/.cache/mindtrace/temp",
             "MINDTRACE_DEFAULT_REGISTRY_DIR": "~/.cache/mindtrace/registry",
+            "MINDTRACE_DEFAULT_HOST_URLS": {
+                "Service": "http://localhost:8000",
+            },
+            "MINDTRACE_DEFAULT_LOG_DIR": "~/.cache/mindtrace/logs",
             "MINDTRACE_MINIO_REGISTRY_URI": "~/.cache/mindtrace/minio-registry",
             "MINDTRACE_MINIO_ENDPOINT": "localhost:9000",
             "MINDTRACE_MINIO_ACCESS_KEY": "minioadmin",
             "MINDTRACE_MINIO_SECRET_KEY": "minioadmin",
+            "MINDTRACE_SERVER_PIDS_DIR_PATH": "~/.cache/mindtrace/pids",
         }
         # Update defaults with any provided kwargs
         default_config.update(kwargs)

--- a/mindtrace/core/mindtrace/core/logging/logger.py
+++ b/mindtrace/core/mindtrace/core/logging/logger.py
@@ -16,6 +16,40 @@ def default_formatter(fmt: Optional[str] = None) -> logging.Formatter:
     return logging.Formatter(fmt or default_fmt)
 
 
+def default_logger(
+    name: str,
+    stream_level: int = logging.ERROR,
+    file_level: int = logging.DEBUG,
+    file_name: str | None = None,
+    **kwargs
+) -> Logger:
+    """Create a default logger with consistent configuration.
+    
+    This is a convenience function that creates a logger with the standard
+    Mindtrace configuration.
+    
+    Args:
+        name: Logger name
+        stream_level: Level for console output
+        file_level: Level for file output  
+        file_name: Custom log file path
+        **kwargs: Additional arguments passed to setup_logger
+        
+    Returns:
+        Configured logger instance
+    """
+    if file_name:
+        log_dir = Path(file_name).parent
+        kwargs['log_dir'] = log_dir
+        
+    return setup_logger(
+        name=name,
+        stream_level=stream_level,
+        file_level=file_level,
+        **kwargs
+    )
+
+
 def setup_logger(
     name: str = "mindtrace",
     log_dir: Optional[Path] = None,
@@ -67,7 +101,7 @@ def setup_logger(
     if log_dir:
         log_file_path = os.path.join(log_dir,child_log_path)
     else:
-        log_file_path = os.path.join(default_config["LOGGER"]["LOG_DIR"], child_log_path)
+        log_file_path = os.path.join(default_config["MINDTRACE_DEFAULT_LOG_DIR"], child_log_path)
     
     os.makedirs(Path(log_file_path).parent, exist_ok=True)
     file_handler = RotatingFileHandler(

--- a/mindtrace/core/mindtrace/core/logging/logger.py
+++ b/mindtrace/core/mindtrace/core/logging/logger.py
@@ -16,40 +16,6 @@ def default_formatter(fmt: Optional[str] = None) -> logging.Formatter:
     return logging.Formatter(fmt or default_fmt)
 
 
-def default_logger(
-    name: str,
-    stream_level: int = logging.ERROR,
-    file_level: int = logging.DEBUG,
-    file_name: str | None = None,
-    **kwargs
-) -> Logger:
-    """Create a default logger with consistent configuration.
-    
-    This is a convenience function that creates a logger with the standard
-    Mindtrace configuration.
-    
-    Args:
-        name: Logger name
-        stream_level: Level for console output
-        file_level: Level for file output  
-        file_name: Custom log file path
-        **kwargs: Additional arguments passed to setup_logger
-        
-    Returns:
-        Configured logger instance
-    """
-    if file_name:
-        log_dir = Path(file_name).parent
-        kwargs['log_dir'] = log_dir
-        
-    return setup_logger(
-        name=name,
-        stream_level=stream_level,
-        file_level=file_level,
-        **kwargs
-    )
-
-
 def setup_logger(
     name: str = "mindtrace",
     log_dir: Optional[Path] = None,

--- a/mindtrace/core/mindtrace/core/types/task_schema.py
+++ b/mindtrace/core/mindtrace/core/types/task_schema.py
@@ -1,0 +1,10 @@
+from typing import Type
+
+from pydantic import BaseModel
+
+
+class TaskSchema(BaseModel):
+    """A task schema with strongly-typed input and output models"""
+    name: str
+    input_schema: Type[BaseModel]
+    output_schema: Type[BaseModel]

--- a/mindtrace/core/mindtrace/core/types/task_schema.py
+++ b/mindtrace/core/mindtrace/core/types/task_schema.py
@@ -1,10 +1,10 @@
-from typing import Type
+from typing import Literal, Type
 
 from pydantic import BaseModel
 
 
 class TaskSchema(BaseModel):
     """A task schema with strongly-typed input and output models"""
-    name: str
-    input_schema: Type[BaseModel]
-    output_schema: Type[BaseModel]
+    name: Literal[str]
+    input_schema: None | Type[BaseModel] = None
+    output_schema: None | Type[BaseModel] = None

--- a/mindtrace/core/mindtrace/core/utils/__init__.py
+++ b/mindtrace/core/mindtrace/core/utils/__init__.py
@@ -1,1 +1,12 @@
-from mindtrace.core.utils.checks import ifnone, first_not_none
+from mindtrace.core.utils.checks import check_libs, first_not_none, ifnone, ifnone_url
+from mindtrace.core.utils.lambdas import named_lambda
+from mindtrace.core.utils.dynamic import instantiate_target
+
+__all__ = [
+    "check_libs",
+    "first_not_none",
+    "ifnone",
+    "ifnone_url",
+    "instantiate_target",
+    "named_lambda",
+]

--- a/mindtrace/core/mindtrace/core/utils/checks.py
+++ b/mindtrace/core/mindtrace/core/utils/checks.py
@@ -1,4 +1,5 @@
 from typing import Any, Iterable, TypeVar
+from urllib3.util.url import Url, parse_url
 
 T = TypeVar("T")
 
@@ -7,10 +8,23 @@ def ifnone(val: T | None, default: T) -> T:
     """Return the given value if it is not None, else return the default."""
     return val if val is not None else default
 
-
 def first_not_none(vals: Iterable, default: Any = None):
     """Returns the first not-None value in the given iterable, else returns the default."""
     return next((item for item in vals if item is not None), default)
+
+def ifnone_url(url: str | Url | None, default: str | Url) -> Url:
+    """Wraps ifnone to always return a URL.
+
+    Args:
+        url: The Url to return. If none, the default value will be returned instead.
+        default: The default URL to use if url is None.
+
+    Returns:
+        The Url object.
+    """
+    return ifnone(
+        parse_url(url) if isinstance(url, str) else url, parse_url(default) if isinstance(default, str) else default
+    )
 
 def check_libs(required_libs: list[str]) -> list[str]:
     """Check if all required libraries are available."""

--- a/mindtrace/core/mindtrace/core/utils/checks.py
+++ b/mindtrace/core/mindtrace/core/utils/checks.py
@@ -1,10 +1,8 @@
-from typing import Any, Iterable, TypeVar
+from typing import Any, Iterable
 from urllib3.util.url import Url, parse_url
 
-T = TypeVar("T")
 
-
-def ifnone(val: T | None, default: T) -> T:
+def ifnone(val: Any, default: Any) -> Any:
     """Return the given value if it is not None, else return the default."""
     return val if val is not None else default
 

--- a/mindtrace/core/mindtrace/core/utils/lambdas.py
+++ b/mindtrace/core/mindtrace/core/utils/lambdas.py
@@ -1,0 +1,32 @@
+def named_lambda(name: str, lambda_func: callable) -> callable:
+    """Assigns a name to the given lambda function.
+
+    This method is useful when passing lambda functions to other functions that require a name attribute. For example,
+    when using the autolog decorator, the wrapped function will be logged according the function name. If the original
+    function is a lambda function, it's name attribute will be set to the generic name '<lambda>'.
+
+    Args:
+        name: The name to assign to the lambda function.
+        lambda_func: The lambda function to assign the name to.
+
+    Returns:
+        The lambda function with the name attribute set to the given name.
+
+    Example::
+
+            from mindtrace.core import Mindtrace, named_lambda
+
+            class HyperRunner(Mindtrace):
+                def __init__(self):
+                    super().__init__()
+
+                def run_command(self, command: callable, data: Any):  # cannot control the name of the command
+                    return Mindtrace.autolog(command(data))()
+
+            hyper_runner = HyperRunner()
+            hyper_runner.run_command(lambda x, y: x + y, data=(1, 2))  # autologs to '<lambda>'
+            hyper_runner.run_command(named_lambda("add", lambda x, y: x + y), data=(1, 2))  # autologs to 'add'
+
+    """
+    lambda_func.__name__ = name
+    return lambda_func

--- a/mindtrace/core/mindtrace/core/utils/timers.py
+++ b/mindtrace/core/mindtrace/core/utils/timers.py
@@ -1,0 +1,291 @@
+"""Utility class for simple Timer and TimerCollection classes."""
+
+import time
+from typing import Dict, Optional, Type
+
+from tqdm import tqdm
+
+
+class Timer:
+    """Utility timer class.
+
+    This class can be used to time operations. It can be started, stopped, and reset. The duration of the timer can be
+    retrieved at any time.
+
+    Example::
+
+        import time
+        from mindtrace.core import Timer
+
+        timer = Timer()
+        timer.start()
+        time.sleep(1)
+        timer.stop()
+        print(f'The timer ran for {timer.duration()} seconds.')  # The timer ran for 1.0000000000000002 seconds.
+        timer.reset()
+        timer.start()
+        time.sleep(2)
+        timer.stop()
+        print(f'The timer ran for {timer.duration()} seconds.')  # The timer ran for 2.0000000000000004 seconds.
+
+    """
+
+    def __init__(self):
+        self._start_time: Optional[float] = None
+        self._stop_time: Optional[float] = None
+        self._duration: float = 0.0
+
+    def start(self):
+        """Start the timer."""
+        self._start_time = time.perf_counter()
+        self._stop_time = None
+
+    def stop(self):
+        """Stop the timer."""
+        if self._stop_time is None:
+            self._stop_time = time.perf_counter()
+            self._duration += self._stop_time - self._start_time
+
+    def duration(self) -> float:
+        """Get the duration of the timer."""
+        if self._start_time is not None and self._stop_time is None:
+            return self._duration + (time.perf_counter() - self._start_time)
+        else:
+            return self._duration
+
+    def reset(self):
+        """Reset the timer."""
+        self._start_time = None
+        self._stop_time = None
+        self._duration = 0.0
+
+    def restart(self):
+        """Reset and start the timer."""
+        self.reset()
+        self.start()
+
+    def __str__(self):
+        return f"{self.duration():.3f}s"
+
+
+class TimerCollection:
+    """Utility class for timing multiple operations.
+
+    This class keeps a collection of named timers. Each timer can be started, stopped, and reset. The duration of each
+    timer can be retrieved at any time. If a timer is stopped and restarted, the duration will be added to the previous
+    duration. The timers can be reset individually, or all at once.
+
+    Example::
+
+        import time
+        from mindtrace.core import TimerCollection
+
+        tc = TimerCollection()
+        tc.start('Timer 1')
+        tc.start('Timer 2')
+        time.sleep(1)
+        tc.stop('Timer 1')
+        time.sleep(1)
+        tc.stop('Timer 2')
+        tc.start('Timer 3')
+        time.sleep(1)
+        tc.reset('Timer 1')
+        print(tc)
+            # Timer 1: 0.000s
+            # Timer 2: 2.000s
+            # Timer 3: 1.000s
+        tc.reset_all()
+        print(tc)
+            # Timer 1: 0.000s
+            # Timer 2: 0.000s
+            # Timer 3: 0.000s
+
+    """
+
+    def __init__(self):
+        self._timers: Dict[str, Timer] = {}
+
+    def start(self, name: str):
+        """Start the timer with the given name. If the timer does not exist, it will be created."""
+        if name not in self._timers:
+            self._timers[name] = Timer()
+        self._timers[name].start()
+
+    def stop(self, name: str):
+        """Stop the timer with the given name.
+
+        Raises:
+            KeyError: If the timer with the given name does not exist.
+        """
+        if name not in self._timers:
+            raise KeyError(f"Timer {name} does not exist. Unable to stop.")
+        self._timers[name].stop()
+
+    def duration(self, name: str) -> float:
+        """Get the duration of the timer with the given name.
+
+        Raises:
+            KeyError: If the timer with the given name does not exist.
+        """
+        if name not in self._timers:
+            raise KeyError(f"Timer {name} does not exist. Unable to get duration.")
+        return self._timers[name].duration()
+
+    def reset(self, name: str):
+        """Reset the timer with the given name.
+
+        Raises:
+            KeyError: If the timer with the given name does not exist.
+        """
+        if name not in self._timers:
+            raise KeyError(f"Timer {name} does not exist. Unable to reset.")
+        self._timers[name].reset()
+
+    def restart(self, name: str):
+        """Reset and start the timer with the given name.
+
+        Raises:
+            KeyError: If the timer with the given name does not exist.
+        """
+        if name not in self._timers:
+            raise KeyError(f"Timer {name} does not exist. Unable to restart.")
+        self._timers[name].restart()
+
+    def reset_all(self):
+        """Reset all timers."""
+        for timer in self._timers.values():
+            timer.reset()
+
+    def names(self):
+        """Get the names of all timers."""
+        return self._timers.keys()
+
+    def __str__(self):
+        """Print each timer to the nearest microsecond."""
+        return "\n".join([f"{name}: {timer.duration():.6f}s" for name, timer in self._timers.items()])
+
+
+class Timeout:
+    """Utility for adding a timeout to a given method.
+
+    The given method will be run and rerun until an exception is not raised, or the timeout period is reached.
+
+    If the method raises an exception that is in the exceptions tuple, that exception will be caught and ignored. After
+    a retry_delay, the method will be run again. This process will continue until the method runs without raising an
+    exception, or the timeout period is passed.
+
+    If the timeout is reached, a TimeoutError will be raised. If the method ever raises an exception that is not in the
+    exceptions tuple, the timeout process will stop and that exception will be reraised.
+
+    Args:
+        timeout: The maximum time in seconds that the method can run before a TimeoutError is raised.
+        retry_delay: The time in seconds to wait between attempts to run the method.
+        exceptions: A tuple of exceptions that will be caught and ignored. By default, all exceptions are caught.
+        progress_bar: A boolean indicating whether to display a progress bar while waiting for the timeout.
+        desc: A description to display in the progress bar.
+
+    Returns:
+        The result of the given method.
+
+    Raises:
+        TimeoutError: If the timeout is reached.
+        Exception: Any raised exception not in the exceptions tuple will be reraised.
+
+    Example— Running Timeout Manually::
+
+        import requests
+        from urllib3.util.url import parse_url, Url
+        from mindtrace.core import Timeout
+        from mindtrace.services import Service
+        
+        def get_server_status(url: Url):
+            # The following request may fail for two categories of reasons:
+            #   1. The server has not launched yet: Will raise a ConnectionError, we should retry.
+            #   2. Any other reason: Will raise some other exception, we should break out and reraise it.
+            # Both cases will be raised to the Timeout class. We will tell the Timeout object to ignore ConnectionError.
+            response = requests.request("POST", str(url) + "status")
+
+            if response.status_code == 200:
+                return json.loads(response.content)["status"]  # Server is up and responding
+            else:
+                raise HTTPException(response.status_code, response.content)  # Request completed but something is wrong
+
+        url = parse_url("http://localhost:8080/")
+        timeout = Timeout(timeout=60.0, exceptions=(ConnectionRefusedError, requests.exceptions.ConnectionError))
+
+        Service.launch(url)
+        status = timeout.run(get_server_status, url)  # Will wait up to 60 seconds for the server to launch.
+        print(f"Server status: {status}")
+
+
+    Example— Using Timeout as a Decorator::
+
+        import requests
+        from urllib3.util.url import parse_url, Url
+        from mindtrace.core import Timeout
+        from mindtrace.services import Service
+
+        @Timeout(timeout=60.0, exceptions=(ConnectionRefusedError, requests.exceptions.ConnectionError))
+        def get_server_status(url: Url):
+            response = requests.request("POST", str(url) + "status")
+            if response.status_code == 200:
+                return json.loads(response.content)["status"]
+            else:
+                raise HTTPException(response.status_code, response.content)
+
+        url = parse_url("http://localhost:8080/")
+        Service.launch(url)
+
+        try:
+            status = get_server_status(url)  # Will wait up to 60 seconds for the server to launch.
+        except TimeoutError as e:
+            print(f"The server did not respond within the timeout period: {e}")  # Timeout of 60 seconds reached.
+        except Exception as e:  # Guaranteed not to be one of the given exceptions in the exceptions tuple.
+            print(f"An unexpected error occurred: {e}")
+        else:
+            print(f"Server status: {status}")
+
+    """
+
+    def __init__(
+        self,
+        timeout: float = 60.0,
+        retry_delay: float = 1.0,
+        exceptions: tuple[Type[Exception], ...] = (Exception,),
+        progress_bar: bool = False,
+        desc: str | None = None,
+    ):
+        self.timeout = timeout
+        self.retry_delay = retry_delay
+        self.exceptions = exceptions
+        self.progress_bar = progress_bar
+        self.desc = desc
+
+    def _wrapper(self, func, *args, **kwargs):
+        _progress_bar = tqdm(total=self.timeout, desc=self.desc, leave=False) if self.progress_bar else None
+        start_time = time.perf_counter()
+        while True:
+            if _progress_bar:
+                _progress_bar.update()
+            try:
+                result = func(*args, **kwargs)
+            except self.exceptions as e:  # ignore exception and try again after retry_delay
+                if time.perf_counter() - start_time > self.timeout:
+                    raise TimeoutError(f"Timeout of {self.timeout} seconds reached.") from e
+                time.sleep(self.retry_delay)
+            except Exception as e:  # reraise exception
+                if _progress_bar:
+                    _progress_bar.close()
+                raise e
+            else:
+                if _progress_bar:
+                    _progress_bar.close()
+                return result
+
+    def __call__(self, func):
+        """Wrap the given function. This method allows the Timeout class to be used as a decorator."""
+        return lambda *args, **kwargs: self._wrapper(func, *args, **kwargs)
+
+    def run(self, func, *args, **kwargs):
+        """Run the given function with the given args and kwargs."""
+        return self._wrapper(func, *args, **kwargs)

--- a/mindtrace/core/pyproject.toml
+++ b/mindtrace/core/pyproject.toml
@@ -3,6 +3,7 @@ name = "mindtrace-core"
 version = "0.1.0"
 dependencies = [
     "pillow>=11.2.1",
+    "pydantic>=2.11.1",
     "tqdm>=4.67.1",
 ]
 

--- a/mindtrace/core/pyproject.toml
+++ b/mindtrace/core/pyproject.toml
@@ -3,6 +3,7 @@ name = "mindtrace-core"
 version = "0.1.0"
 dependencies = [
     "pillow>=11.2.1",
+    "tqdm>=4.67.1",
 ]
 
 [tool.setuptools]

--- a/mindtrace/registry/mindtrace/registry/core/archiver.py
+++ b/mindtrace/registry/mindtrace/registry/core/archiver.py
@@ -21,7 +21,7 @@ class Archiver(Mindtrace, BaseMaterializer, metaclass=ArchiverMeta):
 
     def __init__(self, uri: str, *args, **kwargs):
         super().__init__(uri=uri, *args, **kwargs)
-        self.logger.debug(f"Archiver initialized at: {self.uri}")
+        self.logger.debug(f"Archiver initialized at: {uri}")
 
     @abstractmethod
     def save(self, data: Any):

--- a/mindtrace/services/mindtrace/services/__init__.py
+++ b/mindtrace/services/mindtrace/services/__init__.py
@@ -1,0 +1,10 @@
+from mindtrace.services.base.connection_manager import ConnectionManager
+from mindtrace.services.base.types import Heartbeat, ServerStatus
+from mindtrace.services.base.service import Service
+
+__all__ = [
+    "ConnectionManager",
+    "Heartbeat",
+    "Service",
+    "ServerStatus",
+]

--- a/mindtrace/services/mindtrace/services/__init__.py
+++ b/mindtrace/services/mindtrace/services/__init__.py
@@ -1,10 +1,18 @@
 from mindtrace.services.base.connection_manager import ConnectionManager
-from mindtrace.services.base.types import Heartbeat, ServerStatus
+from mindtrace.services.base.types import Heartbeat, ServerStatus, EndpointsSchema, StatusSchema, HeartbeatSchema, ServerIDSchema, PIDFileSchema, ShutdownSchema
+from mindtrace.services.base.utils import generate_connection_manager
 from mindtrace.services.base.service import Service
 
 __all__ = [
     "ConnectionManager",
+    "EndpointsSchema",
+    "generate_connection_manager",
     "Heartbeat",
+    "HeartbeatSchema",
+    "PIDFileSchema",
+    "ServerIDSchema",
     "Service",
     "ServerStatus",
+    "ShutdownSchema",
+    "StatusSchema",
 ]

--- a/mindtrace/services/mindtrace/services/base/connect.py
+++ b/mindtrace/services/mindtrace/services/base/connect.py
@@ -1,4 +1,0 @@
-from mindtrace.core import Mindtrace
-
-class ConnectionManagerBase(Mindtrace):
-    pass

--- a/mindtrace/services/mindtrace/services/base/connection_manager.py
+++ b/mindtrace/services/mindtrace/services/base/connection_manager.py
@@ -1,0 +1,113 @@
+"""Client-side helper class for communicating with any ServerBase server."""
+
+import json
+from typing import List
+from urllib.parse import urljoin
+from uuid import UUID
+
+from fastapi import HTTPException
+import requests
+from urllib3.util.url import parse_url, Url
+
+from mindtrace.core import Mindtrace, ifnone
+from mindtrace.services.base.types import Heartbeat, ServerStatus
+
+
+class ConnectionManager(Mindtrace):
+    """Client-side helper class for communicating with Mindtrace servers."""
+
+    def __init__(self, url: Url | None = None, server_id: UUID | None = None, server_pid_file: str | None = None):
+        super().__init__()
+        self.url = ifnone(url, default=parse_url(self.config["MINDTRACE_DEFAULT_HOST_URLS"]["Service"]))
+        self._server_id = server_id
+        self._server_pid_file = server_pid_file
+
+    @property
+    def endpoints(self) -> List[str]:
+        """Get the list of registered endpoints on the server."""
+        response = requests.request("POST", urljoin(str(self.url), "endpoints"), timeout=60)
+        if response.status_code != 200:
+            raise HTTPException(response.status_code, response.content)
+        return json.loads(response.content)["endpoints"]
+
+    @property
+    def status(self) -> ServerStatus:
+        """Get the status of the server."""
+        try:
+            response = requests.post(urljoin(str(self.url), "status"), timeout=60)
+            if response.status_code != 200:
+                return ServerStatus.Down
+            else:
+                return ServerStatus(json.loads(response.content)["status"])
+        except Exception as e:
+            self.logger.warning(f"Failed to get status of server at {self.url}: {e}")
+            return ServerStatus.Down
+
+    def heartbeat(self) -> Heartbeat:
+        """Get the heartbeat of the server.
+
+        The heartbeat includes both the server's status, as well as any additional diagnostic information the server may
+        provide.
+        """
+        response = requests.request("POST", urljoin(str(self.url), "heartbeat"), timeout=60)
+        if response.status_code != 200:
+            raise HTTPException(response.status_code, response.content)
+        response = json.loads(response.content)["heartbeat"]
+        return Heartbeat(
+            status=ServerStatus(response["status"]),
+            server_id=response["server_id"],
+            message=response["message"],
+            details=response["details"],
+        )
+
+    @property
+    def server_id(self) -> UUID:
+        """Get the server's unique id."""
+        if self._server_id is not None:
+            return self._server_id
+        else:
+            response = requests.post(urljoin(str(self.url), "server_id"), timeout=60)
+            if response.status_code != 200:
+                raise HTTPException(response.status_code, response.content)
+            self._server_id = UUID(json.loads(response.content)["server_id"])
+            return self._server_id
+
+    @property
+    def pid_file(self) -> str:
+        """Get the server's pid file."""
+        if self._server_pid_file is not None:
+            return self._server_pid_file
+        else:
+            response = requests.post(urljoin(str(self.url), "pid_file"), timeout=60)
+            if response.status_code != 200:
+                raise HTTPException(response.status_code, response.content)
+            return json.loads(response.content)["pid_file"]
+
+    def shutdown(self):
+        """Shutdown the server.
+
+        Example::
+
+            from mindtrace.services import Service, ServerStatus
+
+            cm = Service.launch()
+            assert cm.status == ServerStatus.Available
+
+            cm.shutdown()
+            assert cm.status == ServerStatus.Down
+        """
+        response = requests.request("POST", urljoin(str(self.url), "shutdown"), timeout=60)
+        if response.status_code != 200:
+            raise HTTPException(response.status_code, response.content)
+        return response
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.logger.debug(f"Shutting down {self.name} Server.")
+        try:
+            self.shutdown()
+        finally:
+            if exc_type is not None:
+                info = (exc_type, exc_val, exc_tb)
+                self.logger.exception("Exception occurred", exc_info=info)
+                return self.suppress
+        return False

--- a/mindtrace/services/mindtrace/services/base/launcher.py
+++ b/mindtrace/services/mindtrace/services/base/launcher.py
@@ -1,12 +1,13 @@
 import argparse
+from argparse import RawTextHelpFormatter
 import json
 import logging
 import os
-from argparse import RawTextHelpFormatter
+from pathlib import Path
 
 from gunicorn.app.base import BaseApplication
-from mindtrace.core.logging.logger import setup_logger
-from mindtrace.core.utils import instantiate_target
+
+from mindtrace.core import instantiate_target, setup_logger
 
 
 class Launcher(BaseApplication):
@@ -29,7 +30,7 @@ class Launcher(BaseApplication):
             name=server.unique_name,
             stream_level=logging.INFO,
             file_level=logging.DEBUG,
-            file_name=os.path.join(server.config["DIR_PATHS"]["LOGS"], f"{server.name}_logs.txt"),
+            log_dir=Path(server.config["MINDTRACE_DEFAULT_LOG_DIR"]),
         )
         self.application = server.app
         server.url = options.bind

--- a/mindtrace/services/mindtrace/services/base/serve.py
+++ b/mindtrace/services/mindtrace/services/base/serve.py
@@ -1,5 +1,0 @@
-from mindtrace.core import Mindtrace
-
-
-class Service(Mindtrace):
-    pass

--- a/mindtrace/services/mindtrace/services/base/service.py
+++ b/mindtrace/services/mindtrace/services/base/service.py
@@ -1,0 +1,432 @@
+"""Service base class. Provides unified methods for all Mindtrace (micro)services."""
+
+import atexit
+from contextlib import asynccontextmanager
+from importlib.metadata import version
+import json
+import logging
+import os
+from pathlib import Path
+import psutil
+import requests
+import signal
+import subprocess
+from typing import Type, TypeVar
+import uuid
+from uuid import UUID
+
+import fastapi
+from fastapi import FastAPI, HTTPException
+from urllib3.util.url import parse_url, Url
+
+from mindtrace.core import ifnone, ifnone_url, Mindtrace, named_lambda, Timeout
+from mindtrace.services import ConnectionManager, Heartbeat, ServerStatus
+
+T = TypeVar("T", bound="Service")  # A generic variable that can be 'Service', or any subclass.
+C = TypeVar("C", bound="ConnectionManager")  # '' '' '' 'ConnectionManager', or any subclass.
+
+
+class Service(Mindtrace):
+    """Base class for all Mindtrace services."""
+
+    _status = ServerStatus.Down
+    _endpoints: list[str] = []
+    _client_interface: Type[C] = ConnectionManager
+    _active_servers: dict[UUID, psutil.Process] = {}
+
+    def __init__(
+        self,
+        *,
+        url: str | Url | None = None,
+        host: str | None = None,
+        port: int | None = None,
+        summary: str | None = None,
+        description: str | None = None,
+        terms_of_service: str | None = None,
+        license_info: str | None = None,
+    ):
+        """Initialize server instance. This is for internal use by the launch() method.
+
+        Args:
+            url: Full URL string or Url object
+            host: Host address (e.g. "localhost" or "192.168.1.100")
+            port: Port number
+            summary: Summary of the server
+            description: Description of the server
+            terms_of_service: Terms of service for the server
+            license_info: License information for the server
+
+        Warning: Services should be created via the ServiceClass.launch() method. The __init__ method here should be
+        considered private internal use.
+        """
+        super().__init__()
+        self._status: ServerStatus = ServerStatus.Available
+        self.id, self.pid_file = self._generate_id_and_pid_file()
+
+        # Build URL with the following priority:
+        # 1. Explicit URL parameter
+        # 2. Host/port parameters
+        # 3. Default URL from config
+        self._url = self.build_url(url=url, host=host, port=port)
+        self._endpoints_metadata: dict[
+            str, dict[str, list[str] | str]
+        ] = {}  # path -> {"methods": [...], "role": "public"}
+
+        """
+        self.logger = default_logger(
+            name=self.unique_name,
+            stream_level=logging.INFO,
+            file_level=logging.DEBUG,
+            file_name=self.default_log_file(),
+        )
+        """
+
+        description = ifnone(description, default=f"{self.name} server.")
+        version_str = "Mindtrace " + version("mindtrace-services")
+
+        @asynccontextmanager
+        async def lifespan(app: FastAPI):
+            """Lifespan for the FastAPI app."""
+            self.logger.info(f"Server {self.id} starting up.")
+            yield
+            await self.shutdown_cleanup()
+            self.logger.info(f"Server {self.id} shut down.")
+
+        self.app = FastAPI(
+            title=self.name,
+            description=description,
+            summary=summary,
+            version=version_str,
+            terms_of_service=terms_of_service,
+            license_info=license_info,
+            lifespan=lifespan,
+        )
+        self.add_endpoint(path="/endpoints", func=named_lambda("endpoints", lambda: {"endpoints": self.endpoints}))
+        self.add_endpoint(
+            path="/endpoint_metadata",
+            func=named_lambda("endpoint_metadata", lambda: {"endpoint_metadata": self._endpoints_metadata}),
+        )
+        self.add_endpoint(path="/status", func=named_lambda("status", lambda: {"status": self.status}))
+        self.add_endpoint(path="/heartbeat", func=named_lambda("heartbeat", lambda: {"heartbeat": self.heartbeat()}))
+        self.add_endpoint(path="/server_id", func=named_lambda("server_id", lambda: {"server_id": self.id}))
+        self.add_endpoint(path="/pid_file", func=named_lambda("pid_file", lambda: {"pid_file": self.pid_file}))
+        self.add_endpoint(path="/shutdown", func=self.shutdown, autolog_kwargs={"log_level": logging.DEBUG})
+
+    @classmethod
+    def _generate_id_and_pid_file(cls, unique_id: UUID | None = None, pid_file: str | None = None) -> tuple[UUID, str]:
+        """Generate a unique_id and pid_file for the server.
+
+        The logic used ensures that the pid_file contains the (human-readable) class name as well as the unique_id.
+        """
+
+        # The following logic assures that the pid_file contains the unique_id
+        if unique_id is not None and pid_file is not None:
+            if str(unique_id) not in pid_file:
+                raise ValueError(f"unique_id {unique_id} not found in pid_file {pid_file}")
+        elif unique_id is not None and pid_file is None:
+            unique_id = unique_id
+            pid_file = cls._server_id_to_pid_file(unique_id)
+        elif unique_id is None and pid_file is not None:
+            unique_id = cls._pid_file_to_server_id(pid_file)
+            pid_file = pid_file
+        else:  # unique_id is None and pid_file is None
+            unique_id = uuid.uuid1()
+            pid_file = cls._server_id_to_pid_file(unique_id)
+
+        Path(pid_file).parent.mkdir(parents=True, exist_ok=True)
+        return unique_id, pid_file
+
+    @classmethod
+    def _server_id_to_pid_file(cls, server_id: UUID) -> str:
+        return os.path.join(cls.config["MINDTRACE_SERVER_PIDS_DIR_PATH"], f"{cls.__name__}_{server_id}_pid.txt")
+
+    @classmethod
+    def _pid_file_to_server_id(cls, pid_file: str) -> UUID:
+        return UUID(pid_file.split("_")[-2])
+
+    @classmethod
+    def status_at_host(cls, url: str | Url, timeout: int = 60) -> ServerStatus:
+        """Check the status of the service at the given host url.
+
+        This command may be used to check if a service (including this one) is available at a given host, useful for
+        determining when a service has been successfully launched.
+
+        Args:
+            url: The host URL of the service.
+        """
+        url = parse_url(url) if isinstance(url, str) else url
+        try:
+            response = requests.request("POST", str(url) + "/status", timeout=timeout)
+        except requests.exceptions.ConnectionError:
+            return ServerStatus.Down
+        if response.status_code != 200:
+            return ServerStatus.Down
+
+        status = ServerStatus(response.json()["status"])
+        return status
+
+    @classmethod
+    def connect(cls: Type[T], url: str | Url | None = None, timeout: int = 60) -> C:
+        """Connect to an existing service.
+
+        The returned connection manager is determined by the registered connection manager for the service. If one has
+        not explicitly been registered, the default connection manager (ConnectionManagerBase) will be used.
+
+        Args:
+            url: The host URL of the service.
+
+        Returns:
+            A connection manager for the service.
+
+        Raises:
+            HTTPException: If the server fails to connect, an HTTPException will be raised with status code 503.
+        """
+        url = ifnone_url(url, default=cls.default_url())
+        host_status = cls.status_at_host(url, timeout=timeout)
+        if host_status == ServerStatus.Available:
+            return cls._client_interface(url=url)
+        raise HTTPException(status_code=503, detail=f"Server failed to connect: {host_status}")
+
+    @classmethod
+    def launch(
+        cls: Type[T],
+        *,
+        url: str | Url | None = None,
+        host: str | None = None,
+        port: int | None = None,
+        block: bool = False,
+        num_workers: int = 1,
+        wait_for_launch: bool = True,
+        timeout: int = 60,
+        progress_bar: bool = True,
+        **kwargs,
+    ):
+        """Launch a new server instance.
+
+        The server can be configured through either explicit URL parameters or through kwargs. All kwargs are passed
+        directly to the server instance's __init__ method.
+
+        Args:
+            url: Full URL string or Url object (highest priority)
+            host: Host address (used if url not provided)
+            port: Port number (used if url not provided)
+            block: If True, blocks the calling process and keeps the server running
+            num_workers: Number of worker processes
+            wait_for_launch: Whether to wait for server startup
+            timeout: Timeout for server startup in seconds
+            progress_bar: Show progress bar during startup
+            **kwargs: Additional parameters passed to the server's __init__ method
+        """
+        # Build the launch URL with priority
+        launch_url = cls.build_url(url=url, host=host, port=port)
+
+        # Check that there is not already a service at the given URL
+        try:
+            existing_status = cls.status_at_host(launch_url)
+            if existing_status != ServerStatus.Down:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Server {cls.unique_name} at {launch_url} is already running with status {existing_status}.",
+                )
+        except RuntimeError as e:
+            cls.logger.warning(f"Another service is already running at {launch_url}. New service was NOT launched.")
+            raise e
+
+        # All kwargs (including URL params) go directly to init_params
+        init_params = {"url": str(launch_url), **kwargs}
+
+        # Create launch command
+        server_id = uuid.uuid1()
+        launch_command = [
+            "python",
+            "-m",
+            "mindtrace.services.base.launcher",
+            "-s",
+            cls.unique_name,
+            "-w",
+            str(num_workers),
+            "-b",
+            f"{launch_url.host}:{launch_url.port}",
+            "-p",
+            cls._server_id_to_pid_file(server_id),
+            "-k",
+            "uvicorn.workers.UvicornWorker",
+            "--init-params",
+            json.dumps(init_params),
+        ]
+        cls.logger.warning(f'Launching {cls.unique_name} with command: "{launch_command}"')
+        process = subprocess.Popen(launch_command)
+
+        # Register cleanup if this is the first server
+        cls._active_servers[server_id] = process
+        if len(cls._active_servers) == 1:
+            atexit.register(cls._cleanup_all_servers)
+            signal.signal(signal.SIGTERM, lambda sig, frame: cls._cleanup_all_servers())
+            signal.signal(signal.SIGINT, lambda sig, frame: cls._cleanup_all_servers())
+
+        # Wait for server to be available and get connection manager
+        connection_manager = None
+        if wait_for_launch:
+            timeout_handler = Timeout(
+                timeout=timeout,
+                exceptions=(ConnectionRefusedError, requests.exceptions.ConnectionError, HTTPException),
+                progress_bar=progress_bar,
+                desc=f"Launching {cls.unique_name.split('.')[-1]} at {launch_url}",
+            )
+            try:
+                connection_manager = timeout_handler.run(cls.connect, url=launch_url)
+            except Exception as e:
+                cls._cleanup_server(server_id)
+                raise e
+
+        # If blocking is requested, wait for the process
+        if block:
+            try:
+                process.wait()
+            except KeyboardInterrupt:
+                cls._cleanup_server(server_id)
+                raise
+            finally:
+                cls._cleanup_server(server_id)
+
+        return connection_manager
+
+    @property
+    def endpoints(self) -> list[str]:
+        """Return the available commands for the service."""
+        return list(self._endpoints)
+
+    @property
+    def status(self) -> ServerStatus:
+        """Returns the current status of this service."""
+        return self._status
+
+    def heartbeat(self) -> Heartbeat:
+        """Request the server to do a complete heartbeat check."""
+        return Heartbeat(
+            status=self.status,
+            server_id=self.id,
+            message="Heartbeat check successful.",
+            details=None,
+        )
+
+    @classmethod
+    def _cleanup_server(cls, server_id: UUID):
+        if server_id in cls._active_servers:
+            process = cls._active_servers[server_id]
+            try:
+                parent = psutil.Process(process.pid)
+                children = parent.children(recursive=True)
+                for child in children:
+                    try:
+                        child.terminate()
+                    except psutil.NoSuchProcess:
+                        pass
+                try:
+                    parent.terminate()
+                    parent.wait(timeout=5)
+                except psutil.NoSuchProcess:
+                    pass
+            except (psutil.NoSuchProcess, psutil.TimeoutExpired):
+                cls.logger.debug("Process already terminated.")
+            finally:
+                del cls._active_servers[server_id]
+
+    @classmethod
+    def _cleanup_all_servers(cls):
+        """Cleanup the servers."""
+        for server_id in list(cls._active_servers.keys()):
+            cls._cleanup_server(server_id)
+
+    @staticmethod
+    def shutdown() -> fastapi.Response:
+        """HTTP endpoint to shut down the server."""
+        os.kill(os.getppid(), signal.SIGTERM)  # kill the parent gunicorn process as it will respawn us otherwise
+        os.kill(os.getpid(), signal.SIGTERM)  # kill ourselves as well
+        return fastapi.Response(status_code=200, content="Server shutting down...")
+
+    async def shutdown_cleanup(self):
+        """Cleanup the server.
+
+        Override this method in subclasses to shut down any additional resources (e.g. db connections) as necessary."""
+        try:
+            self.logger.debug(f"Successfully released resources for Server {self.id}.")
+        except Exception as e:
+            self.logger.warning(f"Server did not shut down properly: {e}")
+
+    @classmethod
+    def default_url(cls) -> Url:
+        """Get the default URL for this server type from config.
+
+        Priority:
+
+        1. Server-specific URL from config
+        2. Default ServerBase URL from config
+        3. Fallback to localhost:8000
+        """
+        default_urls = cls.config["MINDTRACE_DEFAULT_HOST_URLS"]
+        server_url = default_urls.get(cls.__name__) or default_urls.get("ServerBase", "http://localhost:8000")
+        return parse_url(server_url)
+
+    @classmethod
+    def build_url(cls, url: str | Url | None = None, host: str | None = None, port: int | None = None) -> Url:
+        """Build a URL with consistent priority logic.
+
+        Priority:
+
+        1. Explicit URL parameter
+        2. Host/port parameters
+        3. Default URL from config
+
+        Args:
+            url: Full URL string or Url object
+            host: Host address (e.g. "localhost" or "192.168.1.100")
+            port: Port number
+
+        Returns:
+            Parsed URL object
+        """
+        if url is not None:
+            if isinstance(url, str):
+                url = url + "/" if not url.endswith("/") else url
+            return parse_url(url) if isinstance(url, str) else url
+
+        if host is not None or port is not None:
+            default_url = cls.default_url()
+            final_host = host or default_url.host
+            final_port = port or default_url.port
+            return parse_url(f"http://{final_host}:{final_port}/")
+
+        return cls.default_url()
+
+    @classmethod
+    def register_connection_manager(cls, connection_manager: Type[ConnectionManager]):
+        """Register a connection manager for this server."""
+        cls._client_interface = connection_manager
+
+    @classmethod
+    def default_log_file(cls) -> str:
+        """Get the default log file for this server type."""
+        return os.path.join(cls.config["MINDTRACE_DEFAULT_LOG_DIR"], f"{cls.__name__}_logs.txt")
+
+    def add_endpoint(
+        self,
+        path,
+        func,
+        api_route_kwargs=None,
+        autolog_kwargs=None,
+        methods: list[str] | None = None,
+        scope: str = "public",
+    ):
+        """Register a new endpoint with optional role."""
+        path = path.removeprefix("/")
+        api_route_kwargs = ifnone(api_route_kwargs, default={})
+        autolog_kwargs = ifnone(autolog_kwargs, default={})
+        self._endpoints.append(path)
+        self._endpoints_metadata[path] = {"methods": ifnone(methods, default=["POST"]), "role": scope}
+        self.app.add_api_route(
+            "/" + path,
+            endpoint=Mindtrace.autolog(self=self, **autolog_kwargs)(func),
+            methods=ifnone(methods, default=["POST"]),
+            **api_route_kwargs,
+        )

--- a/mindtrace/services/mindtrace/services/base/types.py
+++ b/mindtrace/services/mindtrace/services/base/types.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass
 from enum import Enum
 import json
+from typing import Any, Literal, Type
 from uuid import UUID
 
 from pydantic import BaseModel
+
+from mindtrace.core import TaskSchema
 
 
 class ServerStatus(Enum):
@@ -31,7 +34,7 @@ class Heartbeat:
     status: ServerStatus = ServerStatus.Down
     server_id: UUID | None = None
     message: str | None = None
-    details: any = None
+    details: Any = None
 
     def __str__(self):
         if isinstance(self.details, dict):
@@ -47,5 +50,55 @@ class Heartbeat:
             )
 
 
-class SetServerIDInput(BaseModel):
+class EndpointsOutput(BaseModel):
+    endpoints: list[str]
+
+
+class EndpointsSchema(TaskSchema):
+    name: Literal["endpoints"] = "endpoints"
+    output_schema: Type[EndpointsOutput] = EndpointsOutput
+
+
+class StatusOutput(BaseModel):
+    status: ServerStatus
+
+
+class StatusSchema(TaskSchema):
+    name: Literal["status"] = "status"
+    output_schema: Type[StatusOutput] = StatusOutput
+
+
+class HeartbeatOutput(BaseModel):
+    heartbeat: Heartbeat
+
+
+class HeartbeatSchema(TaskSchema):
+    name: Literal["heartbeat"] = "heartbeat"
+    output_schema: Type[HeartbeatOutput] = HeartbeatOutput
+
+
+class ServerIDOutput(BaseModel):
     server_id: UUID
+
+
+class ServerIDSchema(TaskSchema):
+    name: Literal["server_id"] = "server_id"
+    output_schema: Type[ServerIDOutput] = ServerIDOutput
+
+
+class PIDFileOutput(BaseModel):
+    pid_file: str
+
+
+class PIDFileSchema(TaskSchema):
+    name: Literal["pid_file"] = "pid_file"
+    output_schema: Type[PIDFileOutput] = PIDFileOutput
+
+
+class ShutdownOutput(BaseModel):
+    shutdown: bool
+
+
+class ShutdownSchema(TaskSchema):
+    name: Literal["shutdown"] = "shutdown"
+    output_schema: Type[ShutdownOutput] = ShutdownOutput

--- a/mindtrace/services/mindtrace/services/base/utils.py
+++ b/mindtrace/services/mindtrace/services/base/utils.py
@@ -8,7 +8,7 @@ from mindtrace import Mindtrace
 def add_endpoint(app, path, self: Optional["ServerBase"], **kwargs):
     """Register a new endpoint.
 
-    This decorator method is functionally identical as calling add_endpoint on a ServerBase instance. It is useful when
+    This decorator method is functionally identical as calling add_endpoint on a Service instance. It is useful when
     the endpoints are defined in a separate method, such as grouping api routes in a more complicated FastAPI app.
 
     Args:
@@ -20,9 +20,9 @@ def add_endpoint(app, path, self: Optional["ServerBase"], **kwargs):
     Example::
 
         from fastapi import FastAPI
-        from mindtrace.services import ServerBase
+        from mindtrace.services import Service
 
-        class MyServer(ServerBase):
+        class MyServer(Service):
             def __init__(self):
                 super().__init__()
 

--- a/mindtrace/services/pyproject.toml
+++ b/mindtrace/services/pyproject.toml
@@ -2,8 +2,10 @@
 name = "mindtrace-services"
 version = "0.1.0"
 dependencies = [
+    "gunicorn>=23.0.0",
     "mindtrace-core",
     "structlog>=24.4.0",
+    "uvicorn>=0.34.3",
 ]
 
 [tool.setuptools]

--- a/tests/unit/mindtrace/core/utils/test_checks.py
+++ b/tests/unit/mindtrace/core/utils/test_checks.py
@@ -1,8 +1,10 @@
 """Unit test methods for mindtrace.core.utils.checks utility module."""
 
 from unittest.mock import patch
+from urllib3.util.url import parse_url
 
 from mindtrace.core import ifnone, check_libs
+from mindtrace.core.utils.checks import ifnone_url
 
 
 def test_ifnone():
@@ -50,3 +52,48 @@ def test_check_libs():
     with patch('builtins.__import__') as mock_import:
         mock_import.side_effect = ImportError("No module named 'missing_lib'")
         assert check_libs(['missing_lib1', 'missing_lib2']) == ['missing_lib1', 'missing_lib2']
+
+
+def test_ifnone_url():
+    """Test ifnone_url function with various URL inputs."""
+    # Test with string URL and string default
+    result = ifnone_url("http://example.com", "http://default.com")
+    assert str(result) == "http://example.com"
+    assert result.host == "example.com"
+    
+    # Test with None URL and string default
+    result = ifnone_url(None, "http://default.com")
+    assert str(result) == "http://default.com"
+    assert result.host == "default.com"
+    
+    # Test with string URL and Url object default
+    default_url = parse_url("http://default.com")
+    result = ifnone_url("http://example.com", default_url)
+    assert str(result) == "http://example.com"
+    assert result.host == "example.com"
+    
+    # Test with None URL and Url object default
+    default_url = parse_url("http://default.com")
+    result = ifnone_url(None, default_url)
+    assert str(result) == "http://default.com"
+    assert result.host == "default.com"
+    assert result is default_url  # Should return the same object
+    
+    # Test with Url object URL and string default
+    url = parse_url("http://example.com")
+    result = ifnone_url(url, "http://default.com")
+    assert str(result) == "http://example.com"
+    assert result.host == "example.com"
+    assert result is url  # Should return the same object
+    
+    # Test with Url object URL and Url object default
+    url = parse_url("http://example.com")
+    default_url = parse_url("http://default.com")
+    result = ifnone_url(url, default_url)
+    assert str(result) == "http://example.com"
+    assert result.host == "example.com"
+    assert result is url  # Should return the same object
+    
+    # Test with None URL and None default (edge case)
+    result = ifnone_url(None, None)
+    assert result is None

--- a/tests/unit/mindtrace/core/utils/test_lambdas.py
+++ b/tests/unit/mindtrace/core/utils/test_lambdas.py
@@ -1,0 +1,227 @@
+"""Unit tests for mindtrace.core.utils.lambdas module."""
+
+import pytest
+from types import FunctionType
+
+from mindtrace.core.utils.lambdas import named_lambda
+
+
+class TestNamedLambda:
+    """Test suite for the named_lambda function."""
+
+    def test_named_lambda_basic_functionality(self):
+        """Test basic functionality of named_lambda with a simple lambda."""
+        # Create a lambda function
+        original_lambda = lambda x: x * 2
+        
+        # Apply named_lambda
+        named_func = named_lambda("multiply_by_two", original_lambda)
+        
+        # Test that the name was set correctly
+        assert named_func.__name__ == "multiply_by_two"
+        
+        # Test that the function still works correctly
+        assert named_func(5) == 10
+        assert named_func(0) == 0
+        assert named_func(-3) == -6
+
+    def test_named_lambda_returns_same_object(self):
+        """Test that named_lambda returns the same function object."""
+        original_lambda = lambda x: x + 1
+        named_func = named_lambda("increment", original_lambda)
+        
+        # Should return the same object, just with modified __name__
+        assert named_func is original_lambda
+
+    def test_named_lambda_with_multiple_parameters(self):
+        """Test named_lambda with lambda that takes multiple parameters."""
+        add_lambda = lambda x, y: x + y
+        named_add = named_lambda("add_two_numbers", add_lambda)
+        
+        assert named_add.__name__ == "add_two_numbers"
+        assert named_add(3, 4) == 7
+        assert named_add(-1, 1) == 0
+
+    def test_named_lambda_with_keyword_arguments(self):
+        """Test named_lambda with lambda that uses keyword arguments."""
+        greet_lambda = lambda name, greeting="Hello": f"{greeting}, {name}!"
+        named_greet = named_lambda("greet_person", greet_lambda)
+        
+        assert named_greet.__name__ == "greet_person"
+        assert named_greet("Alice") == "Hello, Alice!"
+        assert named_greet("Bob", greeting="Hi") == "Hi, Bob!"
+
+    def test_named_lambda_with_complex_logic(self):
+        """Test named_lambda with more complex lambda logic."""
+        # Lambda with conditional logic
+        abs_lambda = lambda x: x if x >= 0 else -x
+        named_abs = named_lambda("absolute_value", abs_lambda)
+        
+        assert named_abs.__name__ == "absolute_value"
+        assert named_abs(5) == 5
+        assert named_abs(-5) == 5
+        assert named_abs(0) == 0
+
+    def test_named_lambda_with_empty_name(self):
+        """Test named_lambda with empty string name."""
+        test_lambda = lambda x: x
+        named_func = named_lambda("", test_lambda)
+        
+        assert named_func.__name__ == ""
+        assert named_func(42) == 42
+
+    def test_named_lambda_with_special_characters_in_name(self):
+        """Test named_lambda with special characters in name."""
+        test_lambda = lambda x: x
+        special_name = "test_function_123!@#"
+        named_func = named_lambda(special_name, test_lambda)
+        
+        assert named_func.__name__ == special_name
+        assert named_func("test") == "test"
+
+    def test_named_lambda_preserves_original_behavior(self):
+        """Test that named_lambda preserves all original function behavior."""
+        # Lambda that returns a complex data structure
+        data_lambda = lambda: {"key": "value", "numbers": [1, 2, 3]}
+        named_data = named_lambda("create_data", data_lambda)
+        
+        assert named_data.__name__ == "create_data"
+        result = named_data()
+        assert result == {"key": "value", "numbers": [1, 2, 3]}
+        assert isinstance(result, dict)
+
+    def test_named_lambda_with_regular_function(self):
+        """Test named_lambda works with regular functions, not just lambdas."""
+        def regular_function(x):
+            return x ** 2
+        
+        original_name = regular_function.__name__
+        assert original_name == "regular_function"
+        
+        renamed_func = named_lambda("square_number", regular_function)
+        
+        assert renamed_func.__name__ == "square_number"
+        assert renamed_func(4) == 16
+        assert renamed_func is regular_function  # Same object
+
+    def test_named_lambda_with_builtin_function_raises_error(self):
+        """Test named_lambda raises error with built-in functions (read-only __name__)."""
+        # Built-in functions have read-only __name__ attributes
+        with pytest.raises(AttributeError, match="attribute '__name__' of 'builtin_function_or_method' objects is not writable"):
+            named_lambda("get_length", len)
+
+    def test_named_lambda_with_method_raises_error(self):
+        """Test named_lambda with instance methods raises error (no __name__ attribute)."""
+        class TestClass:
+            def __init__(self, value):
+                self.value = value
+            
+            def get_value(self):
+                return self.value
+        
+        obj = TestClass(42)
+        # Bound methods don't have a __name__ attribute
+        with pytest.raises(AttributeError, match="'method' object has no attribute '__name__'"):
+            named_lambda("retrieve_value", obj.get_value)
+
+    def test_named_lambda_type_preservation(self):
+        """Test that named_lambda preserves the function type."""
+        original_lambda = lambda x: x
+        named_func = named_lambda("identity", original_lambda)
+        
+        assert isinstance(named_func, FunctionType)
+        assert callable(named_func)
+
+    def test_named_lambda_with_none_function_raises_error(self):
+        """Test that named_lambda raises appropriate error when function is None."""
+        with pytest.raises(AttributeError):
+            named_lambda("test_name", None)
+
+    def test_named_lambda_name_overwrite(self):
+        """Test that named_lambda can overwrite existing function names."""
+        def existing_function():
+            return "original"
+        
+        assert existing_function.__name__ == "existing_function"
+        
+        # Rename the function
+        renamed_func = named_lambda("new_function_name", existing_function)
+        
+        assert renamed_func.__name__ == "new_function_name"
+        assert renamed_func() == "original"
+        
+        # Original function's name is also changed (same object)
+        assert existing_function.__name__ == "new_function_name"
+
+    def test_named_lambda_with_closure(self):
+        """Test named_lambda with lambda that uses closure variables."""
+        multiplier = 3
+        multiply_lambda = lambda x: x * multiplier
+        named_multiply = named_lambda("triple", multiply_lambda)
+        
+        assert named_multiply.__name__ == "triple"
+        assert named_multiply(4) == 12
+        
+        # Test that closure still works after renaming
+        # Note: In this case, changing the outer variable doesn't affect the lambda
+        # because the lambda captures the variable by reference at the time it's called
+        multiplier = 5  # This WILL affect the lambda since it captures by reference
+        assert named_multiply(4) == 20  # Now uses the updated multiplier value
+
+    def test_named_lambda_docstring_preservation(self):
+        """Test that named_lambda preserves function docstrings."""
+        def documented_function(x):
+            """This function doubles its input."""
+            return x * 2
+        
+        renamed_func = named_lambda("doubler", documented_function)
+        
+        assert renamed_func.__name__ == "doubler"
+        assert renamed_func.__doc__ == "This function doubles its input."
+        assert renamed_func(5) == 10
+
+    def test_named_lambda_multiple_calls_same_function(self):
+        """Test calling named_lambda multiple times on the same function."""
+        original_lambda = lambda x: x + 1
+        
+        # First renaming
+        first_rename = named_lambda("increment", original_lambda)
+        assert first_rename.__name__ == "increment"
+        
+        # Second renaming (should overwrite the name)
+        second_rename = named_lambda("add_one", first_rename)
+        assert second_rename.__name__ == "add_one"
+        
+        # All references point to the same object
+        assert first_rename is second_rename is original_lambda
+        assert original_lambda.__name__ == "add_one"
+
+    def test_named_lambda_with_exception_raising_function(self):
+        """Test named_lambda with functions that raise exceptions."""
+        error_lambda = lambda: 1 / 0
+        named_error = named_lambda("divide_by_zero", error_lambda)
+        
+        assert named_error.__name__ == "divide_by_zero"
+        
+        with pytest.raises(ZeroDivisionError):
+            named_error()
+
+    def test_named_lambda_integration_example(self):
+        """Test integration example similar to the docstring example."""
+        # Simulate the example from the docstring
+        def run_command(command: callable, data):
+            """Simulate a function that needs the command name."""
+            result = command(*data) if isinstance(data, tuple) else command(data)
+            return f"Executed '{command.__name__}' with result: {result}"
+        
+        # Test with unnamed lambda
+        unnamed_lambda = lambda x, y: x + y
+        result1 = run_command(unnamed_lambda, (3, 4))
+        assert "Executed '<lambda>'" in result1
+        assert "result: 7" in result1
+        
+        # Test with named lambda
+        named_add = named_lambda("add", lambda x, y: x + y)
+        result2 = run_command(named_add, (3, 4))
+        assert "Executed 'add'" in result2
+        assert "result: 7" in result2

--- a/tests/unit/mindtrace/core/utils/test_timers.py
+++ b/tests/unit/mindtrace/core/utils/test_timers.py
@@ -1,0 +1,482 @@
+"""Unit tests for mindtrace.core.utils.timers module."""
+
+import pytest
+import time
+from unittest.mock import Mock, patch, MagicMock
+from tqdm import tqdm
+
+from mindtrace.core.utils.timers import Timer, TimerCollection, Timeout
+
+
+class TestTimer:
+    """Test suite for the Timer class."""
+
+    def test_timer_initialization(self):
+        """Test timer is properly initialized."""
+        timer = Timer()
+        assert timer._start_time is None
+        assert timer._stop_time is None
+        assert timer._duration == 0.0
+        assert timer.duration() == 0.0
+
+    @patch('time.perf_counter')
+    def test_timer_start(self, mock_perf_counter):
+        """Test timer start functionality."""
+        mock_perf_counter.return_value = 10.0
+        timer = Timer()
+        timer.start()
+        
+        assert timer._start_time == 10.0
+        assert timer._stop_time is None
+
+    @patch('time.perf_counter')
+    def test_timer_stop(self, mock_perf_counter):
+        """Test timer stop functionality."""
+        mock_perf_counter.side_effect = [10.0, 15.0]
+        timer = Timer()
+        timer.start()
+        timer.stop()
+        
+        assert timer._start_time == 10.0
+        assert timer._stop_time == 15.0
+        assert timer._duration == 5.0
+
+    @patch('time.perf_counter')
+    def test_timer_stop_without_start(self, mock_perf_counter):
+        """Test stopping timer without starting raises TypeError due to None arithmetic."""
+        mock_perf_counter.return_value = 15.0
+        timer = Timer()
+        # This should raise TypeError because _start_time is None
+        with pytest.raises(TypeError):
+            timer.stop()
+
+    @patch('time.perf_counter')
+    def test_timer_multiple_stop_calls(self, mock_perf_counter):
+        """Test multiple stop calls only record the first stop time."""
+        mock_perf_counter.side_effect = [10.0, 15.0, 20.0]
+        timer = Timer()
+        timer.start()
+        timer.stop()
+        timer.stop()  # Second stop should be ignored
+        
+        assert timer._stop_time == 15.0
+        assert timer._duration == 5.0
+
+    @patch('time.perf_counter')
+    def test_timer_duration_while_running(self, mock_perf_counter):
+        """Test getting duration while timer is running."""
+        mock_perf_counter.side_effect = [10.0, 17.5]
+        timer = Timer()
+        timer.start()
+        duration = timer.duration()
+        
+        assert duration == 7.5
+
+    @patch('time.perf_counter')
+    def test_timer_duration_after_stop(self, mock_perf_counter):
+        """Test getting duration after timer is stopped."""
+        mock_perf_counter.side_effect = [10.0, 15.0]
+        timer = Timer()
+        timer.start()
+        timer.stop()
+        
+        assert timer.duration() == 5.0
+
+    @patch('time.perf_counter')
+    def test_timer_cumulative_duration(self, mock_perf_counter):
+        """Test timer accumulates duration across multiple start/stop cycles."""
+        mock_perf_counter.side_effect = [10.0, 15.0, 20.0, 25.0]
+        timer = Timer()
+        
+        # First cycle: 5 seconds
+        timer.start()
+        timer.stop()
+        assert timer.duration() == 5.0
+        
+        # Second cycle: 5 more seconds
+        timer.start()
+        timer.stop()
+        assert timer.duration() == 10.0
+
+    def test_timer_reset(self):
+        """Test timer reset functionality."""
+        timer = Timer()
+        timer._start_time = 10.0
+        timer._stop_time = 15.0
+        timer._duration = 5.0
+        
+        timer.reset()
+        
+        assert timer._start_time is None
+        assert timer._stop_time is None
+        assert timer._duration == 0.0
+
+    @patch('time.perf_counter')
+    def test_timer_restart(self, mock_perf_counter):
+        """Test timer restart functionality."""
+        mock_perf_counter.return_value = 20.0
+        timer = Timer()
+        timer._duration = 5.0  # Simulate some previous duration
+        
+        timer.restart()
+        
+        assert timer._start_time == 20.0
+        assert timer._stop_time is None
+        assert timer._duration == 0.0
+
+    @patch('time.perf_counter')
+    def test_timer_str_representation(self, mock_perf_counter):
+        """Test timer string representation."""
+        mock_perf_counter.side_effect = [10.0, 15.123456]
+        timer = Timer()
+        timer.start()
+        timer.stop()
+        
+        assert str(timer) == "5.123s"
+
+    def test_timer_str_representation_zero(self):
+        """Test timer string representation when duration is zero."""
+        timer = Timer()
+        assert str(timer) == "0.000s"
+
+
+class TestTimerCollection:
+    """Test suite for the TimerCollection class."""
+
+    def test_timer_collection_initialization(self):
+        """Test timer collection is properly initialized."""
+        tc = TimerCollection()
+        assert tc._timers == {}
+        assert list(tc.names()) == []
+
+    @patch('time.perf_counter')
+    def test_start_new_timer(self, mock_perf_counter):
+        """Test starting a new timer creates it."""
+        mock_perf_counter.return_value = 10.0
+        tc = TimerCollection()
+        tc.start('test_timer')
+        
+        assert 'test_timer' in tc._timers
+        assert tc._timers['test_timer']._start_time == 10.0
+
+    @patch('time.perf_counter')
+    def test_start_existing_timer(self, mock_perf_counter):
+        """Test starting an existing timer."""
+        mock_perf_counter.side_effect = [10.0, 15.0, 20.0]
+        tc = TimerCollection()
+        tc.start('test_timer')
+        tc.stop('test_timer')
+        tc.start('test_timer')  # Restart existing timer
+        
+        assert tc._timers['test_timer']._start_time == 20.0
+
+    @patch('time.perf_counter')
+    def test_stop_existing_timer(self, mock_perf_counter):
+        """Test stopping an existing timer."""
+        mock_perf_counter.side_effect = [10.0, 15.0]
+        tc = TimerCollection()
+        tc.start('test_timer')
+        tc.stop('test_timer')
+        
+        assert tc._timers['test_timer']._stop_time == 15.0
+
+    def test_stop_nonexistent_timer(self):
+        """Test stopping a non-existent timer raises KeyError."""
+        tc = TimerCollection()
+        with pytest.raises(KeyError, match="Timer nonexistent does not exist. Unable to stop."):
+            tc.stop('nonexistent')
+
+    @patch('time.perf_counter')
+    def test_duration_existing_timer(self, mock_perf_counter):
+        """Test getting duration of an existing timer."""
+        mock_perf_counter.side_effect = [10.0, 15.0]
+        tc = TimerCollection()
+        tc.start('test_timer')
+        tc.stop('test_timer')
+        
+        assert tc.duration('test_timer') == 5.0
+
+    def test_duration_nonexistent_timer(self):
+        """Test getting duration of a non-existent timer raises KeyError."""
+        tc = TimerCollection()
+        with pytest.raises(KeyError, match="Timer nonexistent does not exist. Unable to get duration."):
+            tc.duration('nonexistent')
+
+    @patch('time.perf_counter')
+    def test_reset_existing_timer(self, mock_perf_counter):
+        """Test resetting an existing timer."""
+        mock_perf_counter.side_effect = [10.0, 15.0]
+        tc = TimerCollection()
+        tc.start('test_timer')
+        tc.stop('test_timer')
+        
+        tc.reset('test_timer')
+        
+        assert tc._timers['test_timer']._duration == 0.0
+        assert tc._timers['test_timer']._start_time is None
+
+    def test_reset_nonexistent_timer(self):
+        """Test resetting a non-existent timer raises KeyError."""
+        tc = TimerCollection()
+        with pytest.raises(KeyError, match="Timer nonexistent does not exist. Unable to reset."):
+            tc.reset('nonexistent')
+
+    @patch('time.perf_counter')
+    def test_restart_existing_timer(self, mock_perf_counter):
+        """Test restarting an existing timer."""
+        mock_perf_counter.side_effect = [10.0, 15.0, 20.0]
+        tc = TimerCollection()
+        tc.start('test_timer')
+        tc.stop('test_timer')
+        
+        tc.restart('test_timer')
+        
+        assert tc._timers['test_timer']._start_time == 20.0
+        assert tc._timers['test_timer']._duration == 0.0
+
+    def test_restart_nonexistent_timer(self):
+        """Test restarting a non-existent timer raises KeyError."""
+        tc = TimerCollection()
+        with pytest.raises(KeyError, match="Timer nonexistent does not exist. Unable to restart."):
+            tc.restart('nonexistent')
+
+    @patch('time.perf_counter')
+    def test_reset_all_timers(self, mock_perf_counter):
+        """Test resetting all timers."""
+        mock_perf_counter.side_effect = [10.0, 15.0, 20.0, 25.0]
+        tc = TimerCollection()
+        tc.start('timer1')
+        tc.stop('timer1')
+        tc.start('timer2')
+        tc.stop('timer2')
+        
+        tc.reset_all()
+        
+        assert tc._timers['timer1']._duration == 0.0
+        assert tc._timers['timer2']._duration == 0.0
+
+    @patch('time.perf_counter')
+    def test_names_method(self, mock_perf_counter):
+        """Test getting names of all timers."""
+        mock_perf_counter.return_value = 10.0
+        tc = TimerCollection()
+        tc.start('timer1')
+        tc.start('timer2')
+        tc.start('timer3')
+        
+        names = list(tc.names())
+        assert set(names) == {'timer1', 'timer2', 'timer3'}
+
+    @patch('time.perf_counter')
+    def test_str_representation(self, mock_perf_counter):
+        """Test string representation of timer collection."""
+        mock_perf_counter.side_effect = [10.0, 15.123456, 20.0, 25.654321]
+        tc = TimerCollection()
+        tc.start('timer1')
+        tc.stop('timer1')
+        tc.start('timer2')
+        tc.stop('timer2')
+        
+        result = str(tc)
+        lines = result.split('\n')
+        
+        # Check that both timers are represented with 6 decimal places
+        assert len(lines) == 2
+        assert 'timer1: 5.123456s' in lines
+        assert 'timer2: 5.654321s' in lines
+
+    def test_str_representation_empty(self):
+        """Test string representation of empty timer collection."""
+        tc = TimerCollection()
+        assert str(tc) == ""
+
+
+class TestTimeout:
+    """Test suite for the Timeout class."""
+
+    def test_timeout_initialization_defaults(self):
+        """Test timeout initialization with default values."""
+        timeout = Timeout()
+        assert timeout.timeout == 60.0
+        assert timeout.retry_delay == 1.0
+        assert timeout.exceptions == (Exception,)
+        assert timeout.progress_bar is False
+        assert timeout.desc is None
+
+    def test_timeout_initialization_custom(self):
+        """Test timeout initialization with custom values."""
+        timeout = Timeout(
+            timeout=30.0,
+            retry_delay=0.5,
+            exceptions=(ValueError, TypeError),
+            progress_bar=True,
+            desc="Testing"
+        )
+        assert timeout.timeout == 30.0
+        assert timeout.retry_delay == 0.5
+        assert timeout.exceptions == (ValueError, TypeError)
+        assert timeout.progress_bar is True
+        assert timeout.desc == "Testing"
+
+    @patch('time.perf_counter')
+    @patch('time.sleep')
+    def test_timeout_run_success_immediately(self, mock_sleep, mock_perf_counter):
+        """Test timeout run with immediate success."""
+        mock_perf_counter.return_value = 0.0
+        
+        def test_func(x, y):
+            return x + y
+        
+        timeout = Timeout(timeout=5.0)
+        result = timeout.run(test_func, 2, 3)
+        
+        assert result == 5
+        mock_sleep.assert_not_called()
+
+    @patch('time.perf_counter')
+    @patch('time.sleep')
+    def test_timeout_run_success_after_retries(self, mock_sleep, mock_perf_counter):
+        """Test timeout run with success after retries."""
+        mock_perf_counter.side_effect = [0.0, 1.0, 2.0]
+        
+        call_count = 0
+        def test_func():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ValueError("Not ready yet")
+            return "success"
+        
+        timeout = Timeout(timeout=5.0, retry_delay=0.1, exceptions=(ValueError,))
+        result = timeout.run(test_func)
+        
+        assert result == "success"
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(0.1)
+
+    @patch('time.perf_counter')
+    @patch('time.sleep')
+    def test_timeout_run_timeout_exceeded(self, mock_sleep, mock_perf_counter):
+        """Test timeout run when timeout is exceeded."""
+        mock_perf_counter.side_effect = [0.0, 3.0, 6.0]  # Exceeds 5.0 timeout
+        
+        def test_func():
+            raise ValueError("Always fails")
+        
+        timeout = Timeout(timeout=5.0, retry_delay=0.1, exceptions=(ValueError,))
+        
+        with pytest.raises(TimeoutError, match="Timeout of 5.0 seconds reached."):
+            timeout.run(test_func)
+
+    @patch('time.perf_counter')
+    @patch('time.sleep')
+    def test_timeout_run_unexpected_exception(self, mock_sleep, mock_perf_counter):
+        """Test timeout run with unexpected exception."""
+        mock_perf_counter.return_value = 0.0
+        
+        def test_func():
+            raise TypeError("Unexpected error")
+        
+        timeout = Timeout(timeout=5.0, exceptions=(ValueError,))
+        
+        with pytest.raises(TypeError, match="Unexpected error"):
+            timeout.run(test_func)
+        
+        mock_sleep.assert_not_called()
+
+    @patch('time.perf_counter')
+    @patch('time.sleep')
+    def test_timeout_as_decorator(self, mock_sleep, mock_perf_counter):
+        """Test timeout used as a decorator."""
+        mock_perf_counter.return_value = 0.0
+        
+        @Timeout(timeout=5.0)
+        def test_func(x):
+            return x * 2
+        
+        result = test_func(5)
+        assert result == 10
+
+    @patch('time.perf_counter')
+    @patch('time.sleep')
+    def test_timeout_decorator_with_exception(self, mock_sleep, mock_perf_counter):
+        """Test timeout decorator with exception handling."""
+        mock_perf_counter.side_effect = [0.0, 1.0]
+        
+        call_count = 0
+        @Timeout(timeout=5.0, retry_delay=0.1, exceptions=(ValueError,))
+        def test_func():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("Not ready")
+            return "success"
+        
+        result = test_func()
+        assert result == "success"
+        mock_sleep.assert_called_once_with(0.1)
+
+    @patch('mindtrace.core.utils.timers.tqdm')
+    @patch('time.perf_counter')
+    @patch('time.sleep')
+    def test_timeout_with_progress_bar(self, mock_sleep, mock_perf_counter, mock_tqdm):
+        """Test timeout with progress bar enabled."""
+        mock_perf_counter.return_value = 0.0
+        mock_progress_bar = MagicMock()
+        mock_tqdm.return_value = mock_progress_bar
+        
+        def test_func():
+            return "success"
+        
+        timeout = Timeout(timeout=5.0, progress_bar=True, desc="Testing")
+        result = timeout.run(test_func)
+        
+        assert result == "success"
+        mock_tqdm.assert_called_once_with(total=5.0, desc="Testing", leave=False)
+        mock_progress_bar.update.assert_called_once()
+        mock_progress_bar.close.assert_called_once()
+
+    @patch('mindtrace.core.utils.timers.tqdm')
+    @patch('time.perf_counter')
+    @patch('time.sleep')
+    def test_timeout_progress_bar_with_exception(self, mock_sleep, mock_perf_counter, mock_tqdm):
+        """Test timeout progress bar is closed when unexpected exception occurs."""
+        mock_perf_counter.return_value = 0.0
+        mock_progress_bar = MagicMock()
+        mock_tqdm.return_value = mock_progress_bar
+        
+        def test_func():
+            raise RuntimeError("Unexpected error")
+        
+        timeout = Timeout(timeout=5.0, progress_bar=True, exceptions=(ValueError,))
+        
+        with pytest.raises(RuntimeError):
+            timeout.run(test_func)
+        
+        mock_progress_bar.close.assert_called_once()
+
+    @patch('time.perf_counter')
+    @patch('time.sleep')
+    def test_timeout_with_args_and_kwargs(self, mock_sleep, mock_perf_counter):
+        """Test timeout properly passes args and kwargs to the function."""
+        mock_perf_counter.return_value = 0.0
+        
+        def test_func(a, b, c=None):
+            return f"{a}-{b}-{c}"
+        
+        timeout = Timeout()
+        result = timeout.run(test_func, "arg1", "arg2", c="kwarg1")
+        
+        assert result == "arg1-arg2-kwarg1"
+
+    def test_timeout_call_returns_wrapped_function(self):
+        """Test that calling timeout returns a properly wrapped function."""
+        timeout = Timeout()
+        
+        def test_func(x):
+            return x * 2
+        
+        wrapped_func = timeout(test_func)
+        result = wrapped_func(5)
+        
+        assert result == 10


### PR DESCRIPTION
This PR builds on #44, and should be merged in after it.

# Auto-generation for Connection Managers

This PR implements an auto-generator for ConnectionManagers. It adds a `generate_connection_manager` method to `mindtrace.services.base.utils` that can be called by a `Service` class to auto-generate a ConnectManager, which may be returned upon calling the service's `connect` method.

The main idea is that now when calling a service's `connect` method, the following logic is followed:

```python
if cls._client_interface is None:
    return generate_connection_manager(cls)(url=url)
else:
    return cls._client_interface(url=url)
```

That is, the same `Service`/`ConnectionManager` relationship exists as before, but now if a `ConnectionManager` is not explicitly registered to a class, it is auto-generated every time the service's `connect` method is called. If a `ConnectionManager` class _is_ registered to a `Service` class, it defaults to previous behavior, returning the registered ConnectionManager class instead.

## Updated `add_endpoint` method

To aid the new `generate_connection_manager` in generating its magic, when calling `Service.add_endpoint()`, a `schema: TaskSchema` must now be passed in, which is saved to the service's `endpoints` dict (which was before a list). The generate method makes use of each endpoint's schema to add type validation as well as defining the returned ConnectionManager's methods with the right arguments. 

Note that all endpoints added via `add_endpoint` are, by default, put through the general logic of generating connection manager methods for Service endpoints, except for the `shutdown` method, which remains defined by the base ConnectionManager class, and gets special logic. This "special" logic includes two components: (1) whether to block for the shutdown call, and (2) returning a valid response after the service itself has been shut down.

## Both `GET` and `POST` requests default to connection manager methods

A slight modification from previous `Service` implementations— all generated endpoints are now methods in the returned connection manager, with naked properties not currently supported. That is, 

```python
from mindtrace.services import Service
cm = Service.launch()
cm.status  # no longer supported
cm.status()  # it is now generated as a method
```

This behavior can be modified as desired in future iterations.

## Usage example

```
from mindtrace.services import Service

cm = Service.launch()

cm.status()  # StatusOutput(status=<ServerStatus.Available: 'Available'>)
cm.heartbeat()  # HeartbeatOutput(heartbeat=Heartbeat(status=<ServerStatus.Available: 'Available'>, server_id=UUID('355143ec-5075-11f0-90c6-677c4904e0b4'), message='Heartbeat check successful.', details=None))
cm.endpoints()  # EndpointsOutput(endpoints=['endpoints', 'status', 'heartbeat', 'server_id', 'pid_file', 'shutdown'])
cm.server_id()  # ServerIDOutput(server_id=UUID('355143ec-5075-11f0-90c6-677c4904e0b4'))
cm.pid_file()  # PIDFileOutput(pid_file='~/.cache/mindtrace/pids/Service_355143ec-5075-11f0-90c6-677c4904e0b4_pid.txt')
cm.shutdown(block=True)  # ShutdownOutput(shutdown=True)
```

## Documentation & Testing

As an intermediary PR, full documentation and testing is not included.

Still, all tests should pass, with ~98% coverage, including additional tests specifically for the new `generate_connection_manager` method, as well as fixing some issues that seem to have appeared with a previous merge between logging and the registry module.

```bash
uv clone git@github.com:mindtrace/mindtrace && cd mindtrace
git checkout services/feature/cm-generator
uv sync
uv tool install ds-run
ds test
```