### PR TITLE
MCPService Class PR Draft

### DIFF
--- a/mindtrace/services/mindtrace/services/__init__.py
+++ b/mindtrace/services/mindtrace/services/__init__.py
@@ -22,6 +22,8 @@ from mindtrace.services.mcp.types import (
     ExecuteSchema, 
     ExecuteInput, 
     ExecuteOutput,
+    SchemaOutput,
+    SchemaSchema,
 )
 from mindtrace.services.mcp.mcp_service import MCPService
 

--- a/mindtrace/services/mindtrace/services/__init__.py
+++ b/mindtrace/services/mindtrace/services/__init__.py
@@ -24,6 +24,8 @@ from mindtrace.services.mcp.types import (
     ExecuteOutput,
     SchemaOutput,
     SchemaSchema,
+    StateOutput,
+    StateSchema,
 )
 from mindtrace.services.mcp.mcp_service import MCPService
 

--- a/mindtrace/services/mindtrace/services/__init__.py
+++ b/mindtrace/services/mindtrace/services/__init__.py
@@ -1,18 +1,45 @@
 from mindtrace.services.core.connection_manager import ConnectionManager
-from mindtrace.services.core.types import Heartbeat, ServerStatus, EndpointsSchema, StatusSchema, HeartbeatSchema, ServerIDSchema, PIDFileSchema, ShutdownSchema
+from mindtrace.services.core.pipeline import Pipeline
+from mindtrace.services.core.types import (
+    EndpointsSchema, 
+    Heartbeat, 
+    HeartbeatSchema, 
+    PIDFileSchema, 
+    ServerIDSchema, 
+    ServerStatus, 
+    ShutdownOutput,
+    ShutdownSchema, 
+    StatusSchema, 
+)
 from mindtrace.services.core.utils import generate_connection_manager
 from mindtrace.services.core.service import Service
+from mindtrace.services.mcp.types import (
+    Capability, 
+    CapabilitiesSchema, 
+    CapabilitiesOutput, 
+    IdentityOutput, 
+    IdentitySchema, 
+    ExecuteSchema, 
+    ExecuteInput, 
+    ExecuteOutput,
+)
+from mindtrace.services.mcp.mcp_service import MCPService
 
 __all__ = [
+    "CapabilitiesSchema",
     "ConnectionManager",
     "EndpointsSchema",
+    "ExecuteSchema",
     "generate_connection_manager",
     "Heartbeat",
     "HeartbeatSchema",
+    "IdentitySchema",
+    "MCPService",
     "PIDFileSchema",
     "ServerIDSchema",
     "Service",
     "ServerStatus",
+    "ShutdownOutput",
     "ShutdownSchema",
     "StatusSchema",
 ]

--- a/mindtrace/services/mindtrace/services/core/service.py
+++ b/mindtrace/services/mindtrace/services/core/service.py
@@ -125,11 +125,11 @@ class Service(Mindtrace):
         )
         #self.add_endpoint(path="/shutdown", func=self.shutdown, schema=ShutdownSchema(), autolog_kwargs={"log_level": logging.DEBUG})
 
-        self.add_endpoint(path="/endpoints", func=named_lambda("endpoints", lambda _ = None: {"endpoints": list(self._endpoints.keys())}), schema=EndpointsSchema())
-        self.add_endpoint(path="/status", func=named_lambda("status", lambda _ = None: {"status": self.status.value}), schema=StatusSchema())
-        self.add_endpoint(path="/heartbeat", func=named_lambda("heartbeat", lambda _ = None: {"heartbeat": self.heartbeat()}), schema=HeartbeatSchema())
-        self.add_endpoint(path="/server_id", func=named_lambda("server_id", lambda _ = None: {"server_id": self.id}), schema=ServerIDSchema())
-        self.add_endpoint(path="/pid_file", func=named_lambda("pid_file", lambda _ = None: {"pid_file": self.pid_file}), schema=PIDFileSchema())
+        self.add_endpoint(path="/endpoints", func=named_lambda("endpoints", lambda t = None: {"endpoints": list(self._endpoints.keys())}), schema=EndpointsSchema())
+        self.add_endpoint(path="/status", func=named_lambda("status", lambda t = None: {"status": self.status.value}), schema=StatusSchema())
+        self.add_endpoint(path="/heartbeat", func=named_lambda("heartbeat", lambda t = None: {"heartbeat": self.heartbeat()}), schema=HeartbeatSchema())
+        self.add_endpoint(path="/server_id", func=named_lambda("server_id", lambda t = None: {"server_id": self.id}), schema=ServerIDSchema())
+        self.add_endpoint(path="/pid_file", func=named_lambda("pid_file", lambda t = None: {"pid_file": self.pid_file}), schema=PIDFileSchema())
         self.add_endpoint(path="/shutdown", func=self.shutdown, schema=ShutdownSchema(), autolog_kwargs={"log_level": logging.DEBUG})
 
 
