### PR TITLE
Add pytest fixtures to mock time consuming sleeps in hardware tests

### DIFF
--- a/tests/unit/mindtrace/hardware/cameras/conftest.py
+++ b/tests/unit/mindtrace/hardware/cameras/conftest.py
@@ -1,6 +1,6 @@
 import asyncio
-import os
 import pathlib
+
 import pytest
 
 
@@ -46,6 +46,7 @@ def fast_camera_sleep_and_imwrite(monkeypatch):
     # Patch mock camera image generation to be lightweight
     try:
         import numpy as np  # noqa: F401
+
         from mindtrace.hardware.cameras.backends.daheng.mock_daheng import MockDahengCamera
 
         def _fast_generate_daheng(self):  # type: ignore[no-redef]
@@ -61,6 +62,7 @@ def fast_camera_sleep_and_imwrite(monkeypatch):
 
     try:
         import numpy as np  # noqa: F401
+
         from mindtrace.hardware.cameras.backends.basler.mock_basler import MockBaslerCamera
 
         def _fast_generate_basler(self):  # type: ignore[no-redef]
@@ -96,4 +98,4 @@ def enforce_timing_for_concurrency_test(monkeypatch, request):
             monkeypatch.setattr(MockDahengCamera, "capture", _slightly_slow_capture, raising=False)
         except Exception:
             pass
-    yield 
+    yield

--- a/tests/unit/mindtrace/hardware/plcs/conftest.py
+++ b/tests/unit/mindtrace/hardware/plcs/conftest.py
@@ -1,5 +1,5 @@
-import asyncio
 import os
+
 import pytest
 
 
@@ -42,6 +42,7 @@ def enable_mock_plc_backend():
 @pytest.fixture(autouse=True)
 def fast_plc_sleep(monkeypatch):
     """Patch asyncio.sleep in PLC modules to return immediately (no real waiting)."""
+
     async def _fast_sleep(_delay, *args, **kwargs):
         return None
 
@@ -66,4 +67,4 @@ def fast_plc_sleep(monkeypatch):
         raising=False,
     )
 
-    yield 
+    yield


### PR DESCRIPTION
This PR creates a number of pytest fixtures for the hardware test suite (the PLC and camera tests explicitly) that mock sleeps etc. in order to speed up the tests.

No tests are actually changed.

# Details

Running:
```bash
ds test: tests/unit/mindtrace/hardware/cameras/test_cameras.py tests/unit/mindtrace/hardware/plcs/test_plcs.py -q --durations=0
```

Before:
```text
======================================================================= slowest durations ========================================================================
143.15s call     unit/mindtrace/hardware/plcs/test_plcs.py::TestPLCManager::test_batch_operations
48.02s call     unit/mindtrace/hardware/plcs/test_plcs.py::TestPLCManager::test_plc_discovery
6.31s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestCameraPerformance::test_batch_capture_with_bandwidth_management
4.79s call     unit/mindtrace/hardware/cameras/test_cameras.py::test_camera_integration_scenario
4.27s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestNetworkBandwidthManagement::test_bandwidth_management_with_mixed_operations
3.55s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestHDRCapture::test_batch_hdr_capture
3.30s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestNetworkBandwidthManagement::test_bandwidth_management_persistence
2.97s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestCameraPerformance::test_rapid_capture_sequence
2.88s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestCameraPerformance::test_camera_resource_cleanup
2.59s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestHDRCapture::test_hdr_capture_with_custom_levels
...
95 passed in 274.83s (0:04:34)
```

After:
```text
======================================================================= slowest durations ========================================================================
1.55s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestCameraErrorHandling::test_camera_operation_after_shutdown
1.51s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestRetryLogic::test_capture_retry_on_connection_error
1.41s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestRetryLogic::test_retry_with_custom_retry_count
1.01s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestRetryLogic::test_retry_with_different_delays
0.91s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestRetryLogic::test_capture_retry_on_timeout_error
0.55s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestNetworkBandwidthManagement::test_concurrent_capture_limiting
0.52s setup    unit/mindtrace/hardware/cameras/test_cameras.py::TestMockDahengCamera::test_camera_initialization
0.21s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestRetryLogic::test_retry_logging
0.21s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestRetryLogic::test_capture_returns_false_treated_as_error
0.21s call     unit/mindtrace/hardware/cameras/test_cameras.py::TestRetryLogic::test_capture_returns_none_treated_as_error
...
95 passed in 11.06s
```

# Testing

All tests should pass just as before, but the test coverage is very low and needs to be improved, perhaps through additional integration tests that can use the hardware they're testing.