### PR TITLE
Feature/fix redis pubsub timeout errors

### DIFF
--- a/mindtrace/jobs/mindtrace/jobs/redis/client.py
+++ b/mindtrace/jobs/mindtrace/jobs/redis/client.py
@@ -168,3 +168,16 @@ class RedisClient(OrchestratorBackend):
 
     def count_queue_messages(self, queue_name: str, **kwargs) -> int:
         return self.connection.count_queue_messages(queue_name, **kwargs)
+
+    def close(self):
+        """Close the Redis connection and clean up resources."""
+        if hasattr(self, 'connection') and self.connection is not None:
+            self.connection.close()
+            self.connection = None
+
+    def __del__(self):
+        """Ensure cleanup happens when the object is garbage collected."""
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/mindtrace/jobs/mindtrace/jobs/redis/client.py
+++ b/mindtrace/jobs/mindtrace/jobs/redis/client.py
@@ -171,7 +171,7 @@ class RedisClient(OrchestratorBackend):
 
     def close(self):
         """Close the Redis connection and clean up resources."""
-        if hasattr(self, 'connection') and self.connection is not None:
+        if hasattr(self, "connection") and self.connection is not None:
             self.connection.close()
             self.connection = None
 

--- a/mindtrace/jobs/mindtrace/jobs/redis/connection.py
+++ b/mindtrace/jobs/mindtrace/jobs/redis/connection.py
@@ -51,7 +51,10 @@ class RedisConnection(BrokerConnectionBase):
         except redis.ConnectionError as e:
             self.logger.warning(f"Error connecting to Redis: {str(e)}")
         self.queues = {}
-        self._local_lock = threading.Lock()  # Thread lock for local state modificationse events.
+        self._local_lock = threading.Lock()  # Thread lock for local state modifications
+        self._shutdown_event = threading.Event()  # Event to signal shutdown to background thread
+        self._pubsub = None  # Store pubsub instance for proper cleanup
+        self._event_thread = None  # Store thread reference for cleanup
         self._load_queue_metadata()  # Load previously declared queues from metadata.
         self._start_event_listener()  # Start a background thread to listen for queue events.
 
@@ -92,7 +95,26 @@ class RedisConnection(BrokerConnectionBase):
             return False
 
     def close(self):
-        """Close the connection to the Redis server."""
+        """Close the connection to the Redis server and shutdown background thread."""
+        # Signal the background thread to shutdown
+        self._shutdown_event.set()
+
+        # Close pubsub connection if it exists
+        with self._local_lock:
+            if self._pubsub is not None:
+                try:
+                    self._pubsub.close()
+                except Exception as e:
+                    self.logger.error(f"Error closing pubsub connection: {str(e)}")
+                self._pubsub = None
+
+        # Wait for the background thread to finish (with timeout)
+        if self._event_thread is not None and self._event_thread.is_alive():
+            self._event_thread.join(timeout=1.0)
+            if self._event_thread.is_alive():
+                self.logger.warning("Background event thread did not shutdown gracefully")
+
+        # Close main Redis connection
         if self.connection is not None:
             try:
                 self.connection.close()
@@ -101,16 +123,29 @@ class RedisConnection(BrokerConnectionBase):
             self.connection = None  # type: ignore
             self.logger.debug(f"{self.name} closed Redis connection.")
 
+    def __del__(self):
+        """Ensure cleanup happens when the object is garbage collected."""
+        try:
+            self.close()
+        except Exception:
+            pass
+
     def _start_event_listener(self):
         """Start a background thread to subscribe to queue events and update local state."""
-        thread = threading.Thread(target=self._subscribe_to_events, daemon=True)
-        thread.start()
+        self._event_thread = threading.Thread(target=self._subscribe_to_events, daemon=True)
+        self._event_thread.start()
 
     def _subscribe_to_events(self):
-        pubsub = self.connection.pubsub()
-        pubsub.subscribe(self.EVENTS_CHANNEL)
-        for message in pubsub.listen():
-            if message["type"] == "message":
+        try:
+            self._pubsub = self.connection.pubsub()
+            self._pubsub.subscribe(self.EVENTS_CHANNEL)
+
+            for message in self._pubsub.listen():
+                if self._shutdown_event.is_set():
+                    break
+                if message["type"] != "message":
+                    continue
+
                 try:
                     data = json.loads(message["data"].decode("utf-8"))
                     event = data.get("event")
@@ -147,6 +182,16 @@ class RedisConnection(BrokerConnectionBase):
                                 del self.queues[qname]
                 except Exception:
                     pass
+        except Exception as e:
+            self.logger.error(f"Event listener thread exception: {str(e)}")
+        finally:
+            with self._local_lock:
+                if self._pubsub is not None:
+                    try:
+                        self._pubsub.close()
+                    except Exception:
+                        pass
+                    self._pubsub = None
 
     def _load_queue_metadata(self):
         """Load all declared queues from the centralized metadata hash."""

