### PR TITLE
Add Scope(Line,Plant) Selector

### DIFF
--- a/mindtrace/apps/mindtrace/apps/poseidon/poseidon/components_v2/layout/appshell.py
+++ b/mindtrace/apps/mindtrace/apps/poseidon/poseidon/components_v2/layout/appshell.py
@@ -1,8 +1,10 @@
 import reflex as rx
 
 from poseidon.styles.global_styles import T
+from poseidon.state.auth import AuthState
+from poseidon.state.line_scope import ScopeState
 
-from .header import Header
+from .header.header import Header
 from .sidebar.sidebar import Sidebar
 
 
@@ -13,7 +15,11 @@ def AppShell(
     sidebar_active: str,
     header_right: rx.Component | None = None,
     subheader: rx.Component | None = None,
+    show_scope_selector: bool = False,
 ) -> rx.Component:
+
+
+
     main = rx.hstack(
         Sidebar(active=sidebar_active),
         rx.box(
@@ -25,7 +31,7 @@ def AppShell(
         align="start",
     )
     return rx.box(
-        Header(title=title, right_slot=header_right),
+        Header(title=title, right_slot=header_right, show_scope_selector=show_scope_selector),
         rx.cond(
             subheader is not None,
             rx.box(
@@ -39,4 +45,5 @@ def AppShell(
         bg=T.bg,
         min_h="100vh",
         overscroll_behavior="none",
+        on_mount=lambda: ScopeState.ensure_directory(AuthState.user_organization_id)
     )

--- a/mindtrace/apps/mindtrace/apps/poseidon/poseidon/components_v2/layout/header/header.py
+++ b/mindtrace/apps/mindtrace/apps/poseidon/poseidon/components_v2/layout/header/header.py
@@ -1,0 +1,30 @@
+import reflex as rx
+
+from poseidon.components_v2.layout.header.profile_menu import ProfileMenu
+from poseidon.styles.global_styles import T
+
+from poseidon.components_v2.layout.header.scope_selector import ScopeSelector
+
+def Header(*, title: str, right_slot: rx.Component | None = None, show_scope_selector: bool = False) -> rx.Component:
+    return rx.hstack(
+        rx.hstack(
+            rx.box(width="32px", height="32px", bg=T.accent, border_radius="10px"),
+            rx.text(title, font_weight=T.fw_600, text_align="center"),
+            gap=T.space_3,
+            align_items="center",
+            justify_content="center",
+        ),
+        rx.spacer(),
+        right_slot or rx.box(),
+        ScopeSelector() if show_scope_selector else rx.box(),
+        ProfileMenu(),
+        padding=f"{T.space_4} {T.space_6}",
+        height=T.header_h,
+        bg=T.surface,
+        border_bottom=f"1px solid {T.border}",
+        position="sticky",
+        top="0",
+        z_index=str(T.z_header),
+        overscroll_behavior="none",
+        gap=T.space_3,
+    )

--- a/mindtrace/apps/mindtrace/apps/poseidon/poseidon/components_v2/layout/header/profile_menu.py
+++ b/mindtrace/apps/mindtrace/apps/poseidon/poseidon/components_v2/layout/header/profile_menu.py
@@ -4,6 +4,7 @@ from poseidon.state.auth import AuthState
 from poseidon.styles.global_styles import T
 
 
+
 def ProfileMenu() -> rx.Component:
     avatar = rx.box(
         AuthState.initials,
@@ -93,28 +94,4 @@ def ProfileMenu() -> rx.Component:
             content,
         ),
         rx.link("Login", href="/login", color=T.accent),
-    )
-
-
-def Header(*, title: str, right_slot: rx.Component | None = None) -> rx.Component:
-    return rx.hstack(
-        rx.hstack(
-            rx.box(width="32px", height="32px", bg=T.accent, border_radius="10px"),
-            rx.text(title, font_weight=T.fw_600, text_align="center"),
-            gap=T.space_3,
-            align_items="center",
-            justify_content="center",
-        ),
-        rx.spacer(),
-        right_slot or rx.box(),
-        ProfileMenu(),
-        padding=f"{T.space_4} {T.space_6}",
-        height=T.header_h,
-        bg=T.surface,
-        border_bottom=f"1px solid {T.border}",
-        position="sticky",
-        top="0",
-        z_index=str(T.z_header),
-        overscroll_behavior="none",
-        gap=T.space_3,
     )

--- a/mindtrace/apps/mindtrace/apps/poseidon/poseidon/components_v2/layout/header/scope_selector.py
+++ b/mindtrace/apps/mindtrace/apps/poseidon/poseidon/components_v2/layout/header/scope_selector.py
@@ -1,0 +1,50 @@
+from re import T
+import reflex as rx
+from poseidon.styles.global_styles import C, Ty,T
+from poseidon.styles.variants import COMPONENT_VARIANTS
+from poseidon.state.line_scope import ScopeState
+
+def ScopeSelector():
+    truncate = {
+        "white_space": "nowrap",
+        "overflow": "hidden",
+        "text_overflow": "ellipsis",
+    }
+    trigger_base = {
+        **COMPONENT_VARIANTS["select"]["base"],
+        **COMPONENT_VARIANTS["select"]["compact"],
+        "_focus": COMPONENT_VARIANTS["select"]["focus"],
+        "_hover": COMPONENT_VARIANTS["select"]["hover"],
+        **truncate,
+    }
+    plant_trigger_style = {**trigger_base, "width": "120px", "min_width": "120px"}
+    line_trigger_style = {**trigger_base, "width": "150px", "min_width": "150px"}
+
+    return rx.hstack(
+        rx.select.root(
+            rx.select.trigger(placeholder="Plant", style=plant_trigger_style),
+            rx.select.content(
+                rx.select.item("Plant: All", value="all",_hover={"background": T.ring, "color": T.accent}),
+                rx.foreach(
+                    ScopeState.plants,
+                    lambda item: rx.select.item(f"Plant: {item[1]}", value=item[0],_hover={"background": T.ring, "color": T.accent}),
+                ),
+            ),
+            value=ScopeState.selected_plant,
+            on_change=ScopeState.change_plant,
+        ),
+        rx.select.root(
+            rx.select.trigger(placeholder="Line", style=line_trigger_style),
+            rx.select.content(
+                rx.select.item("Line: All", value="all",_hover={"background": T.ring, "color": T.accent}),
+                rx.foreach(
+                    ScopeState.lines_for_selected,
+                    lambda item: rx.select.item(f"Line: {item[1]}", value=item[0],_hover={"background": T.ring, "color": T.accent}),
+                ),
+            ),
+            value=ScopeState.selected_line,
+            on_change=ScopeState.change_line,
+        ),
+        align="center",
+        spacing="2",
+    )

--- a/mindtrace/apps/mindtrace/apps/poseidon/poseidon/poseidon.py
+++ b/mindtrace/apps/mindtrace/apps/poseidon/poseidon/poseidon.py
@@ -12,6 +12,7 @@ and implements role-based authentication for secure access control.
 
 import reflex as rx
 
+from poseidon.components_v2.layout.header.scope_selector import ScopeSelector
 from poseidon.components_v2.layout.appshell import AppShell
 from poseidon.pages.auth import login_page, register_admin_page, register_page, register_super_admin_page
 from poseidon.pages.camera import camera_configurator_page
@@ -33,7 +34,7 @@ app = rx.App(
 )
 
 
-def with_shell(body_fn, *, title, active, header_right_fn=None, subheader_fn=None):
+def with_shell(body_fn, *, title, active, header_right_fn=None, subheader_fn=None, show_scope_selector=False):
     def wrapped():
         return AppShell(
             title=title,
@@ -41,6 +42,7 @@ def with_shell(body_fn, *, title, active, header_right_fn=None, subheader_fn=Non
             header_right=header_right_fn() if header_right_fn else None,
             subheader=subheader_fn() if subheader_fn else None,
             body=body_fn(),
+            show_scope_selector=show_scope_selector,
         )
 
     return wrapped
@@ -64,7 +66,7 @@ app.add_page(
 
 # Camera Configurator route
 app.add_page(
-    with_shell(camera_configurator_page, title="Mindtrace - Camera Configurator", active="Camera Configurator"),
+    with_shell(camera_configurator_page, title="Mindtrace - Camera Configurator", active="Camera Configurator", show_scope_selector=True),
     route="/camera-configurator",
 )
 

--- a/mindtrace/apps/mindtrace/apps/poseidon/poseidon/state/line_scope.py
+++ b/mindtrace/apps/mindtrace/apps/poseidon/poseidon/state/line_scope.py
@@ -1,0 +1,79 @@
+# scope_state.py
+import time
+import reflex as rx
+
+class ScopeState(rx.State):
+    plants: list[tuple[str, str]] = []                      # [("p1","Plant 1"), ...]
+    lines_by_plant: dict[str, list[tuple[str, str]]] = {}   # {"p1":[("l1","Line 1"), ...]}
+    loading: bool = False
+    error: str = ""
+    _last_loaded: float = 0.0
+    TTL_SECS: int = 1000
+
+    @rx.event(background=True)
+    async def ensure_directory(self, org_id: str, force: bool = False):
+        now = time.time()
+        if not force and self.plants and (now - self._last_loaded) < self.TTL_SECS:
+            return
+        async with self:
+            self.loading = True
+            self.error = ""
+
+        from poseidon.backend.database.repositories.project_repository import ProjectRepository
+
+        try:
+            projects = await ProjectRepository.get_by_organization(org_id)
+
+            # TODO: Create Plants, hardcoded as org for now. 
+            plants: list[tuple[str, str]] = [("p1", "plant1")]
+            lines_map: dict[str, list[tuple[str, str]]] = {}
+            lines = []
+            for p in projects:
+                project_id = getattr(p, "id")
+                project_name = getattr(p, "name", str(project_id))
+                lines.append((project_id, project_name))
+            lines_map = {"p1": lines}
+                
+
+            async with self:
+                self.plants = plants
+                self.lines_by_plant = lines_map
+                self._last_loaded = time.time()
+                self.loading = False
+
+        except Exception as e:
+            async with self:
+                self.error = str(e)
+                self.loading = False
+    @rx.var
+    def selected_plant(self) -> str:
+        parts = (self.router.page.raw_path or "").split("?")[0].strip("/").split("/")
+        return parts[1] if len(parts) >= 2 and parts[0] == "plants" else "all"
+
+    @rx.var
+    def selected_line(self) -> str:
+        parts = (self.router.page.raw_path or "").split("?")[0].strip("/").split("/")
+        return parts[3] if len(parts) >= 4 and parts[0] == "plants" and parts[2] == "lines" else "all"
+
+    @rx.var
+    def lines_for_selected(self) -> list[tuple[str, str]]:
+        return self.lines_by_plant.get(self.selected_plant, [])
+
+    def _with_qs(self, dest: str) -> str:
+        raw = self.router.page.raw_path or ""
+        return dest + ("?" + raw.split("?", 1)[1] if "?" in raw else "")
+
+    def change_plant(self, plant_id: str):
+        if plant_id == "all":
+            return rx.redirect("/overview")
+        return rx.redirect(self._with_qs(f"/plants/{plant_id}/overview"))
+
+    def change_line(self, line_id: str):
+        plant = self.selected_plant
+        if plant == "all":
+            return None
+        if line_id == "all":
+            return rx.redirect(self._with_qs(f"/plants/{plant}/overview"))
+        parts = (self.router.page.raw_path or "").split("?")[0].strip("/").split("/")
+        sub = "/".join(parts[4:]) or "predictions" if len(parts) >= 4 else "predictions"
+        return rx.redirect(self._with_qs(f"/plants/{plant}/lines/{line_id}/{sub}"))

--- a/mindtrace/apps/mindtrace/apps/poseidon/poseidon/styles/variants.py
+++ b/mindtrace/apps/mindtrace/apps/poseidon/poseidon/styles/variants.py
@@ -77,6 +77,14 @@ COMPONENT_VARIANTS = {
             "color": T.colors.fg,
             "cursor": "pointer",
         },
+        "compact": {
+            "border": f"1px solid {T.colors.border}",
+            "background": T.colors.surface,
+            "backdrop_filter": "none",
+            "border_radius": R.r_sm,
+            "padding": "0.35rem 0.6rem",
+            "font_size": Ty.fs_sm,
+        },
         "focus": {
             "border_color": C.ring,
             "background": T.colors.surface_2,


### PR DESCRIPTION
Added Line scope selector. Need scoped pages implementation to properly test. Opening for reference for dynamic pages, so that they'll use plant_id and line_id. 
Org is treated as Plant, will also create a db collection for plants.

todos following the page implementations:
- [ ] dynamic page routing on sidebar following the analytics and dashboard pages implementations. 
- [ ] db collection for plants
- [ ] maybe keep selected line as local variable for UX