### PR TITLE
Bugfix/log not print

### DIFF
--- a/mindtrace/cluster/mindtrace/cluster/workers/environments/git_env.py
+++ b/mindtrace/cluster/mindtrace/cluster/workers/environments/git_env.py
@@ -54,18 +54,14 @@ class GitEnvironment(Mindtrace):
             base_dir = pathlib.Path(self.config["MINDTRACE_TEMP_DIR"])
             base_dir.mkdir(parents=True, exist_ok=True)
             self.temp_dir = tempfile.mkdtemp(dir=base_dir)
-            print("temp_dir", self.temp_dir)
 
             # Clone repository
             self._clone_repository()
-            print("cloned")
 
             # Setup working directory
             working_dir = self._get_working_dir()
-            print("working_dir", working_dir)
             # Sync dependencies
             self._sync_dependencies(working_dir)
-            print("synced")
             return working_dir
 
         except Exception as e:
@@ -205,7 +201,7 @@ class GitEnvironment(Mindtrace):
 
         working_dir = cwd or self._get_working_dir()
         environment_vars = {**os.environ, **(env or {})}
-        print(command)
+
         try:
             if not detach:
                 result = subprocess.run(

--- a/mindtrace/database/mindtrace/database/backends/mongo_odm_backend.py
+++ b/mindtrace/database/mindtrace/database/backends/mongo_odm_backend.py
@@ -86,6 +86,7 @@ class MongoMindtraceODMBackend(MindtraceODMBackend):
             db_uri (str): MongoDB connection URI string.
             db_name (str): Name of the MongoDB database to use.
         """
+        super().__init__()
         self.model_cls = model_cls
         self.client = AsyncIOMotorClient(db_uri)
         self.db_name = db_name

--- a/mindtrace/database/mindtrace/database/backends/redis_odm_backend.py
+++ b/mindtrace/database/mindtrace/database/backends/redis_odm_backend.py
@@ -82,6 +82,7 @@ class RedisMindtraceODMBackend(MindtraceODMBackend):
             model_cls (Type[ModelType]): The document model class to use for operations.
             redis_url (str): Redis connection URL string.
         """
+        super().__init__()
         self.model_cls = model_cls
         self.redis = get_redis_connection(url=redis_url)
         self._is_initialized = False
@@ -113,7 +114,7 @@ class RedisMindtraceODMBackend(MindtraceODMBackend):
 
                 self._is_initialized = True
             except Exception as e:
-                print(f"Warning: Redis migration failed: {e}")
+                self.logger.warning(f"Redis migration failed: {e}")
                 self._is_initialized = True  # Continue anyway
 
     def is_async(self) -> bool:
@@ -181,7 +182,7 @@ class RedisMindtraceODMBackend(MindtraceODMBackend):
                     raise
                 except Exception:
                     # If all fails, continue without duplicate check but log warning
-                    print(f"Warning: Could not check for duplicates: {e}")
+                    self.logger.warning(f"Could not check for duplicates: {e}")
 
         doc = self.model_cls(**obj_data)
         doc.save()
@@ -302,7 +303,7 @@ class RedisMindtraceODMBackend(MindtraceODMBackend):
                 return self.model_cls.find().all()
         except Exception as e:
             # If query fails, log the error and return empty list
-            print(f"Warning: Redis query failed: {e}")
+            self.logger.warning(f"Redis query failed: {e}")
             # Try to return all documents if specific query fails
             try:
                 return self.model_cls.find().all()

--- a/mindtrace/database/mindtrace/database/backends/unified_odm_backend.py
+++ b/mindtrace/database/mindtrace/database/backends/unified_odm_backend.py
@@ -375,6 +375,7 @@ class UnifiedMindtraceODMBackend(MindtraceODMBackend):
             redis_url: Redis connection URL
             preferred_backend: Which backend to prefer when both are available
         """
+        super().__init__()
         self.mongo_backend = None
         self.redis_backend = None
         self.preferred_backend = preferred_backend


### PR DESCRIPTION
This PR makes sure that Database classes that inherit from Mindtrace call `super().__init__()` so that `self.logger` is available, and replaces some print statements with calls to self.logger. It also removes some extraneous print statements from the cluster module.