--- a/mindtrace/jobs/mindtrace/jobs/redis/consumer_backend.py
+++ b/mindtrace/jobs/mindtrace/jobs/redis/consumer_backend.py
@@ -79,7 +79,7 @@ class RedisConsumerBackend(ConsumerBackendBase):
 
     def close(self):
         """Close the Redis connection and clean up resources."""
-        if hasattr(self, 'connection') and self.connection is not None:
+        if hasattr(self, "connection") and self.connection is not None:
             self.connection.close()
             self.connection = None
 

--- a/mindtrace/jobs/mindtrace/jobs/redis/consumer_backend.py
+++ b/mindtrace/jobs/mindtrace/jobs/redis/consumer_backend.py
@@ -77,6 +77,19 @@ class RedisConsumerBackend(ConsumerBackendBase):
 
         self.logger.info(f"Stopped consuming messages from queues: {queues} (queues empty).")
 
+    def close(self):
+        """Close the Redis connection and clean up resources."""
+        if hasattr(self, 'connection') and self.connection is not None:
+            self.connection.close()
+            self.connection = None
+
+    def __del__(self):
+        """Ensure cleanup happens when the object is garbage collected."""
+        try:
+            self.close()
+        except Exception:
+            pass
+
     def set_poll_timeout(self, timeout: int) -> None:
         """Set the polling timeout for Redis operations."""
         self.poll_timeout = timeout

--- a/tests/unit/mindtrace/jobs/unit/test_redis_client.py
+++ b/tests/unit/mindtrace/jobs/unit/test_redis_client.py
@@ -186,3 +186,138 @@ def test_count_queue_messages_delegates(client):
     mock_conn.count_queue_messages.return_value = 42
     assert client.count_queue_messages("q") == 42
     mock_conn.count_queue_messages.assert_called_with("q")
+
+
+def test_declare_queue_lock_acquisition_failure(client):
+    """Test BlockingIOError when lock acquisition fails for declare_queue."""
+    client, mock_conn = client
+    mock_conn.queues = {}
+    mock_conn.connection.lock.return_value.acquire.return_value = False
+    with pytest.raises(BlockingIOError):
+        client.declare_queue("q", queue_type="fifo")
+
+
+def test_declare_queue_stack_type(client):
+    """Test declaring a stack type queue."""
+    client, mock_conn = client
+    mock_conn.queues = {}
+    mock_conn.connection.lock.return_value.acquire.return_value = True
+    mock_conn.connection.pipeline.return_value.hset.return_value = None
+    mock_conn.connection.pipeline.return_value.execute.return_value = None
+    mock_conn.connection.publish.return_value = 1
+    with patch("mindtrace.jobs.redis.client.RedisStack") as mock_stack:
+        result = client.declare_queue("q", queue_type="stack")
+        assert result["status"] == "success"
+        mock_stack.assert_called_once()
+
+
+def test_declare_queue_priority_type(client):
+    """Test declaring a priority type queue."""
+    client, mock_conn = client
+    mock_conn.queues = {}
+    mock_conn.connection.lock.return_value.acquire.return_value = True
+    mock_conn.connection.pipeline.return_value.hset.return_value = None
+    mock_conn.connection.pipeline.return_value.execute.return_value = None
+    mock_conn.connection.publish.return_value = 1
+    with patch("mindtrace.jobs.redis.client.RedisPriorityQueue") as mock_priority:
+        result = client.declare_queue("q", queue_type="priority")
+        assert result["status"] == "success"
+        mock_priority.assert_called_once()
+
+
+def test_delete_queue_lock_acquisition_failure(client):
+    """Test BlockingIOError when lock acquisition fails for delete_queue."""
+    client, mock_conn = client
+    mock_conn.queues = {"q": MagicMock()}
+    mock_conn.connection.lock.return_value.acquire.return_value = False
+    with pytest.raises(BlockingIOError):
+        client.delete_queue("q")
+
+
+def test_publish_with_priority(client):
+    """Test publishing a message with priority to a priority queue."""
+    client, mock_conn = client
+    fake_queue = MagicMock()
+    fake_queue.__class__.__name__ = "RedisPriorityQueue"
+    mock_conn.queues = {"q": fake_queue}
+
+    class DummyModel(pydantic.BaseModel):
+        foo: str
+
+    msg = DummyModel(foo="bar")
+    fake_queue.push.return_value = None
+    job_id = client.publish("q", msg, priority=5)
+    assert isinstance(job_id, str)
+    # Check that push was called with priority, but don't check exact item content due to UUID
+    args, kwargs = fake_queue.push.call_args
+    assert kwargs["priority"] == 5
+    assert "item" in kwargs
+    assert isinstance(kwargs["item"], str)  # Should be JSON string
+
+
+def test_clean_queue_lock_acquisition_failure(client):
+    """Test BlockingIOError when lock acquisition fails for clean_queue."""
+    client, mock_conn = client
+    fake_queue = MagicMock()
+    fake_queue.key = "key"
+    mock_conn.queues = {"q": fake_queue}
+    mock_conn.connection.lock.return_value.acquire.return_value = False
+    with pytest.raises(BlockingIOError):
+        client.clean_queue("q")
+
+
+def test_close_method(client):
+    """Test the close method."""
+    client, mock_conn = client
+    client.close()
+    mock_conn.close.assert_called_once()
+    assert client.connection is None
+
+
+def test_del_method_exception_handling():
+    """Test __del__ method handles exceptions gracefully."""
+    with patch("mindtrace.jobs.redis.client.RedisConnection") as mock_conn_cls:
+        mock_conn = MagicMock()
+        mock_conn.close.side_effect = Exception("close failed")
+        mock_conn_cls.return_value = mock_conn
+        client = RedisClient(host="localhost", port=6379, db=0)
+        # This should not raise an exception
+        client.__del__()
+
+
+def test_del_method_normal_case():
+    """Test __del__ method normal operation."""
+    with patch("mindtrace.jobs.redis.client.RedisConnection") as mock_conn_cls:
+        mock_conn = MagicMock()
+        mock_conn_cls.return_value = mock_conn
+        client = RedisClient(host="localhost", port=6379, db=0)
+        client.__del__()
+        mock_conn.close.assert_called_once()
+
+
+def test_consumer_backend_args_property():
+    """Test the consumer_backend_args property."""
+    with patch("mindtrace.jobs.redis.client.RedisConnection") as mock_conn_cls:
+        mock_conn = MagicMock()
+        mock_conn_cls.return_value = mock_conn
+        client = RedisClient(host="localhost", port=6379, db=0)
+        args = client.consumer_backend_args
+        assert args["cls"] == "mindtrace.jobs.redis.consumer_backend.RedisConsumerBackend"
+        assert args["kwargs"]["host"] == "localhost"
+        assert args["kwargs"]["port"] == 6379
+        assert args["kwargs"]["db"] == 0
+
+
+def test_create_consumer_backend():
+    """Test the create_consumer_backend method."""
+    with patch("mindtrace.jobs.redis.client.RedisConnection") as mock_conn_cls:
+        mock_conn = MagicMock()
+        mock_conn_cls.return_value = mock_conn
+        client = RedisClient(host="localhost", port=6379, db=0)
+
+        mock_consumer = MagicMock()
+        with patch("mindtrace.jobs.redis.client.RedisConsumerBackend") as mock_backend_cls:
+            backend = client.create_consumer_backend(mock_consumer, "test_queue")
+            mock_backend_cls.assert_called_once_with(
+                "test_queue", mock_consumer, host="localhost", port=6379, db=0
+            )

