### PR TITLE
Fix Registry debug log leakage into root logger output

### DIFF
--- a/mindtrace/registry/mindtrace/registry/core/registry.py
+++ b/mindtrace/registry/mindtrace/registry/core/registry.py
@@ -101,6 +101,10 @@ class Registry(Mindtrace):
                 Default ``True``.
             **kwargs: Additional arguments forwarded to the backend.
         """
+        # Registry is a library-facing API; avoid leaking debug records into
+        # globally configured root handlers (e.g. ZenML import-time logging).
+        kwargs.setdefault("propagate", False)
+
         super().__init__(**kwargs)
 
         is_remote = backend is not None and not isinstance(backend, (str, Path, LocalRegistryBackend))

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -2496,6 +2496,9 @@ def test_load_missing_hash_warning(registry, test_config, caplog):
     """Test that load() logs warning when hash is missing from metadata."""
     import yaml
 
+    # Explicitly opt-in to propagation for this capture-oriented test.
+    registry.logger.propagate = True
+
     # Save an object
     registry.save("test:config", test_config, version="1.0.0")
 

--- a/tests/unit/mindtrace/registry/core/test_registry_logging.py
+++ b/tests/unit/mindtrace/registry/core/test_registry_logging.py
@@ -1,0 +1,38 @@
+import io
+import logging
+from tempfile import TemporaryDirectory
+
+from mindtrace.registry import Registry
+
+
+def test_registry_debug_logs_do_not_propagate_to_root_logger():
+    """Registry debug logs should not leak to root handlers.
+
+    This reproduces the noisy-console scenario where another dependency
+    (e.g. ZenML) configures root handlers. Registry backend debug logs should
+    remain internal unless explicitly opted in.
+    """
+    root_logger = logging.getLogger()
+    old_level = root_logger.level
+
+    capture_stream = io.StringIO()
+    capture_handler = logging.StreamHandler(capture_stream)
+    capture_handler.setLevel(logging.DEBUG)
+
+    root_logger.addHandler(capture_handler)
+    root_logger.setLevel(logging.DEBUG)
+
+    try:
+        with TemporaryDirectory() as temp_dir:
+            registry = Registry(backend=temp_dir, version_objects=True)
+            registry.save("a:shareditem", 1)
+            assert registry.load("a:shareditem") == 1
+
+        output = capture_stream.getvalue()
+        assert "Loading metadata from:" not in output
+        assert "Loaded metadata:" not in output
+        assert "Downloading directory from" not in output
+        assert "Download complete." not in output
+    finally:
+        root_logger.removeHandler(capture_handler)
+        root_logger.setLevel(old_level)


### PR DESCRIPTION
## Summary
Fix noisy Registry debug output leaking to console when root/global logging is configured by ZenML.

This change makes `Registry` a better library citizen by default:
- Sets `propagate=False` by default in `Registry.__init__` (while preserving opt-in override via kwargs)
- Adds a regression test that reproduces root-handler leakage and asserts Registry backend debug logs do not propagate to root

## Root Cause
`Registry` emits debug logs in backend code (expected), but those records propagated to root logger handlers installed by ZenML at import time, causing unexpected CLI/debug spam.

## Changes
- `mindtrace/registry/mindtrace/registry/core/registry.py`
  - `kwargs.setdefault("propagate", False)` before `super().__init__(**kwargs)`
- `tests/unit/mindtrace/registry/core/test_registry_logging.py`
  - New test: `test_registry_debug_logs_do_not_propagate_to_root_logger`
- `tests/unit/mindtrace/registry/core/test_registry.py`
  - Updated one caplog-based warning test to explicitly opt-in to propagation for that capture scenario

## Validation
- Added regression test fails before fix and passes after
- Full unit suite passes:
  - `ds test --unit`
  - Result: `4174 passed, 68 skipped`

Fixes #380
