### PR TITLE
Cleanup remaining Brain wording to Pipeline

### DIFF
--- a/mindtrace/cluster/mindtrace/cluster/core/pipeline_worker.py
+++ b/mindtrace/cluster/mindtrace/cluster/core/pipeline_worker.py
@@ -1,6 +1,6 @@
-"""Brain worker adapter.
+"""Pipeline worker adapter.
 
-Provides a generic Worker wrapper that hosts a Brain instance and executes brain
+Provides a generic Worker wrapper that hosts a Pipeline instance and executes pipeline
 endpoints from queued jobs.
 """
 
@@ -16,13 +16,13 @@ from mindtrace.models import Pipeline, PipelineLoadInput, PipelineUnloadInput
 
 
 class PipelineWorker(Worker):
-    """Generic queue worker that wraps a Brain class.
+    """Generic queue worker that wraps a Pipeline class.
 
     Job payload contract (default):
     - payload["endpoint"]: str (optional if default_endpoint set)
     - payload["input"]: dict (optional)
 
-    The selected endpoint is resolved to a Brain method name by stripping a
+    The selected endpoint is resolved to a Pipeline method name by stripping a
     leading slash if present.
     """
 
@@ -52,7 +52,7 @@ class PipelineWorker(Worker):
         auto_load: bool = True,
         **worker_kwargs,
     ) -> "PipelineWorker":
-        """Construct a PipelineWorker from a Brain class and init kwargs."""
+        """Construct a PipelineWorker from a Pipeline class and init kwargs."""
         return cls(
             pipeline_cls=pipeline_cls,
             pipeline_kwargs=pipeline_kwargs,
@@ -62,7 +62,7 @@ class PipelineWorker(Worker):
         )
 
     def start(self):
-        """Initialize and optionally load wrapped Brain instance."""
+        """Initialize and optionally load wrapped Pipeline instance."""
         pipeline_kwargs = dict(self.pipeline_kwargs)
         # Avoid standing up a second externally-live service when embedding in worker.
         pipeline_kwargs.setdefault("live_service", False)
@@ -71,7 +71,7 @@ class PipelineWorker(Worker):
             self.pipeline.load(PipelineLoadInput(force=False))
 
     def _run(self, job_dict: dict) -> dict:
-        """Run a job payload against a selected Brain endpoint."""
+        """Run a job payload against a selected Pipeline endpoint."""
         if self.pipeline is None:
             raise RuntimeError("PipelineWorker has not been started.")
 
@@ -81,7 +81,7 @@ class PipelineWorker(Worker):
 
         method_name = endpoint.lstrip("/")
         if not hasattr(self.pipeline, method_name):
-            raise ValueError(f"Brain endpoint '{endpoint}' is not available on {self.pipeline.__class__.__name__}.")
+            raise ValueError(f"Pipeline endpoint '{endpoint}' is not available on {self.pipeline.__class__.__name__}.")
 
         method = getattr(self.pipeline, method_name)
         input_payload = job_dict.get("input", {})
@@ -93,9 +93,9 @@ class PipelineWorker(Worker):
         return {"status": JobStatusEnum.COMPLETED, "output": output_dict}
 
     def _validate_input(self, method_name: str, input_payload: Any) -> Any:
-        """Validate payload against Brain endpoint TaskSchema input model when available."""
+        """Validate payload against Pipeline endpoint TaskSchema input model when available."""
         if self.pipeline is None:
-            raise RuntimeError("Brain is not initialized.")
+            raise RuntimeError("Pipeline is not initialized.")
 
         schema = self.pipeline.endpoints.get(method_name)
         if schema is None or schema.input_schema is None:
@@ -114,7 +114,7 @@ class PipelineWorker(Worker):
         return output
 
     async def shutdown_cleanup(self):
-        """Unload wrapped Brain on worker shutdown."""
+        """Unload wrapped Pipeline on worker shutdown."""
         if self.pipeline is not None:
             try:
                 self.pipeline.unload(PipelineUnloadInput(force=False))

--- a/mindtrace/models/mindtrace/models/auto_segmenter.py
+++ b/mindtrace/models/mindtrace/models/auto_segmenter.py
@@ -1,6 +1,6 @@
-"""Auto-segmentation Brain built from Ultralytics YOLO + SAM.
+"""Auto-segmentation Pipeline built from Ultralytics YOLO + SAM.
 
