### PR TITLE
add mongo mcp agent

### DIFF
--- a/mindtrace/services/mindtrace/services/sample/mongo_mcp.py
+++ b/mindtrace/services/mindtrace/services/sample/mongo_mcp.py
@@ -1,0 +1,233 @@
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from mindtrace.core import TaskSchema
+from mindtrace.services import Service
+
+
+class FindInput(BaseModel):
+    """Arguments for running a find query against a MongoDB collection."""
+
+    database: str = Field(..., description="Database name")
+    collection: str = Field(..., description="Collection name")
+    filter: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Query filter matching MongoDB find() syntax",
+    )
+    projection: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Projection document matching MongoDB projection syntax",
+    )
+    limit: int = Field(10, description="Maximum number of documents to return")
+    sort: Optional[Dict[str, int]] = Field(
+        default=None,
+        description="Sort document with fields mapped to 1 (asc) or -1 (desc)",
+    )
+
+
+class FindOutput(BaseModel):
+    """Result of a find query."""
+
+    found_count: int
+    documents: List[Dict[str, Any]]
+
+
+find_task = TaskSchema(name="find", input_schema=FindInput, output_schema=FindOutput)
+
+
+class AggregateInput(BaseModel):
+    """Arguments for running an aggregation pipeline against a MongoDB collection."""
+
+    database: str = Field(..., description="Database name")
+    collection: str = Field(..., description="Collection name")
+    pipeline: List[Dict[str, Any]] = Field(
+        ...,
+        description="Aggregation pipeline (array of stage documents)",
+    )
+
+
+class AggregateOutput(BaseModel):
+    """Result of an aggregation pipeline."""
+
+    result_count: int
+    documents: List[Dict[str, Any]]
+
+
+aggregate_task = TaskSchema(name="aggregate", input_schema=AggregateInput, output_schema=AggregateOutput)
+
+
+class CountInput(BaseModel):
+    """Arguments for counting documents in a MongoDB collection."""
+
+    database: str = Field(..., description="Database name")
+    collection: str = Field(..., description="Collection name")
+    query: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Optional filter to count a subset of documents (matches MongoDB find() filter syntax)",
+    )
+
+
+class CountOutput(BaseModel):
+    """Result of a count operation."""
+
+    count: int
+
+
+count_task = TaskSchema(name="count", input_schema=CountInput, output_schema=CountOutput)
+
+
+class MongoService(Service):
+    def __init__(self, *args, db_url: Optional[str] = None, **kwargs):
+        """Initialize MongoDB service with optional connection URL.
+
+        Args:
+            db_url: Optional MongoDB connection URI, e.g. mongodb://localhost:27017
+        """
+        super().__init__(*args, **kwargs)
+
+        # Store configuration, but don't require it for internal instantiation
+        self.db_url = db_url
+        self.client = None
+
+        # If a URL was provided at launch time, try to eagerly validate; otherwise defer
+        if self.db_url:
+            try:
+                from pymongo import MongoClient
+
+                self.client = MongoClient(self.db_url, serverSelectionTimeoutMS=2000)
+                self.client.admin.command("ping")
+                self.logger.info(f"Successfully connected to MongoDB at {self.db_url}")
+            except Exception as exc:
+                # Log but don't crash server construction; queries will error if used without a valid connection
+                self.logger.error(f"Failed to connect to MongoDB at {self.db_url}: {exc}")
+                self.client = None
+
+        # Expose the find, aggregate, and count endpoints as MCP tools
+        self.add_endpoint("mongo_find", self.mongo_find, schema=find_task, as_tool=True)
+        self.add_endpoint("mongo_aggregate", self.mongo_aggregate, schema=aggregate_task, as_tool=True)
+        self.add_endpoint("mongo_count", self.mongo_count, schema=count_task, as_tool=True)
+
+    def _ensure_client(self):
+        """Ensure MongoDB client is initialized and connected before a query."""
+        if self.client is not None:
+            return
+        if not self.db_url:
+            raise RuntimeError("MongoDB URL not configured. Provide db_url when launching the service.")
+        try:
+            from pymongo import MongoClient
+
+            self.client = MongoClient(self.db_url, serverSelectionTimeoutMS=2000)
+            self.client.admin.command("ping")
+        except Exception as exc:
+            raise RuntimeError(f"MongoDB connection failed: {exc}")
+
+    def mongo_find(self, payload: FindInput) -> FindOutput:
+        """Run a find query against a MongoDB collection.
+
+        Uses the initialized client to execute a filtered query
+        with optional projection, sort, and limit, and returns JSON-safe
+        documents.
+        Example payload:
+        {
+            "database": "<string>",
+            "collection": "<string>",
+            "filter": { "<field>": "<value>" },
+            "projection": { "<field>": 1 },
+            "limit": 10,
+            "sort": { "<field>": 1 }
+        }
+        """
+        from typing import Iterable, Tuple
+
+        try:
+            from bson import ObjectId  # type: ignore
+            from pymongo import ASCENDING, DESCENDING  # type: ignore
+        except Exception as exc:  # pragma: no cover - environment import guard
+            raise RuntimeError(f"Required MongoDB dependencies are missing: {exc}")
+
+        def to_jsonable(obj: Any) -> Any:
+            if isinstance(obj, dict):
+                return {k: to_jsonable(v) for k, v in obj.items()}
+            if isinstance(obj, list):
+                return [to_jsonable(v) for v in obj]
+            try:
+                if isinstance(obj, ObjectId):
+                    return str(obj)
+            except Exception:
+                pass
+            return obj
+
+        # Ensure we have a connected client (supports temp Service instantiation during endpoint discovery)
+        self._ensure_client()
+
+        db = self.client[payload.database]
+        coll = db[payload.collection]
+
+        sort_spec: Optional[Iterable[Tuple[str, int]]] = None
+        if payload.sort:
+            sort_spec = []
+            for field, direction in payload.sort.items():
+                sort_spec.append((field, ASCENDING if int(direction) >= 0 else DESCENDING))
+
+        cursor = coll.find(payload.filter or {}, projection=payload.projection or None)
+        if sort_spec:
+            cursor = cursor.sort(sort_spec)
+        if payload.limit and payload.limit > 0:
+            cursor = cursor.limit(payload.limit)
+
+        docs = list(cursor)
+        jsonable_docs = [to_jsonable(d) for d in docs]
+        return FindOutput(found_count=len(jsonable_docs), documents=jsonable_docs)
+
+    def mongo_aggregate(self, payload: AggregateInput) -> AggregateOutput:
+        """Run an aggregation pipeline against a MongoDB collection.
+        Example payload:
+        {
+            "database": "<string>",
+            "collection": "<string>",
+            "pipeline": [ { "<stage>": { "<key>": "<value>" } } ]
+        }
+
+        Returns JSON-safe documents and a result count.
+        """
+        try:
+            from bson import ObjectId  # type: ignore
+        except Exception as exc:  # pragma: no cover - environment import guard
+            raise RuntimeError(f"Required MongoDB dependencies are missing: {exc}")
+
+        def to_jsonable(obj: Any) -> Any:
+            if isinstance(obj, dict):
+                return {k: to_jsonable(v) for k, v in obj.items()}
+            if isinstance(obj, list):
+                return [to_jsonable(v) for v in obj]
+            try:
+                if isinstance(obj, ObjectId):
+                    return str(obj)
+            except Exception:
+                pass
+            return obj
+
+        self._ensure_client()
+
+        db = self.client[payload.database]
+        coll = db[payload.collection]
+        cursor = coll.aggregate(payload.pipeline)
+        docs = list(cursor)
+        jsonable_docs = [to_jsonable(d) for d in docs]
+        return AggregateOutput(result_count=len(jsonable_docs), documents=jsonable_docs)
+
+    def mongo_count(self, payload: CountInput) -> CountOutput:
+        """Count documents in a MongoDB collection using an optional filter query.
+        Example payload:
+        {
+            "database": "<string>",
+            "collection": "<string>",
+            "query": { "<field>": "<value>" }
+        }
+        """
+        self._ensure_client()
+        db = self.client[payload.database]
+        coll = db[payload.collection]
+        count = coll.count_documents(payload.query or {})
+        return CountOutput(count=count)

