### PR TITLE
PathArchiver with filenames preserved

### DIFF
--- a/mindtrace/registry/mindtrace/registry/__init__.py
+++ b/mindtrace/registry/mindtrace/registry/__init__.py
@@ -3,6 +3,7 @@ from mindtrace.registry.archivers.config_archiver import ConfigArchiver
 from mindtrace.registry.archivers.default_archivers import (
     register_default_materializers,  # Registers default archivers to the Registry class
 )
+from mindtrace.registry.archivers.path_archiver import PathArchiver
 from mindtrace.registry.backends.gcp_registry_backend import GCPRegistryBackend
 from mindtrace.registry.backends.local_registry_backend import LocalRegistryBackend
 from mindtrace.registry.backends.minio_registry_backend import MinioRegistryBackend
@@ -21,6 +22,7 @@ if check_libs(["ultralytics", "torch"]) == []:
 __all__ = [
     "Archiver",
     "ConfigArchiver",
+    "PathArchiver",
     "LocalRegistryBackend",
     "LockTimeoutError",
     "GCPRegistryBackend",

--- a/mindtrace/registry/mindtrace/registry/archivers/default_archivers.py
+++ b/mindtrace/registry/mindtrace/registry/archivers/default_archivers.py
@@ -1,5 +1,6 @@
-from pathlib import PosixPath
+from pathlib import Path, PosixPath, WindowsPath
 
+from mindtrace.registry.archivers.path_archiver import PathArchiver
 from mindtrace.registry.core.registry import Registry
 
 
@@ -22,8 +23,11 @@ def register_default_materializers():
     Registry.register_default_materializer("builtins.tuple", "zenml.materializers.BuiltInContainerMaterializer")
     Registry.register_default_materializer("builtins.set", "zenml.materializers.BuiltInContainerMaterializer")
     Registry.register_default_materializer("builtins.bytes", "zenml.materializers.BytesMaterializer")
-    Registry.register_default_materializer(PosixPath, "zenml.materializers.PathMaterializer")
     Registry.register_default_materializer("pydantic.BaseModel", "zenml.materializers.PydanticMaterializer")
+    # Path types - use PathArchiver to preserve original filenames
+    Registry.register_default_materializer(Path, PathArchiver)
+    Registry.register_default_materializer(PosixPath, PathArchiver)
+    Registry.register_default_materializer(WindowsPath, PathArchiver)
 
     # Core mindtrace materializers
     Registry.register_default_materializer(

--- a/mindtrace/registry/mindtrace/registry/archivers/path_archiver.py
+++ b/mindtrace/registry/mindtrace/registry/archivers/path_archiver.py
@@ -1,0 +1,124 @@
+"""PathArchiver for preserving file/directory names when saving to Registry."""
+
+import json
+import shutil
+import tarfile
+import tempfile
+from pathlib import Path, PosixPath, PurePath, WindowsPath
+from typing import Any, ClassVar, Tuple, Type
+
+from zenml.enums import ArtifactType
+
+from mindtrace.registry.core.archiver import Archiver
+
+
+class PathArchiver(Archiver):
+    """Archiver for Path objects that preserves original filenames.
+
+    Unlike ZenML's PathMaterializer which saves files with a generic name,
+    this archiver preserves the original filename (including extension)
+    when saving and loading Path objects.
+    """
+
+    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (Path, PosixPath, WindowsPath, PurePath)
+    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.DATA
+    METADATA_FILE: ClassVar[str] = "metadata.json"
+    ARCHIVE_NAME: ClassVar[str] = "data.tar.gz"
+
+    def __init__(self, uri: str, **kwargs):
+        super().__init__(uri=uri, **kwargs)
+
+    def save(self, data: Path) -> None:
+        """Save a Path object (file or directory) to the artifact store.
+
+        Args:
+            data: Path to a local file or directory to store.
+
+        Raises:
+            TypeError: If data is not a Path object.
+            FileNotFoundError: If the path does not exist.
+        """
+        if not isinstance(data, (Path, PosixPath, WindowsPath, PurePath)):
+            raise TypeError(f"Expected a Path object, got {type(data).__name__}")
+
+        # Convert to Path if needed
+        data = Path(data)
+
+        if not data.exists():
+            raise FileNotFoundError(f"Path does not exist: {data}")
+
+        uri_path = Path(self.uri)
+        uri_path.mkdir(parents=True, exist_ok=True)
+
+        # Store metadata with original name and type
+        metadata = {
+            "name": data.name,
+            "is_dir": data.is_dir(),
+        }
+
+        with open(uri_path / self.METADATA_FILE, "w") as f:
+            json.dump(metadata, f)
+
+        if data.is_dir():
+            # Create tar.gz archive for directories
+            archive_base = uri_path / "data"
+            shutil.make_archive(
+                base_name=str(archive_base),
+                format="gztar",
+                root_dir=str(data),
+            )
+        else:
+            # Copy file with original name
+            shutil.copy2(str(data), str(uri_path / data.name))
+
+    def load(self, data_type: Type[Any]) -> Path:
+        """Load a Path object from the artifact store.
+
+        Args:
+            data_type: The type to load (unused, always returns Path).
+
+        Returns:
+            Path to the restored file or directory with original name.
+
+        Raises:
+            FileNotFoundError: If the artifact metadata is not found.
+        """
+        uri_path = Path(self.uri)
+        metadata_path = uri_path / self.METADATA_FILE
+
+        if not metadata_path.exists():
+            raise FileNotFoundError(f"Metadata not found at {metadata_path}")
+
+        with open(metadata_path, "r") as f:
+            metadata = json.load(f)
+
+        original_name = metadata["name"]
+        is_dir = metadata["is_dir"]
+
+        # Create a temporary directory that persists after this method returns
+        temp_dir = tempfile.mkdtemp()
+
+        if is_dir:
+            # Extract archive to temp directory with original name
+            archive_path = uri_path / self.ARCHIVE_NAME
+            if not archive_path.exists():
+                raise FileNotFoundError(f"Archive not found at {archive_path}")
+
+            # Create directory with original name
+            output_dir = Path(temp_dir) / original_name
+            output_dir.mkdir(parents=True, exist_ok=True)
+
+            with tarfile.open(str(archive_path), "r:gz") as tar:
+                tar.extractall(path=str(output_dir))
+
+            return output_dir
+        else:
+            # Copy file to temp directory with original name
+            source_file = uri_path / original_name
+            if not source_file.exists():
+                raise FileNotFoundError(f"File not found at {source_file}")
+
+            dest_file = Path(temp_dir) / original_name
+            shutil.copy2(str(source_file), str(dest_file))
+
+            return dest_file

--- a/tests/unit/mindtrace/registry/archivers/test_path_archiver.py
+++ b/tests/unit/mindtrace/registry/archivers/test_path_archiver.py
@@ -1,0 +1,318 @@
+"""Unit tests for PathArchiver."""
+
+import tempfile
+from pathlib import Path, PosixPath
+
+import pytest
+
+from mindtrace.registry.archivers.path_archiver import PathArchiver
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for testing."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
+
+
+@pytest.fixture
+def path_archiver(temp_dir):
+    """Create a PathArchiver instance."""
+    return PathArchiver(uri=temp_dir)
+
+
+@pytest.fixture
+def sample_file(temp_dir):
+    """Create a sample file for testing."""
+    file_path = Path(temp_dir) / "input" / "sample_file.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("Hello, World!")
+    return file_path
+
+
+@pytest.fixture
+def sample_json_file(temp_dir):
+    """Create a sample JSON file for testing."""
+    file_path = Path(temp_dir) / "input" / "config.json"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text('{"key": "value"}')
+    return file_path
+
+
+@pytest.fixture
+def sample_dir(temp_dir):
+    """Create a sample directory with files for testing."""
+    dir_path = Path(temp_dir) / "input" / "sample_directory"
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / "file1.txt").write_text("File 1 content")
+    (dir_path / "file2.txt").write_text("File 2 content")
+    subdir = dir_path / "subdir"
+    subdir.mkdir()
+    (subdir / "file3.txt").write_text("File 3 content")
+    return dir_path
+
+
+class TestPathArchiverInit:
+    def test_path_archiver_init(self, path_archiver, temp_dir):
+        """Test PathArchiver initialization."""
+        assert path_archiver.uri == temp_dir
+        assert hasattr(path_archiver, "logger")
+
+    def test_path_archiver_class_attributes(self):
+        """Test PathArchiver class attributes."""
+        assert PathArchiver.METADATA_FILE == "metadata.json"
+        assert PathArchiver.ARCHIVE_NAME == "data.tar.gz"
+        assert Path in PathArchiver.ASSOCIATED_TYPES
+        assert PosixPath in PathArchiver.ASSOCIATED_TYPES
+
+
+class TestPathArchiverSaveFile:
+    def test_save_file_creates_metadata(self, temp_dir, sample_file):
+        """Test that save creates metadata.json with correct content."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        archiver.save(sample_file)
+
+        metadata_path = archiver_uri / "metadata.json"
+        assert metadata_path.exists()
+
+        import json
+
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+
+        assert metadata["name"] == "sample_file.txt"
+        assert metadata["is_dir"] is False
+
+    def test_save_file_copies_with_original_name(self, temp_dir, sample_file):
+        """Test that save copies file with original name."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        archiver.save(sample_file)
+
+        saved_file = archiver_uri / "sample_file.txt"
+        assert saved_file.exists()
+        assert saved_file.read_text() == "Hello, World!"
+
+    def test_save_file_with_json_extension(self, temp_dir, sample_json_file):
+        """Test that save preserves .json extension."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        archiver.save(sample_json_file)
+
+        saved_file = archiver_uri / "config.json"
+        assert saved_file.exists()
+        assert "key" in saved_file.read_text()
+
+    def test_save_raises_type_error_for_non_path(self, path_archiver):
+        """Test that save raises TypeError for non-Path objects."""
+        with pytest.raises(TypeError, match="Expected a Path object"):
+            path_archiver.save("not a path")
+
+    def test_save_raises_file_not_found_for_missing_path(self, path_archiver, temp_dir):
+        """Test that save raises FileNotFoundError for non-existent paths."""
+        missing_path = Path(temp_dir) / "does_not_exist.txt"
+        with pytest.raises(FileNotFoundError, match="Path does not exist"):
+            path_archiver.save(missing_path)
+
+
+class TestPathArchiverSaveDirectory:
+    def test_save_directory_creates_metadata(self, temp_dir, sample_dir):
+        """Test that save creates metadata.json for directories."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        archiver.save(sample_dir)
+
+        metadata_path = archiver_uri / "metadata.json"
+        assert metadata_path.exists()
+
+        import json
+
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+
+        assert metadata["name"] == "sample_directory"
+        assert metadata["is_dir"] is True
+
+    def test_save_directory_creates_archive(self, temp_dir, sample_dir):
+        """Test that save creates tar.gz archive for directories."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        archiver.save(sample_dir)
+
+        archive_path = archiver_uri / "data.tar.gz"
+        assert archive_path.exists()
+
+
+class TestPathArchiverLoadFile:
+    def test_load_file_preserves_filename(self, temp_dir, sample_file):
+        """Test that load returns Path with original filename."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        archiver.save(sample_file)
+        loaded_path = archiver.load(Path)
+
+        assert loaded_path.name == "sample_file.txt"
+        assert loaded_path.suffix == ".txt"
+        assert loaded_path.exists()
+
+    def test_load_file_preserves_content(self, temp_dir, sample_file):
+        """Test that load returns file with original content."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        archiver.save(sample_file)
+        loaded_path = archiver.load(Path)
+
+        assert loaded_path.read_text() == "Hello, World!"
+
+    def test_load_file_preserves_json_extension(self, temp_dir, sample_json_file):
+        """Test that load preserves .json extension."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        archiver.save(sample_json_file)
+        loaded_path = archiver.load(Path)
+
+        assert loaded_path.name == "config.json"
+        assert loaded_path.suffix == ".json"
+
+    def test_load_raises_file_not_found_for_missing_metadata(self, temp_dir):
+        """Test that load raises FileNotFoundError for missing metadata."""
+        archiver = PathArchiver(uri=temp_dir)
+
+        with pytest.raises(FileNotFoundError, match="Metadata not found"):
+            archiver.load(Path)
+
+    def test_load_raises_file_not_found_for_missing_file(self, temp_dir):
+        """Test that load raises FileNotFoundError when file data is missing."""
+        import json
+
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver_uri.mkdir(parents=True)
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        # Create metadata indicating a file, but don't create the actual file
+        metadata = {"name": "missing_file.txt", "is_dir": False}
+        with open(archiver_uri / "metadata.json", "w") as f:
+            json.dump(metadata, f)
+
+        with pytest.raises(FileNotFoundError, match="File not found"):
+            archiver.load(Path)
+
+
+class TestPathArchiverLoadDirectory:
+    def test_load_directory_preserves_name(self, temp_dir, sample_dir):
+        """Test that load returns directory with original name."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        archiver.save(sample_dir)
+        loaded_path = archiver.load(Path)
+
+        assert loaded_path.name == "sample_directory"
+        assert loaded_path.is_dir()
+
+    def test_load_directory_preserves_contents(self, temp_dir, sample_dir):
+        """Test that load returns directory with all original files."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        archiver.save(sample_dir)
+        loaded_path = archiver.load(Path)
+
+        assert (loaded_path / "file1.txt").exists()
+        assert (loaded_path / "file1.txt").read_text() == "File 1 content"
+        assert (loaded_path / "file2.txt").exists()
+        assert (loaded_path / "subdir" / "file3.txt").exists()
+
+    def test_load_raises_file_not_found_for_missing_archive(self, temp_dir):
+        """Test that load raises FileNotFoundError when archive is missing."""
+        import json
+
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver_uri.mkdir(parents=True)
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        # Create metadata indicating a directory, but don't create the archive
+        metadata = {"name": "missing_directory", "is_dir": True}
+        with open(archiver_uri / "metadata.json", "w") as f:
+            json.dump(metadata, f)
+
+        with pytest.raises(FileNotFoundError, match="Archive not found"):
+            archiver.load(Path)
+
+
+class TestPathArchiverRoundTrip:
+    def test_round_trip_file_with_various_extensions(self, temp_dir):
+        """Test save/load round trip for files with various extensions."""
+        extensions = [".txt", ".json", ".pt", ".csv", ".yaml", ".py"]
+
+        for ext in extensions:
+            archiver_uri = Path(temp_dir) / f"archiver_{ext[1:]}"
+            archiver = PathArchiver(uri=str(archiver_uri))
+
+            input_dir = Path(temp_dir) / "input"
+            input_dir.mkdir(exist_ok=True)
+            input_file = input_dir / f"test_file{ext}"
+            input_file.write_text(f"Content for {ext}")
+
+            archiver.save(input_file)
+            loaded_path = archiver.load(Path)
+
+            assert loaded_path.name == f"test_file{ext}"
+            assert loaded_path.suffix == ext
+            assert loaded_path.read_text() == f"Content for {ext}"
+
+    def test_round_trip_empty_file(self, temp_dir):
+        """Test save/load round trip for empty files."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        input_dir = Path(temp_dir) / "input"
+        input_dir.mkdir(exist_ok=True)
+        input_file = input_dir / "empty.txt"
+        input_file.touch()
+
+        archiver.save(input_file)
+        loaded_path = archiver.load(Path)
+
+        assert loaded_path.name == "empty.txt"
+        assert loaded_path.read_text() == ""
+
+    def test_round_trip_file_without_extension(self, temp_dir):
+        """Test save/load round trip for files without extension."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        input_dir = Path(temp_dir) / "input"
+        input_dir.mkdir(exist_ok=True)
+        input_file = input_dir / "Makefile"
+        input_file.write_text("all:\n\techo hello")
+
+        archiver.save(input_file)
+        loaded_path = archiver.load(Path)
+
+        assert loaded_path.name == "Makefile"
+        assert loaded_path.suffix == ""
+
+    def test_round_trip_empty_directory(self, temp_dir):
+        """Test save/load round trip for empty directories."""
+        archiver_uri = Path(temp_dir) / "archiver"
+        archiver = PathArchiver(uri=str(archiver_uri))
+
+        input_dir = Path(temp_dir) / "input" / "empty_dir"
+        input_dir.mkdir(parents=True)
+
+        archiver.save(input_dir)
+        loaded_path = archiver.load(Path)
+
+        assert loaded_path.name == "empty_dir"
+        assert loaded_path.is_dir()
+        assert list(loaded_path.iterdir()) == []


### PR DESCRIPTION
This PR resolves #275 by adding a `PathArchiver` as the default materializer for `pathlib.Path` objects, which preserves file (with extensions) and dir names.

```python
from pathlib import Path

from mindtrace.registry import Registry, LocalRegistryBackend

file_path = Path("path/to/file.txt")

local_backend = LocalRegistryBackend(
    uri="registry-test/",
)

registry = Registry(backend=local_backend)

registry.save(
    name="file:sample",
    obj=file_path,   
)

loaded_file = registry.load("file:sample")

print(f"File restored to: {loaded_file}")
# File restored to: /tmp/.../file.txt
```

#### Tests
```bash
ds test: tests/unit/mindtrace/registry/archivers/test_path_archiver.py
```