-This Brain runs object detection first, then uses detection boxes as prompts for
+This Pipeline runs object detection first, then uses detection boxes as prompts for
 SAM segmentation.
 """
 
@@ -73,7 +73,7 @@ AutoSegmenterTaskSchema = TaskSchema(
 
 
 class AutoSegmenter(Pipeline):
-    """Brain that combines YOLO detection with SAM segmentation.
+    """Pipeline that combines YOLO detection with SAM segmentation.
 
     Defaults:
     - YOLO model: yolov10m.pt

--- a/mindtrace/models/mindtrace/models/pipeline.py
+++ b/mindtrace/models/mindtrace/models/pipeline.py
@@ -1,10 +1,10 @@
-"""Base Brain abstraction for model-composition services.
+"""Base Pipeline abstraction for model-composition services.
 
-A Brain is a Service with a minimal lifecycle contract:
+A Pipeline is a Service with a minimal lifecycle contract:
 - load: initialize models/resources
 - unload: release models/resources
 
-Concrete Brain implementations define their own inference endpoints using normal
+Concrete Pipeline implementations define their own inference endpoints using normal
 TaskSchema-based Service endpoint registration.
 """
 
@@ -19,33 +19,33 @@ from mindtrace.services import Service
 
 
 class PipelineLoadInput(BaseModel):
-    """Request payload for loading a Brain."""
+    """Request payload for loading a Pipeline."""
 
     force: bool = Field(default=False, description="Force reload even if already loaded.")
 
 
 class PipelineLoadOutput(BaseModel):
-    """Response payload for loading a Brain."""
+    """Response payload for loading a Pipeline."""
 
     loaded: bool
     message: str
 
 
 class PipelineUnloadInput(BaseModel):
-    """Request payload for unloading a Brain."""
+    """Request payload for unloading a Pipeline."""
 
     force: bool = Field(default=False, description="Force unload behavior when supported.")
 
 
 class PipelineUnloadOutput(BaseModel):
-    """Response payload for unloading a Brain."""
+    """Response payload for unloading a Pipeline."""
 
     loaded: bool
     message: str
 
 
 class PipelineLoadedOutput(BaseModel):
-    """Response payload for checking whether a Brain is loaded."""
+    """Response payload for checking whether a Pipeline is loaded."""
 
     loaded: bool
 
@@ -87,31 +87,31 @@ class Pipeline(Service):
 
     @property
     def is_loaded(self) -> bool:
-        """Whether this Brain currently has resources/models loaded."""
+        """Whether this Pipeline currently has resources/models loaded."""
         return self._loaded
 
     def load(self, payload: PipelineLoadInput) -> PipelineLoadOutput:
-        """Load models/resources used by this Brain."""
+        """Load models/resources used by this Pipeline."""
         with self._load_state_lock:
             if self._loaded and not payload.force:
-                return PipelineLoadOutput(loaded=True, message="Brain already loaded.")
+                return PipelineLoadOutput(loaded=True, message="Pipeline already loaded.")
 
             self.on_load(payload)
             self._loaded = True
-            return PipelineLoadOutput(loaded=True, message="Brain loaded successfully.")
+            return PipelineLoadOutput(loaded=True, message="Pipeline loaded successfully.")
 
     def unload(self, payload: PipelineUnloadInput) -> PipelineUnloadOutput:
-        """Unload models/resources used by this Brain."""
+        """Unload models/resources used by this Pipeline."""
         with self._load_state_lock:
             if not self._loaded and not payload.force:
-                return PipelineUnloadOutput(loaded=False, message="Brain already unloaded.")
+                return PipelineUnloadOutput(loaded=False, message="Pipeline already unloaded.")
 
             self.on_unload(payload)
             self._loaded = False
-            return PipelineUnloadOutput(loaded=False, message="Brain unloaded successfully.")
+            return PipelineUnloadOutput(loaded=False, message="Pipeline unloaded successfully.")
 
     def loaded(self) -> PipelineLoadedOutput:
-        """Return current loaded state for this Brain."""
+        """Return current loaded state for this Pipeline."""
         return PipelineLoadedOutput(loaded=self._loaded)
 
     def on_load(self, payload: PipelineLoadInput) -> None:

--- a/tests/unit/mindtrace/cluster/test_pipeline_worker.py
+++ b/tests/unit/mindtrace/cluster/test_pipeline_worker.py
@@ -48,7 +48,7 @@ def _worker_stub(default_endpoint: str | None = "/echo") -> PipelineWorker:
 
 def test_pipeline_worker_from_pipeline_class_without_service_init(monkeypatch):
     def fake_worker_init(self, *args, **kwargs):
-        # Brain-specific kwargs are consumed by PipelineWorker.__init__ before super().__init__
+        # Pipeline-specific kwargs are consumed by PipelineWorker.__init__ before super().__init__
         self.pipeline = None
 
     monkeypatch.setattr("mindtrace.cluster.core.pipeline_worker.Worker.__init__", fake_worker_init)


### PR DESCRIPTION
## Summary
- replace remaining textual "Brain" wording with "Pipeline" in pipeline-related code paths
- update docstrings/comments/error text for consistency after the class/module/worker rename

## Validation
- ruff format .
- ruff check . --fix
- all checks passed
