### PR TITLE
Enhanced Gateway Connection Manager

### DIFF
--- a/mindtrace/services/mindtrace/services/core/types.py
+++ b/mindtrace/services/mindtrace/services/core/types.py
@@ -59,6 +59,15 @@ class EndpointsSchema(TaskSchema):
     output_schema: Type[EndpointsOutput] = EndpointsOutput
 
 
+class DetailedEndpointsOutput(BaseModel):
+    endpoints: dict[str, dict[str, Any]]
+
+
+class DetailedEndpointsSchema(TaskSchema):
+    name: str = "detailed_endpoints"
+    output_schema: Type[DetailedEndpointsOutput] = DetailedEndpointsOutput
+
+
 class StatusOutput(BaseModel):
     status: ServerStatus
 

--- a/mindtrace/services/mindtrace/services/core/utils.py
+++ b/mindtrace/services/mindtrace/services/core/utils.py
@@ -121,6 +121,9 @@ def generate_connection_manager(
     # Create a temporary service instance to get the endpoints
     temp_service = service_cls()
 
+    # Store service endpoints in the connection manager class for ProxyConnectionManager access
+    ServiceConnectionManager._service_endpoints = temp_service._endpoints
+
     # Dynamically define one method per endpoint
     for endpoint_name, endpoint in temp_service._endpoints.items():
         # Skip if this would override an existing method in ConnectionManager

--- a/mindtrace/services/mindtrace/services/gateway/gateway.py
+++ b/mindtrace/services/mindtrace/services/gateway/gateway.py
@@ -1,10 +1,11 @@
-from typing import Type
+from typing import Type, List, Dict, Any
 
-import httpx
 from fastapi import HTTPException, Request, Path
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+import httpx
 from urllib3.util.url import Url
+from pydantic import BaseModel
 
 from mindtrace.core import ifnone_url, TaskSchema
 from mindtrace.services import (
@@ -18,11 +19,41 @@ from mindtrace.services import (
 )
 
 
+class AppInfo(BaseModel):
+    """Information about a registered app."""
+    name: str
+    url: str
+    endpoints: Dict[str, Dict[str, Any]]  # endpoint_name -> {input_schema, output_schema, ...}
+
+
+class ListAppsResponse(BaseModel):
+    """Response model for list_apps endpoint."""
+    apps: List[str]
+
+
+class ListAppsWithSchemasResponse(BaseModel):
+    """Enhanced response model for list_apps_with_schemas endpoint."""
+    apps: List[AppInfo]
+
+
+class ListAppsTaskSchema(TaskSchema):
+    """Schema for listing registered apps."""
+    name: str = "list_apps"
+    output_schema: BaseModel = ListAppsResponse
+
+
+class ListAppsWithSchemasTaskSchema(TaskSchema):
+    """Schema for listing registered apps with their endpoints and schemas."""
+    name: str = "list_apps_with_schemas"
+    output_schema: BaseModel = ListAppsWithSchemasResponse
+
+
 class Gateway(Service):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
         self.registered_routers = {}
+        self.registered_app_info = {}  # Used for apps that provide schemas (i.e. mindtrace-derived apps)
         self.client = httpx.AsyncClient()
 
         # Enable CORS for the gateway
@@ -35,10 +66,29 @@ class Gateway(Service):
         )
 
         self.add_endpoint("/register_app", func=self.register_app, schema=RegisterAppTaskSchema(), methods=["POST"])
+        self.add_endpoint("/list_apps", func=self.list_apps, schema=ListAppsTaskSchema(), methods=["POST"])
+        self.add_endpoint("/list_apps_with_schemas", func=self.list_apps_with_schemas, schema=ListAppsWithSchemasTaskSchema(), methods=["POST"])
 
     def register_app(self, payload: AppConfig):
         """Register a FastAPI app with the gateway."""
         self.registered_routers[payload.name] = str(payload.url)
+        
+        # Try to fetch endpoint information from the registered service
+        try:
+            endpoints_info = self._fetch_service_endpoints(str(payload.url))
+            self.registered_app_info[payload.name] = {
+                "name": payload.name,
+                "url": str(payload.url),
+                "endpoints": endpoints_info
+            }
+        except Exception as e:
+            # If we can't fetch endpoints, store basic info
+            self.logger.warning(f"Could not fetch endpoints for {payload.name}: {e}")
+            self.registered_app_info[payload.name] = {
+                "name": payload.name,
+                "url": str(payload.url),
+                "endpoints": {}
+            }
 
         async def forwarder(request: Request, path: str = Path(...)):
             return await self.forward_request(request, payload.name, path)
@@ -48,6 +98,88 @@ class Gateway(Service):
             forwarder,
             methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
         )
