### PR TITLE
set REDIS_OM_URL in tests; change branch for cluster git test

### DIFF
--- a/scripts/docker_up.sh
+++ b/scripts/docker_up.sh
@@ -37,3 +37,5 @@ export MINDTRACE_WORKER_REDIS_DEFAULT_URL=redis://localhost:6380
 export MINDTRACE_CLUSTER_DEFAULT_REDIS_URL=redis://localhost:6380
 
 export MINDTRACE_CLUSTER_RABBITMQ_PORT=5673
+
+export REDIS_OM_URL=redis://localhost:6380

--- a/tests/integration/mindtrace/cluster/test_cluster_integration_git_launch.py
+++ b/tests/integration/mindtrace/cluster/test_cluster_integration_git_launch.py
@@ -25,7 +25,7 @@ def test_start_worker_from_git():
             worker_class="mindtrace.cluster.workers.echo_worker.EchoWorker",
             worker_params={},
             git_repo_url="https://github.com/Mindtrace/mindtrace.git",
-            git_branch="feature/cluster/git-and-docker",
+            git_branch="feature/tests/different-ports-for-tests",
             job_type="echo",
         )
 

--- a/tests/integration/mindtrace/database/test_redis_odm.py
+++ b/tests/integration/mindtrace/database/test_redis_odm.py
@@ -3,7 +3,6 @@ from typing import List
 import pytest
 from pydantic import BaseModel
 from redis_om import Field
-from redis_om.connections import get_redis_connection
 
 from mindtrace.database import (
     DocumentNotFoundError,

--- a/tests/integration/mindtrace/jobs/integration/test_stack.py
+++ b/tests/integration/mindtrace/jobs/integration/test_stack.py
@@ -98,7 +98,7 @@ class TestStackEquivalence:
         assert local_results[2].name == "equiv_0"
 
         try:
-            redis_stack = RedisStack(f"equiv_test_{int(time.time())}")
+            redis_stack = RedisStack(f"equiv_test_{int(time.time())}", host="localhost", port=6380, db=0)
 
             for job in jobs:
                 redis_stack.push(job)


### PR DESCRIPTION
This PR builds on top of #131, adding minimal changes to make the integration tests pass when containers for redis etc. are running on non-standard ports.

Changes:
 - export `REDIS_OM_URL` in `docker_up.sh`
 - change branch in cluster git integration test, so that the worker in the cloned repo also picks up rabbitmq at 5673 from env
 - fix missing port in one of the `RedisStack` objects in `jobs/integration/test_stack.py`
 
 Tests:
 ```bash
 uv sync
 ds test
 ```