--- a/tests/unit/mindtrace/jobs/unit/test_redis_client.py
+++ b/tests/unit/mindtrace/jobs/unit/test_redis_client.py
@@ -317,7 +317,5 @@ def test_create_consumer_backend():
 
         mock_consumer = MagicMock()
         with patch("mindtrace.jobs.redis.client.RedisConsumerBackend") as mock_backend_cls:
-            backend = client.create_consumer_backend(mock_consumer, "test_queue")
-            mock_backend_cls.assert_called_once_with(
-                "test_queue", mock_consumer, host="localhost", port=6379, db=0
-            )
+            client.create_consumer_backend(mock_consumer, "test_queue")
+            mock_backend_cls.assert_called_once_with("test_queue", mock_consumer, host="localhost", port=6379, db=0)

--- a/tests/unit/mindtrace/jobs/unit/test_redis_connection.py
+++ b/tests/unit/mindtrace/jobs/unit/test_redis_connection.py
@@ -234,6 +234,7 @@ def test_subscribe_to_events_shutdown_signal(monkeypatch):
         conn._shutdown_event.set()
 
         pubsub = MagicMock()
+
         # Create an iterator that will be interrupted by shutdown
         def message_generator():
             yield {"type": "subscribe"}
@@ -266,10 +267,12 @@ def test_subscribe_to_events_non_message_type(monkeypatch):
         conn = RedisConnection(host="localhost", port=6379, db=0)
 
         pubsub = MagicMock()
-        pubsub.listen.return_value = iter([
-            {"type": "subscribe"},  # Non-message type should be skipped
-            {"type": "message", "data": b'{"event": "declare", "queue": "q", "queue_type": "fifo"}'}
-        ])
+        pubsub.listen.return_value = iter(
+            [
+                {"type": "subscribe"},  # Non-message type should be skipped
+                {"type": "message", "data": b'{"event": "declare", "queue": "q", "queue_type": "fifo"}'},
+            ]
+        )
         conn.connection.pubsub.return_value = pubsub
 
         # Set shutdown after processing to exit loop
@@ -279,6 +282,7 @@ def test_subscribe_to_events_non_message_type(monkeypatch):
         # Use side effect to set shutdown after first call
         original_is_set = conn._shutdown_event.is_set
         call_count = [0]
+
         def mock_is_set():
             call_count[0] += 1
             if call_count[0] > 2:  # Allow a few calls then shutdown
@@ -297,14 +301,15 @@ def test_subscribe_to_events_unknown_queue_type(monkeypatch):
         conn = RedisConnection(host="localhost", port=6379, db=0)
 
         pubsub = MagicMock()