+
+    def _fetch_service_endpoints(self, service_url: str) -> Dict[str, Dict[str, Any]]:
+        """Fetch endpoint information from a registered service."""
+        import requests
+        
+        try:
+            # Try to get endpoints from the service
+            response = requests.post(f"{service_url.rstrip('/')}/endpoints", timeout=10)
+            if response.status_code == 200:
+                endpoints_data = response.json()
+                endpoints_list = endpoints_data.get("endpoints", [])
+                
+                # Try to get detailed schema information from the service
+                # First, try the new detailed_endpoints endpoint if it exists
+                try:
+                    schema_response = requests.post(f"{service_url.rstrip('/')}/detailed_endpoints", timeout=10)
+                    if schema_response.status_code == 200:
+                        detailed_endpoints = schema_response.json().get("endpoints", {})
+                        
+                        # Build endpoints info with schema details
+                        endpoints_info = {}
+                        for endpoint_name in endpoints_list:
+                            # Skip system endpoints for cleaner output
+                            if endpoint_name in ["status", "heartbeat", "endpoints", "detailed_endpoints", "server_id", "pid_file", "shutdown"]:
+                                continue
+                            
+                            if endpoint_name in detailed_endpoints:
+                                endpoint_detail = detailed_endpoints[endpoint_name]
+                                endpoints_info[endpoint_name] = {
+                                    "name": endpoint_name,
+                                    "path": f"/{endpoint_name}",
+                                    "methods": ["POST"],  # Default assumption
+                                    "input_schema": endpoint_detail.get("input_schema"),
+                                    "output_schema": endpoint_detail.get("output_schema")
+                                }
+                            else:
+                                # Fallback for endpoints without detailed info
+                                endpoints_info[endpoint_name] = {
+                                    "name": endpoint_name,
+                                    "path": f"/{endpoint_name}",
+                                    "methods": ["POST"],
+                                    "input_schema": None,
+                                    "output_schema": None
+                                }
+                        
+                        return endpoints_info
+                except Exception:
+                    # Fall back to basic endpoint info if detailed_endpoints fails
+                    pass
+                
+                # Fallback: basic endpoint information without schemas
+                endpoints_info = {}
+                for endpoint_name in endpoints_list:
+                    # Skip system endpoints for cleaner output
+                    if endpoint_name in ["status", "heartbeat", "endpoints", "detailed_endpoints", "server_id", "pid_file", "shutdown"]:
+                        continue
+                    
+                    endpoints_info[endpoint_name] = {
+                        "name": endpoint_name,
+                        "path": f"/{endpoint_name}",
+                        "methods": ["POST"],  # Default assumption
+                        "input_schema": None,
+                        "output_schema": None
+                    }
+                
+                return endpoints_info
+        except Exception as e:
+            self.logger.debug(f"Failed to fetch endpoints from {service_url}: {e}")
+        
+        return {}
+
+    def list_apps(self) -> Dict[str, List[str]]:
+        """Return list of currently registered apps."""
+        return {"apps": list(self.registered_routers.keys())}
+
+    def list_apps_with_schemas(self) -> Dict[str, List[AppInfo]]:
+        """Return detailed information about registered apps including their endpoints and schemas."""
+        apps_info = []
+        for app_name, app_info in self.registered_app_info.items():
+            apps_info.append(AppInfo(**app_info))
+        
+        return {"apps": apps_info}
 
     async def forward_request(self, request: Request, app_name: str, path: str):
         """Forward the request to the registered app."""
@@ -89,6 +221,21 @@ class Gateway(Service):
             # Add enhanced functionality to the instance
             base_cm._registered_apps = {}
             
+            # Sync with existing apps on the Gateway
+            try:
+                existing_apps_response = base_cm.list_apps()
+                # Handle both dict and Pydantic model responses
+                if hasattr(existing_apps_response, 'apps'):
+                    existing_apps = existing_apps_response.apps
+                else:
+                    existing_apps = existing_apps_response.get("apps", [])
+                for app_name in existing_apps:
+                    # Create placeholder entries for existing apps (without connection managers)
+                    base_cm._registered_apps[app_name] = None
+            except Exception as e:
+                # If syncing fails, continue with empty registry
+                pass
+            
             # Store original methods if they exist
             original_register_app = getattr(base_cm, 'register_app', None)
             original_aregister_app = getattr(base_cm, 'aregister_app', None)
@@ -107,6 +254,9 @@ class Gateway(Service):
                     )
                     base_cm._registered_apps[name] = proxy_cm
                     setattr(base_cm, name, proxy_cm)
+                else:
+                    # Register without proxy (basic registration)
+                    base_cm._registered_apps[name] = None
                 
                 return result
             
@@ -124,19 +274,36 @@ class Gateway(Service):
                     )
                     base_cm._registered_apps[name] = proxy_cm
                     setattr(base_cm, name, proxy_cm)
+                else:
+                    # Register without proxy (basic registration)
+                    base_cm._registered_apps[name] = None
                 
                 return result
+            
+            def enhanced_registered_apps():
+                """Enhanced registered_apps method that returns detailed app information with schemas."""
+                try:
+                    # Call the new list_apps_with_schemas endpoint
+                    response = base_cm.list_apps_with_schemas()
+                    if hasattr(response, 'apps'):
+                        return response.apps
+                    else:
+                        return response.get("apps", [])
+                except Exception as e:
+                    # Fallback to basic list if enhanced endpoint fails
+                    try:
+                        basic_response = base_cm.list_apps()
+                        if hasattr(basic_response, 'apps'):
+                            return basic_response.apps
+                        else:
+                            return basic_response.get("apps", [])
+                    except Exception:
+                        return list(base_cm._registered_apps.keys())
             
             # Add enhanced methods to the instance
             base_cm.register_app = enhanced_register_app
             base_cm.aregister_app = enhanced_aregister_app
-            
-            # Add registered_apps as a dynamic property
-            def get_registered_apps(self):
-                return list(self._registered_apps.keys())
-            
-            # Create a property descriptor and bind it to the instance
-            base_cm.__class__.registered_apps = property(get_registered_apps)
+            base_cm.registered_apps = enhanced_registered_apps
             
             return base_cm
         

