### PR TITLE
fix: make local registry concurrent delete parent cleanup race-safe

### DIFF
--- a/mindtrace/registry/mindtrace/registry/backends/local_registry_backend.py
+++ b/mindtrace/registry/mindtrace/registry/backends/local_registry_backend.py
@@ -573,14 +573,19 @@ class LocalRegistryBackend(RegistryBackend):
                     if meta_path.exists():
                         meta_path.unlink()
 
-                    # Cleanup parent if empty
+                    # Cleanup parent if empty (race-safe under concurrent deletes).
+                    # Another thread/process may remove `parent` between checks/iteration.
                     parent = target.parent
-                    if parent.exists() and not any(parent.iterdir()):
-                        self.logger.debug(f"Removing empty parent directory: {parent}")
-                        try:
-                            parent.rmdir()
-                        except Exception:
-                            pass
+                    try:
+                        if not any(parent.iterdir()):
+                            self.logger.debug(f"Removing empty parent directory: {parent}")
+                            try:
+                                parent.rmdir()
+                            except Exception:
+                                pass
+                    except FileNotFoundError:
+                        # Parent already removed by a concurrent delete; this is fine.
+                        pass
 
                 results.add(OpResult.success(obj_name, obj_version))
             except Exception as e:

--- a/tests/unit/mindtrace/registry/backends/test_local_registry_backend.py
+++ b/tests/unit/mindtrace/registry/backends/test_local_registry_backend.py
@@ -304,6 +304,25 @@ def test_delete_parent_directory_error(backend, sample_object_dir, sample_metada
         assert not object_path.exists()
 
 
+def test_delete_parent_cleanup_race_on_iterdir(backend, sample_object_dir, sample_metadata):
+    """Delete should succeed when parent disappears before parent.iterdir() runs."""
+    backend.push("test:race", "1.0.0", str(sample_object_dir), sample_metadata)
+
+    parent_path = backend.uri / "test:race"
+    original_iterdir = Path.iterdir
+
+    def mock_iterdir(self):
+        if self == parent_path:
+            raise FileNotFoundError("Simulated concurrent parent removal")
+        return original_iterdir(self)
+
+    with patch.object(Path, "iterdir", mock_iterdir):
+        result = backend.delete("test:race", "1.0.0")
+
+    assert result[("test:race", "1.0.0")].ok
+    assert not (backend.uri / "test:race" / "1.0.0").exists()
+
+
 def test_init_with_file_uri(temp_dir):
     """Test LocalRegistryBackend initialization with file:// URI."""
     # Test that file:// prefix is stripped


### PR DESCRIPTION
## Summary
Fixes a race condition in local registry delete cleanup where `parent.iterdir()` could raise `FileNotFoundError` if another concurrent delete removed the parent directory between checks.

## Changes
- Updated `LocalRegistryBackend.delete()` parent-directory cleanup to be race-safe.
- Treat `FileNotFoundError` during parent cleanup as benign (already cleaned by another worker).
- Added focused unit test covering this race path.

## Testing
- `uv run pytest tests/unit/mindtrace/registry/backends/test_local_registry_backend.py -k "delete_parent_cleanup_race_on_iterdir or delete_parent_directory_error"`
- `uv run pytest tests/integration/mindtrace/registry/core/test_all_supported_backends.py -k "test_concurrent_delete_operations and local"`

Fixes #375