-        pubsub.listen.return_value = iter([
-            {"type": "message", "data": b'{"event": "declare", "queue": "q", "queue_type": "unknown"}'}
-        ])
+        pubsub.listen.return_value = iter(
+            [{"type": "message", "data": b'{"event": "declare", "queue": "q", "queue_type": "unknown"}'}]
+        )
         conn.connection.pubsub.return_value = pubsub
 
         # Set shutdown after processing to exit loop
         call_count = [0]
         original_is_set = conn._shutdown_event.is_set
+
         def mock_is_set():
             call_count[0] += 1
             if call_count[0] > 2:  # Allow a few calls then shutdown
@@ -326,14 +331,13 @@ def test_subscribe_to_events_delete_nonexistent_queue(monkeypatch):
         conn = RedisConnection(host="localhost", port=6379, db=0)
 
         pubsub = MagicMock()
-        pubsub.listen.return_value = iter([
-            {"type": "message", "data": b'{"event": "delete", "queue": "nonexistent"}'}
-        ])
+        pubsub.listen.return_value = iter([{"type": "message", "data": b'{"event": "delete", "queue": "nonexistent"}'}])
         conn.connection.pubsub.return_value = pubsub
 
         # Set shutdown after processing to exit loop
         call_count = [0]
         original_is_set = conn._shutdown_event.is_set
+
         def mock_is_set():
             call_count[0] += 1
             if call_count[0] > 2:  # Allow a few calls then shutdown
@@ -385,14 +389,15 @@ def test_subscribe_to_events_declare_stack_queue(monkeypatch):
         conn = RedisConnection(host="localhost", port=6379, db=0)
 
         pubsub = MagicMock()
-        pubsub.listen.return_value = iter([
-            {"type": "message", "data": b'{"event": "declare", "queue": "stack_q", "queue_type": "stack"}'}
-        ])
+        pubsub.listen.return_value = iter(
+            [{"type": "message", "data": b'{"event": "declare", "queue": "stack_q", "queue_type": "stack"}'}]
+        )
         conn.connection.pubsub.return_value = pubsub
 
         # Set shutdown after processing to exit loop
         call_count = [0]
         original_is_set = conn._shutdown_event.is_set
+
         def mock_is_set():
             call_count[0] += 1
             if call_count[0] > 2:  # Allow a few calls then shutdown
@@ -412,14 +417,15 @@ def test_subscribe_to_events_declare_priority_queue(monkeypatch):
         conn = RedisConnection(host="localhost", port=6379, db=0)
 
         pubsub = MagicMock()
-        pubsub.listen.return_value = iter([
-            {"type": "message", "data": b'{"event": "declare", "queue": "priority_q", "queue_type": "priority"}'}
-        ])
+        pubsub.listen.return_value = iter(
+            [{"type": "message", "data": b'{"event": "declare", "queue": "priority_q", "queue_type": "priority"}'}]
+        )
         conn.connection.pubsub.return_value = pubsub
 
         # Set shutdown after processing to exit loop
         call_count = [0]
         original_is_set = conn._shutdown_event.is_set
+
         def mock_is_set():
             call_count[0] += 1
             if call_count[0] > 2:  # Allow a few calls then shutdown

--- a/tests/unit/mindtrace/jobs/unit/test_redis_connection.py
+++ b/tests/unit/mindtrace/jobs/unit/test_redis_connection.py
@@ -190,3 +190,244 @@ def test_connect_and_close_logger_calls(monkeypatch):
             conn.close()
             assert conn.logger.error.called
             assert conn.logger.debug.called
