### PR TITLE
Update test suite for the Jobs PR

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -16,5 +16,29 @@ services:
       timeout: 20s
       retries: 3
 
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"   # AMQP port
+      - "15672:15672" # Management UI
+    environment:
+      RABBITMQ_DEFAULT_USER: user
+      RABBITMQ_DEFAULT_PASS: password
+    healthcheck:
+      test: ["CMD", "rabbitmqctl", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
 volumes:
   minio_data: 

--- a/tests/integration/mindtrace/jobs/integration/test_consumer_integration.py
+++ b/tests/integration/mindtrace/jobs/integration/test_consumer_integration.py
@@ -1,0 +1,48 @@
+import pytest
+
+from mindtrace.jobs.types.job_specs import JobSchema
+from mindtrace.jobs.consumers.consumer import Consumer
+from mindtrace.jobs.orchestrator import Orchestrator
+from mindtrace.jobs.redis.client import RedisClient
+
+from ..conftest import create_test_job, SampleJobInput, SampleJobOutput
+
+
+class TestConsumerIntegration:
+    """Integration tests for Consumer class with various backends."""
+    
+    @pytest.mark.redis
+    def test_consumer_with_redis_backend(self):
+        """Test consumer functionality with Redis backend."""
+        redis_client = RedisClient(host="localhost", port=6379, db=0)
+        orchestrator = Orchestrator(redis_client)
+        
+        redis_test_schema = JobSchema(
+            name="redis_test_consumer_jobs",
+            input=SampleJobInput(),
+            output=SampleJobOutput()
+        )
+        redis_queue = orchestrator.register(redis_test_schema)
+        
+        class RedisTestWorker(Consumer):
+            def __init__(self, name):
+                super().__init__(name)
+                self.processed_jobs = []
+            
+            def run(self, job_dict):
+                self.processed_jobs.append(job_dict)
+                return {"result": "redis_processed"}
+        
+        consumer = RedisTestWorker("redis_test_consumer_jobs")
+        consumer.connect(orchestrator)
+        
+        test_job = create_test_job("redis_consumer_job")
+        orchestrator.publish(redis_queue, test_job)
+        
+        consumer.consume(num_messages=1)
+        
+        assert len(consumer.processed_jobs) == 1
+        assert isinstance(consumer.processed_jobs[0], dict)
+        assert consumer.processed_jobs[0]["name"] == "redis_consumer_job"
+        
+        redis_client.delete_queue(redis_queue) 

--- a/tests/unit/mindtrace/jobs/unit/test_consumer.py
+++ b/tests/unit/mindtrace/jobs/unit/test_consumer.py
@@ -6,7 +6,7 @@ from mindtrace.jobs.types.job_specs import JobSchema
 from mindtrace.jobs.consumers.consumer import Consumer
 from mindtrace.jobs.orchestrator import Orchestrator
 from mindtrace.jobs.local.client import LocalClient
-from mindtrace.jobs.redis.client import RedisClient
+
 from ..conftest import create_test_job, SampleJobInput, SampleJobOutput
 
 
@@ -145,41 +145,7 @@ class TestConsumer:
         remaining = self.orchestrator.count_queue_messages(self.test_queue)
         assert remaining == 0
     
-    @pytest.mark.redis
-    def test_consumer_with_redis_backend(self):
-        """Test consumer functionality with Redis backend."""
-        redis_client = RedisClient(host="localhost", port=6379, db=0)
-        orchestrator = Orchestrator(redis_client)
-        
-        redis_test_schema = JobSchema(
-            name="redis_test_consumer_jobs",
-            input=SampleJobInput(),
-            output=SampleJobOutput()
-        )
-        redis_queue = orchestrator.register(redis_test_schema)
-        
-        class RedisTestWorker(Consumer):
-            def __init__(self, name):
-                super().__init__(name)
-                self.processed_jobs = []
-            
-            def run(self, job_dict):
-                self.processed_jobs.append(job_dict)
-                return {"result": "redis_processed"}
-        
-        consumer = RedisTestWorker("redis_test_consumer_jobs")
-        consumer.connect(orchestrator)
-        
-        test_job = create_test_job("redis_consumer_job")
-        orchestrator.publish(redis_queue, test_job)
-        
-        consumer.consume(num_messages=1)
-        
-        assert len(consumer.processed_jobs) == 1
-        assert isinstance(consumer.processed_jobs[0], dict)
-        assert consumer.processed_jobs[0]["name"] == "redis_consumer_job"
-        
-        redis_client.delete_queue(redis_queue)
+
     
     def test_consumer_dict_message_structure(self):
         """Test that consumers receive properly structured dict messages."""


### PR DESCRIPTION
This PR is a small PR that does the suggestion mentioned [here](https://github.com/Mindtrace/mindtrace/pull/23#pullrequestreview-2979654648).

Namely, there are two small additions:
- Redis and RabbitMQ Docker containers have been added to the integration test suite's docker-compose.yml file, which will automatically be launched and brought down when the integration test suite is run.
- One of the unit tests actually required Redis, so it has been moved to the integration test suite.

## Testing

With this update, the tests should pass without having to separately run Redis and RabbitMQ.

```bash
git clone git@github.com:mindtrace/mindtrace jobs_tests && cd jobs_tests
git checkout feature/init-job-structure-suggestions
uv sync
ds test
```