### PR TITLE
Bugfix: make Service._endpoints an instance property

### DIFF
--- a/mindtrace/core/mindtrace/core/utils/timers.py
+++ b/mindtrace/core/mindtrace/core/utils/timers.py
@@ -1,7 +1,7 @@
 """Utility class for simple Timer and TimerCollection classes."""
 
 import time
-from typing import Dict, List, Optional, Type
+from typing import Dict, Optional, Type
 
 from tqdm import tqdm
 
@@ -63,7 +63,7 @@ class Timer:
         """Reset and start the timer."""
         self.reset()
         self.start()
-    
+
     def __enter__(self):
         """Enter the context manager."""
         self.start()
@@ -80,7 +80,7 @@ class Timer:
 
 class TimerContext:
     """Context manager for individual timers in a TimerCollection."""
-    
+
     def __init__(self, timer_collection: "TimerCollection", name: str):
         self.timer_collection = timer_collection
         self.name = name

--- a/mindtrace/services/mindtrace/services/core/service.py
+++ b/mindtrace/services/mindtrace/services/core/service.py
@@ -41,7 +41,6 @@ class Service(Mindtrace):
     """Base class for all Mindtrace services."""
 
     _status = ServerStatus.DOWN
-    _endpoints: dict[str, TaskSchema] = {}
     _client_interface: Type[C] | None = None
     _active_servers: dict[UUID, psutil.Process] = {}
 