+
+
+def test_connect_ping_failure(mock_redis):
+    """Test connection failure when ping returns False."""
+    mock_redis.ping.return_value = False
+    # The constructor catches the ConnectionError and logs a warning
+    # It doesn't re-raise the exception, so we check that connection fails
+    conn = RedisConnection(host="localhost", port=6379, db=0)
+    assert not conn.is_connected()  # Should return False since ping failed
+
+
+def test_close_pubsub_error(mock_redis):
+    """Test close method handles pubsub close errors gracefully."""
+    conn = RedisConnection(host="localhost", port=6379, db=0)
+    # Simulate pubsub connection
+    mock_pubsub = MagicMock()
+    mock_pubsub.close.side_effect = Exception("pubsub close failed")
+    conn._pubsub = mock_pubsub
+    # This should not raise an exception
+    conn.close()
+    mock_pubsub.close.assert_called_once()
+
+
+def test_del_method_exception_handling():
+    """Test __del__ method handles exceptions gracefully."""
+    with patch("mindtrace.jobs.redis.connection.redis.Redis") as mock_redis_cls:
+        mock_instance = MagicMock()
+        mock_instance.ping.return_value = True
+        mock_redis_cls.return_value = mock_instance
+        conn = RedisConnection(host="localhost", port=6379, db=0)
+        # Make close raise an exception
+        conn.close = MagicMock(side_effect=Exception("close failed"))
+        # This should not raise an exception
+        conn.__del__()
+
+
+def test_subscribe_to_events_shutdown_signal(monkeypatch):
+    """Test that _subscribe_to_events respects shutdown signal."""
+    with patch("mindtrace.jobs.redis.connection.redis.Redis"):
+        conn = RedisConnection(host="localhost", port=6379, db=0)
+        # Set shutdown event before starting
+        conn._shutdown_event.set()
+
+        pubsub = MagicMock()
+        # Create an iterator that will be interrupted by shutdown
+        def message_generator():
+            yield {"type": "subscribe"}
+            # After first message, shutdown should be detected
+
+        pubsub.listen.return_value = message_generator()
+        conn.connection.pubsub.return_value = pubsub
+
+        # This should exit quickly due to shutdown event
+        conn._subscribe_to_events()
+
+
+def test_subscribe_to_events_exception_handling(monkeypatch):
+    """Test that _subscribe_to_events handles exceptions in the main loop."""
+    with patch("mindtrace.jobs.redis.connection.redis.Redis"):
+        conn = RedisConnection(host="localhost", port=6379, db=0)
+
+        # Make pubsub.listen() raise an exception
+        pubsub = MagicMock()
+        pubsub.listen.side_effect = Exception("connection lost")
+        conn.connection.pubsub.return_value = pubsub
+
+        # This should not raise an exception, just log it
+        conn._subscribe_to_events()
+
+
+def test_subscribe_to_events_non_message_type(monkeypatch):
+    """Test that _subscribe_to_events handles non-message type events."""
+    with patch("mindtrace.jobs.redis.connection.redis.Redis"):
+        conn = RedisConnection(host="localhost", port=6379, db=0)
+
+        pubsub = MagicMock()
+        pubsub.listen.return_value = iter([
+            {"type": "subscribe"},  # Non-message type should be skipped
+            {"type": "message", "data": b'{"event": "declare", "queue": "q", "queue_type": "fifo"}'}
+        ])
+        conn.connection.pubsub.return_value = pubsub
+
+        # Set shutdown after processing to exit loop
+        def set_shutdown():
+            conn._shutdown_event.set()
+
+        # Use side effect to set shutdown after first call
+        original_is_set = conn._shutdown_event.is_set
+        call_count = [0]
+        def mock_is_set():
+            call_count[0] += 1
+            if call_count[0] > 2:  # Allow a few calls then shutdown
+                return True
+            return original_is_set()
+
+        conn._shutdown_event.is_set = mock_is_set
+
+        with patch("threading.Thread"):
+            conn._subscribe_to_events()
+
+
+def test_subscribe_to_events_unknown_queue_type(monkeypatch):
+    """Test _subscribe_to_events with unknown queue type in declare event."""
+    with patch("mindtrace.jobs.redis.connection.redis.Redis"):
+        conn = RedisConnection(host="localhost", port=6379, db=0)
+
+        pubsub = MagicMock()
+        pubsub.listen.return_value = iter([
+            {"type": "message", "data": b'{"event": "declare", "queue": "q", "queue_type": "unknown"}'}
+        ])
+        conn.connection.pubsub.return_value = pubsub
+
+        # Set shutdown after processing to exit loop
+        call_count = [0]
+        original_is_set = conn._shutdown_event.is_set
+        def mock_is_set():
+            call_count[0] += 1
+            if call_count[0] > 2:  # Allow a few calls then shutdown
+                return True
+            return original_is_set()
+
+        conn._shutdown_event.is_set = mock_is_set
+
+        # This should handle unknown queue type gracefully
+        conn._subscribe_to_events()
+
+        # Should not have added anything to queues
+        assert len(conn.queues) == 0
+
+
+def test_subscribe_to_events_delete_nonexistent_queue(monkeypatch):
+    """Test _subscribe_to_events with delete event for nonexistent queue."""
+    with patch("mindtrace.jobs.redis.connection.redis.Redis"):
+        conn = RedisConnection(host="localhost", port=6379, db=0)
+
+        pubsub = MagicMock()
+        pubsub.listen.return_value = iter([
+            {"type": "message", "data": b'{"event": "delete", "queue": "nonexistent"}'}
+        ])
+        conn.connection.pubsub.return_value = pubsub
+
+        # Set shutdown after processing to exit loop
+        call_count = [0]
+        original_is_set = conn._shutdown_event.is_set
+        def mock_is_set():
+            call_count[0] += 1
+            if call_count[0] > 2:  # Allow a few calls then shutdown
+                return True
+            return original_is_set()
+
+        conn._shutdown_event.is_set = mock_is_set
+
+        # This should handle delete of nonexistent queue gracefully
+        conn._subscribe_to_events()
+
+
+def test_subscribe_to_events_pubsub_close_in_finally(monkeypatch):
+    """Test that _subscribe_to_events closes pubsub in finally block."""
+    with patch("mindtrace.jobs.redis.connection.redis.Redis"):
+        conn = RedisConnection(host="localhost", port=6379, db=0)
+
+        # Make pubsub.listen() raise an exception to trigger finally block
+        pubsub = MagicMock()
+        pubsub.listen.side_effect = Exception("connection lost")
+        conn.connection.pubsub.return_value = pubsub
+
+        # This should call pubsub.close() in the finally block
+        conn._subscribe_to_events()
+
+        pubsub.close.assert_called_once()
+
+
+def test_subscribe_to_events_pubsub_close_exception_in_finally(monkeypatch):
+    """Test that _subscribe_to_events handles pubsub close exception in finally block."""
+    with patch("mindtrace.jobs.redis.connection.redis.Redis"):
+        conn = RedisConnection(host="localhost", port=6379, db=0)
+
+        # Make pubsub.listen() raise an exception to trigger finally block
+        pubsub = MagicMock()
+        pubsub.listen.side_effect = Exception("connection lost")
+        pubsub.close.side_effect = Exception("close failed")
+        conn.connection.pubsub.return_value = pubsub
+
+        # This should handle the close exception gracefully
+        conn._subscribe_to_events()
+
+        pubsub.close.assert_called_once()
+
+
+def test_subscribe_to_events_declare_stack_queue(monkeypatch):
+    """Test _subscribe_to_events with declare event for stack queue type."""
+    with patch("mindtrace.jobs.redis.connection.redis.Redis"):
+        conn = RedisConnection(host="localhost", port=6379, db=0)
+
+        pubsub = MagicMock()
+        pubsub.listen.return_value = iter([
+            {"type": "message", "data": b'{"event": "declare", "queue": "stack_q", "queue_type": "stack"}'}
+        ])
+        conn.connection.pubsub.return_value = pubsub
+
+        # Set shutdown after processing to exit loop
+        call_count = [0]
+        original_is_set = conn._shutdown_event.is_set
+        def mock_is_set():
+            call_count[0] += 1
+            if call_count[0] > 2:  # Allow a few calls then shutdown
+                return True
+            return original_is_set()
+
+        conn._shutdown_event.is_set = mock_is_set
+
+        with patch("mindtrace.jobs.redis.connection.RedisStack") as mock_stack:
+            conn._subscribe_to_events()
+            mock_stack.assert_called_once()
+
+
+def test_subscribe_to_events_declare_priority_queue(monkeypatch):
+    """Test _subscribe_to_events with declare event for priority queue type."""
+    with patch("mindtrace.jobs.redis.connection.redis.Redis"):
+        conn = RedisConnection(host="localhost", port=6379, db=0)
+
+        pubsub = MagicMock()
+        pubsub.listen.return_value = iter([
+            {"type": "message", "data": b'{"event": "declare", "queue": "priority_q", "queue_type": "priority"}'}
+        ])
+        conn.connection.pubsub.return_value = pubsub
+
+        # Set shutdown after processing to exit loop
+        call_count = [0]
+        original_is_set = conn._shutdown_event.is_set
+        def mock_is_set():
+            call_count[0] += 1
+            if call_count[0] > 2:  # Allow a few calls then shutdown
+                return True
+            return original_is_set()
+
+        conn._shutdown_event.is_set = mock_is_set
+
+        with patch("mindtrace.jobs.redis.connection.RedisPriorityQueue") as mock_priority:
+            conn._subscribe_to_events()
+            mock_priority.assert_called_once()

