### PR TITLE
registry: update save() for SAM archiver

### DIFF
--- a/mindtrace/registry/mindtrace/registry/archivers/ultralytics/sam_archiver.py
+++ b/mindtrace/registry/mindtrace/registry/archivers/ultralytics/sam_archiver.py
@@ -33,7 +33,11 @@ class SamArchiver(Archiver):
         num_params = model.info()[1]
         if num_params not in self.model_name:
             raise ValueError(f"Unknown model with {num_params} parameters.")
-        model.save(os.path.join(self.uri, f"{self.model_name[num_params]}.pt"))
+        # SAM.save() saves {"model": SAM2Model} and SAM.__init__() expects {"model": state_dict}
+        # We only save the state_dict so that init works normally
+        state_dict = {"model": model.model.state_dict()}
+        # We also save the model name so that the correct SAM model is built when loading
+        torch.save(state_dict, os.path.join(self.uri, f"{self.model_name[num_params]}.pt"))
 
     def load(self, data_type: Type[Any]) -> SAM:
         for file in os.listdir(self.uri):

--- a/mindtrace/registry/mindtrace/registry/archivers/ultralytics/sam_archiver.py
+++ b/mindtrace/registry/mindtrace/registry/archivers/ultralytics/sam_archiver.py
@@ -33,10 +33,8 @@ class SamArchiver(Archiver):
         num_params = model.info()[1]
         if num_params not in self.model_name:
             raise ValueError(f"Unknown model with {num_params} parameters.")
-        # SAM.save() saves {"model": SAM2Model} and SAM.__init__() expects {"model": state_dict}
-        # We only save the state_dict so that init works normally
         state_dict = {"model": model.model.state_dict()}
-        # We also save the model name so that the correct SAM model is built when loading
+        # Save the model name as well so that the correct SAM model is built when loading
         torch.save(state_dict, os.path.join(self.uri, f"{self.model_name[num_params]}.pt"))
 
     def load(self, data_type: Type[Any]) -> SAM:


### PR DESCRIPTION
This PR addresses the failing test of saving and loading an Ultralytics SAM model via the Registry's archivers.

The issue in brief:
```python
import os

import torch
from ultralytics import SAM

os.makedirs("./temp/", exist_ok=True)  # temp dir since the name must remain sam2.1_t.pt

model = SAM("sam2.1_t.pt")  # downloads to ./sam2.1_t.pt, which contains {"model": state_dict}
model.save("./temp/sam2.1_t.pt")  # saves to ./temp/sam2.1_t.pt, which contains {"model": SAM2Model object}

model = SAM("./temp/sam2.1_t.pt")  # fails
```

Solution:
```python
torch.save({"model": model.model.state_dict()}, "./temp/sam2.1_t.pt")  # save only the state_dict
model = SAM("./temp/sam2.1_t.pt")  # works
```

Tests:
```bash
uv sync
ds test: registry --integration
```