--- a/mindtrace/services/mindtrace/services/gateway/proxy_connection_manager.py
+++ b/mindtrace/services/mindtrace/services/gateway/proxy_connection_manager.py
@@ -1,14 +1,22 @@
 import inspect
 from functools import wraps
+from typing import Dict, Any, Callable
 
+import httpx
+from fastapi import HTTPException
 import requests
 from urllib3.util.url import Url
 
-from mindtrace.services.core.connection_manager import ConnectionManager
+from mindtrace.core import TaskSchema
+from mindtrace.services import ConnectionManager
 
 
 class ProxyConnectionManager:
-    """A proxy that forwards requests through the gateway instead of directly through the wrapped connection manager."""
+    """A proxy that forwards requests through the gateway instead of directly through the wrapped connection manager.
+    
+    This class creates proxy methods based on TaskSchemas, providing proper input/output validation
+    and consistent behavior with auto-generated connection managers.
+    """
 
     def __init__(self, gateway_url: str | Url, app_name: str, original_cm: ConnectionManager):
         """Initializes the ProxyConnectionManager.
@@ -21,62 +29,253 @@ class ProxyConnectionManager:
         object.__setattr__(self, "gateway_url", str(gateway_url).rstrip("/"))  # Ensure no trailing slash
         object.__setattr__(self, "app_name", app_name)
         object.__setattr__(self, "original_cm", original_cm)
+        
+        # Extract service endpoints and their schemas
+        service_endpoints = self._extract_service_endpoints(original_cm)
+        object.__setattr__(self, "_service_endpoints", service_endpoints)
+        
+        # Generate proxy methods for all endpoints
+        self._generate_proxy_methods()
+
+    def _extract_service_endpoints(self, original_cm: ConnectionManager) -> Dict[str, TaskSchema]:
+        """Extract service endpoints and their TaskSchemas from the connection manager.
+        
+        This method tries multiple approaches to get the endpoint information:
+        1. From the connection manager class's _service_endpoints (set by generate_connection_manager)
+        2. From the original service class's _endpoints attribute
+        3. Fallback to method introspection (less reliable)
+        """
+        # Try to get endpoints from connection manager class (set by generate_connection_manager)
+        if hasattr(original_cm.__class__, '_service_endpoints'):
+            return original_cm.__class__._service_endpoints
+        
+        # Try to get from the service class if available
+        if hasattr(original_cm, '_service_class'):
+            service_class = original_cm._service_class
+            if hasattr(service_class, '_endpoints'):
+                return service_class._endpoints
+        
+        # Last resort: infer from methods (less reliable)
+        return self._infer_endpoints_from_methods(original_cm)
+    
+    def _infer_endpoints_from_methods(self, original_cm: ConnectionManager) -> Dict[str, TaskSchema]:
+        """Fallback method to infer endpoints from connection manager methods."""
+        endpoints = {}
+        
+        # Get all callable methods from the connection manager
+        for attr_name in dir(original_cm):
+            if not attr_name.startswith('_') and attr_name not in ['url', 'shutdown', 'astatus']:
+                attr = getattr(original_cm, attr_name)
+                if callable(attr) and not attr_name.startswith('a'):  # Skip async versions
+                    # Create a basic TaskSchema without input/output validation
+                    endpoints[attr_name] = TaskSchema(
+                        name=attr_name,
+                        input_schema=None,
+                        output_schema=None
+                    )
+        
+        return endpoints
+    
+    def _generate_proxy_methods(self):
+        """Generate proxy methods for all endpoints based on their TaskSchemas."""
+        service_endpoints = object.__getattribute__(self, "_service_endpoints")
+        
+        # Handle case where service_endpoints might be a Mock (in unit tests)
+        try:
+            # Test if we can actually iterate over items
+            list(service_endpoints.items())
+        except (TypeError, AttributeError):
+            return
+        
+        for endpoint_name, task_schema in service_endpoints.items():
+            # Skip system endpoints that shouldn't be proxied
+            if endpoint_name in ['shutdown', 'status', 'heartbeat', 'endpoints', 'server_id', 'pid_file']:
+                continue
+                
+            # Create sync and async proxy methods
+            sync_method = self._create_proxy_method(endpoint_name, task_schema, is_async=False)
+            async_method = self._create_proxy_method(endpoint_name, task_schema, is_async=True)
+            
+            # Store methods in instance dict for __getattribute__ to find
+            if not hasattr(self, '__dict__'):
+                object.__setattr__(self, '__dict__', {})
+            
+            self.__dict__[endpoint_name] = sync_method
+            self.__dict__[f'a{endpoint_name}'] = async_method
+    
+    def _create_proxy_method(self, endpoint_name: str, task_schema: TaskSchema, is_async: bool = False) -> Callable:
+        """Create a proxy method for a specific endpoint."""
+        
+        if is_async:
+            async def proxy_method(validate_input: bool = True, validate_output: bool = False, **kwargs):
+                return await self._make_async_request(endpoint_name, task_schema, validate_input, validate_output, **kwargs)
+            
+            proxy_method.__name__ = f'a{endpoint_name}'
+            proxy_method.__doc__ = f"Async version: Calls the `{endpoint_name}` endpoint through the gateway"
+        else:
+            def proxy_method(validate_input: bool = True, validate_output: bool = False, **kwargs):
+                return self._make_sync_request(endpoint_name, task_schema, validate_input, validate_output, **kwargs)
+            
+            proxy_method.__name__ = endpoint_name
+            proxy_method.__doc__ = f"Calls the `{endpoint_name}` endpoint through the gateway"
+        
+        return proxy_method
+    
+    def _make_sync_request(self, endpoint_name: str, task_schema: TaskSchema, 
+                          validate_input: bool, validate_output: bool, **kwargs) -> Any:
+        """Make a synchronous request to the gateway."""
+        # Input validation
+        if validate_input and task_schema.input_schema is not None:
+            try:
+                payload = task_schema.input_schema(**kwargs).model_dump()
+            except Exception:
+                # Fallback to raw kwargs if validation fails
+                payload = kwargs
+        else:
+            payload = kwargs
+        
+        # Make request
+        endpoint_url = f"{self.gateway_url}/{self.app_name}/{endpoint_name}"
+        response = requests.post(endpoint_url, json=payload, timeout=60)
+        
+        if response.status_code != 200:
+            raise RuntimeError(f"Gateway proxy request failed for '{endpoint_name}': {response.status_code} - {response.text}")
+        
+        # Parse response
+        try:
+            result = response.json()
+        except Exception:
+            result = {"success": True}  # Default for empty responses
+        
+        # Output validation
+        if validate_output and task_schema.output_schema is not None:
+            try:
+                return task_schema.output_schema(**result)
+            except Exception:
+                # Fallback to raw result if validation fails
+                return result
+        
+        return result
+    
+    async def _make_async_request(self, endpoint_name: str, task_schema: TaskSchema,
+                                validate_input: bool, validate_output: bool, **kwargs) -> Any:
+        """Make an asynchronous request to the gateway."""
+        # Input validation
+        if validate_input and task_schema.input_schema is not None:
+            try:
+                payload = task_schema.input_schema(**kwargs).model_dump()
+            except Exception:
+                # Fallback to raw kwargs if validation fails
+                payload = kwargs
+        else:
+            payload = kwargs
+        
+        # Make async request
+        endpoint_url = f"{self.gateway_url}/{self.app_name}/{endpoint_name}"
+        async with httpx.AsyncClient(timeout=60) as client:
+            response = await client.post(endpoint_url, json=payload)
+        
+        if response.status_code != 200:
+            raise HTTPException(response.status_code, response.text)
+        
+        # Parse response
+        try:
+            result = response.json()
+        except Exception:
+            result = {"success": True}  # Default for empty responses
+        
+        # Output validation
+        if validate_output and task_schema.output_schema is not None:
+            try:
+                return task_schema.output_schema(**result)
+            except Exception:
+                # Fallback to raw result if validation fails
+                return result
+        
+        return result
 
     def __getattribute__(self, attr_name):
-        """Handles both properties dynamically without recursion issues."""
-        if attr_name in ["gateway_url", "app_name", "original_cm"]:
+        """Handles attribute access with proper delegation."""
+        # Internal attributes - access directly
+        internal_attrs = {
+            'gateway_url', 'app_name', 'original_cm', '_service_endpoints', 
+            '_generate_proxy_methods', '_extract_service_endpoints', 
+            '_infer_endpoints_from_methods', '_create_proxy_method',
+            '_make_sync_request', '_make_async_request',
+            '__class__', '__dict__'
+        }
+        
+        if attr_name in internal_attrs:
             return object.__getattribute__(self, attr_name)
-
+        
+        # Check if this is a dynamically created proxy method (stored in instance __dict__)
+        try:
+            instance_dict = object.__getattribute__(self, "__dict__")
+            if attr_name in instance_dict:
+                return object.__getattribute__(self, attr_name)
+        except AttributeError:
+            pass
+        
+        # Check if this is a property on the original connection manager
         original_cm = object.__getattribute__(self, "original_cm")
-
         if hasattr(type(original_cm), attr_name):
             attr = getattr(type(original_cm), attr_name)
-
             if isinstance(attr, property):
-                endpoint = f"{self.gateway_url}/{self.app_name}/{attr_name}"
-                response = requests.get(endpoint, timeout=60)
+                # Handle properties by making a GET request to the gateway
+                endpoint_url = f"{self.gateway_url}/{self.app_name}/{attr_name}"
+                response = requests.get(endpoint_url, timeout=60)
                 if response.status_code == 200:
                     return response.json()
                 raise RuntimeError(f"Failed to get property '{attr_name}': {response.text}")
-
-        # If not found, delegate to `__getattr__()` for method resolution
-        return object.__getattribute__(self, attr_name)
+        
+        # If not found anywhere, raise AttributeError
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr_name}'")
 
     def __getattr__(self, method_name):
-        """Intercepts method calls and routes them through the gateway."""
-        return self.__create_proxy_method(method_name)
-
-    def __create_proxy_method(self, method_name):
-        """Helper function to create a proxy method that routes requests through the Gateway."""
+        """Fallback method for attributes not found in __getattribute__."""
+        # This handles any remaining cases where methods weren't pre-generated
         original_cm = object.__getattribute__(self, "original_cm")
-
+        
         if not hasattr(original_cm, method_name):
             raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{method_name}'")
-
+        
         original_method = getattr(original_cm, method_name)
-
         if not callable(original_method):
             raise AttributeError(f"'{self.__class__.__name__}' object has no callable attribute '{method_name}'")
-
-        # Detect whether the method should use GET or POST based on its signature
-        signature = inspect.signature(original_method)
-        requires_arguments = any(param.default == inspect.Parameter.empty for param in signature.parameters.values())
-
+        
+        # Analyze method signature to determine if it has required parameters
+        import inspect
+        try:
+            signature = inspect.signature(original_method)
+            has_required_params = any(
+                param.default is inspect.Parameter.empty and param.kind not in [
+                    inspect.Parameter.VAR_POSITIONAL, 
+                    inspect.Parameter.VAR_KEYWORD
+                ]
+                for param in signature.parameters.values()
+            )
+        except (ValueError, TypeError):
+            # If we can't analyze the signature, assume it has required params
+            has_required_params = True
+        
+        # Create a basic proxy method without schema validation (fallback)
         @wraps(original_method)
-        def wrapped_method(*args, **kwargs):
-            """Wraps the original method but reroutes the request through the gateway."""
-            endpoint = f"{self.gateway_url}/{self.app_name}/{method_name}"
-
-            if requires_arguments:
-                # If method requires arguments, use POST
-                payload = kwargs if kwargs else (args[0] if args else {})
-                response = requests.post(endpoint, json=payload, timeout=60)
+        def fallback_proxy_method(*args, **kwargs):
+            endpoint_url = f"{self.gateway_url}/{self.app_name}/{method_name}"
+            
+            # Determine HTTP method and payload based on signature analysis
+            if not has_required_params and not args and not kwargs:
+                # Method has no required params and no args provided -> use GET
+                response = requests.get(endpoint_url, timeout=60)
             else:
-                # If method has no arguments, use GET
-                response = requests.get(endpoint, timeout=60)
-
+                # Method has required params or args provided -> use POST
+                # Only use kwargs for payload - ignore positional args for robustness
+                payload = kwargs if kwargs else {}
+                
+                response = requests.post(endpoint_url, json=payload, timeout=60)
+            
             if response.status_code == 200:
                 return response.json()
-            raise RuntimeError(f"Gateway proxy request failed: {response.text}")
-
-        return wrapped_method
+            raise RuntimeError(f"Gateway proxy request failed for '{method_name}': {response.status_code} - {response.text}")
+        
+        return fallback_proxy_method

--- a/mindtrace/services/mindtrace/services/gateway/proxy_connection_manager.py
+++ b/mindtrace/services/mindtrace/services/gateway/proxy_connection_manager.py
@@ -108,13 +108,13 @@ class ProxyConnectionManager:
         """Create a proxy method for a specific endpoint."""
         
         if is_async:
-            async def proxy_method(validate_input: bool = True, validate_output: bool = False, **kwargs):
+            async def proxy_method(validate_input: bool = True, validate_output: bool = True, **kwargs):
                 return await self._make_async_request(endpoint_name, task_schema, validate_input, validate_output, **kwargs)
             
             proxy_method.__name__ = f'a{endpoint_name}'
             proxy_method.__doc__ = f"Async version: Calls the `{endpoint_name}` endpoint through the gateway"
         else:
-            def proxy_method(validate_input: bool = True, validate_output: bool = False, **kwargs):
+            def proxy_method(validate_input: bool = True, validate_output: bool = True, **kwargs):
                 return self._make_sync_request(endpoint_name, task_schema, validate_input, validate_output, **kwargs)
             
             proxy_method.__name__ = endpoint_name

--- a/tests/integration/mindtrace/services/test_gateway_integration.py
+++ b/tests/integration/mindtrace/services/test_gateway_integration.py
@@ -666,8 +666,13 @@ class TestGatewayAppDiscovery:
             else:
                 assert "echo-shared" in apps2
             
-            # However, second CM won't have the proxy attribute since it doesn't have the connection manager
-            assert not hasattr(enhanced_cm2, "echo-shared")
+            # With our new implementation, second CM automatically gets proxy attributes for existing apps
+            assert hasattr(enhanced_cm2, "echo-shared")
+            
+            # Test that the automatically created proxy works
+            result = enhanced_cm2.__getattribute__("echo-shared").echo(message="Auto-proxy test!")
+            # Note: The result will be a dict since it uses a synthetic connection manager
+            assert result["echoed"] == "Auto-proxy test!"
             
             # Step 3: Second CM can register the same app with its own connection manager
             echo_cm2 = EchoService.connect(url=echo_service_for_gateway.url)

--- a/tests/integration/mindtrace/services/test_gateway_integration.py
+++ b/tests/integration/mindtrace/services/test_gateway_integration.py
@@ -396,8 +396,8 @@ class TestGatewayErrorScenarios:
             result1 = enhanced_cm.echo1.echo(message="Hello from echo1!")
             result2 = enhanced_cm.echo2.echo(message="Hello from echo2!")
             
-            assert result1["echoed"] == "Hello from echo1!"
-            assert result2["echoed"] == "Hello from echo2!"
+            assert result1.echoed == "Hello from echo1!"
+            assert result2.echoed == "Hello from echo2!"
 
 
 class TestGatewayErrorHandling:
@@ -517,7 +517,7 @@ class TestGatewayPerformance:
             return await loop.run_in_executor(
                 None,
                 lambda: requests.post(
-                    f"{str(gateway_manager.url).rstrip('/')}/echo/echo",
+                    f"{str(gateway_manager.url).rstrip('/')}/echoer/echo",
                     json={"message": message},
                     timeout=10
                 )
@@ -597,11 +597,11 @@ class TestGatewayComplexScenarios:
             
             # Test different method calls
             echo_result = proxy.echo(message="Hello World!")
-            assert echo_result["echoed"] == "Hello World!"
+            assert echo_result.echoed == "Hello World!"
             
             # Test with different parameters
             echo_result2 = proxy.echo(message="Test Message", delay=0.0)
-            assert echo_result2["echoed"] == "Test Message"
+            assert echo_result2.echoed == "Test Message"
             
             # Test status method (if available)
             try:
@@ -765,8 +765,8 @@ class TestGatewayAppDiscovery:
             result1 = enhanced_cm1.shared_echo.echo(message="From CM1")
             result2 = enhanced_cm2.shared_echo.echo(message="From CM2")
             
-            assert result1["echoed"] == "From CM1"
-            assert result2["echoed"] == "From CM2"
+            assert result1.echoed == "From CM1"
+            assert result2.echoed == "From CM2"
 
     @pytest.mark.asyncio
     async def test_connection_manager_sync_failure_graceful_handling(self):

--- a/tests/unit/mindtrace/services/gateway/test_gateway.py
+++ b/tests/unit/mindtrace/services/gateway/test_gateway.py
@@ -223,6 +223,12 @@ class TestGateway:
             mock_base_cm.register_app = Mock(return_value={'status': 'registered'})
             mock_base_cm.aregister_app = AsyncMock(return_value={'status': 'registered'})
             
+            # Mock the list_apps_with_schemas method that registered_apps() calls
+            from mindtrace.services.gateway.gateway import AppInfo, ListAppsWithSchemasResponse
+            mock_app_info = AppInfo(name="test-service", url="http://localhost:8001/", endpoints={})
+            mock_response = ListAppsWithSchemasResponse(apps=[mock_app_info])
+            mock_base_cm.list_apps_with_schemas = Mock(return_value=mock_response)
+            
             # The mock should return a constructor function that returns the mock instance
             mock_generate.return_value = lambda url: mock_base_cm
             
@@ -262,8 +268,9 @@ class TestGateway:
                     assert hasattr(enhanced_cm, 'test-service')
                     assert getattr(enhanced_cm, 'test-service') == mock_proxy_instance
                     
-                    # Test that registered_apps property works
-                    assert 'test-service' in enhanced_cm.registered_apps
+                    # Test that registered_apps shows the tracked app
+                    registered_apps_result = enhanced_cm.registered_apps()
+                    assert len(registered_apps_result) == 1
 
     @pytest.mark.asyncio
     async def test_enhanced_connection_manager_aregister_app_with_proxy(self, gateway):
@@ -314,6 +321,12 @@ class TestGateway:
             mock_base_cm.url = "http://localhost:8090/"
             mock_base_cm.register_app = Mock(return_value={'status': 'registered'})
             
+            # Mock the list_apps_with_schemas method that registered_apps() calls
+            from mindtrace.services.gateway.gateway import AppInfo, ListAppsWithSchemasResponse
+            mock_app_info = AppInfo(name="simple-service", url="http://localhost:8003/", endpoints={})
+            mock_response = ListAppsWithSchemasResponse(apps=[mock_app_info])
+            mock_base_cm.list_apps_with_schemas = Mock(return_value=mock_response)
+            
             mock_generate.return_value = lambda url: mock_base_cm
             
             with patch.object(Gateway, 'status_at_host', return_value=ServerStatus.AVAILABLE):
@@ -331,12 +344,15 @@ class TestGateway:
                 # Test that original method was called by verifying the result
                 assert result == {'status': 'registered'}
                 
-                # Test that no proxy attribute was created (Mock objects auto-create attributes, 
-                # so we check that _registered_apps is empty instead)
-                assert len(enhanced_cm._registered_apps) == 0
+                # Test that no proxy attribute was created
+                # When registering without connection_manager, the app should be tracked but no proxy created
+                assert len(enhanced_cm._registered_apps) == 1
+                assert "simple-service" in enhanced_cm._registered_apps
+                assert enhanced_cm._registered_apps["simple-service"] is None
                 
-                # Test that registered_apps is empty
-                assert len(enhanced_cm.registered_apps) == 0
+                # Test that registered_apps shows the tracked app
+                registered_apps_result = enhanced_cm.registered_apps()
+                assert len(registered_apps_result) == 1
 
 
 class TestProxyConnectionManagerIntegration:
@@ -416,7 +432,7 @@ class TestProxyConnectionManagerIntegration:
             with pytest.raises(RuntimeError) as exc_info:
                 proxy_cm.echo(message="test")
             
-            assert "Gateway proxy request failed: Internal Server Error" in str(exc_info.value)
+            assert "Gateway proxy request failed for 'echo': 500 - Internal Server Error" in str(exc_info.value)
 
     def test_proxy_attribute_access(self, proxy_cm, mock_original_cm):
         """Test accessing internal attributes of proxy."""

--- a/tests/unit/mindtrace/services/gateway/test_gateway.py
+++ b/tests/unit/mindtrace/services/gateway/test_gateway.py
@@ -407,23 +407,18 @@ class TestProxyConnectionManagerIntegration:
 
     def test_proxy_method_call_no_args(self, proxy_cm):
         """Test method call with no arguments through proxy."""
-        with patch('requests.post') as mock_post:
+        with patch('requests.get') as mock_get:
             mock_response = Mock()
             mock_response.status_code = 200
             mock_response.json.return_value = {'status': 'ok'}
-            mock_post.return_value = mock_response
+            mock_get.return_value = mock_response
             
-            # Get the dynamically created method directly from instance dict to avoid __getattribute__
-            instance_dict = object.__getattribute__(proxy_cm, "__dict__")
-            status_method = instance_dict["status"]
+            # Test calling a no-arg method (status method should use GET since it has no required params)
+            result = proxy_cm.status()
             
-            # Test calling a no-arg method
-            result = status_method()
-            
-            # Verify POST was used (all proxy methods use POST)
-            mock_post.assert_called_once_with(
+            # Verify GET was used for no-arg method
+            mock_get.assert_called_once_with(
                 "http://localhost:8090/test-service/status",
-                json={},
                 timeout=60
             )
 

--- a/tests/unit/mindtrace/services/gateway/test_proxy_connection_manager.py
+++ b/tests/unit/mindtrace/services/gateway/test_proxy_connection_manager.py
@@ -239,23 +239,23 @@ class TestProxyConnectionManagerMethodProxying:
             assert result == {"heartbeat": "ok"}
 
     def test_method_with_positional_args(self, proxy):
-        """Test method call with positional arguments."""
+        """Test method call with positional arguments should use empty payload."""
         with patch('requests.post') as mock_post:
             mock_response = Mock()
             mock_response.status_code = 200
-            mock_response.json.return_value = {"echoed": "hello"}
+            mock_response.json.return_value = {"echoed": ""}
             mock_post.return_value = mock_response
             
-            # Call method with positional argument
+            # Call method with positional argument - should be ignored for robustness
             result = proxy.echo("hello")
             
-            # Should use first positional argument as payload
+            # Should use empty dict as payload since positional args are not supported
             mock_post.assert_called_once_with(
                 "http://localhost:8090/test-service/echo",
-                json="hello",
+                json={},
                 timeout=60
             )
-            assert result == {"echoed": "hello"}
+            assert result == {"echoed": ""}
 
     def test_method_with_no_args_but_required_params(self, proxy):
         """Test method call with no args provided but method has required params."""
@@ -343,7 +343,7 @@ class TestProxyConnectionManagerErrorHandling:
             with pytest.raises(RuntimeError) as exc_info:
                 proxy.echo(message="test")
             
-            assert "Gateway proxy request failed: Internal Server Error" in str(exc_info.value)
+            assert "Gateway proxy request failed for 'echo': 500 - Internal Server Error" in str(exc_info.value)
 
     def test_network_error(self, proxy):
         """Test handling of network errors."""

--- a/tests/unit/mindtrace/services/gateway/test_proxy_connection_manager.py
+++ b/tests/unit/mindtrace/services/gateway/test_proxy_connection_manager.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch, AsyncMock
 import httpx
 import pytest
 import requests
+from urllib3.util.url import Url
 
 from mindtrace.services.gateway.proxy_connection_manager import ProxyConnectionManager
 from mindtrace.services.core.connection_manager import ConnectionManager


### PR DESCRIPTION
This PR implements and closes #82. 

It enables all connection managers generated from connecting to a Gateway-derived class the ability to use registered app endpoints as attributes on the returned connection manager.

Namely,

1. All connection managers generated by a Gateway-derived Service (i.e. including children classes from Gateway) will recognize all registered apps that supplied their own connection manager.
```python
from mindtrace.services import Gateway
from mindtrace.services.sample.echo_service import EchoService

# Launch a custom Service alongside a Gateway, and register the Service to it
echo_cm = EchoService.launch(url=echo_url)
gateway_cm1 = Gateway.launch(url=gateway_url)
gateway_cm1.register_app("echoer", echo_url, echo_cm)

# The Gateway connection manager may now use the EchoService custom endpoints
gateway_cm1.echoer.echo(message="Hello, world!")

# NEW: Newly created Gateway connection managers may now also use the same endpoints
gateway_cm2 = Gateway.connect(url=gateway_url)  # Connecting to a pre-existing Gateway will transfer registered app endpoints
gateway_cm2.echoer.echo(message="Hello world, too!")
```

3. The same works (with a little extra magic) if both connection managers were made _before_ the custom service was registered:
```python
from mindtrace.services import Gateway
from mindtrace.services.sample.echo_service import EchoService

# Connect the second gateway connection manager first
echo_cm = EchoService.launch(url=echo_url)
gateway_cm1 = Gateway.launch(url=gateway_url)
gateway_cm2 = Gateway.connect(url=gateway_url)

# Then register the custom service
gateway_cm1.register_app("echoer", echo_url, echo_cm)

# And the second connection manager will still work
gateway_cm2.echoer.echo(message="Yet another good day, world!")  # Still works
```

This PR is being raise as a draft PR for now, for a few reasons, which I will be unlikely to have time to fix before next week, but would like to make this code available before then:
1. There are a number of dead loose ends which were generated while producing the code which need to be cleaned up;
2. The implemented logic is likely far too complicated for what is needed; equivalently there are logical errors & bugs are still likely;
3. There are a number of additional design decisions, which should likely be made with MCP-compliance in mind, with discussions happening next week;
4. The test coverage needs to be greatly improved;


# Implementation Details

## New `Service.detailed_endpoints()` method

A new `detailed_endpoints` endpoint/method has been added to the `Service` base class, which will return all of the endpoints with their schema information. 

```python
import json
from mindtrace.services import Service

cm = Service.launch()
print(json.dumps(cm.detailed_endpoints().endpoints, indent=4))
"""
{
    "endpoints": {
        "name": "endpoints",
        "input_schema": null,
        "output_schema": {
            "properties": {
                "endpoints": {
                    "items": {
                        "type": "string"
                    },
                    "title": "Endpoints",
                    "type": "array"
                }
            },
            "required": [
                "endpoints"
            ],
            "title": "EndpointsOutput",
            "type": "object"
        }
    },
...
"""
```

## New `Gateway._create_synthetic_connection_manager`

The `Gateway` class has a new method, similar to `generate_connection_manager`, but uses the provided endpoint information from the above to create a `ConnectionManager`. The Gateway only collects and tracks this information for apps that provide it (in `self.registered_app_info`).

TODO: Note that in the current implementation, it is the act of providing a connection manager that triggers the tracking of the service's schemas, but actually non-`Service`-derived classes may also already have said schemas (especially if we are considering it to tie in with MCP-compliance). In the future it should be possible to enable the described behavior for _any_ FastAPI / MCP service that provides associated schemas.

```python
class Gateway(Service):
    def __init__(self)
        self.registered_routers = {}
        self.registered_app_info = {}

   @classmethod
    def _create_synthetic_connection_manager(cls, service_url: str, endpoints: Dict[str, Dict[str, Any]]):
        """Create a synthetic connection manager based on endpoint schema information."""
        from mindtrace.services.core.connection_manager import ConnectionManager
        
        # Create a basic connection manager instance
        synthetic_cm = ConnectionManager(url=service_url)
        
        # Add methods based on the endpoint information
        for endpoint_name, endpoint_info in endpoints.items():
            # Create a method that matches the endpoint signature
            def make_endpoint_method(name):
                def endpoint_method(*args, **kwargs):
                    # This method won't actually be called since the proxy will intercept
                    # But it needs to exist for the proxy to detect it
                    return {"endpoint": name, "args": args, "kwargs": kwargs}
                endpoint_method.__name__ = name
                return endpoint_method
            
            # Add the method to the synthetic connection manager
            setattr(synthetic_cm, endpoint_name, make_endpoint_method(endpoint_name))
        
        return synthetic_cm
```

As this behavior is required by MCP, we may decide to simply make this endpoint match the MCP version. Refer [here](https://github.com/Mindtrace/mindtrace/blob/acba74af09c319ac291b6bee4f716fb4a3760951/mindtrace/services/mindtrace/services/mcp/mcp_service.py#L77) for a working example. 

## Update `Gateway.connect`

The above is used in the updated `Gateway.connect` method. The current logic is quite long, and ties in to the even-longer `ProxyConnectionManager` class, which still exists. 

## New `Gateway.reconnect`

There is a new `Gateway.reconnect` method. It might make sense to do a simpler "reconnect" call, where the original connect kwargs are stored and used again, but instead in the current implementation `reconnect` doesn't attempt to do that, but rather just refreshes the endpoint information. 

In theory it sounded like the simpler implementation, in practice it is just as complicated as the original `connect`. 

## Catching `AttributeError` with a `reconnect` + retry

Consider the following:

```python
from mindtrace.services import Gateway
from mindtrace.services.sample.echo_service import EchoService

echo_url = "http://localhost:8080/"
gateway_url = "http://localhost:8081/"

echo_cm = EchoService.launch(url=echo_url)
gateway_cm = Gateway.launch(url=gateway_url)
gateway_cm2 = Gateway.connect(url=gateway_url)

gateway_cm.register_app("echoer", echo_url, echo_cm) 
```

At this point, if you check if `echoer` is an attribute on each connection manager:
```python
'echoer' in gateway_cm.__dict__  # True
'echoer' in gateway_cm2.__dict__  # False
```

It would appear that the second connection manager doesn't know about `echoer`, but if you reach for it, you find it's there:
```
type(gateway_cm2.echoer)  # <class 'mindtrace.services.gateway.proxy_connection_manager.ProxyConnectionManager'>
```

The main logic that makes the above possible is simply:
1. Catch any `AttributeError` thrown by `__getattribute__`, which occurs when "echoer" is not found as an attribute in `gateway_cm2`;
2. Automatically try to `reconnect` once, refreshing the connection manager attributes, ideally to now contain the updated property;
5. Try calling the attribute one more time, returning any errors this time as usual.

Buried in the updated `connect` method:
```python
class Gateway:
    def connect():
        ...
        # Store original __getattribute__ method
        original_getattribute = base_cm.__class__.__getattribute__
        
        def enhanced_getattribute(self, name):
            """Enhanced __getattribute__ that reconnects and retries on AttributeError for connection manager attributes."""
            try:
                return original_getattribute(self, name)
            except AttributeError as e:
                if (not name.startswith('_') and 
                    not hasattr(type(self), name) and 
                    not hasattr(self.__class__, name)):
                    
                    # Check if this app was registered by this connection manager without a proxy
                    # If so, don't create a synthetic proxy (respect the original registration choice)
                    if name in self._registered_apps and self._registered_apps[name] is None:
                        # This app was registered by this CM without a connection manager, don't create proxy
                        raise e
                    
                    # Try reconnecting to refresh the app list
                    try:
                        self.reconnect()
                        # Try accessing the attribute again after reconnect
                        return original_getattribute(self, name)
                    except Exception:
                        # If reconnect fails or attribute still doesn't exist, raise original error
                        pass
                
                # Re-raise the original AttributeError
                raise e
        
        # Overwrite __getattribute__ with the enhanced version
        base_cm.__class__.__getattribute__ = enhanced_getattribute
```

# Documentation & Testing

Unit and integration tests have been added covering the new use case, but many more tests, including the myriad of corner cases, should be added before considered complete. Tests should still all pass with ~70% coverage on the `Gateway` and `ProxyConnectionManager` files.

```bash
git clone git@github.com:mindtrace/mindtrace enhanced_cm && cd enhanced_cm
git checkout services/feature/gateway-enhanced-cm
uv sync
uv tool install ds-run
ds test
```