@@ -363,7 +363,7 @@ class Service(Mindtrace):
             cls._cleanup_server(server_id)
 
     @staticmethod
-    def shutdown(_ = None) -> fastapi.Response:
+    def shutdown(t = None) -> fastapi.Response:
         """HTTP endpoint to shut down the server."""
         os.kill(os.getppid(), signal.SIGTERM)  # kill the parent gunicorn process as it will respawn us otherwise
         os.kill(os.getpid(), signal.SIGTERM)  # kill ourselves as well

--- a/mindtrace/services/mindtrace/services/core/service.py
+++ b/mindtrace/services/mindtrace/services/core/service.py
@@ -27,8 +27,10 @@ from mindtrace.services import (
     Heartbeat, 
     HeartbeatSchema,
     PIDFileSchema,
+    Pipeline,
     ServerIDSchema,
     ServerStatus, 
+    ShutdownOutput,
     ShutdownSchema,
     StatusSchema, 
 )
@@ -109,12 +111,17 @@ class Service(Mindtrace):
             license_info=license_info,
             lifespan=lifespan,
         )
-        self.add_endpoint(path="/endpoints", func=named_lambda("endpoints", lambda: {"endpoints": list(self._endpoints.keys())}), schema=EndpointsSchema())
-        self.add_endpoint(path="/status", func=named_lambda("status", lambda: {"status": self.status.value}), schema=StatusSchema())
-        self.add_endpoint(path="/heartbeat", func=named_lambda("heartbeat", lambda: {"heartbeat": self.heartbeat()}), schema=HeartbeatSchema())
-        self.add_endpoint(path="/server_id", func=named_lambda("server_id", lambda: {"server_id": self.id}), schema=ServerIDSchema())
-        self.add_endpoint(path="/pid_file", func=named_lambda("pid_file", lambda: {"pid_file": self.pid_file}), schema=PIDFileSchema())
+        #self.add_endpoint(path="/shutdown", func=self.shutdown, schema=ShutdownSchema(), autolog_kwargs={"log_level": logging.DEBUG})
+
+        self.add_endpoint(path="/endpoints", func=named_lambda("endpoints", lambda _ = None: {"endpoints": list(self._endpoints.keys())}), schema=EndpointsSchema())
+        self.add_endpoint(path="/status", func=named_lambda("status", lambda _ = None: {"status": self.status.value}), schema=StatusSchema())
+        self.add_endpoint(path="/heartbeat", func=named_lambda("heartbeat", lambda _ = None: {"heartbeat": self.heartbeat()}), schema=HeartbeatSchema())
+        self.add_endpoint(path="/server_id", func=named_lambda("server_id", lambda _ = None: {"server_id": self.id}), schema=ServerIDSchema())
+        self.add_endpoint(path="/pid_file", func=named_lambda("pid_file", lambda _ = None: {"pid_file": self.pid_file}), schema=PIDFileSchema())
         self.add_endpoint(path="/shutdown", func=self.shutdown, schema=ShutdownSchema(), autolog_kwargs={"log_level": logging.DEBUG})
+
+
+
 
     @classmethod
     def _generate_id_and_pid_file(cls, unique_id: UUID | None = None, pid_file: str | None = None) -> tuple[UUID, str]:
