### PR TITLE
Feature/build - Initial steps for building locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,32 @@ Each layer only depends on modules in lower levels.
 
 ---
 
+
+## 🛠️ Build
+
+Building wheels and source distributions, from the root of the repo:  
+```bash
+uv build --all-packages
+ls dist/
+```
+For building only wheels:  
+```bash
+uv build --all-packages --wheel
+ls dist/
+```
+They may then be installed in a new venv (the entire `mindtrace` package or any submodule `mindtrace-core`) via:  
+```bash
+uv pip install mindtrace --find-links /path/to/dist
+# or
+uv pip install /path/to/dist/mindtrace.whl
+```
+Note: You may need to use `uv pip install --force-reinstall` in case you encounter `ModuleNotFoundError`.  
+Checking the installation:  
+```bash
+uv run python -c "from mindtrace.core import Mindtrace; print('OK')"
+```
+
+
 ## 🛠️ Usage Examples
 
 Installing the full Mindtrace package:

--- a/mindtrace/apps/pyproject.toml
+++ b/mindtrace/apps/pyproject.toml
@@ -15,12 +15,6 @@ dependencies = [
     "mindtrace-automation"
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.apps"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/mindtrace/automation/pyproject.toml
+++ b/mindtrace/automation/pyproject.toml
@@ -11,12 +11,6 @@ dependencies = [
     "mindtrace-cluster"
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.automation"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/mindtrace/cluster/pyproject.toml
+++ b/mindtrace/cluster/pyproject.toml
@@ -9,12 +9,6 @@ dependencies = [
     "mindtrace-services",
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.cluster"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/mindtrace/core/pyproject.toml
+++ b/mindtrace/core/pyproject.toml
@@ -5,12 +5,6 @@ dependencies = [
     "pillow>=11.2.1",
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.core"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/mindtrace/database/pyproject.toml
+++ b/mindtrace/database/pyproject.toml
@@ -7,12 +7,6 @@ dependencies = [
     "redis-om>=0.3.5",
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.database"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/mindtrace/datalake/pyproject.toml
+++ b/mindtrace/datalake/pyproject.toml
@@ -8,12 +8,6 @@ dependencies = [
     "mindtrace-services",
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.datalake"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/mindtrace/hardware/pyproject.toml
+++ b/mindtrace/hardware/pyproject.toml
@@ -6,12 +6,6 @@ dependencies = [
     "mindtrace-services",
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.hardware"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/mindtrace/jobs/pyproject.toml
+++ b/mindtrace/jobs/pyproject.toml
@@ -5,12 +5,6 @@ dependencies = [
     "mindtrace-core",
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.jobs"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/mindtrace/models/pyproject.toml
+++ b/mindtrace/models/pyproject.toml
@@ -7,12 +7,6 @@ dependencies = [
     "mindtrace-services"
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.models"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/mindtrace/registry/pyproject.toml
+++ b/mindtrace/registry/pyproject.toml
@@ -8,12 +8,6 @@ dependencies = [
     "zenml>=0.82.1",
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.registry"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/mindtrace/services/pyproject.toml
+++ b/mindtrace/services/pyproject.toml
@@ -6,12 +6,6 @@ dependencies = [
     "structlog>=24.4.0",
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.services"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/mindtrace/storage/pyproject.toml
+++ b/mindtrace/storage/pyproject.toml
@@ -5,12 +5,6 @@ dependencies = [
     "google-cloud-storage",
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.storage"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/mindtrace/ui/pyproject.toml
+++ b/mindtrace/ui/pyproject.toml
@@ -6,12 +6,6 @@ dependencies = [
     "mindtrace-core"
 ]
 
-[tool.setuptools]
-packages = ["mindtrace.ui"]
-
-[tool.setuptools.package-dir]
-"" = "."
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,3 +151,11 @@ docstring-code-format = false
 # This only has an effect when the `docstring-code-format` setting is
 # enabled.
 docstring-code-line-length = "dynamic"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["mindtrace*"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR updates the `pyproject.toml` files to accommodate the package discovery of all `mindtrace*` modules in a single location.  
It also describes the steps to build and verify the meta-package and individual modules.  

#### Steps:
Essentially from the README:  
Building wheels and source distributions, from the root of the repo:  
```bash
uv build --all-packages
ls dist/
```
For building only wheels:  
```bash
uv build --all-packages --wheel
ls dist/
```
They may then be installed in a new venv (the entire `mindtrace` package or any submodule `mindtrace-core`) via:  
```bash
uv pip install mindtrace --find-links /path/to/dist
# or
uv pip install /path/to/dist/mindtrace.whl
```
Note: You may need to use `uv pip install --force-reinstall` in case you encounter `ModuleNotFoundError`.  
Checking the installation:  
```bash
uv run python -c "from mindtrace.core import Mindtrace; print('OK')"
```
