### PR TITLE
Agents/toolset

### DIFF
--- a/mindtrace/agents/README.md
+++ b/mindtrace/agents/README.md
@@ -20,6 +20,8 @@ pip install mindtrace-agents
 | **Model** | `OpenAIChatModel` | Calls the LLM API (supports streaming) |
 | **Provider** | `OpenAIProvider` / `OllamaProvider` / `GeminiProvider` | Holds the authenticated client |
 | **Tool** | `Tool` | Wraps a Python function for LLM tool-calling |
+| **Toolset** | `FunctionToolset` / `CompoundToolset` / `MCPToolset` | Groups tools and controls which are exposed to the agent |
+| **ToolFilter** | `ToolFilter` | Predicate for selectively showing/hiding tools by name or description |
 | **Callbacks** | `AgentCallbacks` | Lifecycle hooks: before/after LLM call and tool call |
 | **History** | `AbstractHistoryStrategy` / `InMemoryHistory` | Persists conversation across runs |
 | **RunContext** | `RunContext[T]` | Injected into tools — carries deps, retry count, step |
@@ -114,6 +116,134 @@ def lookup_user(ctx: RunContext[AppDeps], user_id: str) -> dict:
 
 deps = AppDeps(db_url="postgresql://...", api_key="secret")
 result = asyncio.run(agent.run("Find user 123", deps=deps))