@@ -346,11 +353,11 @@ class Service(Mindtrace):
             cls._cleanup_server(server_id)
 
     @staticmethod
-    def shutdown() -> fastapi.Response:
+    def shutdown(_ = None) -> fastapi.Response:
         """HTTP endpoint to shut down the server."""
         os.kill(os.getppid(), signal.SIGTERM)  # kill the parent gunicorn process as it will respawn us otherwise
         os.kill(os.getpid(), signal.SIGTERM)  # kill ourselves as well
-        return fastapi.Response(status_code=200, content="Server shutting down...")
+        return ShutdownOutput(shutdown=True)
 
     async def shutdown_cleanup(self):
         """Cleanup the server.
@@ -431,7 +438,12 @@ class Service(Mindtrace):
         api_route_kwargs = ifnone(api_route_kwargs, default={})
         autolog_kwargs = ifnone(autolog_kwargs, default={})
         
-        self._endpoints[path] = schema
+        self._endpoints[path] = Pipeline(
+            name=schema.name,
+            input_schema=getattr(schema, "input_schema", None),
+            output_schema=getattr(schema, "output_schema", None),
+            func=func,
+        )
         self.app.add_api_route(
             "/" + path,
             endpoint=Mindtrace.autolog(self=self, **autolog_kwargs)(func),

--- a/mindtrace/services/mindtrace/services/mcp/mcp_service.py
+++ b/mindtrace/services/mindtrace/services/mcp/mcp_service.py
@@ -31,17 +31,17 @@ class MCPService(Service):
         super().__init__(**kwargs)
         
         # Register MCP-specific endpoints
-        self.add_endpoint("identity", self.identity, schema=IdentitySchema())
-        self.add_endpoint("capabilities", self.capabilities, schema=CapabilitiesSchema())
-        self.add_endpoint("execute", self.execute, schema=ExecuteSchema())
-        self.add_endpoint("schema", self.schema, schema=SchemaSchema())
-        self.add_endpoint("state", self.state, schema=StateSchema())
+        self.add_endpoint("/identity", self.identity, schema=IdentitySchema())
+        self.add_endpoint("/capabilities", self.capabilities, schema=CapabilitiesSchema())
+        self.add_endpoint("/execute", self.execute, schema=ExecuteSchema())
+        self.add_endpoint("/schema", self.schema, schema=SchemaSchema())
+        self.add_endpoint("/state", self.state, schema=StateSchema())
 
     def add_endpoint(self, path, func, *args, **kwargs):
         super().add_endpoint(path, func, *args, **kwargs)
-        # Only add to MCP if it's initialized
-        if self.mcp is not None:
-            self.mcp.tool(name=path)(func)
+        # Normalize tool name by removing leading slash for MCP
+        tool_name = path.lstrip('/')
+        self.mcp.tool(name=tool_name)(func)
 
     def identity(self):
         return IdentityOutput(

--- a/mindtrace/services/mindtrace/services/mcp/mcp_service.py
+++ b/mindtrace/services/mindtrace/services/mcp/mcp_service.py
@@ -1,0 +1,58 @@
+from typing import Any, Literal, Type
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from mindtrace.core import named_lambda, TaskSchema
+from mindtrace.services import (
+    Capability,
+    CapabilitiesOutput, 
+    CapabilitiesSchema, 
+    ExecuteInput,
+    ExecuteOutput, 
+    ExecuteSchema, 
+    IdentityOutput, 
+    IdentitySchema, 
+    Service
+)
+
+
+class MCPService(Service):
+    """Service class extended with MCP-compatible endpoints."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add_endpoint("identity", self.identity, schema=IdentitySchema())
+        self.add_endpoint("capabilities", self.capabilities, schema=CapabilitiesSchema())
+        self.add_endpoint("execute", self.execute, schema=ExecuteSchema())
+
+    def identity(self):
+        return IdentityOutput(
+            name=self.name,
+            version=self.app.version,
+            uuid=self.id,
+            description=self.app.description,
+        )
+
+    def capabilities(self):
+        caps = []
+        for endpoint, schema in self._endpoints.items():
+            if endpoint in {"identity", "capabilities", "execute"}:
+                continue
+            caps.append(
+                Capability(
+                    name=endpoint,
+                    description=schema.name,
+                    input_type=getattr(schema, "input_schema", None).__name__ if getattr(schema, "input_schema", None) else None,
+                    output_type=schema.output_schema.__name__ if schema.output_schema else None,
+                )
+            )
+        return CapabilitiesOutput(capabilities=caps)
+
+    def execute(self, data: ExecuteInput):
+        pipeline = self._endpoints.get(data.capability)
+        if pipeline is None:
+            raise fastapi.HTTPException(status_code=404, detail=f"Unknown capability: {data.capability}")
+        
+        result = pipeline.run(data.inputs or {})
+        return ExecuteOutput(output=result)