@@ -72,6 +71,7 @@ class Service(Mindtrace):
         """
         super().__init__()
         self._status: ServerStatus = ServerStatus.AVAILABLE
+        self._endpoints: dict[str, TaskSchema] = {}
         self.id, self.pid_file = self._generate_id_and_pid_file()
 
         # Build URL with the following priority:

--- a/tests/unit/mindtrace/core/utils/test_timers.py
+++ b/tests/unit/mindtrace/core/utils/test_timers.py
@@ -482,54 +482,54 @@ class TestTimeout:
 class TestTimerContextManager:
     """Test suite for Timer context manager functionality."""
 
-    @patch('time.perf_counter')
+    @patch("time.perf_counter")
     def test_timer_context_manager_basic(self, mock_perf_counter):
         """Test Timer as a context manager."""
         mock_perf_counter.side_effect = [10.0, 15.0]
         timer = Timer()
-        
+
         with timer:
             pass
-        
+
         assert timer._start_time == 10.0
         assert timer._stop_time == 15.0
         assert timer.duration() == 5.0
 
-    @patch('time.perf_counter')
+    @patch("time.perf_counter")
     def test_timer_context_manager_returns_self(self, mock_perf_counter):
         """Test Timer context manager returns the timer instance."""
         mock_perf_counter.side_effect = [10.0, 15.0]
         timer = Timer()
-        
+
         with timer as ctx_timer:
             assert ctx_timer is timer
             assert ctx_timer._start_time == 10.0
 
-    @patch('time.perf_counter')
+    @patch("time.perf_counter")
     def test_timer_context_manager_with_exception(self, mock_perf_counter):
         """Test Timer context manager properly handles exceptions."""
         mock_perf_counter.side_effect = [10.0, 15.0]
         timer = Timer()
-        
+
         with pytest.raises(ValueError, match="test exception"):
             with timer:
                 raise ValueError("test exception")
-        
+
         # Timer should still be stopped even with exception
         assert timer._stop_time == 15.0
         assert timer.duration() == 5.0
 
-    @patch('time.perf_counter')
+    @patch("time.perf_counter")
     def test_timer_context_manager_cumulative(self, mock_perf_counter):
         """Test Timer context manager with cumulative timing."""
         mock_perf_counter.side_effect = [10.0, 15.0, 20.0, 25.0]
         timer = Timer()
-        
+
         # First context
         with timer:
             pass
         assert timer.duration() == 5.0
-        
+
         # Second context (should accumulate)
         with timer:
             pass
@@ -539,87 +539,88 @@ class TestTimerContextManager:
 class TestTimerCollectionContextManager:
     """Test suite for TimerCollection context manager functionality via TimerContext."""
 
-    @patch('time.perf_counter')
+    @patch("time.perf_counter")
     def test_timer_collection_start_returns_context_manager(self, mock_perf_counter):
         """Test TimerCollection.start() returns a context manager."""
         from mindtrace.core.utils.timers import TimerContext
+
         mock_perf_counter.return_value = 10.0
         tc = TimerCollection()
-        
-        context_manager = tc.start('test_timer')
-        
+
+        context_manager = tc.start("test_timer")
+
         assert isinstance(context_manager, TimerContext)
         assert context_manager.timer_collection is tc
-        assert context_manager.name == 'test_timer'
-        assert tc._timers['test_timer']._start_time == 10.0
+        assert context_manager.name == "test_timer"
+        assert tc._timers["test_timer"]._start_time == 10.0
 
-    @patch('time.perf_counter')
+    @patch("time.perf_counter")
     def test_timer_context_manager_basic(self, mock_perf_counter):
         """Test TimerContext as a context manager."""
         mock_perf_counter.side_effect = [10.0, 15.0]
         tc = TimerCollection()
-        
-        with tc.start('timer1'):
-            pass
-        
-        # Timer should be stopped automatically
-        assert tc.duration('timer1') == 5.0
 
-    @patch('time.perf_counter')
+        with tc.start("timer1"):
+            pass
+
+        # Timer should be stopped automatically
+        assert tc.duration("timer1") == 5.0
+
+    @patch("time.perf_counter")
     def test_timer_context_manager_nested(self, mock_perf_counter):
         """Test nested TimerContext managers."""
         mock_perf_counter.side_effect = [10.0, 20.0, 30.0, 40.0]
         tc = TimerCollection()
-        
-        with tc.start('Timer 1'):
-            with tc.start('Timer 2'):
+
+        with tc.start("Timer 1"):
+            with tc.start("Timer 2"):
                 pass  # Timer 2 stops here at 30.0
             # Timer 2 should be stopped, Timer 1 still running
             pass
         # Timer 1 stops here at 40.0
-        
-        assert tc.duration('Timer 1') == 30.0  # 40.0 - 10.0
-        assert tc.duration('Timer 2') == 10.0  # 30.0 - 20.0
 
-    @patch('time.perf_counter')
+        assert tc.duration("Timer 1") == 30.0  # 40.0 - 10.0
+        assert tc.duration("Timer 2") == 10.0  # 30.0 - 20.0
+
+    @patch("time.perf_counter")
     def test_timer_context_manager_with_exception(self, mock_perf_counter):
         """Test TimerContext properly handles exceptions."""
         mock_perf_counter.side_effect = [10.0, 15.0]
         tc = TimerCollection()
-        
-        with pytest.raises(ValueError, match="test exception"):
-            with tc.start('timer1'):
-                raise ValueError("test exception")
-        
-        # Timer should still be stopped even with exception
-        assert tc.duration('timer1') == 5.0
 
-    @patch('time.perf_counter')
+        with pytest.raises(ValueError, match="test exception"):
+            with tc.start("timer1"):
+                raise ValueError("test exception")
+
+        # Timer should still be stopped even with exception
+        assert tc.duration("timer1") == 5.0
+
+    @patch("time.perf_counter")
     def test_timer_context_manager_returns_context(self, mock_perf_counter):
         """Test TimerContext manager returns the context object."""
         mock_perf_counter.side_effect = [10.0, 15.0]
         tc = TimerCollection()
-        
-        with tc.start('timer1') as ctx:
-            assert ctx.name == 'timer1'
+
+        with tc.start("timer1") as ctx:
+            assert ctx.name == "timer1"
             assert ctx.timer_collection is tc
 
-    @patch('time.perf_counter')
+    @patch("time.perf_counter")
     def test_timer_context_manager_multiple_sequential(self, mock_perf_counter):
         """Test multiple sequential context managers work correctly."""
         mock_perf_counter.side_effect = [10.0, 15.0, 20.0, 25.0]
         tc = TimerCollection()
-        
-        with tc.start('Timer 1'):
+
+        with tc.start("Timer 1"):
             pass
         # Timer 1 stopped at 15.0
-        
-        with tc.start('Timer 2'):
+
+        with tc.start("Timer 2"):
             pass
         # Timer 2 stopped at 25.0
-        
-        assert tc.duration('Timer 1') == 5.0  # 15.0 - 10.0
-        assert tc.duration('Timer 2') == 5.0  # 25.0 - 20.0
+
+        assert tc.duration("Timer 1") == 5.0  # 15.0 - 10.0
+        assert tc.duration("Timer 2") == 5.0  # 25.0 - 20.0
 
 
 class TestTimerCollectionAddTimer:
@@ -628,21 +629,21 @@ class TestTimerCollectionAddTimer:
     def test_add_timer_new(self):
         """Test adding a new timer."""
         tc = TimerCollection()
-        tc.add_timer('test_timer')
-        
-        assert 'test_timer' in tc._timers
-        assert isinstance(tc._timers['test_timer'], Timer)
+        tc.add_timer("test_timer")
+
+        assert "test_timer" in tc._timers
+        assert isinstance(tc._timers["test_timer"], Timer)
 
     def test_add_timer_replace_existing(self):
         """Test adding a timer that replaces an existing one."""
         tc = TimerCollection()
-        tc.add_timer('test_timer')
-        old_timer = tc._timers['test_timer']
+        tc.add_timer("test_timer")
+        old_timer = tc._timers["test_timer"]
         old_timer._duration = 5.0  # Set some state
-        
-        tc.add_timer('test_timer')  # Replace
-        new_timer = tc._timers['test_timer']
-        
+
+        tc.add_timer("test_timer")  # Replace
+        new_timer = tc._timers["test_timer"]
+
         assert new_timer is not old_timer
         assert new_timer._duration == 0.0  # New timer is fresh
 
@@ -650,16 +651,17 @@ class TestTimerCollectionAddTimer:
 class TestTimerCollectionStartReturnValue:
     """Test suite for TimerCollection start method return value."""
 
-    @patch('time.perf_counter')
+    @patch("time.perf_counter")
     def test_start_returns_timer_context(self, mock_perf_counter):
         """Test that start method returns a TimerContext instance."""
         from mindtrace.core.utils.timers import TimerContext
+
         mock_perf_counter.return_value = 10.0
         tc = TimerCollection()
-        
-        returned_context = tc.start('test_timer')
-        
+
+        returned_context = tc.start("test_timer")
+
         assert isinstance(returned_context, TimerContext)
         assert returned_context.timer_collection is tc
-        assert returned_context.name == 'test_timer'
-        assert tc._timers['test_timer']._start_time == 10.0
+        assert returned_context.name == "test_timer"
+        assert tc._timers["test_timer"]._start_time == 10.0

--- a/tests/unit/mindtrace/services/core/test_service.py
+++ b/tests/unit/mindtrace/services/core/test_service.py
@@ -803,9 +803,9 @@ class TestServiceGlobalEndpointPollution:
         regular_service = Service()
         service_endpoints = list(regular_service._endpoints.keys())
         # Should NOT contain 'echo'
-        assert (
-            "echo" not in service_endpoints
-        ), f"Global pollution detected: Service._endpoints contains: {service_endpoints}"
+        assert "echo" not in service_endpoints, (
+            f"Global pollution detected: Service._endpoints contains: {service_endpoints}"
+        )
 
         # Generate connection managers
         EchoCM = generate_connection_manager(EchoService)
@@ -816,6 +816,6 @@ class TestServiceGlobalEndpointPollution:
         ]
         # EchoCM should have 'echo', ServiceCM should NOT
         assert "echo" in echo_methods
-        assert (
-            "echo" not in service_methods
-        ), f"Global pollution detected: Service connection manager has methods: {service_methods}"
+        assert "echo" not in service_methods, (
+            f"Global pollution detected: Service connection manager has methods: {service_methods}"
+        )

--- a/tests/unit/mindtrace/services/core/test_service.py
+++ b/tests/unit/mindtrace/services/core/test_service.py
@@ -783,34 +783,39 @@ class TestServiceCleanupMethods:
 
 class TestServiceGlobalEndpointPollution:
     """Test for global endpoint pollution due to class-level _endpoints."""
+
     def test_no_global_endpoint_pollution(self):
-        from mindtrace.services.sample.echo_service import EchoService
         from mindtrace.services.core.utils import generate_connection_manager
+        from mindtrace.services.sample.echo_service import EchoService
 
         # Ensure clean state
-        if hasattr(Service, '_endpoints'):
+        if hasattr(Service, "_endpoints"):
             Service._endpoints.clear()
-        if hasattr(EchoService, '_endpoints'):
+        if hasattr(EchoService, "_endpoints"):
             EchoService._endpoints.clear()
 
         # Create EchoService instance
         echo_service = EchoService()
         echo_endpoints = list(echo_service._endpoints.keys())
         # Should contain 'echo' and system endpoints
-        assert 'echo' in echo_endpoints
+        assert "echo" in echo_endpoints
         # Create a regular Service instance
         regular_service = Service()
         service_endpoints = list(regular_service._endpoints.keys())
         # Should NOT contain 'echo'
-        assert 'echo' not in service_endpoints, (
-            f"Global pollution detected: Service._endpoints contains: {service_endpoints}")
+        assert (
+            "echo" not in service_endpoints
+        ), f"Global pollution detected: Service._endpoints contains: {service_endpoints}"
 
         # Generate connection managers
         EchoCM = generate_connection_manager(EchoService)
         ServiceCM = generate_connection_manager(Service)
-        echo_methods = [attr for attr in dir(EchoCM) if not attr.startswith('_') and callable(getattr(EchoCM, attr))]
-        service_methods = [attr for attr in dir(ServiceCM) if not attr.startswith('_') and callable(getattr(ServiceCM, attr))]
+        echo_methods = [attr for attr in dir(EchoCM) if not attr.startswith("_") and callable(getattr(EchoCM, attr))]
+        service_methods = [
+            attr for attr in dir(ServiceCM) if not attr.startswith("_") and callable(getattr(ServiceCM, attr))
+        ]
         # EchoCM should have 'echo', ServiceCM should NOT
-        assert 'echo' in echo_methods
-        assert 'echo' not in service_methods, (
-            f"Global pollution detected: Service connection manager has methods: {service_methods}")
+        assert "echo" in echo_methods
+        assert (
+            "echo" not in service_methods
+        ), f"Global pollution detected: Service connection manager has methods: {service_methods}"


### PR DESCRIPTION
This PR fixes and closes #78.

# Bug Replication

To replicate the bug, you may do:
```python
from mindtrace.services import Service
from mindtrace.services.sample.echo_service import EchoService

echo_url = "http://localhost:8080/"
service_url = "http://localhost:8081/"

echo = EchoService.launch(url=echo_url)
service = Service.launch(url=service_url)

type(service.echo)  # <class 'method'>
```

I.e. the `service` connection manager is getting an `echo` property from the EchoService, which is clearly a bug.

# Bug Fix

The problem is that `Service._endpoints` is a class property, so when it is updated by `EchoService` it also updates it for `Service`, from which it derives. The fix is to make `Service._endpoints` an instance method.

# Testing

A unit test explicitly for testing this situation has been added, and can be run with:

```bash
git clone git@github.com:mindtrace/mindtrace services_bug_fix && cd services_bug_fix
git checkout bugfix/generate-cm-shared-state
uv sync
uv tool install ds-run
ds test: tests/unit/mindtrace/services/core/test_service.py::TestServiceGlobalEndpointPollution
```