### PR TITLE
Pre-validated ConnectionManager input

### DIFF
--- a/mindtrace/services/mindtrace/services/core/utils.py
+++ b/mindtrace/services/mindtrace/services/core/utils.py
@@ -120,7 +120,7 @@ def generate_connection_manager(
 
     # Create a temporary service instance to get the endpoints
     temp_service = service_cls()
-    
+
     # Store service class and endpoints
     ServiceConnectionManager._service_class = service_cls
     ServiceConnectionManager._service_endpoints = temp_service._endpoints
@@ -134,9 +134,24 @@ def generate_connection_manager(
         endpoint_path = f"/{endpoint_name}"
 
         def make_method(endpoint_path, input_schema, output_schema):
-            def method(self, validate_input: bool = True, validate_output: bool = True, **kwargs):
+            def method(self, *args, validate_input: bool = True, validate_output: bool = True, **kwargs):
                 if validate_input:
-                    payload = input_schema(**kwargs).model_dump() if input_schema is not None else {}
+                    if args:
+                        if len(args) != 1:
+                            raise ValueError(
+                                f"Service method {endpoint_name} must be called with either kwargs or a single argument of type {input_schema}"
+                            )
+                        if not isinstance(args[0], input_schema):
+                            raise ValueError(
+                                f"Service method {endpoint_name} must be called with either kwargs or a single argument of type {input_schema}"
+                            )
+                        if kwargs:
+                            raise ValueError(
+                                f"Service method {endpoint_name} must be called with either kwargs or a single argument of type {input_schema}"
+                            )
+                        payload = args[0].model_dump()
+                    else:
+                        payload = input_schema(**kwargs).model_dump() if input_schema is not None else {}
                 else:
                     payload = kwargs
                 res = httpx.post(str(self.url).rstrip("/") + endpoint_path, json=payload, timeout=30)
@@ -153,9 +168,24 @@ def generate_connection_manager(
                     return result  # raw result dict
                 return output_schema(**result) if output_schema is not None else result
 
-            async def amethod(self, validate_input: bool = True, validate_output: bool = True, **kwargs):
+            async def amethod(self, *args, validate_input: bool = True, validate_output: bool = True, **kwargs):
                 if validate_input:
-                    payload = input_schema(**kwargs).model_dump() if input_schema is not None else {}
+                    if args:
+                        if len(args) != 1:
+                            raise ValueError(
+                                f"Service method a{endpoint_name} must be called with either kwargs or a single argument of type {input_schema}"
+                            )
+                        if not isinstance(args[0], input_schema):
+                            raise ValueError(
+                                f"Service method a{endpoint_name} must be called with either kwargs or a single argument of type {input_schema}"
+                            )
+                        if kwargs:
+                            raise ValueError(
+                                f"Service method a{endpoint_name} must be called with either kwargs or a single argument of type {input_schema}"
+                            )
+                        payload = args[0].model_dump()
+                    else:
+                        payload = input_schema(**kwargs).model_dump() if input_schema is not None else {}
                 else:
                     payload = kwargs
                 async with httpx.AsyncClient(timeout=30) as client:

--- a/tests/integration/mindtrace/services/test_simple_integration.py
+++ b/tests/integration/mindtrace/services/test_simple_integration.py
@@ -3,7 +3,7 @@ import requests
 
 from mindtrace.services import generate_connection_manager
 from mindtrace.services.core.types import EndpointsOutput, HeartbeatOutput, PIDFileOutput, ServerIDOutput, StatusOutput
-from mindtrace.services.sample.echo_service import EchoOutput, EchoService
+from mindtrace.services.sample.echo_service import EchoInput, EchoOutput, EchoService
 
 
 class TestServiceIntegration:
@@ -53,6 +53,33 @@ class TestServiceIntegration:
         async_result = await echo_service_manager.aecho(message="Async integration test")
         assert isinstance(async_result, EchoOutput)
         assert async_result.echoed == "Async integration test"
+
+        input_message = EchoInput(message="Pre-validated test message")
+        result = echo_service_manager.echo(input_message)
+        assert isinstance(result, EchoOutput)
+        assert result.echoed == "Pre-validated test message"
+
+        async_result = await echo_service_manager.aecho(input_message)
+        assert isinstance(async_result, EchoOutput)
+        assert async_result.echoed == "Pre-validated test message"
+
+        with pytest.raises(ValueError, match="must be called with"):
+            echo_service_manager.echo(EchoOutput(echoed="should fail"))
+
+        with pytest.raises(ValueError, match="must be called with"):
+            echo_service_manager.echo(EchoInput(message="should fail"), "can't have a second argument")
+
+        with pytest.raises(ValueError, match="must be called with"):
+            echo_service_manager.echo(EchoInput(message="should fail"), message="can't have things both ways")
+
+        with pytest.raises(ValueError, match="must be called with"):
+            await echo_service_manager.aecho(EchoOutput(echoed="should fail"))
+
+        with pytest.raises(ValueError, match="must be called with"):
+            await echo_service_manager.aecho(EchoInput(message="should fail"), "can't have a second argument")
+
+        with pytest.raises(ValueError, match="must be called with"):
+            await echo_service_manager.aecho(EchoInput(message="should fail"), message="can't have things both ways")
 
         print("All integration tests passed!")
 


### PR DESCRIPTION
Allow dynamic ConnectionManager methods to accept a single argument of the schema input type. That is, both of the following work:

```
from mindtrace.services.sample.echo_service import EchoInput, EchoService
echo_service_manager = EchoService.launch(url="http://localhost:8092", timeout=30)

result = echo_service_manager.echo(message="Integration test message")
assert result.echoed == "Integration test message"

input_message = EchoInput(message="Pre-validated test message")
result = echo_service_manager.echo(input_message)
assert result.echoed == "Pre-validated test message"
```

Tests should run and pass via `uv sync; ds test` and have 100% coverage in Services. 