--- a/mindtrace/services/mindtrace/services/mcp/mcp_service.py
+++ b/mindtrace/services/mindtrace/services/mcp/mcp_service.py
@@ -12,7 +12,9 @@ from mindtrace.services import (
     ExecuteOutput, 
     ExecuteSchema, 
     IdentityOutput, 
-    IdentitySchema, 
+    IdentitySchema,
+    SchemaOutput,
+    SchemaSchema,
     Service
 )
 
@@ -25,6 +27,7 @@ class MCPService(Service):
         self.add_endpoint("identity", self.identity, schema=IdentitySchema())
         self.add_endpoint("capabilities", self.capabilities, schema=CapabilitiesSchema())
         self.add_endpoint("execute", self.execute, schema=ExecuteSchema())
+        self.add_endpoint("schema", self.schema, schema=SchemaSchema())
 
     def identity(self):
         return IdentityOutput(
@@ -56,3 +59,14 @@ class MCPService(Service):
         
         result = pipeline.run(data.inputs or {})
         return ExecuteOutput(output=result)
+
+    def schema(self, _ = None):
+        return SchemaOutput(schemas={
+            name: {
+                "input": task.input_schema.model_json_schema() if task.input_schema else None,
+                "output": task.output_schema.model_json_schema() if task.output_schema else None,
+            }
+            for name, task in self._endpoints.items()
+            if name not in {"identity", "capabilities", "execute"}
+        })
+

--- a/mindtrace/services/mindtrace/services/mcp/types.py
+++ b/mindtrace/services/mindtrace/services/mcp/types.py
@@ -1,0 +1,49 @@
+from pydantic import BaseModel
+from typing import Any, Type
+from uuid import UUID
+
+from mindtrace.core import TaskSchema
+
+
+
+class IdentityOutput(BaseModel):
+    name: str
+    version: str
+    uuid: UUID
+    description: str | None = None
+
+
+class IdentitySchema(TaskSchema):
+    name: str = "identity"
+    output_schema: Type[IdentityOutput] = IdentityOutput
+
+
+class Capability(BaseModel):
+    name: str
+    description: str | None = None
+    input_type: str | None = None
+    output_type: str | None = None
+
+
+class CapabilitiesOutput(BaseModel):
+    capabilities: list[Capability]
+
+
+class CapabilitiesSchema(TaskSchema):
+    name: str = "capabilities"
+    output_schema: Type[CapabilitiesOutput] = CapabilitiesOutput
+
+
+class ExecuteInput(BaseModel):
+    capability: str
+    inputs: Any | None = None
+
+
+class ExecuteOutput(BaseModel):
+    output: Any
+
+
+class ExecuteSchema(TaskSchema):
+    name: str = "execute"
+    input_schema: Type[ExecuteInput] = ExecuteInput
+    output_schema: Type[ExecuteOutput] = ExecuteOutput

--- a/mindtrace/services/mindtrace/services/mcp/types.py
+++ b/mindtrace/services/mindtrace/services/mcp/types.py
@@ -56,3 +56,15 @@ class SchemaOutput(BaseModel):
 class SchemaSchema(TaskSchema):
     name: str = "schema"
     output_schema: Type[SchemaOutput] = SchemaOutput
+
+
+class StateOutput(BaseModel):
+    status: str
+    server_id: str
+    num_endpoints: int
+    details: Dict[str, Any]
+
+
+class StateSchema(TaskSchema):
+    name: str = "state"
+    output_schema: Type[StateOutput] = StateOutput

--- a/mindtrace/services/mindtrace/services/mcp/types.py
+++ b/mindtrace/services/mindtrace/services/mcp/types.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Any, Type
+from typing import Any, Dict, Type
 from uuid import UUID
 
 from mindtrace.core import TaskSchema
@@ -47,3 +47,12 @@ class ExecuteSchema(TaskSchema):
     name: str = "execute"
     input_schema: Type[ExecuteInput] = ExecuteInput
     output_schema: Type[ExecuteOutput] = ExecuteOutput
+
+
+class SchemaOutput(BaseModel):
+    schemas: Dict[str, Dict[str, Any]]  # {capability_name: {input: ..., output: ...}}
+
+
+class SchemaSchema(TaskSchema):
+    name: str = "schema"
+    output_schema: Type[SchemaOutput] = SchemaOutput

--- a/mindtrace/services/pyproject.toml
+++ b/mindtrace/services/pyproject.toml
@@ -2,7 +2,13 @@
 name = "mindtrace-services"
 version = "0.1.0"
 dependencies = [
+    "fastmcp>=2.9.0",
     "gunicorn>=23.0.0",
+    "langchain>=0.3.26",
+    "langchain-mcp-adapters>=0.1.7",
+    "langchain-ollama>=0.3.3",
+    "langgraph>=0.4.10",
+    "mcp>=1.9.4",
     "mindtrace-core",
     "structlog>=24.4.0",
     "uvicorn>=0.34.3",

--- a/samples/services/mcp/mcp_server_with_agent.py
+++ b/samples/services/mcp/mcp_server_with_agent.py
@@ -1,0 +1,161 @@
+# mcp_server_with_agent.py - FastAPI + MCP server with Llama 3.2 agent
+import asyncio
+import subprocess
+import threading
+import traceback
+import time
+import sys
+import os
+
+from langchain_mcp_adapters.tools import load_mcp_tools
+from langchain_ollama import ChatOllama
+from langgraph.prebuilt import create_react_agent
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.session import ClientSession
+
+from mindtrace.services import MCPService
+
+FASTAPI_URL = "http://localhost:8080"
+MCP_URL = "http://localhost:8081/mcp/"
+OLLAMA_BASE_URL = "http://localhost:11434"
+MODEL_NAME = "llama3.2:3b"
+
+async def main():
+    # Launch FastAPI server using subprocess to avoid signal handler issues
+    print("Starting FastAPI server via subprocess...")
+    
+    # Create a temporary script to launch the FastAPI server
+    launcher_script = """
+import sys
+sys.path.insert(0, '/Users/jeremywurbs/projects/mindtrace/mindtrace')
+from mindtrace.services import MCPService
+
+MCPService.launch(
+    name="MindTrace MCP Service",
+    description="MCP-enabled Mindtrace service with FastAPI and MCP endpoints",
+    url="http://localhost:8080",
+    block=True  # This will keep the server running in the subprocess
+)
+"""
+    
+    # Write the launcher script to a temporary file
+    with open('/tmp/fastapi_launcher.py', 'w') as f:
+        f.write(launcher_script)
+    
+    # Start FastAPI server in subprocess
+    fastapi_process = subprocess.Popen([
+        sys.executable, '/tmp/fastapi_launcher.py'
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    
+    # Start MCP server in a separate thread
+    def run_mcp_server():
+        try:
+            print("Starting MCP server...")
+            # Wait a bit for FastAPI to start first
+            time.sleep(5)
+            
+            # Create MCPService instance for MCP server
+            mcp_service = MCPService(
+                name="MindTrace MCP Service",
+                description="MCP-enabled Mindtrace service"
+            )
+            mcp_service.run_mcp_server(host="localhost", port=8081, path="/mcp")
+        except Exception as e:
+            print(f"MCP Server error: {e}")
+            traceback.print_exc()
+    
+    mcp_thread = threading.Thread(target=run_mcp_server, daemon=True)
+    mcp_thread.start()
+    
+    # Wait for both servers to start
+    print("⏳ Waiting for servers to start...")
+    await asyncio.sleep(12)  # Give more time for both servers
+
+    try:
+        print("📡 Servers should now be running:")
+        print(f"   FastAPI: {FASTAPI_URL}")
+        print(f"   MCP: {MCP_URL}")
+        
+        print(f"\n🔗 Connecting to MCP server at: {MCP_URL}")
+        async with streamablehttp_client(MCP_URL) as (read, write, session_id):
+            print("✅ Connected to MCP server!")
+            async with ClientSession(read, write) as session:
+                print("🔄 Initializing MCP session...")
+                await session.initialize()
+                print("✅ MCP session initialized!")
+
+                print("🛠️  Loading MCP tools...")
+                tools = await load_mcp_tools(session)
+                print(f"✅ Loaded {len(tools)} tools: {[tool.name for tool in tools]}")
+
+                print(f"🤖 Setting up Ollama with {MODEL_NAME}...")
+                llm = ChatOllama(
+                    model=MODEL_NAME,
+                    base_url=OLLAMA_BASE_URL,
+                    temperature=0.1,
+                )
+
+                print("🧠 Creating ReAct agent...")
+                agent = create_react_agent(llm, tools)
+
+                # Test queries for the agent
+                test_queries = [
+                    "What's your identity? Tell me about yourself.",
+                    "What is the current status and state of the server?",
+                    "Please check the server heartbeat - I want to see the heartbeat details.",
+                    "What capabilities do you have?",
+                ]
+
+                print("\n🎯 Testing LLM Agent with MCP Tools")
+                print("=" * 50)
+                
+                for i, query in enumerate(test_queries, 1):
+                    print(f"\n--- Query {i}: {query} ---")
+                    try:
+                        result = await agent.ainvoke({"messages": query})
+                        
+                        # Extract the final response
+                        if result and "messages" in result:
+                            final_message = result["messages"][-1]
+                            print(f"🤖 Agent Response: {final_message.content}")
+                        else:
+                            print(f"🤖 Agent Response: {result}")
+                            
+                    except Exception as e:
+                        print(f"❌ Error with query '{query}': {e}")
+                        traceback.print_exc()
+
+                print("\n" + "=" * 50)
+                print("🎉 Dual Server Integration Test Complete!")
+                print("✅ FastAPI server is running via launcher.py + gunicorn!")
+                print("✅ MCP server is working correctly!")
+                print("✅ Tools are accessible to the LLM agent!")
+                print(f"✅ {MODEL_NAME} can reason about and use MCP tools!")
+                print("✅ Parent class endpoints (like heartbeat) are working as MCP tools!")
+                
+                # Test FastAPI endpoints directly
+                print("\n📡 You can also test FastAPI endpoints directly:")
+                print(f"   curl -X POST {FASTAPI_URL}/identity")
+                print(f"   curl -X POST {FASTAPI_URL}/state")
+                print(f"   curl -X POST {FASTAPI_URL}/capabilities")
+                print(f"   curl -X POST {FASTAPI_URL}/heartbeat")  # Parent class endpoint
+
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        traceback.print_exc()
+    finally:
+        # Clean up: terminate the FastAPI subprocess
+        if fastapi_process.poll() is None:  # Process is still running
+            print("🧹 Cleaning up FastAPI server process...")
+            fastapi_process.terminate()
+            try:
+                fastapi_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                fastapi_process.kill()
+        
+        # Clean up temporary file
+        if os.path.exists('/tmp/fastapi_launcher.py'):
+            os.remove('/tmp/fastapi_launcher.py')
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/services/mcp/simple_mcp_server.py
+++ b/samples/services/mcp/simple_mcp_server.py
@@ -1,0 +1,86 @@
+# mcp_test.py - Basic MCP functionality test
+import asyncio
+import threading
+import traceback
+
+from langchain_mcp_adapters.tools import load_mcp_tools
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.session import ClientSession
+
+from mindtrace.services import MCPService
+
+MCP_URL = "http://localhost:8001/mcp/"
+
+
+async def main():
+    # Create MCPService instance
+    mcp_service = MCPService()
+
+    # Start the MCP server in a separate thread
+    def run_mcp_server():
+        try:
+            mcp_service.run_mcp_server(host="localhost", port=8001, path="/mcp")
+        except Exception as e:
+            print(f"MCP Server error: {e}")
+            traceback.print_exc()
+    
+    mcp_thread = threading.Thread(target=run_mcp_server, daemon=True)
+    mcp_thread.start()
+    
+    # Wait a bit for the server to start
+    print("Waiting for MCP server to start...")
+    await asyncio.sleep(3)
+
+    try:
+        print(f"Connecting to MCP server at: {MCP_URL}")
+        # Connect via streamable HTTP transport to the JSON-RPC endpoint
+        async with streamablehttp_client(MCP_URL) as (read, write, session_id):
+            print(f"Connected successfully!")
+            async with ClientSession(read, write) as session:
+                print("Initializing session...")
+                # Perform the MCP handshake (capabilities, schema retrieval, etc.)
+                await session.initialize()
+                print("Session initialized successfully")
+
+                print("Loading MCP tools...")
+                # Load the MCP tools dynamically
+                tools = await load_mcp_tools(session)
+                print(f"Loaded {len(tools)} tools: {[tool.name for tool in tools]}")
+
+                # Test each tool individually
+                print("\n=== Testing MCP Tools ===")
+                
+                for tool in tools:
+                    print(f"\nTesting tool: {tool.name}")
+                    print(f"Description: {tool.description}")
+                    
+                    try:
+                        # Test with empty args for now
+                        if tool.name == "identity":
+                            result = await tool.ainvoke({})
+                            print(f"Result: {result}")
+                        elif tool.name == "capabilities":
+                            result = await tool.ainvoke({})
+                            print(f"Result: {result}")
+                        elif tool.name == "state":
+                            result = await tool.ainvoke({})
+                            print(f"Result: {result}")
+                        elif tool.name == "schema":
+                            result = await tool.ainvoke({})
+                            print(f"Result: {result}")
+                        else:
+                            print(f"Skipping tool {tool.name} (requires specific parameters)")
+                    except Exception as e:
+                        print(f"Error testing tool {tool.name}: {e}")
+
+                print("\n=== MCP Integration Test Complete ===")
+                print("✅ MCP server is working correctly!")
+                print("✅ Tools are accessible via langchain-mcp-adapters!")
+                print("✅ Ready for LLM integration!")
+
+    except Exception as e:
+        print(f"Error: {e}")
+        traceback.print_exc()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
This PR is a working example for how a MCPService could be created and integrated into use with an agent.

As a draft PR, it is not meant to be merged in at this time, at least not before more discussion on its design.

# MCPService Architecture

This PR provides for a `MCPService` class deriving from `Service`, that both adds all endpoints necessary to become MCP-compliant: `/identity`, `/capabilities`, `/execute`, `/schema`, `/state`, which will launch the endpoints as a standard REST interface, as well as registers for them as tools which can be called through a FastMCP server (which supports JSON-RPC 2.0).

In the current iteration (likely not to stay), the two services don't directly communicate, so it's really using one _or_ the other. The `add_endpoint` method now supports both, however. That is, 

```python
class MCPService(Service):
    def add_endpoint(self, path, func, *args, **kwargs):
        super().add_endpoint(path, func, *args, **kwargs)
        self.mcp.tool(name=path)(func)
   def run_mcp_server(self, host="localhost", port=8080, path="/mcp"):
        """Run the MCP server using FastMCP's HTTP transport"""
        self.mcp.run(transport="http", host=host, port=port, path=path)
```

Then, later, to support the REST interface, do `MCPService.launch()` as usual, and to support the JSON-RPC interface do 

```python
service = MCPService()
service.run_mcp_server()
```

```mermaid
graph TD
    A["LLM Agent<br/>(llama3.2:3b)"] -->|"JSON-RPC calls<br/>http://localhost:8081/mcp/"| B["MCP Server<br/>Port 8081"]
    C["REST Client<br/>(curl, browser)"] -->|"HTTP REST calls<br/>http://localhost:8080"| D["FastAPI Server<br/>Port 8080"]
    
    E["Subprocess<br/>MCPService.launch()"] --> D
    F["Thread<br/>mcp_service.run_mcp_server()"] --> B
    
    B --> G["FastMCP Instance<br/>(self.mcp)"]
    D --> H["FastAPI Instance<br/>(self.app)"]
    
    G -->|"tool registration"| I["identity()<br/>capabilities()<br/>heartbeat()<br/>state()<br/>etc."]
    H -->|"endpoint registration"| I
    
    I --> J["Shared Python Functions<br/>(Same Business Logic)"]
    
    subgraph "MCPService.add_endpoint() Magic"
        K["add_endpoint() Method"]
        K -->|"1. super().add_endpoint()"| H
        K -->|"2. self.mcp.tool()"| G
    end
    
    style A fill:#e1f5fe
    style B fill:#f3e5f5
    style D fill:#e8f5e8
    style I fill:#fff3e0
    style J fill:#ffebee
```

## Architecture Overview

This diagram shows how the **MCPService** provides dual protocol access to the same business logic:

### Components:
- **LLM Agent**: Uses MCP JSON-RPC protocol to call tools
- **REST Client**: Uses standard HTTP REST calls
- **MCP Server**: Runs on port 8081, serves MCP protocol
- **FastAPI Server**: Runs on port 8080, serves REST endpoints
- **Shared Functions**: Same Python methods serve both protocols

## Example Usage

`uv sync` the current branch, which will install `ollama` and `langchain`. Pull `llama 3.2` into Ollama: 

```bash
ollama pull llama3.2:3b
```

And then run and examine the `mcp_server_with_agent.py`, which should output something similar to below:

```text
Starting MCP server...
Waiting for MCP server to start...
[06/26/25 10:13:29] INFO     Starting MCP server 'MCPService' with transport 'http' on http://localhost:8081/mcp/                                                       server.py:1297
INFO:     Started server process [75705]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://localhost:8081 (Press CTRL+C to quit)
MCP Server running at: http://localhost:8081/mcp/
Connecting to MCP server...
Connected to MCP server!
Initializing MCP session...
INFO:     ::1:54841 - "POST /mcp/ HTTP/1.1" 200 OK
MCP session initialized!
Loading MCP tools...
INFO:     ::1:54842 - "POST /mcp/ HTTP/1.1" 202 Accepted
INFO:     ::1:54843 - "GET /mcp/ HTTP/1.1" 200 OK
INFO:     ::1:54844 - "POST /mcp/ HTTP/1.1" 200 OK
Loaded 11 tools: ['endpoints', 'status', 'heartbeat', 'server_id', 'pid_file', 'shutdown', 'identity', 'capabilities', 'execute', 'schema', 'state']
Setting up Ollama with llama3.2:3b...
Creating ReAct agent...

Testing LLM Agent with MCP Tools
==================================================

--- Query 2: What is the current status and state of the server? ---
INFO:     ::1:54849 - "POST /mcp/ HTTP/1.1" 200 OK
INFO:     ::1:54850 - "POST /mcp/ HTTP/1.1" 200 OK
Agent Response: The current status of the server is "Available". This means that the server is functioning properly and is ready to receive requests. The server has 11 endpoints, which are likely APIs or services that can be accessed through the server.

Additionally, the server's heartbeat check was successful, indicating that the server is healthy and responsive. If there were any issues with the server, this information would not be present in the output.

In summary, the server is available and functioning properly, making it ready to handle requests from users like you.

--- Query 3: Please check the server heartbeat - I want to see the heartbeat details. ---
INFO:     ::1:54851 - "POST /mcp/ HTTP/1.1" 200 OK
Agent Response: The server heartbeat is available and the status is "Available". The server ID is "d2d72d8a-526d-11f0-acb5-7bb480a8a2ab" and the message indicates that the heartbeat check was successful. However, no additional details are provided in this response.
```