--- a/samples/services/agents/text_to_mongo/README.md
+++ b/samples/services/agents/text_to_mongo/README.md
@@ -1,0 +1,112 @@
+## MongoDB Sample Agent
+
+In this section, we demonstrate how to use the `MCPAgent` from Mindtrace to build a multi-turn conversational agent that interfaces with a MongoDB database using locally hosted large language models (LLMs). The agent can understand natural language queries, translate them into MongoDB operations, and return structured results conversationally.
+
+---
+## Prerequisites Before the Hands-On Session
+### Launch Required Services with Docker
+
+Run the following command to start the services in the background:
+
+``` bash
+docker compose up -d
+```
+This will launch two key containers: 
+- **Ollama**: An open-source LLM runtime 
+- **MongoDB**: A local database to store mock data for querying. If you have a existing database setup, you can skip the mongodb setup.
+
+By default, the setup pulls the `qwen:32b` model. This model has been
+selected based on Qwen model performances on the [Berkeley Function-Calling
+Leaderboard](https://gorilla.cs.berkeley.edu/leaderboard.html) in general.
+
+-   **Size Warning**: The Qwen 32B model requires approximately **20
+    GB** of space.
+-   **Model Selection Tip**: If you prefer a smaller model, you may
+    switch to a lightweight version. However, **context window size
+    is critical** for multi-turn reasoning in our use case, so choose
+    the model accordingly.
+
+
+We've included a mock dataset for demonstration purposes. It will
+automatically be created using a `seed.js` script, and contains: - Weld
+information - Associated images - Corresponding parts
+
+This schema is used to simulate industrial inspection data and supports
+natural language querying.
+
+
+To confirm the Qwen model has been pulled successfully, run the
+following command:
+
+``` bash
+curl http://localhost:11434/api/tags
+```
+
+If the model appears in the response, your setup is complete.
+
+-----
+
+## Run the agent
+
+```bash
+python mongo_agent_multiturn.py
+```
+Try following Queries:
+- Any Greetings (`hi`, `hello`)
+- "count number of welds in welds collection"
+- "can you give me defective weld count"
+- "summary of welds with defect burnthrough"
+
+Tips: `/help` for commands, `/reset` clears history, `/exit` quits.
+
+
+## Code Overview
+
+This sample demonstrates the Model Context Protocol (MCP) pattern. The LLM does not connect to MongoDB directly. Instead, it interacts with MCP tools exposed by the MongoService, a class that inherits from the Mindtrace `Service` base. The agent decides when to call which tool and how to use the results to answer your question.
+
+### Remote MCP service (Mongo tools)
+
+A sample remote MCP server is implemented in the codebase at the module path `mindtrace.services.sample.mongo_mcp`. It registers three tools:
+- `mongo_find(FindInput) -> FindOutput`
+- `mongo_aggregate(AggregateInput) -> AggregateOutput`
+- `mongo_count(CountInput) -> CountOutput`
+
+We launch the MCP server in-process, passing the MongoDB connection URL, and obtain an MCPClient instance. This client can be used to create an MCPToolSession, which allows the agent to discover and invoke tools exposed by the MongoService.
+
+```python
+mcp_client = MongoService.mcp.launch(
+    host="localhost", port=8000, wait_for_launch=True, timeout=10,
+    db_url="mongodb://admin:secret123@localhost:27017",
+)
+```
+### MCPToolSession
+The MCPToolSession is an async context manager. When opened, it loads tools for the provided mcp_client via the MCP protocol and populates `session.tools` and `session.tools_by_name`. When the session is closed, it gracefully tears down the connection.
+```
+mcp_session = MCPToolSession(client=mcp_client)
+```
+### The Agent Config
+```python
+AgentConfig(
+            model="qwen3:32b",
+            base_url="http://localhost:11434",
+            tool_choice="any",
+            system_prompt=""" """,
+        ),
+```
+This AgentConfig is passed to both the LLM provider (Ollama) and the agent execution graph.
+Combined with the tools loaded by MCPToolSession, it enables tool-augmented reasoning. When the LLM decides to use a tool (e.g., to answer a database query), the agent:
+
+Looks up the correct tool in tools_by_name
+
+Executes it with the appropriate arguments
+
+Feeds the results back into the ongoing conversation
+
+
+
+
+
+
+
+
+

--- a/samples/services/agents/text_to_mongo/docker-compose.yml
+++ b/samples/services/agents/text_to_mongo/docker-compose.yml
@@ -1,0 +1,58 @@
+services:
+  ollama:
+    container_name: ollama
+    image: ollama/ollama:latest
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      - CUDA_VISIBLE_DEVICES=0
+      - LOG_LEVEL=debug
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              count: all
+    volumes:
+      - ollama:/root/.ollama
+      - models:/models
+      - ./entrypoint.sh:/entrypoint.sh
+    entrypoint: ["/usr/bin/bash", "/entrypoint.sh"]
+    pull_policy: always
+    tty: true
+    ports:
+      - "11434:11434"
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"
+    networks:
+      - ollama-net
+    restart: unless-stopped
+
+  mongodb:
+    image: mongo:7
+    container_name: mongodb
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: admin
+      MONGO_INITDB_ROOT_PASSWORD: secret123
+    volumes:
+      - mongo_data:/data/db
+      - ./mongo-seed:/docker-entrypoint-initdb.d
+    ports:
+      - "27017:27017"
+    networks:
+      - ollama-net
+
+volumes:
+  models:
+  ollama:
+  mongo_data:
+
+networks:
+  ollama-net:
+    driver: bridge

--- a/samples/services/agents/text_to_mongo/entrypoint.sh
+++ b/samples/services/agents/text_to_mongo/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Start Ollama in the background.
+/bin/ollama serve &
+# Record Process ID.
+pid=$!
+
+# Pause for Ollama to start.
+sleep 5
+
+echo "Retrieve qwen3:32b model..."
+ollama pull qwen3:32b
+echo "Done!"
+
+# Wait for Ollama process to finish.
+wait $pid

--- a/samples/services/agents/text_to_mongo/mongo-seed/seed.js
+++ b/samples/services/agents/text_to_mongo/mongo-seed/seed.js
@@ -1,0 +1,68 @@
+// ./mongo-seed/seed.js
+// Seed three collections: welds, parts, image
+// - welds: { name, camera_id, defect, image_id }
+// - parts: { serial_number, analytic_id }
+// - image: { camera_id, image_id, analytic_id }
+
+// Helpers
+function getDefectForCamera(cameraIndexOneBased) {
+  // Cameras 6..9 get specific defects, others are Healthy
+  if (cameraIndexOneBased === 6) return "burnthrough";
+  if (cameraIndexOneBased === 7) return "missing";
+  if (cameraIndexOneBased === 8) return "cold_weld";
+  if (cameraIndexOneBased === 9) return "spatter";
+  return "Healthy";
+}
+
+function getAnalyticIdForImage(imageIndexOneBased) {
+  // Map images to analytic groups, matching the screenshots
+  if (imageIndexOneBased >= 1 && imageIndexOneBased <= 11) return 4567;
+  if (imageIndexOneBased >= 12 && imageIndexOneBased <= 22) return 4568;
+  if (imageIndexOneBased >= 23 && imageIndexOneBased <= 33) return 4569;
+  return 4570; // 34..44
+}
+
+const dbName = db.getSiblingDB("demo");
+
+// Clean previous data (idempotent seeding)
+dbName.welds.deleteMany({});
+dbName.parts.deleteMany({});
+dbName.image.deleteMany({});
+
+// Parts collection (Serial Number -> Analytic_Id)
+const parts = [
+  { serial_number: "12345", analytic_id: 4567 },
+  { serial_number: "12346", analytic_id: 4568 },
+  { serial_number: "12347", analytic_id: 4569 },
+  { serial_number: "12348", analytic_id: 4570 },
+];
+
+// Image collection (camera_id, image_id, Analytic_Id)
+const imageDocs = [];
+// Generate 44 images across 12 cameras (cycling), grouped into 4 analytics
+for (let i = 1; i <= 44; i++) {
+  const camIdx = ((i - 1) % 12) + 1; // 1..12
+  imageDocs.push({
+    camera_id: `cam${camIdx}`,
+    image_id: `image${i}`,
+    analytic_id: getAnalyticIdForImage(i),
+  });
+}
+
+// Welds collection (name, camera_id, defect, image_id)
+const welds = [];
+for (let i = 1; i <= 44; i++) {
+  const camIdx = ((i - 1) % 12) + 1; // 1..12
+  const weldIdx = ((i - 1) % 12) + 1; // IBWA1..IBWA12 cycling
+  welds.push({
+    name: `IBWA${weldIdx}`,
+    camera_id: `cam${camIdx}`,
+    defect: getDefectForCamera(camIdx),
+    image_id: `image${i}`,
+  });
+}
+
+// Insert into MongoDB
+dbName.parts.insertMany(parts);
+dbName.image.insertMany(imageDocs);
+dbName.welds.insertMany(welds);

--- a/samples/services/agents/text_to_mongo/mongo_agent_multiturn.py
+++ b/samples/services/agents/text_to_mongo/mongo_agent_multiturn.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Interactive CLI agent with multi-turn conversations using MCPLangGraphAgent.
+
+Run:
+    python mongo_agent_multiturn.py
+
+Commands:
+    /exit or /quit: exit the CLI
+    /reset: clear the conversation history
+    /help: show commands
+"""
+
+import asyncio
+
+from langchain_core.messages import HumanMessage, AIMessage
+from langchain_ollama.chat_models import ChatOllama
+
+from mindtrace.services.sample.mongo_mcp import MongoService
+from mindtrace.services.agents.langraph import AgentConfig, MCPAgent
+from mindtrace.services.agents.langraph.graph import GraphBuilder, GraphContext
+from mindtrace.services.agents.langraph.mcp_tools import MCPToolSession
+
+async def main():
+    # MongoDB connection URL - you can modify this as needed
+    db_url = "mongodb://admin:secret123@localhost:27017"
+    
+    mcp_client = MongoService.mcp.launch(
+                                                    host="localhost",
+                                                    port=8000,
+                                                    wait_for_launch=True,
+                                                    timeout=10,
+                                                    db_url=db_url,
+                                                )
+    mcp_session = MCPToolSession(client=mcp_client)
+    
+    agent = MCPAgent(
+        mcp_session=mcp_session,
+        config=AgentConfig(
+            model="qwen3:32b",
+            base_url="http://localhost:11434",
+            tool_choice="any",
+            system_prompt="""You are a friendly MongoDB assistant created by Mindtrace for the "demo" database with 3 collections: `welds`, `image`, and `parts`.
+                                Use:
+                                - `mongo_find` for basic queries
+                                - `mongo_count` for counting
+                                - `mongo_aggregate` for pipelines (joins, group, sort)
+
+                                Schema Summary:
+                                - welds: name, camera_id, defect, image_id
+                                - image: image_id, camera_id, analytic_id
+                                - parts: serial_number, analytic_id
+
+                                Relations:
+                                - welds.image_id = image.image_id
+                                - image.analytic_id = parts.analytic_id
+                                Reply to any user greeting with a friendly message, if you are not able to answer the question, say you are not sure.
+                                
+                                Database structure (agent guidance):
+                                - Collection: welds
+                                - name: e.g., "IBWA1", "IBWA2"
+                                - camera_id: e.g., "cam1" to "cam12"
+                                - defect: e.g., "burnthrough", "missing", "cold_weld", "spatter", "Healthy"
+                                - image_id: e.g., "image1" to "image44"
+                                - Collection: image
+                                - camera_id: same as in welds
+                                - image_id: same as in welds
+                                - analytic_id: e.g., [4567, 4568, 4569, 4570]
+                                - Collection: parts
+                                - serial_number: e.g., "12345", "12346"
+                                - analytic_id: e.g., [4567, 4568, 4569, 4570]
+                                Relationships:
+                                - welds.image_id == image.image_id
+                                - image.analytic_id == parts.analytic_id
+                            """,
+        ),
+    )
+
+    print("=== Mindtrace CLI Agent (multi-turn) ===")
+    print("Type /help for commands.\n")
+
+    thread_id = "cli-mongo"
+    conversation = []  # list of LangChain messages
+
+    async def ainput(prompt: str) -> str:
+        return await asyncio.to_thread(input, prompt)
+
+    # Keep a persistent MCP session and compiled agent for the whole CLI session
+    async with agent.open_agent(thread_id) as (compiled_agent, agent_cfg):
+        while True:
+            user_text = await ainput("You: ")
+            if not user_text:
+                continue
+            cmd = user_text.strip().lower()
+            if cmd in {"/exit", "/quit"}:
+                print("Goodbye!")
+                break
+            if cmd == "/reset":
+                conversation.clear()
+                print("History cleared.")
+                continue
+            if cmd == "/help":
+                print("/exit or /quit: exit; /reset: clear history; /help: show commands")
+                continue
+
+            # Append user turn to conversation
+            conversation.append(HumanMessage(content=user_text))
+
+            # Stream a single turn using full conversation context
+            prev_len = len(conversation)
+            latest_state_messages = conversation
+            # Use the open agent to avoid re-launching MCP every turn
+            try:
+                async for step in compiled_agent.astream(conversation, agent_cfg, stream_mode="values"):
+                    current = step["messages"]
+                    # Print only the new messages since the start of this turn
+                    new_msgs = current[prev_len:]
+                    for m in new_msgs:
+                        try:
+                            m.pretty_print()
+                        except Exception:
+                            print(f"Assistant: {getattr(m, 'content', str(m))}")
+                    latest_state_messages = current
+            except Exception as e:
+                print(f"Assistant: Encountered an error while processing your request: {e}")
+
+            # Persist full state as the new conversation for next turn
+            conversation = list(latest_state_messages)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+
+    # Sample Queries
+    # count number of welds in welds collection
+    # can you give me defective weld count
+    # can you give me summary of defective welds
+    # can you give me summary of welds with defect burnthrough
+    # can you use mindtrace tools to give me summary of defective welds


### PR DESCRIPTION
This PR introduces a sample MongoDB agent built using the `MCPAgent` class from Mindtrace. It demonstrates how to create a multi-turn conversational agent(cli based) capable of interacting with a MongoDB database through Remote MCP Services. This serves as a reference implementation for developers looking to build or expand agent-based workflows using the package.