--- a/tests/unit/mindtrace/jobs/unit/test_redis_consumer_backend.py
+++ b/tests/unit/mindtrace/jobs/unit/test_redis_consumer_backend.py
@@ -95,3 +95,217 @@ def test_receive_message_queue_not_declared(backend):
     mock_conn._local_lock = MagicMock().__enter__.return_value
     with pytest.raises(KeyError):
         backend.receive_message("not_declared")
+
+
+def test_consume_with_string_queues(backend):
+    """Test consume method with string queues parameter."""
+    backend, mock_conn = backend
+    backend.receive_message = MagicMock(side_effect=[{"id": 1}, None])
+    backend.process_message = MagicMock(return_value=True)
+    backend.logger = MagicMock()
+    # Pass string instead of list - should be converted to list
+    backend.consume(num_messages=1, queues="test_queue", block=False)
+    backend.process_message.assert_called_once_with({"id": 1})
+
+
+def test_consume_with_exception_blocking(backend):
+    """Test consume method handles exceptions in blocking mode."""
+    backend, mock_conn = backend
+    backend.queues = ["q"]
+    backend.receive_message = MagicMock(side_effect=Exception("connection error"))
+    backend.logger = MagicMock()
+
+    # Mock time.sleep to avoid actual delays
+    with patch("time.sleep") as mock_sleep:
+        # Set up to exit after one iteration
+        call_count = [0]
+        def side_effect(*args):
+            call_count[0] += 1
+            if call_count[0] >= 2:  # Exit after a couple iterations
+                raise KeyboardInterrupt()
+        mock_sleep.side_effect = side_effect
+
+        backend.consume(num_messages=1, block=True)
+
+    backend.logger.debug.assert_called()
+    mock_sleep.assert_called()
+
+
+def test_consume_with_exception_non_blocking(backend):
+    """Test consume method handles exceptions in non-blocking mode."""
+    backend, mock_conn = backend
+    backend.queues = ["q"]
+    backend.receive_message = MagicMock(side_effect=Exception("connection error"))
+    backend.logger = MagicMock()
+
+    # In non-blocking mode, should return immediately on exception
+    backend.consume(num_messages=1, block=False)
+
+    backend.logger.debug.assert_called()
+
+
+def test_consume_keyboard_interrupt(backend):
+    """Test consume method handles KeyboardInterrupt gracefully."""
+    backend, mock_conn = backend
+    backend.queues = ["q"]
+    backend.receive_message = MagicMock(side_effect=KeyboardInterrupt())
+    backend.logger = MagicMock()
+
+    # Should catch KeyboardInterrupt and log
+    backend.consume(num_messages=1, block=True)
+
+    backend.logger.info.assert_any_call("Consumption interrupted by user.")
+
+
+def test_consume_until_empty_with_string_queues(backend):
+    """Test consume_until_empty with string queues parameter."""
+    backend, mock_conn = backend
+    mock_conn.count_queue_messages.side_effect = [1, 0]
+    backend.consume = MagicMock()
+    backend.logger = MagicMock()
+
+    # Pass string instead of list - should be converted to list
+    backend.consume_until_empty(queues="test_queue", block=False)
+    backend.consume.assert_called_with(num_messages=1, queues=["test_queue"], block=False)
+
+
+def test_receive_message_with_get_method(backend):
+    """Test receive_message with queue that has 'get' method."""
+    backend, mock_conn = backend
+    fake_queue = MagicMock()
+    fake_queue.get.return_value = '{"foo": "bar"}'
+    # Remove pop method so get method is used
+    del fake_queue.pop
+    mock_conn.queues = {"q": fake_queue}
+    mock_conn._local_lock = MagicMock().__enter__.return_value
+
+    with patch("json.loads", return_value={"foo": "bar"}):
+        result = backend.receive_message("q")
+        assert result == {"foo": "bar"}
+        fake_queue.get.assert_called_with(block=False, timeout=None)
+
+
+def test_receive_message_unsupported_queue_type(backend):
+    """Test receive_message with queue that has neither get nor pop method."""
+    backend, mock_conn = backend
+    fake_queue = MagicMock()
+    # Remove both get and pop methods
+    del fake_queue.get
+    del fake_queue.pop
+    mock_conn.queues = {"q": fake_queue}
+    mock_conn._local_lock = MagicMock().__enter__.return_value
+
+    result = backend.receive_message("q")
+    assert result is None  # Should return None on exception
+
+
+def test_receive_message_json_decode_error(backend):
+    """Test receive_message handles JSON decode errors."""
+    backend, mock_conn = backend
+    fake_queue = MagicMock()
+    fake_queue.pop.return_value = 'invalid json'
+    mock_conn.queues = {"q": fake_queue}
+    mock_conn._local_lock = MagicMock().__enter__.return_value
+
+    result = backend.receive_message("q")
+    assert result is None  # Should return None on JSON decode error
+
+
+def test_close_method(backend):
+    """Test the close method."""
+    backend, mock_conn = backend
+    backend.close()
+    mock_conn.close.assert_called_once()
+    assert backend.connection is None
+
+
+def test_del_method_exception_handling():
+    """Test __del__ method handles exceptions gracefully."""
+    with patch("mindtrace.jobs.redis.consumer_backend.RedisConnection") as mock_conn_cls:
+        mock_conn = MagicMock()
+        mock_conn.close.side_effect = Exception("close failed")
+        mock_conn_cls.return_value = mock_conn
+        backend = RedisConsumerBackend("q", MagicMock(), "localhost", 6379, 0)
+        # This should not raise an exception
+        backend.__del__()
+
+
+def test_del_method_normal_case():
+    """Test __del__ method normal operation."""
+    with patch("mindtrace.jobs.redis.consumer_backend.RedisConnection") as mock_conn_cls:
+        mock_conn = MagicMock()
+        mock_conn_cls.return_value = mock_conn
+        backend = RedisConsumerBackend("q", MagicMock(), "localhost", 6379, 0)
+        backend.__del__()
+        mock_conn.close.assert_called_once()
+
+
+def test_consume_no_message_non_blocking(backend):
+    """Test consume method when no message is available in non-blocking mode."""
+    backend, mock_conn = backend
+    backend.queues = ["q"]
+    backend.receive_message = MagicMock(return_value=None)
+    backend.logger = MagicMock()
+
+    # Should return immediately when no message and not blocking
+    backend.consume(num_messages=1, block=False)
+
+    backend.receive_message.assert_called_once()
+
+
+def test_receive_message_general_exception(backend):
+    """Test receive_message handles general exceptions."""
+    backend, mock_conn = backend
+    fake_queue = MagicMock()
+    fake_queue.pop.side_effect = RuntimeError("general error")
+    mock_conn.queues = {"q": fake_queue}
+    mock_conn._local_lock = MagicMock().__enter__.return_value
+
+    result = backend.receive_message("q")
+    assert result is None  # Should return None on general exception
+
+
+def test_receive_message_with_pop_method(backend):
+    """Test receive_message with queue that only has 'pop' method (no 'get')."""
+    backend, mock_conn = backend
+    fake_queue = MagicMock()
+    fake_queue.pop.return_value = '{"foo": "bar"}'
+    # Ensure get method doesn't exist so pop method is used
+    if hasattr(fake_queue, 'get'):
+        delattr(fake_queue, 'get')
+    mock_conn.queues = {"q": fake_queue}
+    mock_conn._local_lock = MagicMock().__enter__.return_value
+
+    with patch("json.loads", return_value={"foo": "bar"}):
+        result = backend.receive_message("q")
+        assert result == {"foo": "bar"}
+        fake_queue.pop.assert_called_with(block=False, timeout=None)
+
+
+def test_receive_message_exception_in_json_loads(backend):
+    """Test receive_message handles exception during JSON parsing."""
+    backend, mock_conn = backend
+    fake_queue = MagicMock()
+    fake_queue.pop.return_value = '{"invalid": json}'
+    if hasattr(fake_queue, 'get'):
+        delattr(fake_queue, 'get')
+    mock_conn.queues = {"q": fake_queue}
+    mock_conn._local_lock = MagicMock().__enter__.return_value
+
+    # This will cause a JSON decode error which should be caught
+    result = backend.receive_message("q")
+    assert result is None  # Should return None on JSON decode error
+
+
+def test_receive_message_empty_exception(backend):
+    """Test receive_message handles Empty exception specifically."""
+    backend, mock_conn = backend
+    fake_queue = MagicMock()
+    fake_queue.pop.side_effect = Empty()
+    if hasattr(fake_queue, 'get'):
+        delattr(fake_queue, 'get')
+    mock_conn.queues = {"q": fake_queue}
+    mock_conn._local_lock = MagicMock().__enter__.return_value
+
+    result = backend.receive_message("q")
+    assert result is None  # Should return None on Empty exception

