### PR TITLE
Small integration test fix and quality of life improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,15 @@ test = """
     # Run only integration tests
     # ds test --integration
 
-    # Run specific test file or function
-    # ds test tests/unit/mindtrace/registry/backends/test_minio_registry_backend.py::test_register_materializer
+    # Run specific test file or function (note the colon after 'test')
+    # ds test: tests/unit/mindtrace/registry/backends/test_minio_registry_backend.py::test_register_materializer
+
+    # Run specific test directories (note the colon after 'test')
+    # ds test: tests/unit
+    # ds test: tests/integration/mindtrace/services
+
+    # Run multiple test paths (note the colon after 'test')
+    # ds test: tests/unit tests/integration/mindtrace/services
 
     bash scripts/run_tests.sh ${@:- --maxfail=1 --slow-last}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ test = """
     # ds test --integration
 
     # Run specific test file or function (note the colon after 'test')
-    # ds test: tests/unit/mindtrace/registry/backends/test_minio_registry_backend.py::test_register_materializer
+    # ds test: tests/integration/mindtrace/services/test_simple_integration.py::TestServiceIntegration::test_url_construction_logic
 
     # Run specific test directories (note the colon after 'test')
     # ds test: tests/unit
@@ -84,7 +84,7 @@ test = """
     # Run multiple test paths (note the colon after 'test')
     # ds test: tests/unit tests/integration/mindtrace/services
 
-    bash scripts/run_tests.sh ${@:- --maxfail=1 --slow-last}
+    bash scripts/run_tests.sh ${@:-}
 """
 
 [tool.ruff]

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -67,7 +67,7 @@ echo "No specific test paths provided, using suite-based logic"
 RUN_UNIT=false
 RUN_INTEGRATION=false
 RUN_STRESS=false
