### PR TITLE
Add RegistryMindtraceODMBackend implementation

### DIFF
--- a/mindtrace/database/mindtrace/database/__init__.py
+++ b/mindtrace/database/mindtrace/database/__init__.py
@@ -1,5 +1,5 @@
 from mindtrace.database.backends.mindtrace_odm_backend import MindtraceODMBackend
-from mindtrace.database.backends.local_odm_backend import LocalMindtraceODMBackend
+from mindtrace.database.backends.registry_odm_backend import RegistryMindtraceODMBackend
 from mindtrace.database.backends.mongo_odm_backend import MindtraceDocument, MongoMindtraceODMBackend
 from mindtrace.database.backends.redis_odm_backend import MindtraceRedisDocument, RedisMindtraceODMBackend
 from mindtrace.database.backends.unified_odm_backend import BackendType, UnifiedMindtraceDocument, UnifiedMindtraceODMBackend
@@ -10,7 +10,7 @@ __all__ = [
     "MindtraceODMBackend",
     "DocumentNotFoundError",
     "DuplicateInsertError",
-    "LocalMindtraceODMBackend",
+    "RegistryMindtraceODMBackend",
     "MindtraceDocument",
     "MindtraceRedisDocument",
     "MongoMindtraceODMBackend",

--- a/mindtrace/database/mindtrace/database/sample/user.py
+++ b/mindtrace/database/mindtrace/database/sample/user.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+class User(BaseModel):
+    name: str
+    id: int | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)

--- a/mindtrace/database/pyproject.toml
+++ b/mindtrace/database/pyproject.toml
@@ -7,9 +7,13 @@ dependencies = [
     "redis>=4.0.0",
     "redis-om>=0.3.5",
     "motor>=3.3.0",
+    "mindtrace-registry",
 ]
 
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.uv.sources]
+mindtrace-registry = { workspace = true }
 

--- a/mindtrace/registry/mindtrace/registry/core/registry.py
+++ b/mindtrace/registry/mindtrace/registry/core/registry.py
@@ -742,6 +742,7 @@ class Registry(Mindtrace):
         self.register_materializer("builtins.bytes", "zenml.materializers.BytesMaterializer")
         self.register_materializer(PosixPath, "zenml.materializers.PathMaterializer")
         self.register_materializer("pydantic.BaseModel", "zenml.materializers.PydanticMaterializer")
+        self.register_materializer("pydantic.main.BaseModel", "zenml.materializers.PydanticMaterializer")
 
         # Core mindtrace materializers
         self.register_materializer(


### PR DESCRIPTION
This PR is an initial implementation for a Registry-backed MindtraceODM backend.

# Usage

The `RegistryMindtraceODMBackend` class will actually accept anything the `Registry` accepts. For compatibility with the other database backends, it is probably best to stick to `pydantic.BaseModel` objects.

```python
# mindtrace.database.sample.user
from datetime import datetime
from pydantic import BaseModel, Field

class User(BaseModel):
    name: str
    id: int | None = None
    created_at: datetime = Field(default_factory=datetime.now)
    updated_at: datetime = Field(default_factory=datetime.now)
```

```python
from mindtrace.database import RegistryMindtraceODMBackend
from mindtrace.database.sample.user import User

backend = RegistryMindtraceODMBackend()

alice_id = backend.insert(User(name="alice", id=1))  # 'ad111286-61c8-11f0-95dc-a562f3bed9c2'
bob_id = backend.insert(User(name="bob", id=2))  # 'db2ceffa-61c8-11f0-95dc-a562f3bed9c2'

user = backend.get(alice_id)  # User(name='alice' id=1 created_at=datetime.datetime(2025, 7, 15, 23, 11, 37, 340371), updated_at=datetime.datetime(2025, 7, 15, 23, 11, 37, 340383))

users = backend.all()  # [User(name='alice', ...), User(name='bob', ...)]

backend.delete(alice_id)
backend.all()  # [User(name='bob', ...)]
```

## Documentation and Testing

The only documentation is the above. There are no tests. It is also not obvious if the above can actually be incorporated into the `MindtraceODM` directly. This PR should be incorporated into the general Database PR for documentation and testing, and may require some work to do so.