+```
+
+---
+
+## Toolsets
+
+Toolsets are the primary way to supply tools to an agent. They group related tools together and give you control over which tools are visible to the model at runtime.
+
+### FunctionToolset
+
+`FunctionToolset` collects Python `Tool` objects and exposes them to the agent. Use it when you want to organise tools manually or share a toolset across multiple agents.
+
+```python
+from mindtrace.agents.toolsets import FunctionToolset
+from mindtrace.agents.tools import Tool
+
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+async def fetch(url: str) -> str:
+    """Fetch a URL."""
+    ...
+
+toolset = FunctionToolset(max_retries=2)
+toolset.add_tool(Tool(add))
+toolset.add_tool(Tool(fetch))
+
+agent = MindtraceAgent(model=model, toolset=toolset)
+```
+
+`max_retries` on the toolset is the default for every tool added to it. Override per-tool by setting `Tool(..., max_retries=N)` before calling `add_tool()`.
+
+### CompoundToolset
+
+`CompoundToolset` merges tools from multiple toolsets into one. Later toolsets win on name collisions — use `prefix` on `MCPToolset` to avoid conflicts.
+
+```python
+from mindtrace.agents.toolsets import CompoundToolset, FunctionToolset
+
+agent = MindtraceAgent(
+    model=model,
+    toolset=CompoundToolset(
+        MCPToolset.from_http("http://localhost:8001/mcp-server/mcp/"),
+        FunctionToolset(),   # local tools
+    ),
+)
+```
+
+### MCPToolset
+
+`MCPToolset` exposes tools from any remote MCP server. Requires `fastmcp`:
+
+```bash
+pip install 'mindtrace-agents[mcp]'
+```
+
+**Constructors**
+
+```python
+from mindtrace.agents.toolsets import MCPToolset
+
+# HTTP (streamable-http) — default for Mindtrace services
+ts = MCPToolset.from_http("http://localhost:8001/mcp-server/mcp/")
+
+# SSE (legacy HTTP)
+ts = MCPToolset.from_sse("http://localhost:9000/sse")
+
+# stdio — local subprocess servers (e.g. npx)
+ts = MCPToolset.from_stdio(["npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp"])
+```
+
+**Prefix** — avoid name collisions when combining multiple MCP services:
+
+```python
+ts = MCPToolset.from_http("http://localhost:8002/mcp/", prefix="db")
+# tools are exposed as "db__query", "db__list_tables", etc.
+```
+
+---
+
+## Filtering tools
+
+Every toolset exposes shorthand methods that return a `FilteredToolset`. Chain them to control exactly which tools the agent sees.
+
+```python
+# Allow only named tools
+toolset.include("search", "summarise")
+
+# Block a specific tool
+toolset.exclude("drop_table")
+
+# Glob patterns
+toolset.include_pattern("read_*", "list_*")
+toolset.exclude_pattern("admin_*")
+
+# Compose via FilteredToolset.with_filter() for boolean logic
+from mindtrace.agents.toolsets import ToolFilter
+
+f = ToolFilter.include_pattern("read_*") & ~ToolFilter.include("read_credentials")
+toolset.with_filter(f)
+```
+
+Filtering applies at `get_tools()` time — the underlying toolset is unchanged.
+
+### ToolFilter API
+
+| Factory | Behaviour |
+|---------|-----------|
+| `ToolFilter.include(*names)` | Allow only tools whose name is in `names` |
+| `ToolFilter.exclude(*names)` | Block tools whose name is in `names` |
+| `ToolFilter.include_pattern(*globs)` | Allow tools matching any glob (e.g. `"read_*"`) |
+| `ToolFilter.exclude_pattern(*globs)` | Block tools matching any glob |
+| `ToolFilter.by_description(fn)` | Custom predicate on the tool description string |
+
+Filters compose with `&` (AND), `|` (OR), and `~` (NOT).
+
+### Combining filtering with CompoundToolset
+
+```python
+agent = MindtraceAgent(
+    model=model,
+    toolset=CompoundToolset(
+        MCPToolset.from_http("http://localhost:8001/mcp/").include("generate_image"),
+        MCPToolset.from_http("http://localhost:8002/mcp/").exclude_pattern("admin_*"),
+        FunctionToolset(),
+    ),
+)
 ```
 
 ---
@@ -301,7 +431,7 @@ mindtrace/agents/
 ├── events/              # streaming event types
 ├── messages/            # ModelMessage, parts, builder
 ├── tools/               # Tool, ToolDefinition
-├── toolsets/            # AbstractToolset, FunctionToolset
+├── toolsets/            # AbstractToolset, FunctionToolset, CompoundToolset, MCPToolset, ToolFilter, FilteredToolset
 ├── providers/           # Provider ABC + OpenAI, Ollama, Gemini
 ├── models/              # Model ABC + OpenAIChatModel
 ├── callbacks/           # AgentCallbacks + _invoke helper

--- a/mindtrace/agents/mindtrace/agents/__init__.py
+++ b/mindtrace/agents/mindtrace/agents/__init__.py
@@ -16,7 +16,7 @@ from .profiles import ModelProfile
 from .prompts import UserPromptPart
 from .providers import GeminiProvider, OllamaProvider, OpenAIProvider, Provider
 from .tools import RunContext, Tool, ToolDefinition
-from .toolsets import AbstractToolset, FunctionToolset
+from .toolsets import AbstractToolset, CompoundToolset, FunctionToolset, MCPToolset, ToolFilter
 
 __all__ = [
     "AbstractHistoryStrategy",
@@ -26,9 +26,11 @@ __all__ = [
     "AgentDepsT",
     "AgentRunResult",
     "AgentRunResultEvent",
+    "CompoundToolset",
     "FunctionToolset",
     "GeminiProvider",
     "InMemoryHistory",
+    "MCPToolset",
     "Model",
     "ModelMessage",
     "ModelProfile",
@@ -50,6 +52,7 @@ __all__ = [
     "Tool",
     "ToolCallPart",
     "ToolDefinition",
+    "ToolFilter",
     "ToolResultEvent",
     "ToolReturnPart",
     "UserPromptPart",

--- a/mindtrace/agents/mindtrace/agents/core/base.py
+++ b/mindtrace/agents/mindtrace/agents/core/base.py
@@ -21,6 +21,8 @@ from ..messages._parts import SystemPromptPart
 from ..models import Model, ModelRequestParameters, ModelResponse
 from ..prompts import UserContent, UserPromptPart
 from ..tools import RunContext, Tool
+from ..toolsets._toolset import AbstractToolset
+from ..toolsets.compound import CompoundToolset
 from ..toolsets.function import FunctionToolset
 from .abstract import AbstractMindtraceAgent, OutputDataT
 
@@ -33,6 +35,7 @@ class MindtraceAgent(AbstractMindtraceAgent[AgentDepsT, OutputDataT]):
         model: Model,
         *,
         tools: Sequence[Tool] | None = None,
+        toolset: AbstractToolset | None = None,
         system_prompt: str | None = None,
         name: str | None = None,
         deps_type: type = type(None),
@@ -52,10 +55,19 @@ class MindtraceAgent(AbstractMindtraceAgent[AgentDepsT, OutputDataT]):
         self.history = history
         self._entered_count = 0
         self._lock = asyncio.Lock()
-        toolset: FunctionToolset = FunctionToolset()
+
+        func_toolset: FunctionToolset = FunctionToolset()
         for tool in self.tools:
-            toolset.add_tool(tool)
-        self._tool_manager: ToolManager = ToolManager(toolset=toolset)
+            func_toolset.add_tool(tool)
+
+        if toolset is None:
+            effective_toolset: AbstractToolset = func_toolset
+        elif self.tools:
+            effective_toolset = CompoundToolset(func_toolset, toolset)
+        else:
+            effective_toolset = toolset
+
+        self._tool_manager: ToolManager = ToolManager(toolset=effective_toolset)
 
     @property
     def name(self) -> str | None:

--- a/mindtrace/agents/mindtrace/agents/toolsets/__init__.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/__init__.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+from ._filter import ToolFilter
 from ._toolset import AbstractToolset, ToolsetTool
+from .compound import CompoundToolset
+from .filtered import FilteredToolset
 from .function import FunctionToolset, FunctionToolsetTool
+from .mcp import MCPToolset
 
 __all__ = [
     "AbstractToolset",
+    "CompoundToolset",
+    "FilteredToolset",
     "FunctionToolset",
     "FunctionToolsetTool",
+    "MCPToolset",
+    "ToolFilter",
     "ToolsetTool",
 ]

--- a/mindtrace/agents/mindtrace/agents/toolsets/_filter.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/_filter.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import fnmatch
+from typing import Callable
+
+
+class ToolFilter:
+    """
+    Predicate over tool name and description.
+
+    Compose filters with ``&`` (AND), ``|`` (OR), ``~`` (NOT).
+    Prefer the shorthand methods on any toolset (``.include()``, ``.exclude()``,
+    ``.include_pattern()``, ``.exclude_pattern()``) over constructing this directly.
+    Use ``ToolFilter`` directly only when you need boolean composition.
+
+    Example::
+
+        from mindtrace.agents.toolsets import ToolFilter
+
+        # Only read ops, but never the credentials one
+        f = ToolFilter.include_pattern("read_*") & ~ToolFilter.include("read_credentials")
+        toolset = MCPToolset.from_http(url).with_filter(f)
+    """
+
+    def __init__(self, predicate: Callable[[str, str | None], bool]) -> None:
+        self._predicate = predicate
+
+    def allows(self, name: str, description: str | None = None) -> bool:
+        return self._predicate(name, description)
+
+    # ------------------------------------------------------------------
+    # Composition
+    # ------------------------------------------------------------------
+
+    def __and__(self, other: ToolFilter) -> ToolFilter:
+        return ToolFilter(lambda n, d: self.allows(n, d) and other.allows(n, d))
+
+    def __or__(self, other: ToolFilter) -> ToolFilter:
+        return ToolFilter(lambda n, d: self.allows(n, d) or other.allows(n, d))
+
+    def __invert__(self) -> ToolFilter:
+        return ToolFilter(lambda n, d: not self.allows(n, d))
+
+    # ------------------------------------------------------------------
+    # Factories
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def include(cls, *names: str) -> ToolFilter:
+        """Allow only tools whose name is in ``names``."""
+        allowed = frozenset(names)
+        return cls(lambda n, d: n in allowed)
+
+    @classmethod
+    def exclude(cls, *names: str) -> ToolFilter:
+        """Allow all tools except those in ``names``."""
+        blocked = frozenset(names)
+        return cls(lambda n, d: n not in blocked)
+
+    @classmethod
+    def include_pattern(cls, *patterns: str) -> ToolFilter:
+        """Allow tools whose name matches any glob pattern (e.g. ``"read_*"``)."""
+        return cls(lambda n, d: any(fnmatch.fnmatch(n, p) for p in patterns))
+
+    @classmethod
+    def exclude_pattern(cls, *patterns: str) -> ToolFilter:
+        """Block tools whose name matches any glob pattern."""
+        return cls(lambda n, d: not any(fnmatch.fnmatch(n, p) for p in patterns))
+
+    @classmethod
+    def by_description(cls, predicate: Callable[[str | None], bool]) -> ToolFilter:
+        """Filter on description text — useful when names are not descriptive."""
+        return cls(lambda n, d: predicate(d))
+
+
+__all__ = ["ToolFilter"]

--- a/mindtrace/agents/mindtrace/agents/toolsets/_toolset.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/_toolset.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any, Generic
+from typing import TYPE_CHECKING, Any, Generic
 
 from .._run_context import RunContext
 from ..tools import ToolAgentDepsT, ToolDefinition
+
+if TYPE_CHECKING:
+    from ._filter import ToolFilter
+    from .filtered import FilteredToolset
 
 
 @dataclass
@@ -28,6 +32,39 @@ class AbstractToolset(Generic[ToolAgentDepsT]):
         tool: ToolsetTool,
     ) -> Any:
         raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Tool visibility — shorthand filter methods
+    # ------------------------------------------------------------------
+
+    def include(self, *names: str) -> FilteredToolset:
+        """Expose only the named tools from this toolset."""
+        from ._filter import ToolFilter
+        from .filtered import FilteredToolset
+        return FilteredToolset(self, ToolFilter.include(*names))
+
+    def exclude(self, *names: str) -> FilteredToolset:
+        """Expose all tools except the named ones."""
+        from ._filter import ToolFilter
+        from .filtered import FilteredToolset
+        return FilteredToolset(self, ToolFilter.exclude(*names))
+
+    def include_pattern(self, *patterns: str) -> FilteredToolset:
+        """Expose tools whose name matches any glob pattern (e.g. ``"read_*"``)."""
+        from ._filter import ToolFilter
+        from .filtered import FilteredToolset
+        return FilteredToolset(self, ToolFilter.include_pattern(*patterns))
+
+    def exclude_pattern(self, *patterns: str) -> FilteredToolset:
+        """Block tools whose name matches any glob pattern."""
+        from ._filter import ToolFilter
+        from .filtered import FilteredToolset
+        return FilteredToolset(self, ToolFilter.exclude_pattern(*patterns))
+
+    def with_filter(self, filter: ToolFilter) -> FilteredToolset:
+        """Apply a custom composed ``ToolFilter`` to this toolset."""
+        from .filtered import FilteredToolset
+        return FilteredToolset(self, filter)
 
 
 __all__ = [

--- a/mindtrace/agents/mindtrace/agents/toolsets/_toolset.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/_toolset.py
@@ -41,29 +41,34 @@ class AbstractToolset(Generic[ToolAgentDepsT]):
         """Expose only the named tools from this toolset."""
         from ._filter import ToolFilter
         from .filtered import FilteredToolset
+
         return FilteredToolset(self, ToolFilter.include(*names))
 
     def exclude(self, *names: str) -> FilteredToolset:
         """Expose all tools except the named ones."""
         from ._filter import ToolFilter
         from .filtered import FilteredToolset
+
         return FilteredToolset(self, ToolFilter.exclude(*names))
 
     def include_pattern(self, *patterns: str) -> FilteredToolset:
         """Expose tools whose name matches any glob pattern (e.g. ``"read_*"``)."""
         from ._filter import ToolFilter
         from .filtered import FilteredToolset
+
         return FilteredToolset(self, ToolFilter.include_pattern(*patterns))
 
     def exclude_pattern(self, *patterns: str) -> FilteredToolset:
         """Block tools whose name matches any glob pattern."""
         from ._filter import ToolFilter
         from .filtered import FilteredToolset
+
         return FilteredToolset(self, ToolFilter.exclude_pattern(*patterns))
 
     def with_filter(self, filter: ToolFilter) -> FilteredToolset:
         """Apply a custom composed ``ToolFilter`` to this toolset."""
         from .filtered import FilteredToolset
+
         return FilteredToolset(self, filter)
 
 

--- a/mindtrace/agents/mindtrace/agents/toolsets/compound.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/compound.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .._run_context import RunContext
+from ..tools import ToolAgentDepsT
+from ._toolset import AbstractToolset, ToolsetTool
+
+
+class CompoundToolset(AbstractToolset[ToolAgentDepsT]):
+    """
+    Merges tools from multiple toolsets into one.
+
+    Later toolsets win on name collisions — use ``tool_prefix`` on ``MCPToolset``
+    to avoid conflicts when combining toolsets from different services.
+
+    Example::
+
+        agent = MindtraceAgent(
+            model=model,
+            toolset=CompoundToolset(
+                MCPToolset.from_http("http://localhost:8001/mcp-server/mcp/").include("generate_image"),
+                MCPToolset.from_http("http://localhost:8002/mcp-server/mcp/").include("query_db"),
+                FunctionToolset(),  # local tools
+            ),
+        )
+    """
+
+    def __init__(self, *toolsets: AbstractToolset) -> None:
+        self._toolsets = list(toolsets)
+        # Populated by get_tools(); maps tool name → owning toolset for fast routing.
+        self._routing: dict[str, AbstractToolset] = {}
+
+    async def get_tools(self, ctx: RunContext[ToolAgentDepsT]) -> dict[str, ToolsetTool]:
+        merged: dict[str, ToolsetTool] = {}
+        self._routing = {}
+        for ts in self._toolsets:
+            tools = await ts.get_tools(ctx)
+            for name, tool in tools.items():
+                merged[name] = tool
+                self._routing[name] = ts
+        return merged
+
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[ToolAgentDepsT],
+        tool: ToolsetTool,
+    ) -> Any:
+        source = self._routing.get(name)
+        if source is None:
+            raise ValueError(f"Unknown tool {name!r}. Was get_tools() called first?")
+        return await source.call_tool(name, tool_args, ctx, tool)
+
+
+__all__ = ["CompoundToolset"]

--- a/mindtrace/agents/mindtrace/agents/toolsets/filtered.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/filtered.py
@@ -26,11 +26,7 @@ class FilteredToolset(AbstractToolset[ToolAgentDepsT]):
 
     async def get_tools(self, ctx: RunContext[ToolAgentDepsT]) -> dict[str, ToolsetTool]:
         all_tools = await self._inner.get_tools(ctx)
-        return {
-            name: tool
-            for name, tool in all_tools.items()
-            if self._filter.allows(name, tool.tool_def.description)
-        }
+        return {name: tool for name, tool in all_tools.items() if self._filter.allows(name, tool.tool_def.description)}
 
     async def call_tool(
         self,

--- a/mindtrace/agents/mindtrace/agents/toolsets/filtered.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/filtered.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .._run_context import RunContext
+from ..tools import ToolAgentDepsT
+from ._filter import ToolFilter
+from ._toolset import AbstractToolset, ToolsetTool
+
+
+class FilteredToolset(AbstractToolset[ToolAgentDepsT]):
+    """
+    Wraps any ``AbstractToolset`` and hides tools that do not pass a ``ToolFilter``.
+
+    Not constructed directly — obtain via the shorthand methods on any toolset::
+
+        toolset.include("tool_a", "tool_b")
+        toolset.exclude("dangerous_tool")
+        toolset.include_pattern("read_*")
+        toolset.with_filter(ToolFilter.include_pattern("read_*") & ~ToolFilter.include("read_env"))
+    """
+
+    def __init__(self, inner: AbstractToolset[ToolAgentDepsT], filter: ToolFilter) -> None:
+        self._inner = inner
+        self._filter = filter
+
+    async def get_tools(self, ctx: RunContext[ToolAgentDepsT]) -> dict[str, ToolsetTool]:
+        all_tools = await self._inner.get_tools(ctx)
+        return {
+            name: tool
+            for name, tool in all_tools.items()
+            if self._filter.allows(name, tool.tool_def.description)
+        }
+
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[ToolAgentDepsT],
+        tool: ToolsetTool,
+    ) -> Any:
+        return await self._inner.call_tool(name, tool_args, ctx, tool)
+
+
+__all__ = ["FilteredToolset"]

--- a/mindtrace/agents/mindtrace/agents/toolsets/mcp.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/mcp.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .._run_context import RunContext
+from ..tools import ToolAgentDepsT, ToolDefinition
+from ._toolset import AbstractToolset, ToolsetTool
+
+
+class MCPToolset(AbstractToolset[ToolAgentDepsT]):
+    """
+    Exposes tools from any remote MCP server to a ``MindtraceAgent``.
+
+    Supports HTTP (streamable-http), SSE, and stdio transports.
+    Requires ``fastmcp`` — install with ``pip install mindtrace-agents[mcp]``.
+
+    Do not construct directly; use the class methods::
+
+        # Mindtrace service (HTTP)
+        MCPToolset.from_http("http://localhost:8001/mcp-server/mcp/")
+
+        # Any SSE-based MCP server
+        MCPToolset.from_sse("http://localhost:9000/sse")
+
+        # Local stdio server (e.g. npx MCP servers)
+        MCPToolset.from_stdio(["npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp"])
+
+    Control which tools are visible to the agent::
+
+        MCPToolset.from_http(url).include("search", "summarise")
+        MCPToolset.from_http(url).exclude("drop_table")
+        MCPToolset.from_http(url).include_pattern("read_*", "list_*")
+
+    Avoid name collisions when combining multiple services::
+
+        MCPToolset.from_http(url, prefix="fs")   # exposes "fs__read_file", "fs__list_dir"
+    """
+
+    def __init__(
+        self,
+        transport_factory: Callable[[], Any],
+        *,
+        prefix: str | None = None,
+    ) -> None:
+        self._transport_factory = transport_factory
+        self._prefix = prefix
+        # Populated by get_tools(); maps exposed name → original MCP tool name.
+        self._name_map: dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_http(cls, url: str, *, prefix: str | None = None) -> MCPToolset:
+        """Connect via HTTP (streamable-http) transport — the default for Mindtrace services."""
+        return cls(lambda: url, prefix=prefix)
+
+    @classmethod
+    def from_sse(cls, url: str, *, prefix: str | None = None) -> MCPToolset:
+        """Connect via SSE transport (legacy MCP HTTP)."""
+        def _make():
+            try:
+                from fastmcp.client.transports import SSETransport
+            except ImportError:
+                raise ImportError(
+                    "fastmcp is required for MCPToolset. "
+                    "Install with: pip install 'mindtrace-agents[mcp]'"
+                )
+            return SSETransport(url)
+        return cls(_make, prefix=prefix)
+
+    @classmethod
+    def from_stdio(
+        cls,
+        command: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        prefix: str | None = None,
+    ) -> MCPToolset:
+        """Connect via stdio transport — for local subprocess MCP servers (e.g. npx)."""
+        def _make():
+            try:
+                from fastmcp.client.transports import StdioTransport
+            except ImportError:
+                raise ImportError(
+                    "fastmcp is required for MCPToolset. "
+                    "Install with: pip install 'mindtrace-agents[mcp]'"
+                )
+            return StdioTransport(command, env=env)
+        return cls(_make, prefix=prefix)
+
+    # ------------------------------------------------------------------
+    # AbstractToolset interface
+    # ------------------------------------------------------------------
+
+    async def get_tools(self, ctx: RunContext[ToolAgentDepsT]) -> dict[str, ToolsetTool]:
+        try:
+            from fastmcp import Client
+        except ImportError:
+            raise ImportError(
+                "fastmcp is required for MCPToolset. "
+                "Install with: pip install 'mindtrace-agents[mcp]'"
+            )
+
+        async with Client(self._transport_factory()) as client:
+            response = await client.list_tools()
+
+        # list_tools() returns list[mcp.types.Tool] directly
+        self._name_map = {}
+        tools: dict[str, ToolsetTool] = {}
+        for mcp_tool in response:
+            exposed = f"{self._prefix}__{mcp_tool.name}" if self._prefix else mcp_tool.name
+            self._name_map[exposed] = mcp_tool.name
+            tools[exposed] = ToolsetTool(
+                tool_def=ToolDefinition(
+                    name=exposed,
+                    description=mcp_tool.description,
+                    parameters_json_schema=mcp_tool.inputSchema or {},
+                ),
+                max_retries=None,
+            )
+        return tools
+
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[ToolAgentDepsT],
+        tool: ToolsetTool,
+    ) -> Any:
+        try:
+            from fastmcp import Client
+        except ImportError:
+            raise ImportError(
+                "fastmcp is required for MCPToolset. "
+                "Install with: pip install 'mindtrace-agents[mcp]'"
+            )
+
+        mcp_name = self._name_map.get(name, name)
+        async with Client(self._transport_factory()) as client:
+            result = await client.call_tool(mcp_name, arguments=tool_args)
+
+        # call_tool() returns CallToolResult; .content is list[ContentBlock]
+        # structured responses (dataclass/dict) are in .data — prefer that when present
+        if result.data is not None:
+            return str(result.data)
+        return "\n".join(
+            part.text if hasattr(part, "text") else str(part)
+            for part in result.content
+        )
+
+
+__all__ = ["MCPToolset"]

--- a/mindtrace/agents/mindtrace/agents/toolsets/mcp.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/mcp.py
@@ -59,15 +59,16 @@ class MCPToolset(AbstractToolset[ToolAgentDepsT]):
     @classmethod
     def from_sse(cls, url: str, *, prefix: str | None = None) -> MCPToolset:
         """Connect via SSE transport (legacy MCP HTTP)."""
+
         def _make():
             try:
                 from fastmcp.client.transports import SSETransport
             except ImportError:
                 raise ImportError(
-                    "fastmcp is required for MCPToolset. "
-                    "Install with: pip install 'mindtrace-agents[mcp]'"
+                    "fastmcp is required for MCPToolset. Install with: pip install 'mindtrace-agents[mcp]'"
                 )
             return SSETransport(url)
+
         return cls(_make, prefix=prefix)
 
     @classmethod
@@ -79,15 +80,16 @@ class MCPToolset(AbstractToolset[ToolAgentDepsT]):
         prefix: str | None = None,
     ) -> MCPToolset:
         """Connect via stdio transport — for local subprocess MCP servers (e.g. npx)."""
+
         def _make():
             try:
                 from fastmcp.client.transports import StdioTransport
             except ImportError:
                 raise ImportError(
-                    "fastmcp is required for MCPToolset. "
-                    "Install with: pip install 'mindtrace-agents[mcp]'"
+                    "fastmcp is required for MCPToolset. Install with: pip install 'mindtrace-agents[mcp]'"
                 )
             return StdioTransport(command, env=env)
+
         return cls(_make, prefix=prefix)
 
     # ------------------------------------------------------------------
@@ -98,10 +100,7 @@ class MCPToolset(AbstractToolset[ToolAgentDepsT]):
         try:
             from fastmcp import Client
         except ImportError:
-            raise ImportError(
-                "fastmcp is required for MCPToolset. "
-                "Install with: pip install 'mindtrace-agents[mcp]'"
-            )
+            raise ImportError("fastmcp is required for MCPToolset. Install with: pip install 'mindtrace-agents[mcp]'")
 
         async with Client(self._transport_factory()) as client:
             response = await client.list_tools()
@@ -132,10 +131,7 @@ class MCPToolset(AbstractToolset[ToolAgentDepsT]):
         try:
             from fastmcp import Client
         except ImportError:
-            raise ImportError(
-                "fastmcp is required for MCPToolset. "
-                "Install with: pip install 'mindtrace-agents[mcp]'"
-            )
+            raise ImportError("fastmcp is required for MCPToolset. Install with: pip install 'mindtrace-agents[mcp]'")
 
         mcp_name = self._name_map.get(name, name)
         async with Client(self._transport_factory()) as client:
@@ -145,10 +141,7 @@ class MCPToolset(AbstractToolset[ToolAgentDepsT]):
         # structured responses (dataclass/dict) are in .data — prefer that when present
         if result.data is not None:
             return str(result.data)
-        return "\n".join(
-            part.text if hasattr(part, "text") else str(part)
-            for part in result.content
-        )
+        return "\n".join(part.text if hasattr(part, "text") else str(part) for part in result.content)
 
 
 __all__ = ["MCPToolset"]

--- a/mindtrace/agents/pyproject.toml
+++ b/mindtrace/agents/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "mindtrace-core>=0.9.4",
 ]
 
+[project.optional-dependencies]
+mcp = ["fastmcp>=2.13.0"]
+
 [project.urls]
 Homepage = "https://mindtrace.ai"
 Repository = "https://github.com/mindtrace/mindtrace"

--- a/samples/agents/mcp_service_agent.py
+++ b/samples/agents/mcp_service_agent.py
@@ -1,0 +1,72 @@
+"""
+Agent using remote MCP tools from a Mindtrace service.
+
+Launches EchoService in a subprocess, connects an MCPToolset to its MCP
+endpoint, then runs a MindtraceAgent with gpt-4o-mini that calls those tools.
+
+EchoService exposes two tools:
+  - echo            — returns the message unchanged
+  - reverse_message — returns the message reversed
+
+Run:
+    OPENAI_API_KEY=... python samples/agents/mcp_service_agent.py
+"""
+
+import asyncio
+import os
+from mindtrace.agents import MCPToolset, MindtraceAgent, OpenAIChatModel, OpenAIProvider
+from mindtrace.services.samples.echo_mcp import EchoService
+
+
+async def main() -> None:
+    # --- Launch EchoService in a subprocess ---
+    # connection manager holds the URL and shuts the process down on __exit__
+    # OPENAI_API_KEY should be set via environment variable (see docstring)
+    with EchoService.launch(port=8004) as cm:
+        print(f"EchoService running at {cm.url}")
+        print(f"MCP endpoint: {cm.mcp_url}\n")
+
+        # --- Wire up the MCPToolset ---
+        # .include() limits what the agent sees — avoids giving it tools it
+        # doesn't need and keeps the LLM prompt clean.
+        toolset = MCPToolset.from_http(cm.mcp_url).include("echo", "reverse_message")
+
+        # Omit .include() to expose every tool the service publishes:
+        # toolset = MCPToolset.from_http(cm.mcp_url)
+
+        # --- Build the agent ---
+        provider = OpenAIProvider()  # reads OPENAI_API_KEY from environment
+        model = OpenAIChatModel("gpt-4o-mini", provider=provider)
+
+        agent = MindtraceAgent(
+            model=model,
+            toolset=toolset,
+            system_prompt=(
+                "You have access to two tools: echo and reverse_message. "
+                "Use them when asked. Be concise."
+            ),
+            name="echo_agent",
+        )
+
+        # --- Run 1: echo ---
+        print("=== echo ===")
+        result = await agent.run('Echo the message "Hello from MindTrace!"')
+        print(result)
+
+        # --- Run 2: reverse ---
+        print("\n=== reverse_message ===")
+        result = await agent.run('Reverse the message "abcdefg"')
+        print(result)
+
+        # --- Run 3: both in one turn ---
+        print("\n=== chained ===")
+        result = await agent.run(
+            'Echo "ping", then reverse "pong" and tell me both results.'
+        )
+        print(result)
+
+    print("\nEchoService shut down.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/agents/remote_mcp_agent.py
+++ b/samples/agents/remote_mcp_agent.py
@@ -13,7 +13,7 @@ Run:
 """
 
 import asyncio
-import os
+
 from mindtrace.agents import MCPToolset, MindtraceAgent, OpenAIChatModel, OpenAIProvider
 from mindtrace.services.samples.echo_mcp import EchoService
 
@@ -41,10 +41,7 @@ async def main() -> None:
         agent = MindtraceAgent(
             model=model,
             toolset=toolset,
-            system_prompt=(
-                "You have access to two tools: echo and reverse_message. "
-                "Use them when asked. Be concise."
-            ),
+            system_prompt=("You have access to two tools: echo and reverse_message. Use them when asked. Be concise."),
             name="echo_agent",
         )
 
@@ -60,9 +57,7 @@ async def main() -> None:
 
         # --- Run 3: both in one turn ---
         print("\n=== chained ===")
-        result = await agent.run(
-            'Echo "ping", then reverse "pong" and tell me both results.'
-        )
+        result = await agent.run('Echo "ping", then reverse "pong" and tell me both results.')
         print(result)
 
     print("\nEchoService shut down.")

--- a/tests/unit/mindtrace/agents/test_toolsets.py
+++ b/tests/unit/mindtrace/agents/test_toolsets.py
@@ -1,0 +1,579 @@
+"""Unit tests for mindtrace.agents.toolsets."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mindtrace.agents._run_context import RunContext
+from mindtrace.agents.tools import Tool, ToolDefinition
+from mindtrace.agents.toolsets import (
+    AbstractToolset,
+    CompoundToolset,
+    FilteredToolset,
+    FunctionToolset,
+    FunctionToolsetTool,
+    MCPToolset,
+    ToolFilter,
+    ToolsetTool,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx() -> RunContext:
+    return RunContext(deps=None)
+
+
+def _make_toolset_tool(name: str, description: str | None = None) -> ToolsetTool:
+    return ToolsetTool(
+        tool_def=ToolDefinition(name=name, description=description),
+        max_retries=None,
+    )
+
+
+class _StubToolset(AbstractToolset):
+    """Simple concrete toolset for testing abstract interface."""
+
+    def __init__(self, tools: dict[str, ToolsetTool], call_result: Any = "stub_result") -> None:
+        self._tools = tools
+        self._call_result = call_result
+        self.called_with: list[tuple[str, dict[str, Any]]] = []
+
+    async def get_tools(self, ctx: RunContext) -> dict[str, ToolsetTool]:
+        return dict(self._tools)
+
+    async def call_tool(self, name: str, tool_args: dict[str, Any], ctx: RunContext, tool: ToolsetTool) -> Any:
+        self.called_with.append((name, tool_args))
+        return self._call_result
+
+
+# ---------------------------------------------------------------------------
+# ToolFilter
+# ---------------------------------------------------------------------------
+
+
+class TestToolFilter:
+    """Tests for ToolFilter predicate and composition."""
+
+    def test_include_allows_named_tools(self):
+        f = ToolFilter.include("foo", "bar")
+        assert f.allows("foo") is True
+        assert f.allows("bar") is True
+        assert f.allows("baz") is False
+
+    def test_exclude_blocks_named_tools(self):
+        f = ToolFilter.exclude("danger")
+        assert f.allows("safe") is True
+        assert f.allows("danger") is False
+
+    def test_include_pattern_glob(self):
+        f = ToolFilter.include_pattern("read_*")
+        assert f.allows("read_file") is True
+        assert f.allows("read_db") is True
+        assert f.allows("write_file") is False
+
+    def test_exclude_pattern_glob(self):
+        f = ToolFilter.exclude_pattern("drop_*")
+        assert f.allows("drop_table") is False
+        assert f.allows("select_table") is True
+
+    def test_include_pattern_multiple_patterns(self):
+        f = ToolFilter.include_pattern("read_*", "list_*")
+        assert f.allows("read_file") is True
+        assert f.allows("list_dir") is True
+        assert f.allows("write_file") is False
+
+    def test_and_composition(self):
+        f = ToolFilter.include_pattern("read_*") & ~ToolFilter.include("read_credentials")
+        assert f.allows("read_file") is True
+        assert f.allows("read_credentials") is False
+
+    def test_or_composition(self):
+        f = ToolFilter.include("foo") | ToolFilter.include("bar")
+        assert f.allows("foo") is True
+        assert f.allows("bar") is True
+        assert f.allows("baz") is False
+
+    def test_invert(self):
+        f = ~ToolFilter.include("secret")
+        assert f.allows("secret") is False
+        assert f.allows("public") is True
+
+    def test_by_description_predicate(self):
+        f = ToolFilter.by_description(lambda d: d is not None and "safe" in d)
+        assert f.allows("anything", "this is safe") is True
+        assert f.allows("anything", "dangerous op") is False
+        assert f.allows("anything", None) is False
+
+    def test_allows_passes_description(self):
+        seen: list[str | None] = []
+        f = ToolFilter(lambda n, d: (seen.append(d), True)[1])
+        f.allows("tool", "my description")
+        assert seen == ["my description"]
+
+    def test_chained_and_or(self):
+        f = (ToolFilter.include("a") | ToolFilter.include("b")) & ~ToolFilter.include("b")
+        assert f.allows("a") is True
+        assert f.allows("b") is False
+        assert f.allows("c") is False
+
+
+# ---------------------------------------------------------------------------
+# AbstractToolset – shorthand filter methods
+# ---------------------------------------------------------------------------
+
+
+class TestAbstractToolsetShorthands:
+    """Tests for .include(), .exclude(), .include_pattern(), .exclude_pattern(), .with_filter()."""
+
+    def _stub(self) -> _StubToolset:
+        return _StubToolset(
+            {
+                "read_file": _make_toolset_tool("read_file"),
+                "write_file": _make_toolset_tool("write_file"),
+                "drop_table": _make_toolset_tool("drop_table"),
+            }
+        )
+
+    def test_include_returns_filtered_toolset(self):
+        ts = self._stub().include("read_file")
+        assert isinstance(ts, FilteredToolset)
+
+    def test_exclude_returns_filtered_toolset(self):
+        ts = self._stub().exclude("drop_table")
+        assert isinstance(ts, FilteredToolset)
+
+    def test_include_pattern_returns_filtered_toolset(self):
+        ts = self._stub().include_pattern("read_*")
+        assert isinstance(ts, FilteredToolset)
+
+    def test_exclude_pattern_returns_filtered_toolset(self):
+        ts = self._stub().exclude_pattern("drop_*")
+        assert isinstance(ts, FilteredToolset)
+
+    def test_with_filter_returns_filtered_toolset(self):
+        ts = self._stub().with_filter(ToolFilter.include("read_file"))
+        assert isinstance(ts, FilteredToolset)
+
+    async def test_include_limits_visible_tools(self):
+        ts = self._stub().include("read_file")
+        tools = await ts.get_tools(_ctx())
+        assert set(tools.keys()) == {"read_file"}
+
+    async def test_exclude_removes_tool(self):
+        ts = self._stub().exclude("drop_table")
+        tools = await ts.get_tools(_ctx())
+        assert "drop_table" not in tools
+        assert "read_file" in tools
+        assert "write_file" in tools
+
+    async def test_include_pattern_filters_correctly(self):
+        ts = self._stub().include_pattern("read_*")
+        tools = await ts.get_tools(_ctx())
+        assert set(tools.keys()) == {"read_file"}
+
+    async def test_exclude_pattern_filters_correctly(self):
+        ts = self._stub().exclude_pattern("drop_*")
+        tools = await ts.get_tools(_ctx())
+        assert "drop_table" not in tools
+        assert "read_file" in tools
+
+
+# ---------------------------------------------------------------------------
+# FilteredToolset
+# ---------------------------------------------------------------------------
+
+
+class TestFilteredToolset:
+    """Tests for FilteredToolset.get_tools() and call_tool()."""
+
+    async def test_get_tools_applies_filter(self):
+        inner = _StubToolset(
+            {
+                "a": _make_toolset_tool("a"),
+                "b": _make_toolset_tool("b"),
+                "c": _make_toolset_tool("c"),
+            }
+        )
+        ts = FilteredToolset(inner, ToolFilter.include("a", "c"))
+        tools = await ts.get_tools(_ctx())
+        assert set(tools.keys()) == {"a", "c"}
+
+    async def test_call_tool_delegates_to_inner(self):
+        inner = _StubToolset({"my_tool": _make_toolset_tool("my_tool")}, call_result="inner_result")
+        ts = FilteredToolset(inner, ToolFilter.include("my_tool"))
+        ctx = _ctx()
+        tool = _make_toolset_tool("my_tool")
+        result = await ts.call_tool("my_tool", {"x": 1}, ctx, tool)
+        assert result == "inner_result"
+        assert inner.called_with == [("my_tool", {"x": 1})]
+
+    async def test_filters_by_description(self):
+        inner = _StubToolset(
+            {
+                "safe_op": _make_toolset_tool("safe_op", "This is a safe operation"),
+                "danger_op": _make_toolset_tool("danger_op", "This is dangerous"),
+            }
+        )
+        ts = FilteredToolset(inner, ToolFilter.by_description(lambda d: d is not None and "safe" in d))
+        tools = await ts.get_tools(_ctx())
+        assert "safe_op" in tools
+        assert "danger_op" not in tools
+
+    async def test_empty_result_when_all_filtered(self):
+        inner = _StubToolset({"a": _make_toolset_tool("a")})
+        ts = FilteredToolset(inner, ToolFilter.exclude("a"))
+        tools = await ts.get_tools(_ctx())
+        assert tools == {}
+
+
+# ---------------------------------------------------------------------------
+# CompoundToolset
+# ---------------------------------------------------------------------------
+
+
+class TestCompoundToolset:
+    """Tests for CompoundToolset.get_tools() and call_tool()."""
+
+    async def test_merges_tools_from_multiple_toolsets(self):
+        ts1 = _StubToolset({"tool_a": _make_toolset_tool("tool_a")})
+        ts2 = _StubToolset({"tool_b": _make_toolset_tool("tool_b")})
+        compound = CompoundToolset(ts1, ts2)
+        tools = await compound.get_tools(_ctx())
+        assert set(tools.keys()) == {"tool_a", "tool_b"}
+
+    async def test_later_toolset_wins_on_collision(self):
+        tool_v1 = _make_toolset_tool("shared", "version 1")
+        tool_v2 = _make_toolset_tool("shared", "version 2")
+        ts1 = _StubToolset({"shared": tool_v1})
+        ts2 = _StubToolset({"shared": tool_v2})
+        compound = CompoundToolset(ts1, ts2)
+        tools = await compound.get_tools(_ctx())
+        assert tools["shared"].tool_def.description == "version 2"
+
+    async def test_call_tool_routes_to_correct_source(self):
+        ts1 = _StubToolset({"a": _make_toolset_tool("a")}, call_result="from_ts1")
+        ts2 = _StubToolset({"b": _make_toolset_tool("b")}, call_result="from_ts2")
+        compound = CompoundToolset(ts1, ts2)
+        ctx = _ctx()
+        await compound.get_tools(ctx)  # populate routing
+        result_a = await compound.call_tool("a", {}, ctx, _make_toolset_tool("a"))
+        result_b = await compound.call_tool("b", {}, ctx, _make_toolset_tool("b"))
+        assert result_a == "from_ts1"
+        assert result_b == "from_ts2"
+
+    async def test_call_tool_before_get_tools_raises(self):
+        ts = _StubToolset({"x": _make_toolset_tool("x")})
+        compound = CompoundToolset(ts)
+        with pytest.raises(ValueError, match="Unknown tool"):
+            await compound.call_tool("x", {}, _ctx(), _make_toolset_tool("x"))
+
+    async def test_empty_compound_returns_empty(self):
+        compound = CompoundToolset()
+        tools = await compound.get_tools(_ctx())
+        assert tools == {}
+
+    async def test_routing_refreshed_on_repeated_get_tools(self):
+        """A second call to get_tools() resets routing so stale entries are replaced."""
+        ts = _StubToolset({"t": _make_toolset_tool("t")})
+        compound = CompoundToolset(ts)
+        await compound.get_tools(_ctx())
+        # Swap the inner toolset's tools map so routing must refresh
+        ts._tools = {"t2": _make_toolset_tool("t2")}
+        tools = await compound.get_tools(_ctx())
+        assert "t2" in tools
+        assert "t" not in tools
+
+
+# ---------------------------------------------------------------------------
+# FunctionToolset
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionToolset:
+    """Tests for FunctionToolset.add_tool(), get_tools(), and call_tool()."""
+
+    def _make_tool(self, name: str = "my_tool") -> Tool:
+        def fn(x: int) -> int:
+            """Return x."""
+            return x * 2
+
+        return Tool(fn, name=name)
+
+    def test_add_tool_stores_tool(self):
+        ts = FunctionToolset()
+        tool = self._make_tool()
+        ts.add_tool(tool)
+        assert "my_tool" in ts.tools
+
+    def test_add_duplicate_tool_raises(self):
+        ts = FunctionToolset()
+        ts.add_tool(self._make_tool())
+        with pytest.raises(ValueError, match="conflicts"):
+            ts.add_tool(self._make_tool())
+
+    def test_add_tool_inherits_toolset_max_retries(self):
+        ts = FunctionToolset(max_retries=5)
+        tool = self._make_tool()
+        assert tool.max_retries is None
+        ts.add_tool(tool)
+        assert tool.max_retries == 5
+
+    def test_add_tool_preserves_explicit_max_retries(self):
+        ts = FunctionToolset(max_retries=5)
+        tool = self._make_tool()
+        tool.max_retries = 2
+        ts.add_tool(tool)
+        assert tool.max_retries == 2
+
+    async def test_get_tools_returns_function_toolset_tool(self):
+        ts = FunctionToolset()
+        ts.add_tool(self._make_tool())
+        tools = await ts.get_tools(_ctx())
+        assert "my_tool" in tools
+        assert isinstance(tools["my_tool"], FunctionToolsetTool)
+
+    async def test_get_tools_empty_toolset(self):
+        ts = FunctionToolset()
+        tools = await ts.get_tools(_ctx())
+        assert tools == {}
+
+    async def test_call_tool_sync_function(self):
+        def add(a: int, b: int) -> int:
+            """Add a and b."""
+            return a + b
+
+        ts = FunctionToolset()
+        ts.add_tool(Tool(add))
+        ctx = _ctx()
+        tools = await ts.get_tools(ctx)
+        result = await ts.call_tool("add", {"a": 3, "b": 4}, ctx, tools["add"])
+        assert result == 7
+
+    async def test_call_tool_async_function(self):
+        async def greet(name: str) -> str:
+            """Greet."""
+            return f"hi {name}"
+
+        ts = FunctionToolset()
+        ts.add_tool(Tool(greet))
+        ctx = _ctx()
+        tools = await ts.get_tools(ctx)
+        result = await ts.call_tool("greet", {"name": "world"}, ctx, tools["greet"])
+        assert result == "hi world"
+
+    async def test_get_tools_max_retries_propagated(self):
+        ts = FunctionToolset(max_retries=3)
+
+        def fn(x: int) -> int:
+            """fn."""
+            return x
+
+        ts.add_tool(Tool(fn))
+        tools = await ts.get_tools(_ctx())
+        assert tools["fn"].max_retries == 3
+
+    async def test_get_tools_tool_max_retries_overrides_toolset(self):
+        ts = FunctionToolset(max_retries=3)
+
+        def fn(x: int) -> int:
+            """fn."""
+            return x
+
+        t = Tool(fn, max_retries=7)
+        ts.add_tool(t)
+        tools = await ts.get_tools(_ctx())
+        assert tools["fn"].max_retries == 7
+
+
+# ---------------------------------------------------------------------------
+# MCPToolset
+# ---------------------------------------------------------------------------
+
+
+class TestMCPToolsetConstructors:
+    """Tests for MCPToolset class methods (no live server needed)."""
+
+    def test_from_http_stores_url(self):
+        ts = MCPToolset.from_http("http://localhost:8001/mcp/")
+        assert ts._transport_factory() == "http://localhost:8001/mcp/"
+
+    def test_from_http_with_prefix(self):
+        ts = MCPToolset.from_http("http://localhost:8001/mcp/", prefix="svc")
+        assert ts._prefix == "svc"
+
+    def test_from_sse_raises_without_fastmcp(self):
+        ts = MCPToolset.from_sse("http://localhost:9000/sse")
+        with pytest.raises(ImportError, match="fastmcp"):
+            with patch.dict("sys.modules", {"fastmcp": None, "fastmcp.client.transports": None}):
+                ts._transport_factory()
+
+    def test_from_stdio_raises_without_fastmcp(self):
+        ts = MCPToolset.from_stdio(["npx", "some-server"])
+        with pytest.raises(ImportError, match="fastmcp"):
+            with patch.dict("sys.modules", {"fastmcp": None, "fastmcp.client.transports": None}):
+                ts._transport_factory()
+
+    def test_prefix_none_by_default(self):
+        ts = MCPToolset.from_http("http://localhost/")
+        assert ts._prefix is None
+
+
+class TestMCPToolsetGetTools:
+    """Tests for MCPToolset.get_tools() with mocked fastmcp Client."""
+
+    def _make_mcp_tool(self, name: str, description: str = "desc", schema: dict | None = None):
+        t = MagicMock()
+        t.name = name
+        t.description = description
+        t.inputSchema = schema or {}
+        return t
+
+    async def test_get_tools_returns_toolset_tools(self):
+        mcp_tools = [self._make_mcp_tool("search"), self._make_mcp_tool("summarise")]
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=mcp_tools)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("fastmcp.Client", return_value=mock_client):
+            ts = MCPToolset.from_http("http://localhost/")
+            tools = await ts.get_tools(_ctx())
+
+        assert set(tools.keys()) == {"search", "summarise"}
+        for tool in tools.values():
+            assert isinstance(tool, ToolsetTool)
+
+    async def test_get_tools_applies_prefix(self):
+        mcp_tools = [self._make_mcp_tool("read_file")]
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=mcp_tools)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("fastmcp.Client", return_value=mock_client):
+            ts = MCPToolset.from_http("http://localhost/", prefix="fs")
+            tools = await ts.get_tools(_ctx())
+
+        assert "fs__read_file" in tools
+        assert "read_file" not in tools
+
+    async def test_get_tools_raises_without_fastmcp(self):
+        ts = MCPToolset.from_http("http://localhost/")
+        with patch.dict("sys.modules", {"fastmcp": None}):
+            with pytest.raises(ImportError, match="fastmcp"):
+                await ts.get_tools(_ctx())
+
+    async def test_get_tools_stores_name_map(self):
+        mcp_tools = [self._make_mcp_tool("do_thing")]
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=mcp_tools)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("fastmcp.Client", return_value=mock_client):
+            ts = MCPToolset.from_http("http://localhost/", prefix="p")
+            await ts.get_tools(_ctx())
+
+        assert ts._name_map == {"p__do_thing": "do_thing"}
+
+
+class TestMCPToolsetCallTool:
+    """Tests for MCPToolset.call_tool() with mocked fastmcp Client."""
+
+    def _mock_result(self, data=None, content_texts: list[str] | None = None):
+        result = MagicMock()
+        result.data = data
+        if content_texts is not None:
+            parts = []
+            for t in content_texts:
+                p = MagicMock()
+                p.text = t
+                parts.append(p)
+            result.content = parts
+        else:
+            result.content = []
+        return result
+
+    async def _setup_ts_with_tool(self, tool_name: str = "search") -> MCPToolset:
+        mcp_tool = MagicMock()
+        mcp_tool.name = tool_name
+        mcp_tool.description = "desc"
+        mcp_tool.inputSchema = {}
+
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=[mcp_tool])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("fastmcp.Client", return_value=mock_client):
+            ts = MCPToolset.from_http("http://localhost/")
+            await ts.get_tools(_ctx())
+        return ts
+
+    async def test_call_tool_returns_data_when_present(self):
+        ts = await self._setup_ts_with_tool("search")
+        call_result = self._mock_result(data={"answer": 42})
+
+        mock_client = AsyncMock()
+        mock_client.call_tool = AsyncMock(return_value=call_result)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("fastmcp.Client", return_value=mock_client):
+            result = await ts.call_tool("search", {"q": "test"}, _ctx(), _make_toolset_tool("search"))
+
+        assert result == str({"answer": 42})
+
+    async def test_call_tool_joins_content_parts(self):
+        ts = await self._setup_ts_with_tool("search")
+        call_result = self._mock_result(data=None, content_texts=["Hello", "World"])
+
+        mock_client = AsyncMock()
+        mock_client.call_tool = AsyncMock(return_value=call_result)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("fastmcp.Client", return_value=mock_client):
+            result = await ts.call_tool("search", {}, _ctx(), _make_toolset_tool("search"))
+
+        assert result == "Hello\nWorld"
+
+    async def test_call_tool_uses_original_name_via_name_map(self):
+        """call_tool() resolves the prefixed name back to the original MCP tool name."""
+        mcp_tool = MagicMock()
+        mcp_tool.name = "real_name"
+        mcp_tool.description = "d"
+        mcp_tool.inputSchema = {}
+
+        list_client = AsyncMock()
+        list_client.list_tools = AsyncMock(return_value=[mcp_tool])
+        list_client.__aenter__ = AsyncMock(return_value=list_client)
+        list_client.__aexit__ = AsyncMock(return_value=False)
+
+        call_result = self._mock_result(data="ok")
+        call_client = AsyncMock()
+        call_client.call_tool = AsyncMock(return_value=call_result)
+        call_client.__aenter__ = AsyncMock(return_value=call_client)
+        call_client.__aexit__ = AsyncMock(return_value=False)
+
+        clients = iter([list_client, call_client])
+
+        with patch("fastmcp.Client", side_effect=lambda _: next(clients)):
+            ts = MCPToolset.from_http("http://localhost/", prefix="svc")
+            await ts.get_tools(_ctx())
+            await ts.call_tool("svc__real_name", {}, _ctx(), _make_toolset_tool("svc__real_name"))
+
+        call_client.call_tool.assert_called_once_with("real_name", arguments={})
+
+    async def test_call_tool_raises_without_fastmcp(self):
+        ts = MCPToolset.from_http("http://localhost/")
+        ts._name_map = {"x": "x"}
+        with patch.dict("sys.modules", {"fastmcp": None}):
+            with pytest.raises(ImportError, match="fastmcp"):
+                await ts.call_tool("x", {}, _ctx(), _make_toolset_tool("x"))


### PR DESCRIPTION
  Toolset layer for mindtrace-agents                   
                                                                                                                    
  Introduces a structured way to supply tools to an agent beyond passing a flat list of Tool objects.               
   
  The new toolsets/ module adds four building blocks:                                                               
                  
  - FunctionToolset — groups Tool objects with a shared max_retries default; replaces ad-hoc tools=[...] lists for
  anything non-trivial.
  - CompoundToolset — merges tools from multiple toolsets into one, with last-writer-wins collision semantics for
  easy composition.
  - MCPToolset — connects to any MCP server over HTTP, SSE, or stdio and surfaces its tools to the agent with zero
  boilerplate.
  - ToolFilter / FilteredToolset — predicate-based filtering (exact names, glob patterns, description text)
  composable with &, |, ~; exposed as shorthand methods (.include(), .exclude(), .include_pattern(), etc.) on every
  toolset.

  MindtraceAgent is updated to accept a toolset kwarg alongside the existing tools list, and the README documents
  all new APIs.