### PR TITLE
Support lint and format with ruff>=0.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,23 @@ publish_to_pypi = """
 """
 
 [tool.ruff]
+src = [
+    ".",
+    "mindtrace/apps",
+    "mindtrace/automation",
+    "mindtrace/cluster",
+    "mindtrace/core",
+    "mindtrace/database",
+    "mindtrace/datalake",
+    "mindtrace/hardware",
+    "mindtrace/jobs",
+    "mindtrace/models",
+    "mindtrace/registry",
+    "mindtrace/services",
+    "mindtrace/storage",
+    "mindtrace/ui",
+]
+
 # Exclude a variety of commonly ignored directories.
 exclude = [
     ".bzr",
@@ -150,6 +167,7 @@ exclude = [
     "venv",
     "applications",
 ]
+
 # Same as Black.
 line-length = 120
 indent-width = 4


### PR DESCRIPTION
This PR addresses the breaking changes in ruff 0.13+ regarding first-party imports.
Details here: https://github.com/Mindtrace/mindtrace/pull/190#issuecomment-3327977611

Changes:
- explicitly add project roots as sources, so that import paths can be resolved as first-party

Tests:
`ruff check` and `ruff format --check` should now work with both 0.12.x and 0.13+ versions.
```
uv tool install "ruff>=0.13"
ruff check mindtrace/ tests/
uv tool install "ruff<0.13"
ruff check mindtrace/ tests/
```