-RUN_ALL=true  # Default to running all tests
+RUN_ALL=true  # Default to running unit and integration tests (but not stress)
 
 # Parse command line arguments for suite flags
 while [[ $# -gt 0 ]]; do
@@ -95,11 +95,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# If no specific flags were provided, run all tests
+# If no specific flags were provided, run unit and integration tests (but not stress)
 if [ "$RUN_ALL" = true ]; then
     RUN_UNIT=true
     RUN_INTEGRATION=true
-    RUN_STRESS=true
+    # RUN_STRESS remains false - only runs when explicitly requested
 fi
 
 # Start MinIO container if running integration tests or all tests

--- a/tests/integration/mindtrace/services/conftest.py
+++ b/tests/integration/mindtrace/services/conftest.py
@@ -17,6 +17,5 @@ async def echo_service_manager():
         with EchoService.launch(url="http://localhost:8090", timeout=15) as cm:
             yield cm
     except Exception as e:
-        # If service launch fails, yield None so tests can handle gracefully
         print(f"Service launch failed: {e}")
-        yield None
+        raise

--- a/tests/integration/mindtrace/services/test_simple_integration.py
+++ b/tests/integration/mindtrace/services/test_simple_integration.py
@@ -4,6 +4,7 @@ import requests
 
 from mindtrace.services import generate_connection_manager
 from mindtrace.services.sample.echo_service import EchoService, EchoOutput
+from mindtrace.services.core.types import EndpointsOutput, StatusOutput, HeartbeatOutput, ServerIDOutput, PIDFileOutput
 
 
 class TestServiceIntegration:
@@ -80,60 +81,60 @@ class TestServiceIntegration:
         
         # Test endpoints endpoint (sync)
         endpoints_result = echo_service_manager.endpoints()
-        assert isinstance(endpoints_result, dict)
-        assert "echo" in endpoints_result  # Our custom endpoint
+        assert isinstance(endpoints_result, EndpointsOutput)
+        assert "echo" in endpoints_result.endpoints  # Our custom endpoint
         
         # Default endpoints should also be present
         default_endpoint_names = ["endpoints", "status", "heartbeat", "server_id", "pid_file", "shutdown"]
         for endpoint_name in default_endpoint_names:
-            assert endpoint_name in endpoints_result, f"Missing default endpoint: {endpoint_name}"
+            assert endpoint_name in endpoints_result.endpoints, f"Missing default endpoint: {endpoint_name}"
         
         # Test endpoints endpoint (async)
         aendpoints_result = await echo_service_manager.aendpoints()
-        assert isinstance(aendpoints_result, dict)
-        assert aendpoints_result == endpoints_result  # Should be the same
+        assert isinstance(aendpoints_result, EndpointsOutput)
+        assert aendpoints_result.endpoints == endpoints_result.endpoints  # Should be the same
         
         # Test status endpoint (sync)
         status_result = echo_service_manager.status()
-        assert isinstance(status_result, dict)
-        assert "status" in status_result
-        assert status_result["status"] in ["running", "ready", "healthy"]  # Common status values
+        assert isinstance(status_result, StatusOutput)
+        assert status_result.status.value in ["Available", "Down"]  # ServerStatus enum values
         
         # Test status endpoint (async)
         astatus_result = await echo_service_manager.astatus()
-        assert isinstance(astatus_result, dict)
-        assert "status" in astatus_result
+        assert isinstance(astatus_result, StatusOutput)
+        assert astatus_result.status == status_result.status
         
         # Test heartbeat endpoint (sync)
         heartbeat_result = echo_service_manager.heartbeat()
-        assert isinstance(heartbeat_result, dict)
-        assert "timestamp" in heartbeat_result or "heartbeat" in heartbeat_result
+        assert isinstance(heartbeat_result, HeartbeatOutput)
+        assert heartbeat_result.heartbeat is not None
+        assert heartbeat_result.heartbeat.status is not None
         
         # Test heartbeat endpoint (async)
         aheartbeat_result = await echo_service_manager.aheartbeat()
-        assert isinstance(aheartbeat_result, dict)
-        assert "timestamp" in aheartbeat_result or "heartbeat" in aheartbeat_result
+        assert isinstance(aheartbeat_result, HeartbeatOutput)
+        assert aheartbeat_result.heartbeat is not None
         
         # Test server_id endpoint (sync)
         server_id_result = echo_service_manager.server_id()
-        assert isinstance(server_id_result, dict)
-        assert "server_id" in server_id_result or "id" in server_id_result
+        assert isinstance(server_id_result, ServerIDOutput)
+        assert server_id_result.server_id is not None
         
         # Test server_id endpoint (async)
         aserver_id_result = await echo_service_manager.aserver_id()
-        assert isinstance(aserver_id_result, dict)
-        assert "server_id" in aserver_id_result or "id" in aserver_id_result
+        assert isinstance(aserver_id_result, ServerIDOutput)
+        assert aserver_id_result.server_id == server_id_result.server_id
         
         # Test pid_file endpoint (sync)
         pid_file_result = echo_service_manager.pid_file()
-        assert isinstance(pid_file_result, dict)
+        assert isinstance(pid_file_result, PIDFileOutput)
         # PID file might be None if not configured, that's okay
-        assert "pid_file" in pid_file_result or "pid" in pid_file_result
+        assert pid_file_result.pid_file is not None
         
         # Test pid_file endpoint (async)
         apid_file_result = await echo_service_manager.apid_file()
-        assert isinstance(apid_file_result, dict)
-        assert "pid_file" in apid_file_result or "pid" in apid_file_result
+        assert isinstance(apid_file_result, PIDFileOutput)
+        assert apid_file_result.pid_file == pid_file_result.pid_file
         
         # Note: Not testing shutdown endpoint as it would terminate the service
         # But we can verify the method exists

--- a/tests/integration/mindtrace/services/test_simple_integration.py
+++ b/tests/integration/mindtrace/services/test_simple_integration.py
@@ -60,24 +60,6 @@ class TestServiceIntegration:
     @pytest.mark.asyncio
     async def test_default_service_endpoints(self, echo_service_manager):
         """Test all default Service endpoints (sync and async versions)"""
-        if echo_service_manager is None:
-            # Service didn't start - verify connection manager has the methods but they fail appropriately
-            print("Service didn't start, testing default endpoint method existence")
-            
-            ConnectionManager = generate_connection_manager(EchoService)
-            manager = ConnectionManager(url="http://localhost:8090")
-            
-            # Verify all default endpoint methods exist
-            default_endpoints = ['endpoints', 'status', 'heartbeat', 'server_id', 'pid_file', 'shutdown']
-            for endpoint in default_endpoints:
-                assert hasattr(manager, endpoint), f"Missing sync method: {endpoint}"
-                assert hasattr(manager, f"a{endpoint}"), f"Missing async method: a{endpoint}"
-            
-            print("All default endpoint methods exist on connection manager")
-            return
-            
-        # Service is running - test all default endpoints
-        print("Testing default service endpoints with running service")
         
         # Test endpoints endpoint (sync)
         endpoints_result = echo_service_manager.endpoints()

--- a/tests/stress/mindtrace/services/conftest.py
+++ b/tests/stress/mindtrace/services/conftest.py
@@ -14,7 +14,7 @@ async def echo_service_manager():
     can use to interact with the running service.
     """
     try:
-        with EchoService.launch(url="http://localhost:8090", timeout=15) as cm:
+        with EchoService.launch(url="http://localhost:8090", timeout=20) as cm:
             yield cm
     except Exception as e:
         # If service launch fails, yield None so tests can handle gracefully


### PR DESCRIPTION
This PR includes a couple small integration test fixes and quality of life improvements when running `ds test`.

Namely:

- The `services` integration test suite will now fail (error) if it is unable to launch the EchoService fixture, which it uses for the rest of the tests;
- The `ds test` command (i.e. the `run_tests.sh` bash script) has been updated to implement the following behavior:

   - If one or more paths are provided, pytest is run on those paths and nothing more happens. Paths must begin with `tests/`. There is additional logic to determine if any of the tests are in the integration test suite and, if so, the associated docker compose file will still be launched and brought down as usual.

E.g. 
   
 ```bash
ds test: tests/unit/mindtrace/core tests/unit/mindtrace/registry
```

   - The default `ds test` now only runs the unit and integration test suites. To run the stress test suite, pass in the flag explicitly.

E.g. 

```bash
ds test
```

   - Flags for the unit test suites are still available (`--unit`, `--integration`, `--stress`) and work as before:

```bash
ds test --unit --integration
ds test --stress
```

## Note on the extra colon

Note that you are required to use the extra colon (`:`) after `ds test` if you want to pass in any extra arguments. My understanding of ds is the format follows: 

`ds command <arguments that will get sent to ds>: <arguments that will get sent to command>`

Also note that `--` (double dash) is a key token processed by `ds` to mean "the end of arguments [after a colon]". **But** if the first argument starts with a `-` (hyphen), the colon may be omitted. 

### Proper usage

All that is to say, I am not 100% sure on the logic behind `ds` command parsing, but I have tested the following and they all work. Note that the location of `:` (colons) and `--` (double hyphens) is not optional. Or, at least, your mileage may vary if you change them around.

`ds test` - Run unit and integration tests (default)
`ds test --unit` - Run only unit tests
`ds test --integration` - Run only integration tests
`ds test --stress` - Run only stress tests
`ds test: tests/unit` - Run specific directory
`ds test: tests/integration/mindtrace/services` - Run specific directory
`ds test: tests/unit tests/integration/mindtrace/services` - Run multiple paths
`ds test: tests/integration/mindtrace/services/test_simple_integration.py::TestServiceIntegration::test_url_construction_logic` - Run specific test function

## Documentation & Testing

The tests should all pass. There doesn't seem to be full test coverage, but that should be unrelated to this PR.