--- a/tests/unit/mindtrace/jobs/unit/test_redis_consumer_backend.py
+++ b/tests/unit/mindtrace/jobs/unit/test_redis_consumer_backend.py
@@ -119,10 +119,12 @@ def test_consume_with_exception_blocking(backend):
     with patch("time.sleep") as mock_sleep:
         # Set up to exit after one iteration
         call_count = [0]
+
         def side_effect(*args):
             call_count[0] += 1
             if call_count[0] >= 2:  # Exit after a couple iterations
                 raise KeyboardInterrupt()
+
         mock_sleep.side_effect = side_effect
 
         backend.consume(num_messages=1, block=True)
@@ -203,7 +205,7 @@ def test_receive_message_json_decode_error(backend):
     """Test receive_message handles JSON decode errors."""
     backend, mock_conn = backend
     fake_queue = MagicMock()
-    fake_queue.pop.return_value = 'invalid json'
+    fake_queue.pop.return_value = "invalid json"
     mock_conn.queues = {"q": fake_queue}
     mock_conn._local_lock = MagicMock().__enter__.return_value
 
@@ -271,8 +273,8 @@ def test_receive_message_with_pop_method(backend):
     fake_queue = MagicMock()
     fake_queue.pop.return_value = '{"foo": "bar"}'
     # Ensure get method doesn't exist so pop method is used
