### PR TITLE
Fix reflex gitignores on root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,14 @@ cython_debug/
 
 # Stress test results
 stress_test_results/
+
+# Reflex stuff:
+__pycache__/
+*.py[cod]
+.states
+assets/external/
+*.db
+.web
+.env*
+!.env.example
+

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,5 @@ assets/external/
 .env*
 !.env.example
 
+# Mac stuff
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -177,8 +177,6 @@ cython_debug/
 stress_test_results/
 
 # Reflex stuff:
-__pycache__/
-*.py[cod]
 .states
 assets/external/
 *.db


### PR DESCRIPTION
This PR adds all the required gitignores inside one root `.gitignore` file.
Ignores sub-cache folders created by Reflex when firing a Reflex app.

```bash
# Reflex stuff:
.states
assets/external/
*.db
.web
.env*
!.env.example
```