-    if hasattr(fake_queue, 'get'):
-        delattr(fake_queue, 'get')
+    if hasattr(fake_queue, "get"):
+        delattr(fake_queue, "get")
     mock_conn.queues = {"q": fake_queue}
     mock_conn._local_lock = MagicMock().__enter__.return_value
 
@@ -287,8 +289,8 @@ def test_receive_message_exception_in_json_loads(backend):
     backend, mock_conn = backend
     fake_queue = MagicMock()
     fake_queue.pop.return_value = '{"invalid": json}'
-    if hasattr(fake_queue, 'get'):
-        delattr(fake_queue, 'get')
+    if hasattr(fake_queue, "get"):
+        delattr(fake_queue, "get")
     mock_conn.queues = {"q": fake_queue}
     mock_conn._local_lock = MagicMock().__enter__.return_value
 
@@ -302,8 +304,8 @@ def test_receive_message_empty_exception(backend):
     backend, mock_conn = backend
     fake_queue = MagicMock()
     fake_queue.pop.side_effect = Empty()
-    if hasattr(fake_queue, 'get'):
-        delattr(fake_queue, 'get')
+    if hasattr(fake_queue, "get"):
+        delattr(fake_queue, "get")
     mock_conn.queues = {"q": fake_queue}
     mock_conn._local_lock = MagicMock().__enter__.return_value
 


### PR DESCRIPTION
This PR addresses the redis TimeoutError warnings when running the full test suite: `ds test`

Changes:
 - add `close()` and `__del__()` methods for RedisConnection, RedisClient and RedisConsumerBackend classes
 - use a shutdown event to cleanly break out of the pubsub loop in the daemon thread that starts on RedisConnection's init
 - add more unit tests

Tests:
```
uv sync
ds test
```
