### PR TITLE
Agents/memo dist

### DIFF
--- a/mindtrace/agents/README.md
+++ b/mindtrace/agents/README.md
@@ -25,6 +25,9 @@ pip install mindtrace-agents
 | **Callbacks** | `AgentCallbacks` | Lifecycle hooks: before/after LLM call and tool call |
 | **History** | `AbstractHistoryStrategy` / `InMemoryHistory` | Persists conversation across runs |
 | **RunContext** | `RunContext[T]` | Injected into tools — carries deps, retry count, step |
+| **Memory** | `MemoryToolset` / `InMemoryStore` / `JsonFileStore` | Agent-controlled persistent memory exposed as tools |
+| **Task Queue** | `LocalTaskQueue` / `RabbitMQTaskQueue` | Distribute agent execution across processes or workers |
+| **DistributedAgent** | `DistributedAgent` | Transparent wrapper that routes `run()` through a task queue |
 
 ---
 
@@ -418,6 +421,185 @@ agent.logger.info("Starting run", session_id="abc")
 
 ---
 
+---
+
+## Multi-Agent Coworking
+
+Agents are first-class tools. Pass any `MindtraceAgent` directly into `tools=[]` alongside regular `Tool` objects — the framework converts it automatically.
+
+```python
+researcher = MindtraceAgent(
+    model=model,
+    name="researcher",
+    description="Research a topic and return facts",  # shown to LLM as tool description
+    tools=[web_search_tool],
+)
+
+writer = MindtraceAgent(
+    model=model,
+    name="writer",
+    description="Write a structured report from given facts",
+    tools=[format_tool],
+)
+
+orchestrator = MindtraceAgent(
+    model=model,
+    tools=[researcher, writer, some_regular_tool],  # mix freely
+)
+
+result = await orchestrator.run("Write a report on climate change")
+```
+
+The `description` field is required when using an agent as a tool — it's what the LLM reads to decide when to call it. Parent `deps` are forwarded to sub-agents automatically via `RunContext`.
+
+### Context exchange between agents
+
+| Deployment | Mechanism |
+|---|---|
+| Same process | `deps` carries shared state directly — mutations visible across agents |
+| Distributed workers | `deps` carries a **client** (Redis, DB) — workers read/write through it, not raw data |
+
+`deps` is serialised when submitted to a task queue. Don't put live in-memory objects in deps for distributed use — put connection config and reconnect on the worker side.
+
+### HandoffPart
+
+Use `HandoffPart` to mark an explicit handoff boundary in an agent's message history. Useful for observability and keeping sub-agent history scoped:
+
+```python
+from mindtrace.agents import HandoffPart
+
+part = HandoffPart(
+    from_agent="orchestrator",
+    to_agent="writer",
+    summary="Researcher found: sea levels rose 20cm since 1980",
+)
+```
+
+---
+
+## Agent Memory
+
+`MemoryToolset` exposes persistent memory as LLM-callable tools. The agent decides what to save and when to recall — no code wiring needed.
+
+```python
+from mindtrace.agents import MindtraceAgent, MemoryToolset, JsonFileStore, CompoundToolset
+from mindtrace.agents.toolsets import FunctionToolset
+
+memory = JsonFileStore("./agent_memory.json")  # persists across restarts
+
+agent = MindtraceAgent(
+    model=model,
+    toolset=CompoundToolset(
+        FunctionToolset([my_tools]),
+        MemoryToolset(memory, namespace="user_123"),
+    ),
+)
+```
+
+**Tools exposed to the agent:**
+
+| Tool | Args | Effect |
+|---|---|---|
+| `save_memory` | `key, value` | Persist a fact |
+| `recall_memory` | `key` | Retrieve by key |
+| `search_memory` | `query, top_k=5` | Substring search across all memories |
+| `forget_memory` | `key` | Delete an entry |
+| `list_memories` | — | List all keys |
+
+The `namespace` parameter scopes entries per-user or per-session — two `MemoryToolset` instances on the same store with different namespaces never see each other's data.
+
+### Memory backends
+
+| Class | Persistence | `search()` |
+|---|---|---|
+| `InMemoryStore` | None (lost on restart) | Substring |
+| `JsonFileStore` | Local `.json` file | Substring |
+
+Implement `AbstractMemoryStore` for custom backends (Redis, vector DB, etc.). The only method that varies meaningfully is `search()` — simple backends use substring, vector backends use embeddings.
+
+```python
+from mindtrace.agents import AbstractMemoryStore, MemoryEntry
+
+class RedisMemoryStore(AbstractMemoryStore):
+    async def save(self, key, value, metadata=None): ...
+    async def get(self, key) -> MemoryEntry | None: ...
+    async def search(self, query, top_k=5) -> list[MemoryEntry]: ...
+    async def delete(self, key): ...
+    async def list_keys(self) -> list[str]: ...
+```
+
+Install optional extras for third-party backends:
+
+```bash
+pip install 'mindtrace-agents[memory-redis]'   # Redis
+pip install 'mindtrace-agents[memory-vector]'  # ChromaDB
+```
+
+---
+
+## Distributed Execution
+
+### Task queues
+
+`AbstractTaskQueue` decouples task submission from execution. Use `LocalTaskQueue` for single-process orchestration, `RabbitMQTaskQueue` for multi-worker deployments.
+
+```python
+from mindtrace.agents import LocalTaskQueue, AgentTask
+
+queue = LocalTaskQueue()
+queue.register(researcher)   # agents must be registered by name
+
+task_id = await queue.submit(AgentTask(
+    agent_name="researcher",
+    input="What caused the 2008 financial crisis?",
+    deps=my_deps,
+    session_id="s1",
+))
+result = await queue.get_result(task_id)
+```
+
+`TaskStatus` values: `PENDING → RUNNING → DONE | FAILED`
+
+### DistributedAgent
+
+`DistributedAgent` wraps any agent and routes `run()` through a task queue. The API is identical to `MindtraceAgent` — callers don't need to change.
+
+```python
+from mindtrace.agents import DistributedAgent
+
+distributed_researcher = DistributedAgent(researcher, task_queue=queue)
+result = await distributed_researcher.run("Research topic")  # executes via queue
+```
+
+### RabbitMQ
+
+Requires `aio-pika`:
+
+```bash
+pip install 'mindtrace-agents[distributed-rabbitmq]'
+```
+
+**Caller side** (submit tasks):
+
+```python
+from mindtrace.agents.execution.rabbitmq import RabbitMQTaskQueue
+
+queue = RabbitMQTaskQueue(url="amqp://guest:guest@localhost/")
+distributed = DistributedAgent(researcher, task_queue=queue)
+result = await distributed.run("Research topic")
+```
+
+**Worker side** (consume and execute):
+
+```python
+queue = RabbitMQTaskQueue(url="amqp://guest:guest@localhost/")
+await queue.serve(researcher)  # blocks; run N replicas for parallelism
+```
+
+RabbitMQ round-robins tasks across replicas automatically. `AgentTask` is serialised with `pickle` — `deps` must be pickle-serialisable. For cross-process use, put connection config in `deps` (not live connections).
+
+---
+
 ## Package layout
 
 ```
@@ -429,12 +611,14 @@ mindtrace/agents/
 ├── prompts.py           # UserPromptPart, BinaryContent, ImageUrl
 ├── profiles/            # ModelProfile capability flags
 ├── events/              # streaming event types
-├── messages/            # ModelMessage, parts, builder
+├── messages/            # ModelMessage, parts (incl. HandoffPart), builder
 ├── tools/               # Tool, ToolDefinition
 ├── toolsets/            # AbstractToolset, FunctionToolset, CompoundToolset, MCPToolset, ToolFilter, FilteredToolset
 ├── providers/           # Provider ABC + OpenAI, Ollama, Gemini
 ├── models/              # Model ABC + OpenAIChatModel
 ├── callbacks/           # AgentCallbacks + _invoke helper
 ├── history/             # AbstractHistoryStrategy + InMemoryHistory
-└── core/                # AbstractMindtraceAgent, MindtraceAgent, WrapperAgent
+├── memory/              # AbstractMemoryStore, InMemoryStore, JsonFileStore, MemoryToolset
+├── execution/           # AbstractTaskQueue, AgentTask, LocalTaskQueue, RabbitMQTaskQueue
+└── core/                # AbstractMindtraceAgent, MindtraceAgent, WrapperAgent, DistributedAgent
 ```

--- a/mindtrace/agents/README.md
+++ b/mindtrace/agents/README.md
@@ -20,6 +20,8 @@ pip install mindtrace-agents
 | **Model** | `OpenAIChatModel` | Calls the LLM API (supports streaming) |
 | **Provider** | `OpenAIProvider` / `OllamaProvider` / `GeminiProvider` | Holds the authenticated client |
 | **Tool** | `Tool` | Wraps a Python function for LLM tool-calling |
+| **Toolset** | `FunctionToolset` / `CompoundToolset` / `MCPToolset` | Groups tools and controls which are exposed to the agent |
+| **ToolFilter** | `ToolFilter` | Predicate for selectively showing/hiding tools by name or description |
 | **Callbacks** | `AgentCallbacks` | Lifecycle hooks: before/after LLM call and tool call |
 | **History** | `AbstractHistoryStrategy` / `InMemoryHistory` | Persists conversation across runs |
 | **RunContext** | `RunContext[T]` | Injected into tools — carries deps, retry count, step |
@@ -114,6 +116,134 @@ def lookup_user(ctx: RunContext[AppDeps], user_id: str) -> dict:
 
 deps = AppDeps(db_url="postgresql://...", api_key="secret")
 result = asyncio.run(agent.run("Find user 123", deps=deps))
+```
+
+---
+
+## Toolsets
+
+Toolsets are the primary way to supply tools to an agent. They group related tools together and give you control over which tools are visible to the model at runtime.
+
+### FunctionToolset
+
+`FunctionToolset` collects Python `Tool` objects and exposes them to the agent. Use it when you want to organise tools manually or share a toolset across multiple agents.
+
+```python
+from mindtrace.agents.toolsets import FunctionToolset
+from mindtrace.agents.tools import Tool
+
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+async def fetch(url: str) -> str:
+    """Fetch a URL."""
+    ...
+
+toolset = FunctionToolset(max_retries=2)
+toolset.add_tool(Tool(add))
+toolset.add_tool(Tool(fetch))
+
+agent = MindtraceAgent(model=model, toolset=toolset)
+```
+
+`max_retries` on the toolset is the default for every tool added to it. Override per-tool by setting `Tool(..., max_retries=N)` before calling `add_tool()`.
+
+### CompoundToolset
+
+`CompoundToolset` merges tools from multiple toolsets into one. Later toolsets win on name collisions — use `prefix` on `MCPToolset` to avoid conflicts.
+
+```python
+from mindtrace.agents.toolsets import CompoundToolset, FunctionToolset
+
+agent = MindtraceAgent(
+    model=model,
+    toolset=CompoundToolset(
+        MCPToolset.from_http("http://localhost:8001/mcp-server/mcp/"),
+        FunctionToolset(),   # local tools
+    ),
+)
+```
+
+### MCPToolset
+
+`MCPToolset` exposes tools from any remote MCP server. Requires `fastmcp`:
+
+```bash
+pip install 'mindtrace-agents[mcp]'
+```
+
+**Constructors**
+
+```python
+from mindtrace.agents.toolsets import MCPToolset
+
+# HTTP (streamable-http) — default for Mindtrace services
+ts = MCPToolset.from_http("http://localhost:8001/mcp-server/mcp/")
+
+# SSE (legacy HTTP)
+ts = MCPToolset.from_sse("http://localhost:9000/sse")
+
+# stdio — local subprocess servers (e.g. npx)
+ts = MCPToolset.from_stdio(["npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp"])
+```
+
+**Prefix** — avoid name collisions when combining multiple MCP services:
+
+```python
+ts = MCPToolset.from_http("http://localhost:8002/mcp/", prefix="db")
+# tools are exposed as "db__query", "db__list_tables", etc.
+```
+
+---
+
+## Filtering tools
+
+Every toolset exposes shorthand methods that return a `FilteredToolset`. Chain them to control exactly which tools the agent sees.
+
+```python
+# Allow only named tools
+toolset.include("search", "summarise")
+
+# Block a specific tool
+toolset.exclude("drop_table")
+
+# Glob patterns
+toolset.include_pattern("read_*", "list_*")
+toolset.exclude_pattern("admin_*")
+
+# Compose via FilteredToolset.with_filter() for boolean logic
+from mindtrace.agents.toolsets import ToolFilter
+
+f = ToolFilter.include_pattern("read_*") & ~ToolFilter.include("read_credentials")
+toolset.with_filter(f)
+```
+
+Filtering applies at `get_tools()` time — the underlying toolset is unchanged.
+
+### ToolFilter API
+
+| Factory | Behaviour |
+|---------|-----------|
+| `ToolFilter.include(*names)` | Allow only tools whose name is in `names` |
+| `ToolFilter.exclude(*names)` | Block tools whose name is in `names` |
+| `ToolFilter.include_pattern(*globs)` | Allow tools matching any glob (e.g. `"read_*"`) |
+| `ToolFilter.exclude_pattern(*globs)` | Block tools matching any glob |
+| `ToolFilter.by_description(fn)` | Custom predicate on the tool description string |
+
+Filters compose with `&` (AND), `|` (OR), and `~` (NOT).
+
+### Combining filtering with CompoundToolset
+
+```python
+agent = MindtraceAgent(
+    model=model,
+    toolset=CompoundToolset(
+        MCPToolset.from_http("http://localhost:8001/mcp/").include("generate_image"),
+        MCPToolset.from_http("http://localhost:8002/mcp/").exclude_pattern("admin_*"),
+        FunctionToolset(),
+    ),
+)
 ```
 
 ---
@@ -301,7 +431,7 @@ mindtrace/agents/
 ├── events/              # streaming event types
 ├── messages/            # ModelMessage, parts, builder
 ├── tools/               # Tool, ToolDefinition
-├── toolsets/            # AbstractToolset, FunctionToolset
+├── toolsets/            # AbstractToolset, FunctionToolset, CompoundToolset, MCPToolset, ToolFilter, FilteredToolset
 ├── providers/           # Provider ABC + OpenAI, Ollama, Gemini
 ├── models/              # Model ABC + OpenAIChatModel
 ├── callbacks/           # AgentCallbacks + _invoke helper

--- a/mindtrace/agents/mindtrace/agents/__init__.py
+++ b/mindtrace/agents/mindtrace/agents/__init__.py
@@ -1,5 +1,7 @@
 from .callbacks import AgentCallbacks
-from .core import AbstractMindtraceAgent, AgentDepsT, MindtraceAgent, OutputDataT, WrapperAgent
+from .core import AbstractMindtraceAgent, AgentDepsT, DistributedAgent, MindtraceAgent, OutputDataT, WrapperAgent
+from .execution import AbstractTaskQueue, AgentTask, LocalTaskQueue, TaskStatus
+from .memory import AbstractMemoryStore, InMemoryStore, JsonFileStore, MemoryEntry, MemoryToolset
 from .events import (
     AgentRunResult,
     AgentRunResultEvent,
@@ -10,7 +12,7 @@ from .events import (
     ToolResultEvent,
 )
 from .history import AbstractHistoryStrategy, InMemoryHistory
-from .messages import ModelMessage, SystemPromptPart, TextPart, ToolCallPart, ToolReturnPart
+from .messages import HandoffPart, ModelMessage, SystemPromptPart, TextPart, ToolCallPart, ToolReturnPart
 from .models import Model, ModelRequestParameters, ModelResponse, OpenAIChatModel
 from .profiles import ModelProfile
 from .prompts import UserPromptPart
@@ -20,17 +22,27 @@ from .toolsets import AbstractToolset, CompoundToolset, FunctionToolset, MCPTool
 
 __all__ = [
     "AbstractHistoryStrategy",
+    "AbstractMemoryStore",
     "AbstractMindtraceAgent",
+    "AbstractTaskQueue",
     "AbstractToolset",
     "AgentCallbacks",
     "AgentDepsT",
     "AgentRunResult",
     "AgentRunResultEvent",
+    "AgentTask",
     "CompoundToolset",
+    "DistributedAgent",
     "FunctionToolset",
     "GeminiProvider",
+    "HandoffPart",
     "InMemoryHistory",
+    "InMemoryStore",
+    "JsonFileStore",
+    "LocalTaskQueue",
     "MCPToolset",
+    "MemoryEntry",
+    "MemoryToolset",
     "Model",
     "ModelMessage",
     "ModelProfile",
@@ -48,6 +60,7 @@ __all__ = [
     "Provider",
     "RunContext",
     "SystemPromptPart",
+    "TaskStatus",
     "TextPart",
     "Tool",
     "ToolCallPart",

--- a/mindtrace/agents/mindtrace/agents/__init__.py
+++ b/mindtrace/agents/mindtrace/agents/__init__.py
@@ -16,7 +16,7 @@ from .profiles import ModelProfile
 from .prompts import UserPromptPart
 from .providers import GeminiProvider, OllamaProvider, OpenAIProvider, Provider
 from .tools import RunContext, Tool, ToolDefinition
-from .toolsets import AbstractToolset, FunctionToolset
+from .toolsets import AbstractToolset, CompoundToolset, FunctionToolset, MCPToolset, ToolFilter
 
 __all__ = [
     "AbstractHistoryStrategy",
@@ -26,9 +26,11 @@ __all__ = [
     "AgentDepsT",
     "AgentRunResult",
     "AgentRunResultEvent",
+    "CompoundToolset",
     "FunctionToolset",
     "GeminiProvider",
     "InMemoryHistory",
+    "MCPToolset",
     "Model",
     "ModelMessage",
     "ModelProfile",
@@ -50,6 +52,7 @@ __all__ = [
     "Tool",
     "ToolCallPart",
     "ToolDefinition",
+    "ToolFilter",
     "ToolResultEvent",
     "ToolReturnPart",
     "UserPromptPart",

--- a/mindtrace/agents/mindtrace/agents/__init__.py
+++ b/mindtrace/agents/mindtrace/agents/__init__.py
@@ -1,7 +1,5 @@
 from .callbacks import AgentCallbacks
 from .core import AbstractMindtraceAgent, AgentDepsT, DistributedAgent, MindtraceAgent, OutputDataT, WrapperAgent
-from .execution import AbstractTaskQueue, AgentTask, LocalTaskQueue, TaskStatus
-from .memory import AbstractMemoryStore, InMemoryStore, JsonFileStore, MemoryEntry, MemoryToolset
 from .events import (
     AgentRunResult,
     AgentRunResultEvent,
@@ -11,7 +9,9 @@ from .events import (
     PartStartEvent,
     ToolResultEvent,
 )
+from .execution import AbstractTaskQueue, AgentTask, LocalTaskQueue, TaskStatus
 from .history import AbstractHistoryStrategy, InMemoryHistory
+from .memory import AbstractMemoryStore, InMemoryStore, JsonFileStore, MemoryEntry, MemoryToolset
 from .messages import HandoffPart, ModelMessage, SystemPromptPart, TextPart, ToolCallPart, ToolReturnPart
 from .models import Model, ModelRequestParameters, ModelResponse, OpenAIChatModel
 from .profiles import ModelProfile

--- a/mindtrace/agents/mindtrace/agents/core/__init__.py
+++ b/mindtrace/agents/mindtrace/agents/core/__init__.py
@@ -1,10 +1,12 @@
 from .abstract import AbstractMindtraceAgent, AgentDepsT, OutputDataT, RunOutputDataT
 from .base import MindtraceAgent
+from .distributed import DistributedAgent
 from .wrapper import WrapperAgent
 
 __all__ = [
     "AbstractMindtraceAgent",
     "AgentDepsT",
+    "DistributedAgent",
     "MindtraceAgent",
     "OutputDataT",
     "RunOutputDataT",

--- a/mindtrace/agents/mindtrace/agents/core/abstract.py
+++ b/mindtrace/agents/mindtrace/agents/core/abstract.py
@@ -27,6 +27,11 @@ class AbstractMindtraceAgent(Generic[AgentDepsT, OutputDataT], MindtraceABC):
 
     @property
     @abstractmethod
+    def description(self) -> str | None:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
     def deps_type(self) -> type:
         raise NotImplementedError
 

--- a/mindtrace/agents/mindtrace/agents/core/base.py
+++ b/mindtrace/agents/mindtrace/agents/core/base.py
@@ -21,6 +21,8 @@ from ..messages._parts import SystemPromptPart
 from ..models import Model, ModelRequestParameters, ModelResponse
 from ..prompts import UserContent, UserPromptPart
 from ..tools import RunContext, Tool
+from ..toolsets._toolset import AbstractToolset
+from ..toolsets.compound import CompoundToolset
 from ..toolsets.function import FunctionToolset
 from .abstract import AbstractMindtraceAgent, OutputDataT
 
@@ -33,6 +35,7 @@ class MindtraceAgent(AbstractMindtraceAgent[AgentDepsT, OutputDataT]):
         model: Model,
         *,
         tools: Sequence[Tool] | None = None,
+        toolset: AbstractToolset | None = None,
         system_prompt: str | None = None,
         name: str | None = None,
         deps_type: type = type(None),
@@ -52,10 +55,19 @@ class MindtraceAgent(AbstractMindtraceAgent[AgentDepsT, OutputDataT]):
         self.history = history
         self._entered_count = 0
         self._lock = asyncio.Lock()
-        toolset: FunctionToolset = FunctionToolset()
+
+        func_toolset: FunctionToolset = FunctionToolset()
         for tool in self.tools:
-            toolset.add_tool(tool)
-        self._tool_manager: ToolManager = ToolManager(toolset=toolset)
+            func_toolset.add_tool(tool)
+
+        if toolset is None:
+            effective_toolset: AbstractToolset = func_toolset
+        elif self.tools:
+            effective_toolset = CompoundToolset(func_toolset, toolset)
+        else:
+            effective_toolset = toolset
+
+        self._tool_manager: ToolManager = ToolManager(toolset=effective_toolset)
 
     @property
     def name(self) -> str | None:

--- a/mindtrace/agents/mindtrace/agents/core/base.py
+++ b/mindtrace/agents/mindtrace/agents/core/base.py
@@ -29,15 +29,29 @@ from .abstract import AbstractMindtraceAgent, OutputDataT
 AgentDepsT = _AgentDepsT
 
 
+def _agent_to_tool(agent: AbstractMindtraceAgent) -> Tool:
+    """Convert an AbstractMindtraceAgent into a Tool callable by another agent."""
+    agent_name = agent.name or f"agent_{id(agent)}"
+    agent_desc = agent.description or f"Run the {agent_name} agent"
+
+    async def _run(ctx: RunContext, input: str) -> str:  # noqa: A002
+        return await agent.run(input, deps=ctx.deps)
+
+    _run.__name__ = agent_name
+    _run.__doc__ = agent_desc
+    return Tool(_run)
+
+
 class MindtraceAgent(AbstractMindtraceAgent[AgentDepsT, OutputDataT]):
     def __init__(
         self,
         model: Model,
         *,
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool | AbstractMindtraceAgent] | None = None,
         toolset: AbstractToolset | None = None,
         system_prompt: str | None = None,
         name: str | None = None,
+        description: str | None = None,
         deps_type: type = type(None),
         output_type: type = str,
         callbacks: AgentCallbacks | None = None,
@@ -46,15 +60,24 @@ class MindtraceAgent(AbstractMindtraceAgent[AgentDepsT, OutputDataT]):
     ) -> None:
         super().__init__(**kwargs)
         self.model = model
-        self.tools = list(tools or [])
         self.system_prompt = system_prompt
         self._name = name
+        self._description = description
         self._deps_type = deps_type
         self._output_type = output_type
         self.callbacks = callbacks
         self.history = history
         self._entered_count = 0
         self._lock = asyncio.Lock()
+
+        # Separate plain Tools from sub-agents; convert agents to Tools
+        resolved_tools: list[Tool] = []
+        for item in tools or []:
+            if isinstance(item, AbstractMindtraceAgent):
+                resolved_tools.append(_agent_to_tool(item))
+            else:
+                resolved_tools.append(item)
+        self.tools = resolved_tools
 
         func_toolset: FunctionToolset = FunctionToolset()
         for tool in self.tools:
@@ -76,6 +99,10 @@ class MindtraceAgent(AbstractMindtraceAgent[AgentDepsT, OutputDataT]):
     @name.setter
     def name(self, value: str | None) -> None:
         self._name = value
+
+    @property
+    def description(self) -> str | None:
+        return self._description
 
     @property
     def deps_type(self) -> type:

--- a/mindtrace/agents/mindtrace/agents/core/distributed.py
+++ b/mindtrace/agents/mindtrace/agents/core/distributed.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..execution._queue import AbstractTaskQueue, AgentTask
+from .abstract import AbstractMindtraceAgent, AgentDepsT, OutputDataT
+from .wrapper import WrapperAgent
+
+
+class DistributedAgent(WrapperAgent[AgentDepsT, OutputDataT]):
+    """Offloads agent execution to a task queue.
+
+    The API is identical to MindtraceAgent — callers do not need to change.
+    The wrapped agent provides metadata (name, deps_type, output_type) but
+    is not executed locally; tasks are submitted to the queue instead.
+
+    Example::
+
+        queue = LocalTaskQueue()
+        queue.register(researcher)
+
+        distributed_researcher = DistributedAgent(researcher, task_queue=queue)
+
+        # Works exactly like researcher.run() but executes via the queue
+        result = await distributed_researcher.run("Research climate change")
+    """
+
+    def __init__(
+        self,
+        wrapped: AbstractMindtraceAgent[AgentDepsT, OutputDataT],
+        task_queue: AbstractTaskQueue,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(wrapped=wrapped, **kwargs)
+        self._task_queue = task_queue
+
+    async def run(
+        self,
+        input_data: Any,
+        *,
+        deps: AgentDepsT = None,
+        session_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        task = AgentTask(
+            agent_name=self.name or "",
+            input=str(input_data),
+            deps=deps,
+            session_id=session_id,
+            metadata=kwargs.get("metadata", {}),
+        )
+        task_id = await self._task_queue.submit(task)
+        return await self._task_queue.get_result(task_id)
+
+
+__all__ = ["DistributedAgent"]

--- a/mindtrace/agents/mindtrace/agents/core/wrapper.py
+++ b/mindtrace/agents/mindtrace/agents/core/wrapper.py
@@ -26,6 +26,10 @@ class WrapperAgent(AbstractMindtraceAgent[AgentDepsT, OutputDataT]):
         self.wrapped.name = value
 
     @property
+    def description(self) -> str | None:
+        return self.wrapped.description
+
+    @property
     def deps_type(self) -> type:
         return self.wrapped.deps_type
 

--- a/mindtrace/agents/mindtrace/agents/execution/__init__.py
+++ b/mindtrace/agents/mindtrace/agents/execution/__init__.py
@@ -1,0 +1,9 @@
+from ._queue import AbstractTaskQueue, AgentTask, TaskStatus
+from .local import LocalTaskQueue
+
+__all__ = [
+    "AbstractTaskQueue",
+    "AgentTask",
+    "LocalTaskQueue",
+    "TaskStatus",
+]

--- a/mindtrace/agents/mindtrace/agents/execution/_queue.py
+++ b/mindtrace/agents/mindtrace/agents/execution/_queue.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class TaskStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    DONE = "DONE"
+    FAILED = "FAILED"
+
+
+@dataclass
+class AgentTask:
+    agent_name: str
+    input: str
+    deps: Any = None
+    session_id: str | None = None
+    metadata: dict = field(default_factory=dict)
+
+
+class AbstractTaskQueue(ABC):
+    @abstractmethod
+    async def submit(self, task: AgentTask) -> str:
+        """Submit a task and return a task_id."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_result(self, task_id: str) -> Any:
+        """Wait for and return the result of a submitted task."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def cancel(self, task_id: str) -> None:
+        """Cancel a pending or running task."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def status(self, task_id: str) -> TaskStatus:
+        """Return the current status of a task."""
+        raise NotImplementedError
+
+
+__all__ = ["AbstractTaskQueue", "AgentTask", "TaskStatus"]

--- a/mindtrace/agents/mindtrace/agents/execution/local.py
+++ b/mindtrace/agents/mindtrace/agents/execution/local.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+from ..core.abstract import AbstractMindtraceAgent
+from ._queue import AbstractTaskQueue, AgentTask, TaskStatus
+
+
+class LocalTaskQueue(AbstractTaskQueue):
+    """In-process task queue backed by asyncio.
+
+    Agents must be registered before tasks are submitted.
+    Suitable for single-process multi-agent orchestration.
+    """
+
+    def __init__(self) -> None:
+        self._agents: dict[str, AbstractMindtraceAgent] = {}
+        self._futures: dict[str, asyncio.Future] = {}
+        self._statuses: dict[str, TaskStatus] = {}
+
+    def register(self, agent: AbstractMindtraceAgent) -> None:
+        """Register an agent so it can receive tasks by name."""
+        name = agent.name
+        if not name:
+            raise ValueError("Agent must have a name to be registered in LocalTaskQueue.")
+        self._agents[name] = agent
+
+    async def submit(self, task: AgentTask) -> str:
+        if task.agent_name not in self._agents:
+            raise KeyError(f"No agent registered with name: {task.agent_name!r}")
+
+        task_id = str(uuid4())
+        loop = asyncio.get_event_loop()
+        future: asyncio.Future = loop.create_future()
+        self._futures[task_id] = future
+        self._statuses[task_id] = TaskStatus.PENDING
+
+        agent = self._agents[task.agent_name]
+
+        async def _run() -> None:
+            self._statuses[task_id] = TaskStatus.RUNNING
+            try:
+                result = await agent.run(task.input, deps=task.deps, session_id=task.session_id)
+                self._statuses[task_id] = TaskStatus.DONE
+                future.set_result(result)
+            except Exception as exc:
+                self._statuses[task_id] = TaskStatus.FAILED
+                future.set_exception(exc)
+
+        asyncio.create_task(_run())
+        return task_id
+
+    async def get_result(self, task_id: str) -> Any:
+        if task_id not in self._futures:
+            raise KeyError(f"Unknown task_id: {task_id!r}")
+        return await self._futures[task_id]
+
+    async def cancel(self, task_id: str) -> None:
+        future = self._futures.get(task_id)
+        if future and not future.done():
+            future.cancel()
+            self._statuses[task_id] = TaskStatus.FAILED
+
+    async def status(self, task_id: str) -> TaskStatus:
+        return self._statuses.get(task_id, TaskStatus.PENDING)
+
+
+__all__ = ["LocalTaskQueue"]

--- a/mindtrace/agents/mindtrace/agents/execution/rabbitmq.py
+++ b/mindtrace/agents/mindtrace/agents/execution/rabbitmq.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+import pickle
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from ._queue import AbstractTaskQueue, AgentTask, TaskStatus
+
+if TYPE_CHECKING:
+    from ..core.abstract import AbstractMindtraceAgent
+
+try:
+    import aio_pika
+    import aio_pika.abc
+except ImportError as e:
+    raise ImportError(
+        "RabbitMQTaskQueue requires aio-pika. "
+        "Install it with: pip install 'mindtrace-agents[distributed-rabbitmq]'"
+    ) from e
+
+
+class RabbitMQTaskQueue(AbstractTaskQueue):
+    """Task queue backed by RabbitMQ using the AMQP RPC pattern.
+
+    Caller side:  submit() publishes to the agent's named queue and waits on a reply queue.
+    Worker side:  serve() consumes from the agent's named queue and publishes results back.
+
+    Note: AgentTask.deps must be pickle-serializable. For production, avoid passing
+    live connections in deps across processes — use clients that reconnect on the worker side.
+    """
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+        self._pending: dict[str, asyncio.Future] = {}
+        self._statuses: dict[str, TaskStatus] = {}
+        self._connection: aio_pika.abc.AbstractConnection | None = None
+        self._channel: aio_pika.abc.AbstractChannel | None = None
+        self._callback_queue: aio_pika.abc.AbstractQueue | None = None
+
+    async def _ensure_connected(self) -> tuple[aio_pika.abc.AbstractChannel, aio_pika.abc.AbstractQueue]:
+        if self._connection is None or self._connection.is_closed:
+            self._connection = await aio_pika.connect_robust(self.url)
+            self._channel = await self._connection.channel()
+            self._callback_queue = await self._channel.declare_queue(exclusive=True, auto_delete=True)
+
+            async def _on_response(message: aio_pika.abc.AbstractIncomingMessage) -> None:
+                async with message.process():
+                    correlation_id = message.correlation_id
+                    future = self._pending.get(correlation_id)
+                    if future and not future.done():
+                        result = pickle.loads(message.body)
+                        if isinstance(result, Exception):
+                            self._statuses[correlation_id] = TaskStatus.FAILED
+                            future.set_exception(result)
+                        else:
+                            self._statuses[correlation_id] = TaskStatus.DONE
+                            future.set_result(result)
+
+            await self._callback_queue.consume(_on_response)
+
+        return self._channel, self._callback_queue  # type: ignore[return-value]
+
+    async def submit(self, task: AgentTask) -> str:
+        channel, callback_queue = await self._ensure_connected()
+        task_id = str(uuid4())
+
+        loop = asyncio.get_event_loop()
+        future: asyncio.Future = loop.create_future()
+        self._pending[task_id] = future
+        self._statuses[task_id] = TaskStatus.PENDING
+
+        await channel.default_exchange.publish(
+            aio_pika.Message(
+                body=pickle.dumps(task),
+                correlation_id=task_id,
+                reply_to=callback_queue.name,
+            ),
+            routing_key=task.agent_name,
+        )
+        self._statuses[task_id] = TaskStatus.RUNNING
+        return task_id
+
+    async def get_result(self, task_id: str) -> Any:
+        future = self._pending.get(task_id)
+        if future is None:
+            raise KeyError(f"Unknown task_id: {task_id!r}")
+        return await future
+
+    async def cancel(self, task_id: str) -> None:
+        future = self._pending.get(task_id)
+        if future and not future.done():
+            future.cancel()
+            self._statuses[task_id] = TaskStatus.FAILED
+
+    async def status(self, task_id: str) -> TaskStatus:
+        return self._statuses.get(task_id, TaskStatus.PENDING)
+
+    async def serve(self, agent: AbstractMindtraceAgent) -> None:
+        """Worker side — consume tasks for this agent and publish results back.
+
+        Blocks until the process is interrupted.
+        """
+        agent_name = agent.name
+        if not agent_name:
+            raise ValueError("Agent must have a name to serve via RabbitMQTaskQueue.")
+
+        connection = await aio_pika.connect_robust(self.url)
+        async with connection:
+            channel = await connection.channel()
+            await channel.set_qos(prefetch_count=1)
+            queue = await channel.declare_queue(agent_name, durable=True)
+
+            async def _on_task(message: aio_pika.abc.AbstractIncomingMessage) -> None:
+                async with message.process():
+                    task: AgentTask = pickle.loads(message.body)
+                    try:
+                        result = await agent.run(
+                            task.input, deps=task.deps, session_id=task.session_id
+                        )
+                        body = pickle.dumps(result)
+                    except Exception as exc:
+                        body = pickle.dumps(exc)
+
+                    if message.reply_to:
+                        await channel.default_exchange.publish(
+                            aio_pika.Message(
+                                body=body,
+                                correlation_id=message.correlation_id,
+                            ),
+                            routing_key=message.reply_to,
+                        )
+
+            await queue.consume(_on_task)
+            await asyncio.Future()  # run until interrupted
+
+
+__all__ = ["RabbitMQTaskQueue"]

--- a/mindtrace/agents/mindtrace/agents/execution/rabbitmq.py
+++ b/mindtrace/agents/mindtrace/agents/execution/rabbitmq.py
@@ -15,8 +15,7 @@ try:
     import aio_pika.abc
 except ImportError as e:
     raise ImportError(
-        "RabbitMQTaskQueue requires aio-pika. "
-        "Install it with: pip install 'mindtrace-agents[distributed-rabbitmq]'"
+        "RabbitMQTaskQueue requires aio-pika. Install it with: pip install 'mindtrace-agents[distributed-rabbitmq]'"
     ) from e
 
 
@@ -115,9 +114,7 @@ class RabbitMQTaskQueue(AbstractTaskQueue):
                 async with message.process():
                     task: AgentTask = pickle.loads(message.body)
                     try:
-                        result = await agent.run(
-                            task.input, deps=task.deps, session_id=task.session_id
-                        )
+                        result = await agent.run(task.input, deps=task.deps, session_id=task.session_id)
                         body = pickle.dumps(result)
                     except Exception as exc:
                         body = pickle.dumps(exc)

--- a/mindtrace/agents/mindtrace/agents/memory/__init__.py
+++ b/mindtrace/agents/mindtrace/agents/memory/__init__.py
@@ -1,0 +1,12 @@
+from ._store import AbstractMemoryStore, MemoryEntry
+from .in_memory import InMemoryStore
+from .json_file import JsonFileStore
+from .toolset import MemoryToolset
+
+__all__ = [
+    "AbstractMemoryStore",
+    "InMemoryStore",
+    "JsonFileStore",
+    "MemoryEntry",
+    "MemoryToolset",
+]

--- a/mindtrace/agents/mindtrace/agents/memory/_store.py
+++ b/mindtrace/agents/mindtrace/agents/memory/_store.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass
+class MemoryEntry:
+    key: str
+    value: str
+    metadata: dict = field(default_factory=dict)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class AbstractMemoryStore(ABC):
+    @abstractmethod
+    async def save(self, key: str, value: str, metadata: dict | None = None) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get(self, key: str) -> MemoryEntry | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def search(self, query: str, top_k: int = 5) -> list[MemoryEntry]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def delete(self, key: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def list_keys(self) -> list[str]:
+        raise NotImplementedError
+
+
+__all__ = ["AbstractMemoryStore", "MemoryEntry"]

--- a/mindtrace/agents/mindtrace/agents/memory/in_memory.py
+++ b/mindtrace/agents/mindtrace/agents/memory/in_memory.py
@@ -28,7 +28,8 @@ class InMemoryStore(AbstractMemoryStore):
     async def search(self, query: str, top_k: int = 5) -> list[MemoryEntry]:
         query_lower = query.lower()
         matches = [
-            entry for entry in self._data.values()
+            entry
+            for entry in self._data.values()
             if query_lower in entry.key.lower() or query_lower in entry.value.lower()
         ]
         return matches[:top_k]

--- a/mindtrace/agents/mindtrace/agents/memory/in_memory.py
+++ b/mindtrace/agents/mindtrace/agents/memory/in_memory.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from ._store import AbstractMemoryStore, MemoryEntry
+
+
+class InMemoryStore(AbstractMemoryStore):
+    """In-process memory store. Lost on process restart. Useful for dev and tests."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, MemoryEntry] = {}
+
+    async def save(self, key: str, value: str, metadata: dict | None = None) -> None:
+        now = datetime.now(timezone.utc)
+        existing = self._data.get(key)
+        self._data[key] = MemoryEntry(
+            key=key,
+            value=value,
+            metadata=metadata or {},
+            created_at=existing.created_at if existing else now,
+            updated_at=now,
+        )
+
+    async def get(self, key: str) -> MemoryEntry | None:
+        return self._data.get(key)
+
+    async def search(self, query: str, top_k: int = 5) -> list[MemoryEntry]:
+        query_lower = query.lower()
+        matches = [
+            entry for entry in self._data.values()
+            if query_lower in entry.key.lower() or query_lower in entry.value.lower()
+        ]
+        return matches[:top_k]
+
+    async def delete(self, key: str) -> None:
+        self._data.pop(key, None)
+
+    async def list_keys(self) -> list[str]:
+        return list(self._data.keys())
+
+
+__all__ = ["InMemoryStore"]

--- a/mindtrace/agents/mindtrace/agents/memory/json_file.py
+++ b/mindtrace/agents/mindtrace/agents/memory/json_file.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ._store import AbstractMemoryStore, MemoryEntry
+
+_DATE_FMT = "%Y-%m-%dT%H:%M:%S.%f%z"
+
+
+def _entry_to_dict(entry: MemoryEntry) -> dict:
+    return {
+        "key": entry.key,
+        "value": entry.value,
+        "metadata": entry.metadata,
+        "created_at": entry.created_at.isoformat(),
+        "updated_at": entry.updated_at.isoformat(),
+    }
+
+
+def _dict_to_entry(d: dict) -> MemoryEntry:
+    return MemoryEntry(
+        key=d["key"],
+        value=d["value"],
+        metadata=d.get("metadata", {}),
+        created_at=datetime.fromisoformat(d["created_at"]),
+        updated_at=datetime.fromisoformat(d["updated_at"]),
+    )
+
+
+class JsonFileStore(AbstractMemoryStore):
+    """Persists memories to a JSON file. Suitable for single-process apps."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._data: dict[str, MemoryEntry] = {}
+        if self._path.exists():
+            self._load()
+
+    def _load(self) -> None:
+        raw = json.loads(self._path.read_text())
+        self._data = {k: _dict_to_entry(v) for k, v in raw.items()}
+
+    def _flush(self) -> None:
+        self._path.write_text(
+            json.dumps({k: _entry_to_dict(v) for k, v in self._data.items()}, indent=2)
+        )
+
+    async def save(self, key: str, value: str, metadata: dict | None = None) -> None:
+        now = datetime.now(timezone.utc)
+        existing = self._data.get(key)
+        self._data[key] = MemoryEntry(
+            key=key,
+            value=value,
+            metadata=metadata or {},
+            created_at=existing.created_at if existing else now,
+            updated_at=now,
+        )
+        self._flush()
+
+    async def get(self, key: str) -> MemoryEntry | None:
+        return self._data.get(key)
+
+    async def search(self, query: str, top_k: int = 5) -> list[MemoryEntry]:
+        query_lower = query.lower()
+        matches = [
+            entry for entry in self._data.values()
+            if query_lower in entry.key.lower() or query_lower in entry.value.lower()
+        ]
+        return matches[:top_k]
+
+    async def delete(self, key: str) -> None:
+        self._data.pop(key, None)
+        self._flush()
+
+    async def list_keys(self) -> list[str]:
+        return list(self._data.keys())
+
+
+__all__ = ["JsonFileStore"]

--- a/mindtrace/agents/mindtrace/agents/memory/json_file.py
+++ b/mindtrace/agents/mindtrace/agents/memory/json_file.py
@@ -43,9 +43,7 @@ class JsonFileStore(AbstractMemoryStore):
         self._data = {k: _dict_to_entry(v) for k, v in raw.items()}
 
     def _flush(self) -> None:
-        self._path.write_text(
-            json.dumps({k: _entry_to_dict(v) for k, v in self._data.items()}, indent=2)
-        )
+        self._path.write_text(json.dumps({k: _entry_to_dict(v) for k, v in self._data.items()}, indent=2))
 
     async def save(self, key: str, value: str, metadata: dict | None = None) -> None:
         now = datetime.now(timezone.utc)
@@ -65,7 +63,8 @@ class JsonFileStore(AbstractMemoryStore):
     async def search(self, query: str, top_k: int = 5) -> list[MemoryEntry]:
         query_lower = query.lower()
         matches = [
-            entry for entry in self._data.values()
+            entry
+            for entry in self._data.values()
             if query_lower in entry.key.lower() or query_lower in entry.value.lower()
         ]
         return matches[:top_k]

--- a/mindtrace/agents/mindtrace/agents/memory/toolset.py
+++ b/mindtrace/agents/mindtrace/agents/memory/toolset.py
@@ -26,7 +26,7 @@ class MemoryToolset(AbstractToolset[ToolAgentDepsT]):
 
     def _strip_prefix(self, key: str) -> str:
         prefix = f"{self._namespace}:"
-        return key[len(prefix):] if key.startswith(prefix) else key
+        return key[len(prefix) :] if key.startswith(prefix) else key
 
     def _build_toolset(self) -> FunctionToolset:
         store = self._store

--- a/mindtrace/agents/mindtrace/agents/memory/toolset.py
+++ b/mindtrace/agents/mindtrace/agents/memory/toolset.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .._run_context import RunContext
+from ..tools import Tool, ToolAgentDepsT
+from ..toolsets._toolset import AbstractToolset, ToolsetTool
+from ..toolsets.function import FunctionToolset
+from ._store import AbstractMemoryStore
+
+
+class MemoryToolset(AbstractToolset[ToolAgentDepsT]):
+    """Exposes memory operations as agent-native tools.
+
+    The LLM can call save_memory, recall_memory, search_memory,
+    forget_memory, and list_memories to manage persistent state.
+    """
+
+    def __init__(self, store: AbstractMemoryStore, namespace: str = "default") -> None:
+        self._store = store
+        self._namespace = namespace
+        self._inner = self._build_toolset()
+
+    def _prefixed(self, key: str) -> str:
+        return f"{self._namespace}:{key}"
+
+    def _strip_prefix(self, key: str) -> str:
+        prefix = f"{self._namespace}:"
+        return key[len(prefix):] if key.startswith(prefix) else key
+
+    def _build_toolset(self) -> FunctionToolset:
+        store = self._store
+        prefixed = self._prefixed
+        strip = self._strip_prefix
+        ns_prefix = f"{self._namespace}:"
+
+        async def save_memory(key: str, value: str) -> str:
+            """Store a fact or piece of information for later recall."""
+            await store.save(prefixed(key), value)
+            return f"Saved: {key}"
+
+        async def recall_memory(key: str) -> str:
+            """Retrieve a specific memory by its key."""
+            entry = await store.get(prefixed(key))
+            return entry.value if entry else f"No memory found for key: {key}"
+
+        async def search_memory(query: str, top_k: int = 5) -> str:
+            """Search memories by relevance or keyword."""
+            results = await store.search(query, top_k=top_k * 3)
+            scoped = [e for e in results if e.key.startswith(ns_prefix)][:top_k]
+            if not scoped:
+                return "No matching memories found."
+            return "\n".join(f"{strip(e.key)}: {e.value}" for e in scoped)
+
+        async def forget_memory(key: str) -> str:
+            """Delete a memory entry."""
+            await store.delete(prefixed(key))
+            return f"Forgot: {key}"
+
+        async def list_memories() -> str:
+            """List all stored memory keys."""
+            all_keys = await store.list_keys()
+            scoped = [strip(k) for k in all_keys if k.startswith(ns_prefix)]
+            return "\n".join(scoped) if scoped else "No memories stored."
+
+        toolset = FunctionToolset()
+        for fn in [save_memory, recall_memory, search_memory, forget_memory, list_memories]:
+            toolset.add_tool(Tool(fn))
+        return toolset
+
+    async def get_tools(self, ctx: RunContext[ToolAgentDepsT]) -> dict[str, ToolsetTool]:
+        return await self._inner.get_tools(ctx)
+
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[ToolAgentDepsT],
+        tool: ToolsetTool,
+    ) -> Any:
+        return await self._inner.call_tool(name, tool_args, ctx, tool)
+
+
+__all__ = ["MemoryToolset"]

--- a/mindtrace/agents/mindtrace/agents/messages/__init__.py
+++ b/mindtrace/agents/mindtrace/agents/messages/__init__.py
@@ -1,8 +1,9 @@
 from ..prompts import UserPromptPart
 from ._builder import MessagePart, MessagesBuilder, ModelMessage
-from ._parts import SystemPromptPart, TextPart, ToolCallPart, ToolReturnPart
+from ._parts import HandoffPart, SystemPromptPart, TextPart, ToolCallPart, ToolReturnPart
 
 __all__ = [
+    "HandoffPart",
     "MessagePart",
     "MessagesBuilder",
     "ModelMessage",

--- a/mindtrace/agents/mindtrace/agents/messages/_parts.py
+++ b/mindtrace/agents/mindtrace/agents/messages/_parts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -26,4 +26,13 @@ class ToolReturnPart:
     content: str
 
 
-__all__ = ["SystemPromptPart", "TextPart", "ToolCallPart", "ToolReturnPart"]
+@dataclass(frozen=True)
+class HandoffPart:
+    """Marks an agent-to-agent handoff boundary in message history."""
+    from_agent: str
+    to_agent: str
+    summary: str
+    metadata: dict = field(default_factory=dict)
+
+
+__all__ = ["HandoffPart", "SystemPromptPart", "TextPart", "ToolCallPart", "ToolReturnPart"]

--- a/mindtrace/agents/mindtrace/agents/messages/_parts.py
+++ b/mindtrace/agents/mindtrace/agents/messages/_parts.py
@@ -29,6 +29,7 @@ class ToolReturnPart:
 @dataclass(frozen=True)
 class HandoffPart:
     """Marks an agent-to-agent handoff boundary in message history."""
+
     from_agent: str
     to_agent: str
     summary: str

--- a/mindtrace/agents/mindtrace/agents/toolsets/__init__.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/__init__.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+from ._filter import ToolFilter
 from ._toolset import AbstractToolset, ToolsetTool
+from .compound import CompoundToolset
+from .filtered import FilteredToolset
 from .function import FunctionToolset, FunctionToolsetTool
+from .mcp import MCPToolset
 
 __all__ = [
     "AbstractToolset",
+    "CompoundToolset",
+    "FilteredToolset",
     "FunctionToolset",
     "FunctionToolsetTool",
+    "MCPToolset",
+    "ToolFilter",
     "ToolsetTool",
 ]

--- a/mindtrace/agents/mindtrace/agents/toolsets/_filter.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/_filter.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import fnmatch
+from typing import Callable
+
+
+class ToolFilter:
+    """
+    Predicate over tool name and description.
+
+    Compose filters with ``&`` (AND), ``|`` (OR), ``~`` (NOT).
+    Prefer the shorthand methods on any toolset (``.include()``, ``.exclude()``,
+    ``.include_pattern()``, ``.exclude_pattern()``) over constructing this directly.
+    Use ``ToolFilter`` directly only when you need boolean composition.
+
+    Example::
+
+        from mindtrace.agents.toolsets import ToolFilter
+
+        # Only read ops, but never the credentials one
+        f = ToolFilter.include_pattern("read_*") & ~ToolFilter.include("read_credentials")
+        toolset = MCPToolset.from_http(url).with_filter(f)
+    """
+
+    def __init__(self, predicate: Callable[[str, str | None], bool]) -> None:
+        self._predicate = predicate
+
+    def allows(self, name: str, description: str | None = None) -> bool:
+        return self._predicate(name, description)
+
+    # ------------------------------------------------------------------
+    # Composition
+    # ------------------------------------------------------------------
+
+    def __and__(self, other: ToolFilter) -> ToolFilter:
+        return ToolFilter(lambda n, d: self.allows(n, d) and other.allows(n, d))
+
+    def __or__(self, other: ToolFilter) -> ToolFilter:
+        return ToolFilter(lambda n, d: self.allows(n, d) or other.allows(n, d))
+
+    def __invert__(self) -> ToolFilter:
+        return ToolFilter(lambda n, d: not self.allows(n, d))
+
+    # ------------------------------------------------------------------
+    # Factories
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def include(cls, *names: str) -> ToolFilter:
+        """Allow only tools whose name is in ``names``."""
+        allowed = frozenset(names)
+        return cls(lambda n, d: n in allowed)
+
+    @classmethod
+    def exclude(cls, *names: str) -> ToolFilter:
+        """Allow all tools except those in ``names``."""
+        blocked = frozenset(names)
+        return cls(lambda n, d: n not in blocked)
+
+    @classmethod
+    def include_pattern(cls, *patterns: str) -> ToolFilter:
+        """Allow tools whose name matches any glob pattern (e.g. ``"read_*"``)."""
+        return cls(lambda n, d: any(fnmatch.fnmatch(n, p) for p in patterns))
+
+    @classmethod
+    def exclude_pattern(cls, *patterns: str) -> ToolFilter:
+        """Block tools whose name matches any glob pattern."""
+        return cls(lambda n, d: not any(fnmatch.fnmatch(n, p) for p in patterns))
+
+    @classmethod
+    def by_description(cls, predicate: Callable[[str | None], bool]) -> ToolFilter:
+        """Filter on description text — useful when names are not descriptive."""
+        return cls(lambda n, d: predicate(d))
+
+
+__all__ = ["ToolFilter"]

--- a/mindtrace/agents/mindtrace/agents/toolsets/_toolset.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/_toolset.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any, Generic
+from typing import TYPE_CHECKING, Any, Generic
 
 from .._run_context import RunContext
 from ..tools import ToolAgentDepsT, ToolDefinition
+
+if TYPE_CHECKING:
+    from ._filter import ToolFilter
+    from .filtered import FilteredToolset
 
 
 @dataclass
@@ -28,6 +32,39 @@ class AbstractToolset(Generic[ToolAgentDepsT]):
         tool: ToolsetTool,
     ) -> Any:
         raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Tool visibility — shorthand filter methods
+    # ------------------------------------------------------------------
+
+    def include(self, *names: str) -> FilteredToolset:
+        """Expose only the named tools from this toolset."""
+        from ._filter import ToolFilter
+        from .filtered import FilteredToolset
+        return FilteredToolset(self, ToolFilter.include(*names))
+
+    def exclude(self, *names: str) -> FilteredToolset:
+        """Expose all tools except the named ones."""
+        from ._filter import ToolFilter
+        from .filtered import FilteredToolset
+        return FilteredToolset(self, ToolFilter.exclude(*names))
+
+    def include_pattern(self, *patterns: str) -> FilteredToolset:
+        """Expose tools whose name matches any glob pattern (e.g. ``"read_*"``)."""
+        from ._filter import ToolFilter
+        from .filtered import FilteredToolset
+        return FilteredToolset(self, ToolFilter.include_pattern(*patterns))
+
+    def exclude_pattern(self, *patterns: str) -> FilteredToolset:
+        """Block tools whose name matches any glob pattern."""
+        from ._filter import ToolFilter
+        from .filtered import FilteredToolset
+        return FilteredToolset(self, ToolFilter.exclude_pattern(*patterns))
+
+    def with_filter(self, filter: ToolFilter) -> FilteredToolset:
+        """Apply a custom composed ``ToolFilter`` to this toolset."""
+        from .filtered import FilteredToolset
+        return FilteredToolset(self, filter)
 
 
 __all__ = [

--- a/mindtrace/agents/mindtrace/agents/toolsets/_toolset.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/_toolset.py
@@ -41,29 +41,34 @@ class AbstractToolset(Generic[ToolAgentDepsT]):
         """Expose only the named tools from this toolset."""
         from ._filter import ToolFilter
         from .filtered import FilteredToolset
+
         return FilteredToolset(self, ToolFilter.include(*names))
 
     def exclude(self, *names: str) -> FilteredToolset:
         """Expose all tools except the named ones."""
         from ._filter import ToolFilter
         from .filtered import FilteredToolset
+
         return FilteredToolset(self, ToolFilter.exclude(*names))
 
     def include_pattern(self, *patterns: str) -> FilteredToolset:
         """Expose tools whose name matches any glob pattern (e.g. ``"read_*"``)."""
         from ._filter import ToolFilter
         from .filtered import FilteredToolset
+
         return FilteredToolset(self, ToolFilter.include_pattern(*patterns))
 
     def exclude_pattern(self, *patterns: str) -> FilteredToolset:
         """Block tools whose name matches any glob pattern."""
         from ._filter import ToolFilter
         from .filtered import FilteredToolset
+
         return FilteredToolset(self, ToolFilter.exclude_pattern(*patterns))
 
     def with_filter(self, filter: ToolFilter) -> FilteredToolset:
         """Apply a custom composed ``ToolFilter`` to this toolset."""
         from .filtered import FilteredToolset
+
         return FilteredToolset(self, filter)
 
 

--- a/mindtrace/agents/mindtrace/agents/toolsets/compound.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/compound.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .._run_context import RunContext
+from ..tools import ToolAgentDepsT
+from ._toolset import AbstractToolset, ToolsetTool
+
+
+class CompoundToolset(AbstractToolset[ToolAgentDepsT]):
+    """
+    Merges tools from multiple toolsets into one.
+
+    Later toolsets win on name collisions — use ``tool_prefix`` on ``MCPToolset``
+    to avoid conflicts when combining toolsets from different services.
+
+    Example::
+
+        agent = MindtraceAgent(
+            model=model,
+            toolset=CompoundToolset(
+                MCPToolset.from_http("http://localhost:8001/mcp-server/mcp/").include("generate_image"),
+                MCPToolset.from_http("http://localhost:8002/mcp-server/mcp/").include("query_db"),
+                FunctionToolset(),  # local tools
+            ),
+        )
+    """
+
+    def __init__(self, *toolsets: AbstractToolset) -> None:
+        self._toolsets = list(toolsets)
+        # Populated by get_tools(); maps tool name → owning toolset for fast routing.
+        self._routing: dict[str, AbstractToolset] = {}
+
+    async def get_tools(self, ctx: RunContext[ToolAgentDepsT]) -> dict[str, ToolsetTool]:
+        merged: dict[str, ToolsetTool] = {}
+        self._routing = {}
+        for ts in self._toolsets:
+            tools = await ts.get_tools(ctx)
+            for name, tool in tools.items():
+                merged[name] = tool
+                self._routing[name] = ts
+        return merged
+
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[ToolAgentDepsT],
+        tool: ToolsetTool,
+    ) -> Any:
+        source = self._routing.get(name)
+        if source is None:
+            raise ValueError(f"Unknown tool {name!r}. Was get_tools() called first?")
+        return await source.call_tool(name, tool_args, ctx, tool)
+
+
+__all__ = ["CompoundToolset"]

--- a/mindtrace/agents/mindtrace/agents/toolsets/filtered.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/filtered.py
@@ -26,11 +26,7 @@ class FilteredToolset(AbstractToolset[ToolAgentDepsT]):
 
     async def get_tools(self, ctx: RunContext[ToolAgentDepsT]) -> dict[str, ToolsetTool]:
         all_tools = await self._inner.get_tools(ctx)
-        return {
-            name: tool
-            for name, tool in all_tools.items()
-            if self._filter.allows(name, tool.tool_def.description)
-        }
+        return {name: tool for name, tool in all_tools.items() if self._filter.allows(name, tool.tool_def.description)}
 
     async def call_tool(
         self,

--- a/mindtrace/agents/mindtrace/agents/toolsets/filtered.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/filtered.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .._run_context import RunContext
+from ..tools import ToolAgentDepsT
+from ._filter import ToolFilter
+from ._toolset import AbstractToolset, ToolsetTool
+
+
+class FilteredToolset(AbstractToolset[ToolAgentDepsT]):
+    """
+    Wraps any ``AbstractToolset`` and hides tools that do not pass a ``ToolFilter``.
+
+    Not constructed directly — obtain via the shorthand methods on any toolset::
+
+        toolset.include("tool_a", "tool_b")
+        toolset.exclude("dangerous_tool")
+        toolset.include_pattern("read_*")
+        toolset.with_filter(ToolFilter.include_pattern("read_*") & ~ToolFilter.include("read_env"))
+    """
+
+    def __init__(self, inner: AbstractToolset[ToolAgentDepsT], filter: ToolFilter) -> None:
+        self._inner = inner
+        self._filter = filter
+
+    async def get_tools(self, ctx: RunContext[ToolAgentDepsT]) -> dict[str, ToolsetTool]:
+        all_tools = await self._inner.get_tools(ctx)
+        return {
+            name: tool
+            for name, tool in all_tools.items()
+            if self._filter.allows(name, tool.tool_def.description)
+        }
+
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[ToolAgentDepsT],
+        tool: ToolsetTool,
+    ) -> Any:
+        return await self._inner.call_tool(name, tool_args, ctx, tool)
+
+
+__all__ = ["FilteredToolset"]

--- a/mindtrace/agents/mindtrace/agents/toolsets/mcp.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/mcp.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .._run_context import RunContext
+from ..tools import ToolAgentDepsT, ToolDefinition
+from ._toolset import AbstractToolset, ToolsetTool
+
+
+class MCPToolset(AbstractToolset[ToolAgentDepsT]):
+    """
+    Exposes tools from any remote MCP server to a ``MindtraceAgent``.
+
+    Supports HTTP (streamable-http), SSE, and stdio transports.
+    Requires ``fastmcp`` — install with ``pip install mindtrace-agents[mcp]``.
+
+    Do not construct directly; use the class methods::
+
+        # Mindtrace service (HTTP)
+        MCPToolset.from_http("http://localhost:8001/mcp-server/mcp/")
+
+        # Any SSE-based MCP server
+        MCPToolset.from_sse("http://localhost:9000/sse")
+
+        # Local stdio server (e.g. npx MCP servers)
+        MCPToolset.from_stdio(["npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp"])
+
+    Control which tools are visible to the agent::
+
+        MCPToolset.from_http(url).include("search", "summarise")
+        MCPToolset.from_http(url).exclude("drop_table")
+        MCPToolset.from_http(url).include_pattern("read_*", "list_*")
+
+    Avoid name collisions when combining multiple services::
+
+        MCPToolset.from_http(url, prefix="fs")   # exposes "fs__read_file", "fs__list_dir"
+    """
+
+    def __init__(
+        self,
+        transport_factory: Callable[[], Any],
+        *,
+        prefix: str | None = None,
+    ) -> None:
+        self._transport_factory = transport_factory
+        self._prefix = prefix
+        # Populated by get_tools(); maps exposed name → original MCP tool name.
+        self._name_map: dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_http(cls, url: str, *, prefix: str | None = None) -> MCPToolset:
+        """Connect via HTTP (streamable-http) transport — the default for Mindtrace services."""
+        return cls(lambda: url, prefix=prefix)
+
+    @classmethod
+    def from_sse(cls, url: str, *, prefix: str | None = None) -> MCPToolset:
+        """Connect via SSE transport (legacy MCP HTTP)."""
+        def _make():
+            try:
+                from fastmcp.client.transports import SSETransport
+            except ImportError:
+                raise ImportError(
+                    "fastmcp is required for MCPToolset. "
+                    "Install with: pip install 'mindtrace-agents[mcp]'"
+                )
+            return SSETransport(url)
+        return cls(_make, prefix=prefix)
+
+    @classmethod
+    def from_stdio(
+        cls,
+        command: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        prefix: str | None = None,
+    ) -> MCPToolset:
+        """Connect via stdio transport — for local subprocess MCP servers (e.g. npx)."""
+        def _make():
+            try:
+                from fastmcp.client.transports import StdioTransport
+            except ImportError:
+                raise ImportError(
+                    "fastmcp is required for MCPToolset. "
+                    "Install with: pip install 'mindtrace-agents[mcp]'"
+                )
+            return StdioTransport(command, env=env)
+        return cls(_make, prefix=prefix)
+
+    # ------------------------------------------------------------------
+    # AbstractToolset interface
+    # ------------------------------------------------------------------
+
+    async def get_tools(self, ctx: RunContext[ToolAgentDepsT]) -> dict[str, ToolsetTool]:
+        try:
+            from fastmcp import Client
+        except ImportError:
+            raise ImportError(
+                "fastmcp is required for MCPToolset. "
+                "Install with: pip install 'mindtrace-agents[mcp]'"
+            )
+
+        async with Client(self._transport_factory()) as client:
+            response = await client.list_tools()
+
+        # list_tools() returns list[mcp.types.Tool] directly
+        self._name_map = {}
+        tools: dict[str, ToolsetTool] = {}
+        for mcp_tool in response:
+            exposed = f"{self._prefix}__{mcp_tool.name}" if self._prefix else mcp_tool.name
+            self._name_map[exposed] = mcp_tool.name
+            tools[exposed] = ToolsetTool(
+                tool_def=ToolDefinition(
+                    name=exposed,
+                    description=mcp_tool.description,
+                    parameters_json_schema=mcp_tool.inputSchema or {},
+                ),
+                max_retries=None,
+            )
+        return tools
+
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[ToolAgentDepsT],
+        tool: ToolsetTool,
+    ) -> Any:
+        try:
+            from fastmcp import Client
+        except ImportError:
+            raise ImportError(
+                "fastmcp is required for MCPToolset. "
+                "Install with: pip install 'mindtrace-agents[mcp]'"
+            )
+
+        mcp_name = self._name_map.get(name, name)
+        async with Client(self._transport_factory()) as client:
+            result = await client.call_tool(mcp_name, arguments=tool_args)
+
+        # call_tool() returns CallToolResult; .content is list[ContentBlock]
+        # structured responses (dataclass/dict) are in .data — prefer that when present
+        if result.data is not None:
+            return str(result.data)
+        return "\n".join(
+            part.text if hasattr(part, "text") else str(part)
+            for part in result.content
+        )
+
+
+__all__ = ["MCPToolset"]

--- a/mindtrace/agents/mindtrace/agents/toolsets/mcp.py
+++ b/mindtrace/agents/mindtrace/agents/toolsets/mcp.py
@@ -59,15 +59,16 @@ class MCPToolset(AbstractToolset[ToolAgentDepsT]):
     @classmethod
     def from_sse(cls, url: str, *, prefix: str | None = None) -> MCPToolset:
         """Connect via SSE transport (legacy MCP HTTP)."""
+
         def _make():
             try:
                 from fastmcp.client.transports import SSETransport
             except ImportError:
                 raise ImportError(
-                    "fastmcp is required for MCPToolset. "
-                    "Install with: pip install 'mindtrace-agents[mcp]'"
+                    "fastmcp is required for MCPToolset. Install with: pip install 'mindtrace-agents[mcp]'"
                 )
             return SSETransport(url)
+
         return cls(_make, prefix=prefix)
 
     @classmethod
@@ -79,15 +80,16 @@ class MCPToolset(AbstractToolset[ToolAgentDepsT]):
         prefix: str | None = None,
     ) -> MCPToolset:
         """Connect via stdio transport — for local subprocess MCP servers (e.g. npx)."""
+
         def _make():
             try:
                 from fastmcp.client.transports import StdioTransport
             except ImportError:
                 raise ImportError(
-                    "fastmcp is required for MCPToolset. "
-                    "Install with: pip install 'mindtrace-agents[mcp]'"
+                    "fastmcp is required for MCPToolset. Install with: pip install 'mindtrace-agents[mcp]'"
                 )
             return StdioTransport(command, env=env)
+
         return cls(_make, prefix=prefix)
 
     # ------------------------------------------------------------------
@@ -98,10 +100,7 @@ class MCPToolset(AbstractToolset[ToolAgentDepsT]):
         try:
             from fastmcp import Client
         except ImportError:
-            raise ImportError(
-                "fastmcp is required for MCPToolset. "
-                "Install with: pip install 'mindtrace-agents[mcp]'"
-            )
+            raise ImportError("fastmcp is required for MCPToolset. Install with: pip install 'mindtrace-agents[mcp]'")
 
         async with Client(self._transport_factory()) as client:
             response = await client.list_tools()
@@ -132,10 +131,7 @@ class MCPToolset(AbstractToolset[ToolAgentDepsT]):
         try:
             from fastmcp import Client
         except ImportError:
-            raise ImportError(
-                "fastmcp is required for MCPToolset. "
-                "Install with: pip install 'mindtrace-agents[mcp]'"
-            )
+            raise ImportError("fastmcp is required for MCPToolset. Install with: pip install 'mindtrace-agents[mcp]'")
 
         mcp_name = self._name_map.get(name, name)
         async with Client(self._transport_factory()) as client:
@@ -145,10 +141,7 @@ class MCPToolset(AbstractToolset[ToolAgentDepsT]):
         # structured responses (dataclass/dict) are in .data — prefer that when present
         if result.data is not None:
             return str(result.data)
-        return "\n".join(
-            part.text if hasattr(part, "text") else str(part)
-            for part in result.content
-        )
+        return "\n".join(part.text if hasattr(part, "text") else str(part) for part in result.content)
 
 
 __all__ = ["MCPToolset"]

--- a/mindtrace/agents/pyproject.toml
+++ b/mindtrace/agents/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = ["fastmcp>=2.13.0"]
+distributed-rabbitmq = ["aio-pika>=9.0"]
+memory-redis = ["redis>=5.0"]
+memory-vector = ["chromadb>=0.4"]
 
 [project.urls]
 Homepage = "https://mindtrace.ai"

--- a/mindtrace/agents/pyproject.toml
+++ b/mindtrace/agents/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "mindtrace-core>=0.9.4",
 ]
 
+[project.optional-dependencies]
+mcp = ["fastmcp>=2.13.0"]
+
 [project.urls]
 Homepage = "https://mindtrace.ai"
 Repository = "https://github.com/mindtrace/mindtrace"

--- a/samples/agents/mcp_service_agent.py
+++ b/samples/agents/mcp_service_agent.py
@@ -1,0 +1,72 @@
+"""
+Agent using remote MCP tools from a Mindtrace service.
+
+Launches EchoService in a subprocess, connects an MCPToolset to its MCP
+endpoint, then runs a MindtraceAgent with gpt-4o-mini that calls those tools.
+
+EchoService exposes two tools:
+  - echo            — returns the message unchanged
+  - reverse_message — returns the message reversed
+
+Run:
+    OPENAI_API_KEY=... python samples/agents/mcp_service_agent.py
+"""
+
+import asyncio
+import os
+from mindtrace.agents import MCPToolset, MindtraceAgent, OpenAIChatModel, OpenAIProvider
+from mindtrace.services.samples.echo_mcp import EchoService
+
+
+async def main() -> None:
+    # --- Launch EchoService in a subprocess ---
+    # connection manager holds the URL and shuts the process down on __exit__
+    # OPENAI_API_KEY should be set via environment variable (see docstring)
+    with EchoService.launch(port=8004) as cm:
+        print(f"EchoService running at {cm.url}")
+        print(f"MCP endpoint: {cm.mcp_url}\n")
+
+        # --- Wire up the MCPToolset ---
+        # .include() limits what the agent sees — avoids giving it tools it
+        # doesn't need and keeps the LLM prompt clean.
+        toolset = MCPToolset.from_http(cm.mcp_url).include("echo", "reverse_message")
+
+        # Omit .include() to expose every tool the service publishes:
+        # toolset = MCPToolset.from_http(cm.mcp_url)
+
+        # --- Build the agent ---
+        provider = OpenAIProvider()  # reads OPENAI_API_KEY from environment
+        model = OpenAIChatModel("gpt-4o-mini", provider=provider)
+
+        agent = MindtraceAgent(
+            model=model,
+            toolset=toolset,
+            system_prompt=(
+                "You have access to two tools: echo and reverse_message. "
+                "Use them when asked. Be concise."
+            ),
+            name="echo_agent",
+        )
+
+        # --- Run 1: echo ---
+        print("=== echo ===")
+        result = await agent.run('Echo the message "Hello from MindTrace!"')
+        print(result)
+
+        # --- Run 2: reverse ---
+        print("\n=== reverse_message ===")
+        result = await agent.run('Reverse the message "abcdefg"')
+        print(result)
+
+        # --- Run 3: both in one turn ---
+        print("\n=== chained ===")
+        result = await agent.run(
+            'Echo "ping", then reverse "pong" and tell me both results.'
+        )
+        print(result)
+
+    print("\nEchoService shut down.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/agents/remote_mcp_agent.py
+++ b/samples/agents/remote_mcp_agent.py
@@ -13,7 +13,7 @@ Run:
 """
 
 import asyncio
-import os
+
 from mindtrace.agents import MCPToolset, MindtraceAgent, OpenAIChatModel, OpenAIProvider
 from mindtrace.services.samples.echo_mcp import EchoService
 
@@ -41,10 +41,7 @@ async def main() -> None:
         agent = MindtraceAgent(
             model=model,
             toolset=toolset,
-            system_prompt=(
-                "You have access to two tools: echo and reverse_message. "
-                "Use them when asked. Be concise."
-            ),
+            system_prompt=("You have access to two tools: echo and reverse_message. Use them when asked. Be concise."),
             name="echo_agent",
         )
 
@@ -60,9 +57,7 @@ async def main() -> None:
 
         # --- Run 3: both in one turn ---
         print("\n=== chained ===")
-        result = await agent.run(
-            'Echo "ping", then reverse "pong" and tell me both results.'
-        )
+        result = await agent.run('Echo "ping", then reverse "pong" and tell me both results.')
         print(result)
 
     print("\nEchoService shut down.")

--- a/tests/unit/mindtrace/agents/test_agent_as_tool.py
+++ b/tests/unit/mindtrace/agents/test_agent_as_tool.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from mindtrace.agents import MindtraceAgent
 from mindtrace.agents.models import ModelResponse
 from mindtrace.agents.tools import Tool
@@ -118,17 +116,18 @@ class TestAgentAsTool:
             description="Research a topic",
             responses=[text_response("sub result")],
         )
-        parent_model = FakeModel(responses=[
-            tool_call_response("researcher", arguments='{"input": "topic"}'),
-            text_response("got: sub result"),
-        ])
+        parent_model = FakeModel(
+            responses=[
+                tool_call_response("researcher", arguments='{"input": "topic"}'),
+                text_response("got: sub result"),
+            ]
+        )
         parent = MindtraceAgent(model=parent_model, tools=[sub])
         result = await parent.run("go")
         assert result == "got: sub result"
 
     async def test_deps_forwarded_to_sub_agent(self):
         """Parent deps are forwarded to the sub-agent's run() call."""
-        from unittest.mock import AsyncMock, patch
 
         class MyDeps:
             value = 42
@@ -137,7 +136,6 @@ class TestAgentAsTool:
 
         # Patch sub.run to capture what deps it receives
         received: list[Any] = []
-        original_run = sub.run
 
         async def spy_run(input_data, *, deps=None, **kwargs):
             received.append(deps)

--- a/tests/unit/mindtrace/agents/test_agent_as_tool.py
+++ b/tests/unit/mindtrace/agents/test_agent_as_tool.py
@@ -1,0 +1,161 @@
+"""Unit tests for agents-as-tools (section 1.1) and description field."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mindtrace.agents import MindtraceAgent
+from mindtrace.agents.models import ModelResponse
+from mindtrace.agents.tools import Tool
+
+from .conftest import FakeModel, text_response, tool_call_response
+
+
+def _make_agent(responses: list[ModelResponse] | None = None, **kwargs: Any) -> MindtraceAgent:
+    return MindtraceAgent(model=FakeModel(responses=responses), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# description field
+# ---------------------------------------------------------------------------
+
+
+class TestDescriptionField:
+    """Tests for the description property on MindtraceAgent."""
+
+    def test_description_stored(self):
+        """description is returned by the property."""
+        agent = _make_agent(description="Does research")
+        assert agent.description == "Does research"
+
+    def test_description_defaults_to_none(self):
+        """description defaults to None when not provided."""
+        agent = _make_agent()
+        assert agent.description is None
+
+    def test_description_independent_of_name(self):
+        """description and name can be set independently."""
+        agent = _make_agent(name="researcher", description="Research a topic")
+        assert agent.name == "researcher"
+        assert agent.description == "Research a topic"
+
+
+# ---------------------------------------------------------------------------
+# Agents passed in tools=[]
+# ---------------------------------------------------------------------------
+
+
+class TestAgentAsTool:
+    """Tests for passing AbstractMindtraceAgent instances directly into tools=[]."""
+
+    def test_agent_in_tools_is_converted_to_tool(self):
+        """An agent passed in tools=[] is converted to a Tool (not stored as agent)."""
+        sub = _make_agent(name="sub", description="A sub-agent")
+        parent = _make_agent(tools=[sub])
+        assert len(parent.tools) == 1
+        assert isinstance(parent.tools[0], Tool)
+
+    def test_agent_tool_name_matches_agent_name(self):
+        """The generated Tool's name matches the sub-agent's name."""
+        sub = _make_agent(name="researcher", description="Research things")
+        parent = _make_agent(tools=[sub])
+        assert parent.tools[0].name == "researcher"
+
+    def test_agent_tool_description_matches_agent_description(self):
+        """The generated Tool's description comes from the sub-agent's description."""
+        sub = _make_agent(name="writer", description="Write reports")
+        parent = _make_agent(tools=[sub])
+        tool_def = parent.tools[0].tool_def()
+        assert tool_def.description == "Write reports"
+
+    def test_mixed_tools_and_agents(self):
+        """Tools and agents can be mixed freely in tools=[]."""
+
+        def plain_tool(x: int) -> int:
+            """A plain tool."""
+            return x
+
+        sub = _make_agent(name="sub", description="sub agent")
+        parent = _make_agent(tools=[Tool(plain_tool), sub])
+        assert len(parent.tools) == 2
+        names = {t.name for t in parent.tools}
+        assert "plain_tool" in names
+        assert "sub" in names
+
+    def test_multiple_agents_in_tools(self):
+        """Multiple agents can be passed and are all converted to Tools."""
+        a1 = _make_agent(name="agent_a", description="Agent A")
+        a2 = _make_agent(name="agent_b", description="Agent B")
+        parent = _make_agent(tools=[a1, a2])
+        assert len(parent.tools) == 2
+        names = {t.name for t in parent.tools}
+        assert names == {"agent_a", "agent_b"}
+
+    async def test_sub_agent_called_when_llm_requests_it(self):
+        """When the LLM requests the sub-agent tool, sub_agent.run() is invoked."""
+        sub = _make_agent(
+            name="researcher",
+            description="Research a topic",
+            responses=[text_response("climate facts")],
+        )
+        parent_responses = [
+            tool_call_response("researcher", arguments='{"input": "climate"}'),
+            text_response("final answer"),
+        ]
+        parent = MindtraceAgent(
+            model=FakeModel(responses=parent_responses),
+            tools=[sub],
+        )
+        result = await parent.run("Tell me about climate")
+        assert result == "final answer"
+
+    async def test_sub_agent_result_feeds_back_to_parent(self):
+        """The sub-agent's output is visible to the parent as a tool result."""
+        sub = _make_agent(
+            name="researcher",
+            description="Research a topic",
+            responses=[text_response("sub result")],
+        )
+        parent_model = FakeModel(responses=[
+            tool_call_response("researcher", arguments='{"input": "topic"}'),
+            text_response("got: sub result"),
+        ])
+        parent = MindtraceAgent(model=parent_model, tools=[sub])
+        result = await parent.run("go")
+        assert result == "got: sub result"
+
+    async def test_deps_forwarded_to_sub_agent(self):
+        """Parent deps are forwarded to the sub-agent's run() call."""
+        from unittest.mock import AsyncMock, patch
+
+        class MyDeps:
+            value = 42
+
+        sub = _make_agent(name="sub", description="sub agent", deps_type=MyDeps)
+
+        # Patch sub.run to capture what deps it receives
+        received: list[Any] = []
+        original_run = sub.run
+
+        async def spy_run(input_data, *, deps=None, **kwargs):
+            received.append(deps)
+            return "sub result"
+
+        sub.run = spy_run
+
+        parent_responses = [
+            tool_call_response("sub", arguments='{"input": "go"}'),
+            text_response("parent done"),
+        ]
+        parent = MindtraceAgent(
+            model=FakeModel(responses=parent_responses),
+            tools=[sub],
+            deps_type=MyDeps,
+        )
+
+        deps = MyDeps()
+        await parent.run("start", deps=deps)
+        assert len(received) == 1
+        assert received[0] is deps

--- a/tests/unit/mindtrace/agents/test_execution.py
+++ b/tests/unit/mindtrace/agents/test_execution.py
@@ -1,0 +1,331 @@
+"""Unit tests for mindtrace.agents.execution and DistributedAgent."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mindtrace.agents import DistributedAgent, MindtraceAgent
+from mindtrace.agents.execution import AbstractTaskQueue, AgentTask, LocalTaskQueue, TaskStatus
+from mindtrace.agents.models import ModelResponse
+
+from .conftest import FakeModel, text_response
+
+
+def _make_agent(responses: list[ModelResponse] | None = None, **kwargs: Any) -> MindtraceAgent:
+    return MindtraceAgent(model=FakeModel(responses=responses), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# AgentTask
+# ---------------------------------------------------------------------------
+
+
+class TestAgentTask:
+    """Tests for the AgentTask dataclass."""
+
+    def test_required_fields(self):
+        """AgentTask stores agent_name and input."""
+        task = AgentTask(agent_name="researcher", input="What is AI?")
+        assert task.agent_name == "researcher"
+        assert task.input == "What is AI?"
+
+    def test_optional_fields_default(self):
+        """deps, session_id, and metadata default correctly."""
+        task = AgentTask(agent_name="a", input="b")
+        assert task.deps is None
+        assert task.session_id is None
+        assert task.metadata == {}
+
+    def test_all_fields_stored(self):
+        """All fields can be set explicitly."""
+        task = AgentTask(
+            agent_name="writer",
+            input="write report",
+            deps={"token": "abc"},
+            session_id="s1",
+            metadata={"priority": 1},
+        )
+        assert task.deps == {"token": "abc"}
+        assert task.session_id == "s1"
+        assert task.metadata == {"priority": 1}
+
+
+# ---------------------------------------------------------------------------
+# TaskStatus
+# ---------------------------------------------------------------------------
+
+
+class TestTaskStatus:
+    """Tests for the TaskStatus enum."""
+
+    def test_values_exist(self):
+        """All four status values are defined."""
+        assert TaskStatus.PENDING == "PENDING"
+        assert TaskStatus.RUNNING == "RUNNING"
+        assert TaskStatus.DONE == "DONE"
+        assert TaskStatus.FAILED == "FAILED"
+
+
+# ---------------------------------------------------------------------------
+# LocalTaskQueue
+# ---------------------------------------------------------------------------
+
+
+class TestLocalTaskQueueRegister:
+    """Tests for LocalTaskQueue.register()."""
+
+    def test_register_requires_name(self):
+        """Registering an agent without a name raises ValueError."""
+        queue = LocalTaskQueue()
+        agent = _make_agent()  # name=None
+        with pytest.raises(ValueError, match="name"):
+            queue.register(agent)
+
+    def test_register_stores_agent(self):
+        """Registered agent can be looked up by name."""
+        queue = LocalTaskQueue()
+        agent = _make_agent(name="researcher")
+        queue.register(agent)
+        assert queue._agents["researcher"] is agent
+
+
+class TestLocalTaskQueueSubmit:
+    """Tests for LocalTaskQueue.submit() and get_result()."""
+
+    async def test_submit_unknown_agent_raises(self):
+        """submit() raises KeyError if the agent was not registered."""
+        queue = LocalTaskQueue()
+        task = AgentTask(agent_name="ghost", input="hello")
+        with pytest.raises(KeyError, match="ghost"):
+            await queue.submit(task)
+
+    async def test_submit_returns_task_id(self):
+        """submit() returns a non-empty string task_id."""
+        queue = LocalTaskQueue()
+        agent = _make_agent(name="a", responses=[text_response("ok")])
+        queue.register(agent)
+        task_id = await queue.submit(AgentTask(agent_name="a", input="go"))
+        assert isinstance(task_id, str)
+        assert task_id  # non-empty
+
+    async def test_get_result_returns_agent_output(self):
+        """get_result() waits for and returns the agent's run() output."""
+        queue = LocalTaskQueue()
+        agent = _make_agent(name="a", responses=[text_response("answer")])
+        queue.register(agent)
+        task_id = await queue.submit(AgentTask(agent_name="a", input="question"))
+        result = await queue.get_result(task_id)
+        assert result == "answer"
+
+    async def test_get_result_unknown_task_id_raises(self):
+        """get_result() raises KeyError for an unknown task_id."""
+        queue = LocalTaskQueue()
+        with pytest.raises(KeyError, match="unknown"):
+            await queue.get_result("unknown")
+
+    async def test_status_transitions(self):
+        """Task status transitions from PENDING → RUNNING → DONE."""
+        queue = LocalTaskQueue()
+
+        # Use an event to pause the agent mid-run so we can observe RUNNING
+        started = asyncio.Event()
+        finished = asyncio.Event()
+
+        async def slow_tool() -> str:
+            """Slow tool."""
+            started.set()
+            await finished.wait()
+            return "done"
+
+        from mindtrace.agents.tools import Tool
+        responses = [
+            ModelResponse(
+                text="",
+                tool_calls=[{"name": "slow_tool", "id": "t1", "arguments": "{}"}],
+            ),
+            text_response("complete"),
+        ]
+        agent = MindtraceAgent(
+            model=FakeModel(responses=responses),
+            name="slow",
+            tools=[Tool(slow_tool)],
+        )
+        queue.register(agent)
+        task_id = await queue.submit(AgentTask(agent_name="slow", input="go"))
+
+        assert await queue.status(task_id) in (TaskStatus.PENDING, TaskStatus.RUNNING)
+
+        finished.set()
+        await queue.get_result(task_id)
+        assert await queue.status(task_id) == TaskStatus.DONE
+
+    async def test_cancel_marks_task_failed(self):
+        """cancel() marks the task as FAILED and cancels the Future."""
+        queue = LocalTaskQueue()
+        blocker = asyncio.Event()
+
+        async def blocking_tool() -> str:
+            """Block forever."""
+            await blocker.wait()
+            return "never"
+
+        from mindtrace.agents.tools import Tool
+        responses = [
+            ModelResponse(
+                text="",
+                tool_calls=[{"name": "blocking_tool", "id": "t1", "arguments": "{}"}],
+            ),
+            text_response("done"),
+        ]
+        agent = MindtraceAgent(
+            model=FakeModel(responses=responses),
+            name="blocked",
+            tools=[Tool(blocking_tool)],
+        )
+        queue.register(agent)
+        task_id = await queue.submit(AgentTask(agent_name="blocked", input="go"))
+        await asyncio.sleep(0)  # allow task to start
+
+        await queue.cancel(task_id)
+        assert await queue.status(task_id) == TaskStatus.FAILED
+
+    async def test_deps_forwarded_to_agent(self):
+        """deps from AgentTask are passed to agent.run()."""
+        received: list[Any] = []
+        agent = _make_agent(name="dep_agent", responses=[text_response("ok")])
+
+        async def spy_run(input_data, *, deps=None, **kwargs):
+            received.append(deps)
+            return "ok"
+
+        agent.run = spy_run
+
+        queue = LocalTaskQueue()
+        queue.register(agent)
+        task_id = await queue.submit(AgentTask(agent_name="dep_agent", input="go", deps={"key": "val"}))
+        await queue.get_result(task_id)
+
+        assert received == [{"key": "val"}]
+
+
+# ---------------------------------------------------------------------------
+# DistributedAgent
+# ---------------------------------------------------------------------------
+
+
+class TestDistributedAgent:
+    """Tests for DistributedAgent."""
+
+    def test_delegates_name_to_wrapped(self):
+        """name comes from the wrapped agent."""
+        agent = _make_agent(name="researcher")
+        distributed = DistributedAgent(agent, task_queue=LocalTaskQueue())
+        assert distributed.name == "researcher"
+
+    def test_delegates_description_to_wrapped(self):
+        """description comes from the wrapped agent."""
+        agent = _make_agent(name="a", description="Does research")
+        distributed = DistributedAgent(agent, task_queue=LocalTaskQueue())
+        assert distributed.description == "Does research"
+
+    def test_delegates_deps_type(self):
+        """deps_type comes from the wrapped agent."""
+        agent = _make_agent(deps_type=dict)
+        distributed = DistributedAgent(agent, task_queue=LocalTaskQueue())
+        assert distributed.deps_type is dict
+
+    async def test_run_submits_to_queue_and_returns_result(self):
+        """run() submits a task and returns the queue result."""
+        mock_queue = AsyncMock(spec=AbstractTaskQueue)
+        mock_queue.submit.return_value = "task-123"
+        mock_queue.get_result.return_value = "queue result"
+
+        agent = _make_agent(name="a")
+        distributed = DistributedAgent(agent, task_queue=mock_queue)
+        result = await distributed.run("hello")
+
+        mock_queue.submit.assert_called_once()
+        submitted_task: AgentTask = mock_queue.submit.call_args[0][0]
+        assert submitted_task.agent_name == "a"
+        assert submitted_task.input == "hello"
+
+        mock_queue.get_result.assert_called_once_with("task-123")
+        assert result == "queue result"
+
+    async def test_run_forwards_deps(self):
+        """deps passed to run() are forwarded in the AgentTask."""
+        mock_queue = AsyncMock(spec=AbstractTaskQueue)
+        mock_queue.submit.return_value = "tid"
+        mock_queue.get_result.return_value = "ok"
+
+        agent = _make_agent(name="a")
+        distributed = DistributedAgent(agent, task_queue=mock_queue)
+        await distributed.run("input", deps={"token": "abc"})
+
+        task: AgentTask = mock_queue.submit.call_args[0][0]
+        assert task.deps == {"token": "abc"}
+
+    async def test_run_forwards_session_id(self):
+        """session_id passed to run() is forwarded in the AgentTask."""
+        mock_queue = AsyncMock(spec=AbstractTaskQueue)
+        mock_queue.submit.return_value = "tid"
+        mock_queue.get_result.return_value = "ok"
+
+        agent = _make_agent(name="a")
+        distributed = DistributedAgent(agent, task_queue=mock_queue)
+        await distributed.run("input", session_id="sess-1")
+
+        task: AgentTask = mock_queue.submit.call_args[0][0]
+        assert task.session_id == "sess-1"
+
+    async def test_distributed_agent_with_local_queue_end_to_end(self):
+        """DistributedAgent + LocalTaskQueue executes the wrapped agent correctly."""
+        agent = _make_agent(name="worker", responses=[text_response("local result")])
+        queue = LocalTaskQueue()
+        queue.register(agent)
+        distributed = DistributedAgent(agent, task_queue=queue)
+        result = await distributed.run("do work")
+        assert result == "local result"
+
+
+# ---------------------------------------------------------------------------
+# HandoffPart
+# ---------------------------------------------------------------------------
+
+
+class TestHandoffPart:
+    """Tests for the HandoffPart message part."""
+
+    def test_fields_stored(self):
+        """HandoffPart stores from_agent, to_agent, summary, and metadata."""
+        from mindtrace.agents.messages import HandoffPart
+
+        part = HandoffPart(
+            from_agent="orchestrator",
+            to_agent="writer",
+            summary="Researcher found: climate facts",
+            metadata={"step": 1},
+        )
+        assert part.from_agent == "orchestrator"
+        assert part.to_agent == "writer"
+        assert part.summary == "Researcher found: climate facts"
+        assert part.metadata == {"step": 1}
+
+    def test_default_metadata_is_empty(self):
+        """metadata defaults to empty dict."""
+        from mindtrace.agents.messages import HandoffPart
+
+        part = HandoffPart(from_agent="a", to_agent="b", summary="ctx")
+        assert part.metadata == {}
+
+    def test_is_frozen(self):
+        """HandoffPart is immutable (frozen dataclass)."""
+        from mindtrace.agents.messages import HandoffPart
+
+        part = HandoffPart(from_agent="a", to_agent="b", summary="s")
+        with pytest.raises((AttributeError, TypeError)):
+            part.summary = "changed"  # type: ignore[misc]

--- a/tests/unit/mindtrace/agents/test_execution.py
+++ b/tests/unit/mindtrace/agents/test_execution.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -142,6 +142,7 @@ class TestLocalTaskQueueSubmit:
             return "done"
 
         from mindtrace.agents.tools import Tool
+
         responses = [
             ModelResponse(
                 text="",
@@ -174,6 +175,7 @@ class TestLocalTaskQueueSubmit:
             return "never"
 
         from mindtrace.agents.tools import Tool
+
         responses = [
             ModelResponse(
                 text="",

--- a/tests/unit/mindtrace/agents/test_memory.py
+++ b/tests/unit/mindtrace/agents/test_memory.py
@@ -5,13 +5,9 @@ from __future__ import annotations
 import json
 import tempfile
 from pathlib import Path
-from typing import Any
-
-import pytest
 
 from mindtrace.agents._run_context import RunContext
 from mindtrace.agents.memory import (
-    AbstractMemoryStore,
     InMemoryStore,
     JsonFileStore,
     MemoryEntry,
@@ -34,6 +30,7 @@ class TestMemoryEntry:
     def test_fields_stored(self):
         """MemoryEntry stores key, value, and metadata."""
         from datetime import datetime, timezone
+
         now = datetime.now(timezone.utc)
         entry = MemoryEntry(key="k", value="v", metadata={"tag": "x"}, created_at=now, updated_at=now)
         assert entry.key == "k"
@@ -43,6 +40,7 @@ class TestMemoryEntry:
     def test_default_metadata_is_empty_dict(self):
         """metadata defaults to an empty dict."""
         from datetime import datetime, timezone
+
         now = datetime.now(timezone.utc)
         entry = MemoryEntry(key="k", value="v", created_at=now, updated_at=now)
         assert entry.metadata == {}
@@ -90,6 +88,7 @@ class TestInMemoryStore:
     async def test_updated_at_changes_on_update(self):
         """updated_at is refreshed when an existing key is saved again."""
         import asyncio
+
         store = InMemoryStore()
         await store.save("k", "v1")
         original = await store.get("k")

--- a/tests/unit/mindtrace/agents/test_memory.py
+++ b/tests/unit/mindtrace/agents/test_memory.py
@@ -1,0 +1,360 @@
+"""Unit tests for mindtrace.agents.memory."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mindtrace.agents._run_context import RunContext
+from mindtrace.agents.memory import (
+    AbstractMemoryStore,
+    InMemoryStore,
+    JsonFileStore,
+    MemoryEntry,
+    MemoryToolset,
+)
+
+
+def _ctx() -> RunContext:
+    return RunContext(deps=None)
+
+
+# ---------------------------------------------------------------------------
+# MemoryEntry
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryEntry:
+    """Tests for the MemoryEntry dataclass."""
+
+    def test_fields_stored(self):
+        """MemoryEntry stores key, value, and metadata."""
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        entry = MemoryEntry(key="k", value="v", metadata={"tag": "x"}, created_at=now, updated_at=now)
+        assert entry.key == "k"
+        assert entry.value == "v"
+        assert entry.metadata == {"tag": "x"}
+
+    def test_default_metadata_is_empty_dict(self):
+        """metadata defaults to an empty dict."""
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        entry = MemoryEntry(key="k", value="v", created_at=now, updated_at=now)
+        assert entry.metadata == {}
+
+
+# ---------------------------------------------------------------------------
+# InMemoryStore
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryStore:
+    """Tests for InMemoryStore."""
+
+    async def test_save_and_get(self):
+        """save() stores a value; get() retrieves it."""
+        store = InMemoryStore()
+        await store.save("fact1", "The sky is blue")
+        entry = await store.get("fact1")
+        assert entry is not None
+        assert entry.value == "The sky is blue"
+        assert entry.key == "fact1"
+
+    async def test_get_missing_key_returns_none(self):
+        """get() returns None for a key that was never saved."""
+        store = InMemoryStore()
+        assert await store.get("missing") is None
+
+    async def test_save_overwrites_value(self):
+        """Saving to an existing key updates the value."""
+        store = InMemoryStore()
+        await store.save("k", "old")
+        await store.save("k", "new")
+        entry = await store.get("k")
+        assert entry.value == "new"
+
+    async def test_save_preserves_created_at_on_update(self):
+        """created_at is not changed when an existing key is updated."""
+        store = InMemoryStore()
+        await store.save("k", "v1")
+        original = await store.get("k")
+        await store.save("k", "v2")
+        updated = await store.get("k")
+        assert updated.created_at == original.created_at
+
+    async def test_updated_at_changes_on_update(self):
+        """updated_at is refreshed when an existing key is saved again."""
+        import asyncio
+        store = InMemoryStore()
+        await store.save("k", "v1")
+        original = await store.get("k")
+        await asyncio.sleep(0.01)
+        await store.save("k", "v2")
+        updated = await store.get("k")
+        assert updated.updated_at >= original.updated_at
+
+    async def test_delete_removes_entry(self):
+        """delete() removes the key so subsequent get() returns None."""
+        store = InMemoryStore()
+        await store.save("k", "v")
+        await store.delete("k")
+        assert await store.get("k") is None
+
+    async def test_delete_nonexistent_key_is_noop(self):
+        """delete() on a missing key does not raise."""
+        store = InMemoryStore()
+        await store.delete("ghost")  # should not raise
+
+    async def test_list_keys(self):
+        """list_keys() returns all saved keys."""
+        store = InMemoryStore()
+        await store.save("a", "1")
+        await store.save("b", "2")
+        keys = await store.list_keys()
+        assert set(keys) == {"a", "b"}
+
+    async def test_list_keys_empty(self):
+        """list_keys() returns empty list when no entries saved."""
+        store = InMemoryStore()
+        assert await store.list_keys() == []
+
+    async def test_search_matches_value(self):
+        """search() returns entries whose value contains the query."""
+        store = InMemoryStore()
+        await store.save("fact1", "Python is a programming language")
+        await store.save("fact2", "The ocean is blue")
+        results = await store.search("programming")
+        assert len(results) == 1
+        assert results[0].key == "fact1"
+
+    async def test_search_matches_key(self):
+        """search() also matches against the key string."""
+        store = InMemoryStore()
+        await store.save("python_fact", "Some value")
+        results = await store.search("python")
+        assert len(results) == 1
+
+    async def test_search_is_case_insensitive(self):
+        """search() matches regardless of case."""
+        store = InMemoryStore()
+        await store.save("k", "Hello World")
+        results = await store.search("hello")
+        assert len(results) == 1
+
+    async def test_search_top_k_limits_results(self):
+        """search() returns at most top_k results."""
+        store = InMemoryStore()
+        for i in range(10):
+            await store.save(f"key_{i}", "common term")
+        results = await store.search("common", top_k=3)
+        assert len(results) <= 3
+
+    async def test_search_no_matches_returns_empty(self):
+        """search() returns empty list when no entries match."""
+        store = InMemoryStore()
+        await store.save("k", "unrelated")
+        results = await store.search("xyzzy")
+        assert results == []
+
+    async def test_save_with_metadata(self):
+        """save() stores metadata alongside the value."""
+        store = InMemoryStore()
+        await store.save("k", "v", metadata={"source": "web"})
+        entry = await store.get("k")
+        assert entry.metadata == {"source": "web"}
+
+
+# ---------------------------------------------------------------------------
+# JsonFileStore
+# ---------------------------------------------------------------------------
+
+
+class TestJsonFileStore:
+    """Tests for JsonFileStore."""
+
+    def _tmp_path(self) -> Path:
+        return Path(tempfile.mktemp(suffix=".json"))
+
+    async def test_save_and_get(self):
+        """save() writes to disk; get() reads it back."""
+        path = self._tmp_path()
+        store = JsonFileStore(path)
+        await store.save("k", "persisted value")
+        entry = await store.get("k")
+        assert entry is not None
+        assert entry.value == "persisted value"
+
+    async def test_persists_across_instances(self):
+        """Data saved by one instance is readable by a fresh instance."""
+        path = self._tmp_path()
+        store1 = JsonFileStore(path)
+        await store1.save("key", "hello")
+
+        store2 = JsonFileStore(path)
+        entry = await store2.get("key")
+        assert entry is not None
+        assert entry.value == "hello"
+
+    async def test_file_is_valid_json(self):
+        """The written file is valid JSON."""
+        path = self._tmp_path()
+        store = JsonFileStore(path)
+        await store.save("k", "v")
+        data = json.loads(path.read_text())
+        assert "k" in data
+
+    async def test_delete_removes_from_file(self):
+        """delete() removes entry and flushes to disk."""
+        path = self._tmp_path()
+        store = JsonFileStore(path)
+        await store.save("k", "v")
+        await store.delete("k")
+        store2 = JsonFileStore(path)
+        assert await store2.get("k") is None
+
+    async def test_get_missing_returns_none(self):
+        """get() returns None for a key not in the file."""
+        path = self._tmp_path()
+        store = JsonFileStore(path)
+        assert await store.get("missing") is None
+
+    async def test_list_keys(self):
+        """list_keys() returns all saved keys."""
+        path = self._tmp_path()
+        store = JsonFileStore(path)
+        await store.save("a", "1")
+        await store.save("b", "2")
+        keys = await store.list_keys()
+        assert set(keys) == {"a", "b"}
+
+    async def test_search_substring(self):
+        """search() performs substring match across entries."""
+        path = self._tmp_path()
+        store = JsonFileStore(path)
+        await store.save("note1", "async programming tips")
+        await store.save("note2", "sync vs async")
+        await store.save("note3", "database indexing")
+        results = await store.search("async")
+        assert len(results) == 2
+
+    async def test_nonexistent_file_starts_empty(self):
+        """A store pointed at a non-existent file starts with no entries."""
+        path = Path(tempfile.mktemp(suffix=".json"))
+        store = JsonFileStore(path)
+        assert await store.list_keys() == []
+
+
+# ---------------------------------------------------------------------------
+# MemoryToolset
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryToolset:
+    """Tests for MemoryToolset — memory operations exposed as agent tools."""
+
+    async def _get_tool_names(self, toolset: MemoryToolset) -> set[str]:
+        tools = await toolset.get_tools(_ctx())
+        return set(tools.keys())
+
+    async def test_exposes_five_tools(self):
+        """MemoryToolset exposes exactly the five memory tools."""
+        ts = MemoryToolset(InMemoryStore())
+        names = await self._get_tool_names(ts)
+        assert names == {"save_memory", "recall_memory", "search_memory", "forget_memory", "list_memories"}
+
+    async def test_save_and_recall(self):
+        """save_memory stores a value; recall_memory retrieves it."""
+        store = InMemoryStore()
+        ts = MemoryToolset(store)
+        ctx = _ctx()
+        tools = await ts.get_tools(ctx)
+
+        await ts.call_tool("save_memory", {"key": "city", "value": "Paris"}, ctx, tools["save_memory"])
+        result = await ts.call_tool("recall_memory", {"key": "city"}, ctx, tools["recall_memory"])
+        assert result == "Paris"
+
+    async def test_recall_missing_key(self):
+        """recall_memory returns a not-found message for an unknown key."""
+        ts = MemoryToolset(InMemoryStore())
+        ctx = _ctx()
+        tools = await ts.get_tools(ctx)
+        result = await ts.call_tool("recall_memory", {"key": "ghost"}, ctx, tools["recall_memory"])
+        assert "ghost" in result
+
+    async def test_forget_removes_entry(self):
+        """forget_memory deletes an entry so subsequent recall returns not-found."""
+        store = InMemoryStore()
+        ts = MemoryToolset(store)
+        ctx = _ctx()
+        tools = await ts.get_tools(ctx)
+
+        await ts.call_tool("save_memory", {"key": "temp", "value": "data"}, ctx, tools["save_memory"])
+        await ts.call_tool("forget_memory", {"key": "temp"}, ctx, tools["forget_memory"])
+        result = await ts.call_tool("recall_memory", {"key": "temp"}, ctx, tools["recall_memory"])
+        assert "temp" in result  # not-found message
+
+    async def test_list_memories(self):
+        """list_memories returns all saved keys (without namespace prefix)."""
+        store = InMemoryStore()
+        ts = MemoryToolset(store, namespace="ns")
+        ctx = _ctx()
+        tools = await ts.get_tools(ctx)
+
+        await ts.call_tool("save_memory", {"key": "a", "value": "1"}, ctx, tools["save_memory"])
+        await ts.call_tool("save_memory", {"key": "b", "value": "2"}, ctx, tools["save_memory"])
+        result = await ts.call_tool("list_memories", {}, ctx, tools["list_memories"])
+        assert "a" in result
+        assert "b" in result
+
+    async def test_list_memories_empty(self):
+        """list_memories returns a message when no memories are stored."""
+        ts = MemoryToolset(InMemoryStore())
+        ctx = _ctx()
+        tools = await ts.get_tools(ctx)
+        result = await ts.call_tool("list_memories", {}, ctx, tools["list_memories"])
+        assert result  # non-empty message
+
+    async def test_search_memory(self):
+        """search_memory returns matching entries."""
+        store = InMemoryStore()
+        ts = MemoryToolset(store)
+        ctx = _ctx()
+        tools = await ts.get_tools(ctx)
+
+        await ts.call_tool("save_memory", {"key": "fact1", "value": "Python is fast"}, ctx, tools["save_memory"])
+        await ts.call_tool("save_memory", {"key": "fact2", "value": "Go is compiled"}, ctx, tools["save_memory"])
+        result = await ts.call_tool("search_memory", {"query": "Python"}, ctx, tools["search_memory"])
+        assert "Python" in result
+        assert "Go" not in result
+
+    async def test_namespace_isolates_entries(self):
+        """Two MemoryToolsets with different namespaces do not share entries."""
+        store = InMemoryStore()
+        ts_a = MemoryToolset(store, namespace="user_a")
+        ts_b = MemoryToolset(store, namespace="user_b")
+
+        ctx = _ctx()
+        tools_a = await ts_a.get_tools(ctx)
+        tools_b = await ts_b.get_tools(ctx)
+
+        await ts_a.call_tool("save_memory", {"key": "secret", "value": "a_data"}, ctx, tools_a["save_memory"])
+
+        result = await ts_b.call_tool("recall_memory", {"key": "secret"}, ctx, tools_b["recall_memory"])
+        assert "a_data" not in result  # not visible in namespace b
+
+    async def test_namespace_prefix_not_visible_in_list(self):
+        """list_memories returns keys without the internal namespace prefix."""
+        store = InMemoryStore()
+        ts = MemoryToolset(store, namespace="myns")
+        ctx = _ctx()
+        tools = await ts.get_tools(ctx)
+
+        await ts.call_tool("save_memory", {"key": "mykey", "value": "v"}, ctx, tools["save_memory"])
+        result = await ts.call_tool("list_memories", {}, ctx, tools["list_memories"])
+        assert "myns:" not in result
+        assert "mykey" in result

--- a/tests/unit/mindtrace/agents/test_toolsets.py
+++ b/tests/unit/mindtrace/agents/test_toolsets.py
@@ -1,0 +1,579 @@
+"""Unit tests for mindtrace.agents.toolsets."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mindtrace.agents._run_context import RunContext
+from mindtrace.agents.tools import Tool, ToolDefinition
+from mindtrace.agents.toolsets import (
+    AbstractToolset,
+    CompoundToolset,
+    FilteredToolset,
+    FunctionToolset,
+    FunctionToolsetTool,
+    MCPToolset,
+    ToolFilter,
+    ToolsetTool,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx() -> RunContext:
+    return RunContext(deps=None)
+
+
+def _make_toolset_tool(name: str, description: str | None = None) -> ToolsetTool:
+    return ToolsetTool(
+        tool_def=ToolDefinition(name=name, description=description),
+        max_retries=None,
+    )
+
+
+class _StubToolset(AbstractToolset):
+    """Simple concrete toolset for testing abstract interface."""
+
+    def __init__(self, tools: dict[str, ToolsetTool], call_result: Any = "stub_result") -> None:
+        self._tools = tools
+        self._call_result = call_result
+        self.called_with: list[tuple[str, dict[str, Any]]] = []
+
+    async def get_tools(self, ctx: RunContext) -> dict[str, ToolsetTool]:
+        return dict(self._tools)
+
+    async def call_tool(self, name: str, tool_args: dict[str, Any], ctx: RunContext, tool: ToolsetTool) -> Any:
+        self.called_with.append((name, tool_args))
+        return self._call_result
+
+
+# ---------------------------------------------------------------------------
+# ToolFilter
+# ---------------------------------------------------------------------------
+
+
+class TestToolFilter:
+    """Tests for ToolFilter predicate and composition."""
+
+    def test_include_allows_named_tools(self):
+        f = ToolFilter.include("foo", "bar")
+        assert f.allows("foo") is True
+        assert f.allows("bar") is True
+        assert f.allows("baz") is False
+
+    def test_exclude_blocks_named_tools(self):
+        f = ToolFilter.exclude("danger")
+        assert f.allows("safe") is True
+        assert f.allows("danger") is False
+
+    def test_include_pattern_glob(self):
+        f = ToolFilter.include_pattern("read_*")
+        assert f.allows("read_file") is True
+        assert f.allows("read_db") is True
+        assert f.allows("write_file") is False
+
+    def test_exclude_pattern_glob(self):
+        f = ToolFilter.exclude_pattern("drop_*")
+        assert f.allows("drop_table") is False
+        assert f.allows("select_table") is True
+
+    def test_include_pattern_multiple_patterns(self):
+        f = ToolFilter.include_pattern("read_*", "list_*")
+        assert f.allows("read_file") is True
+        assert f.allows("list_dir") is True
+        assert f.allows("write_file") is False
+
+    def test_and_composition(self):
+        f = ToolFilter.include_pattern("read_*") & ~ToolFilter.include("read_credentials")
+        assert f.allows("read_file") is True
+        assert f.allows("read_credentials") is False
+
+    def test_or_composition(self):
+        f = ToolFilter.include("foo") | ToolFilter.include("bar")
+        assert f.allows("foo") is True
+        assert f.allows("bar") is True
+        assert f.allows("baz") is False
+
+    def test_invert(self):
+        f = ~ToolFilter.include("secret")
+        assert f.allows("secret") is False
+        assert f.allows("public") is True
+
+    def test_by_description_predicate(self):
+        f = ToolFilter.by_description(lambda d: d is not None and "safe" in d)
+        assert f.allows("anything", "this is safe") is True
+        assert f.allows("anything", "dangerous op") is False
+        assert f.allows("anything", None) is False
+
+    def test_allows_passes_description(self):
+        seen: list[str | None] = []
+        f = ToolFilter(lambda n, d: (seen.append(d), True)[1])
+        f.allows("tool", "my description")
+        assert seen == ["my description"]
+
+    def test_chained_and_or(self):
+        f = (ToolFilter.include("a") | ToolFilter.include("b")) & ~ToolFilter.include("b")
+        assert f.allows("a") is True
+        assert f.allows("b") is False
+        assert f.allows("c") is False
+
+
+# ---------------------------------------------------------------------------
+# AbstractToolset – shorthand filter methods
+# ---------------------------------------------------------------------------
+
+
+class TestAbstractToolsetShorthands:
+    """Tests for .include(), .exclude(), .include_pattern(), .exclude_pattern(), .with_filter()."""
+
+    def _stub(self) -> _StubToolset:
+        return _StubToolset(
+            {
+                "read_file": _make_toolset_tool("read_file"),
+                "write_file": _make_toolset_tool("write_file"),
+                "drop_table": _make_toolset_tool("drop_table"),
+            }
+        )
+
+    def test_include_returns_filtered_toolset(self):
+        ts = self._stub().include("read_file")
+        assert isinstance(ts, FilteredToolset)
+
+    def test_exclude_returns_filtered_toolset(self):
+        ts = self._stub().exclude("drop_table")
+        assert isinstance(ts, FilteredToolset)
+
+    def test_include_pattern_returns_filtered_toolset(self):
+        ts = self._stub().include_pattern("read_*")
+        assert isinstance(ts, FilteredToolset)
+
+    def test_exclude_pattern_returns_filtered_toolset(self):
+        ts = self._stub().exclude_pattern("drop_*")
+        assert isinstance(ts, FilteredToolset)
+
+    def test_with_filter_returns_filtered_toolset(self):
+        ts = self._stub().with_filter(ToolFilter.include("read_file"))
+        assert isinstance(ts, FilteredToolset)
+
+    async def test_include_limits_visible_tools(self):
+        ts = self._stub().include("read_file")
+        tools = await ts.get_tools(_ctx())
+        assert set(tools.keys()) == {"read_file"}
+
+    async def test_exclude_removes_tool(self):
+        ts = self._stub().exclude("drop_table")
+        tools = await ts.get_tools(_ctx())
+        assert "drop_table" not in tools
+        assert "read_file" in tools
+        assert "write_file" in tools
+
+    async def test_include_pattern_filters_correctly(self):
+        ts = self._stub().include_pattern("read_*")
+        tools = await ts.get_tools(_ctx())
+        assert set(tools.keys()) == {"read_file"}
+
+    async def test_exclude_pattern_filters_correctly(self):
+        ts = self._stub().exclude_pattern("drop_*")
+        tools = await ts.get_tools(_ctx())
+        assert "drop_table" not in tools
+        assert "read_file" in tools
+
+
+# ---------------------------------------------------------------------------
+# FilteredToolset
+# ---------------------------------------------------------------------------
+
+
+class TestFilteredToolset:
+    """Tests for FilteredToolset.get_tools() and call_tool()."""
+
+    async def test_get_tools_applies_filter(self):
+        inner = _StubToolset(
+            {
+                "a": _make_toolset_tool("a"),
+                "b": _make_toolset_tool("b"),
+                "c": _make_toolset_tool("c"),
+            }
+        )
+        ts = FilteredToolset(inner, ToolFilter.include("a", "c"))
+        tools = await ts.get_tools(_ctx())
+        assert set(tools.keys()) == {"a", "c"}
+
+    async def test_call_tool_delegates_to_inner(self):
+        inner = _StubToolset({"my_tool": _make_toolset_tool("my_tool")}, call_result="inner_result")
+        ts = FilteredToolset(inner, ToolFilter.include("my_tool"))
+        ctx = _ctx()
+        tool = _make_toolset_tool("my_tool")
+        result = await ts.call_tool("my_tool", {"x": 1}, ctx, tool)
+        assert result == "inner_result"
+        assert inner.called_with == [("my_tool", {"x": 1})]
+
+    async def test_filters_by_description(self):
+        inner = _StubToolset(
+            {
+                "safe_op": _make_toolset_tool("safe_op", "This is a safe operation"),
+                "danger_op": _make_toolset_tool("danger_op", "This is dangerous"),
+            }
+        )
+        ts = FilteredToolset(inner, ToolFilter.by_description(lambda d: d is not None and "safe" in d))
+        tools = await ts.get_tools(_ctx())
+        assert "safe_op" in tools
+        assert "danger_op" not in tools
+
+    async def test_empty_result_when_all_filtered(self):
+        inner = _StubToolset({"a": _make_toolset_tool("a")})
+        ts = FilteredToolset(inner, ToolFilter.exclude("a"))
+        tools = await ts.get_tools(_ctx())
+        assert tools == {}
+
+
+# ---------------------------------------------------------------------------
+# CompoundToolset
+# ---------------------------------------------------------------------------
+
+
+class TestCompoundToolset:
+    """Tests for CompoundToolset.get_tools() and call_tool()."""
+
+    async def test_merges_tools_from_multiple_toolsets(self):
+        ts1 = _StubToolset({"tool_a": _make_toolset_tool("tool_a")})
+        ts2 = _StubToolset({"tool_b": _make_toolset_tool("tool_b")})
+        compound = CompoundToolset(ts1, ts2)
+        tools = await compound.get_tools(_ctx())
+        assert set(tools.keys()) == {"tool_a", "tool_b"}
+
+    async def test_later_toolset_wins_on_collision(self):
+        tool_v1 = _make_toolset_tool("shared", "version 1")
+        tool_v2 = _make_toolset_tool("shared", "version 2")
+        ts1 = _StubToolset({"shared": tool_v1})
+        ts2 = _StubToolset({"shared": tool_v2})
+        compound = CompoundToolset(ts1, ts2)
+        tools = await compound.get_tools(_ctx())
+        assert tools["shared"].tool_def.description == "version 2"
+
+    async def test_call_tool_routes_to_correct_source(self):
+        ts1 = _StubToolset({"a": _make_toolset_tool("a")}, call_result="from_ts1")
+        ts2 = _StubToolset({"b": _make_toolset_tool("b")}, call_result="from_ts2")
+        compound = CompoundToolset(ts1, ts2)
+        ctx = _ctx()
+        await compound.get_tools(ctx)  # populate routing
+        result_a = await compound.call_tool("a", {}, ctx, _make_toolset_tool("a"))
+        result_b = await compound.call_tool("b", {}, ctx, _make_toolset_tool("b"))
+        assert result_a == "from_ts1"
+        assert result_b == "from_ts2"
+
+    async def test_call_tool_before_get_tools_raises(self):
+        ts = _StubToolset({"x": _make_toolset_tool("x")})
+        compound = CompoundToolset(ts)
+        with pytest.raises(ValueError, match="Unknown tool"):
+            await compound.call_tool("x", {}, _ctx(), _make_toolset_tool("x"))
+
+    async def test_empty_compound_returns_empty(self):
+        compound = CompoundToolset()
+        tools = await compound.get_tools(_ctx())
+        assert tools == {}
+
+    async def test_routing_refreshed_on_repeated_get_tools(self):
+        """A second call to get_tools() resets routing so stale entries are replaced."""
+        ts = _StubToolset({"t": _make_toolset_tool("t")})
+        compound = CompoundToolset(ts)
+        await compound.get_tools(_ctx())
+        # Swap the inner toolset's tools map so routing must refresh
+        ts._tools = {"t2": _make_toolset_tool("t2")}
+        tools = await compound.get_tools(_ctx())
+        assert "t2" in tools
+        assert "t" not in tools
+
+
+# ---------------------------------------------------------------------------
+# FunctionToolset
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionToolset:
+    """Tests for FunctionToolset.add_tool(), get_tools(), and call_tool()."""
+
+    def _make_tool(self, name: str = "my_tool") -> Tool:
+        def fn(x: int) -> int:
+            """Return x."""
+            return x * 2
+
+        return Tool(fn, name=name)
+
+    def test_add_tool_stores_tool(self):
+        ts = FunctionToolset()
+        tool = self._make_tool()
+        ts.add_tool(tool)
+        assert "my_tool" in ts.tools
+
+    def test_add_duplicate_tool_raises(self):
+        ts = FunctionToolset()
+        ts.add_tool(self._make_tool())
+        with pytest.raises(ValueError, match="conflicts"):
+            ts.add_tool(self._make_tool())
+
+    def test_add_tool_inherits_toolset_max_retries(self):
+        ts = FunctionToolset(max_retries=5)
+        tool = self._make_tool()
+        assert tool.max_retries is None
+        ts.add_tool(tool)
+        assert tool.max_retries == 5
+
+    def test_add_tool_preserves_explicit_max_retries(self):
+        ts = FunctionToolset(max_retries=5)
+        tool = self._make_tool()
+        tool.max_retries = 2
+        ts.add_tool(tool)
+        assert tool.max_retries == 2
+
+    async def test_get_tools_returns_function_toolset_tool(self):
+        ts = FunctionToolset()
+        ts.add_tool(self._make_tool())
+        tools = await ts.get_tools(_ctx())
+        assert "my_tool" in tools
+        assert isinstance(tools["my_tool"], FunctionToolsetTool)
+
+    async def test_get_tools_empty_toolset(self):
+        ts = FunctionToolset()
+        tools = await ts.get_tools(_ctx())
+        assert tools == {}
+
+    async def test_call_tool_sync_function(self):
+        def add(a: int, b: int) -> int:
+            """Add a and b."""
+            return a + b
+
+        ts = FunctionToolset()
+        ts.add_tool(Tool(add))
+        ctx = _ctx()
+        tools = await ts.get_tools(ctx)
+        result = await ts.call_tool("add", {"a": 3, "b": 4}, ctx, tools["add"])
+        assert result == 7
+
+    async def test_call_tool_async_function(self):
+        async def greet(name: str) -> str:
+            """Greet."""
+            return f"hi {name}"
+
+        ts = FunctionToolset()
+        ts.add_tool(Tool(greet))
+        ctx = _ctx()
+        tools = await ts.get_tools(ctx)
+        result = await ts.call_tool("greet", {"name": "world"}, ctx, tools["greet"])
+        assert result == "hi world"
+
+    async def test_get_tools_max_retries_propagated(self):
+        ts = FunctionToolset(max_retries=3)
+
+        def fn(x: int) -> int:
+            """fn."""
+            return x
+
+        ts.add_tool(Tool(fn))
+        tools = await ts.get_tools(_ctx())
+        assert tools["fn"].max_retries == 3
+
+    async def test_get_tools_tool_max_retries_overrides_toolset(self):
+        ts = FunctionToolset(max_retries=3)
+
+        def fn(x: int) -> int:
+            """fn."""
+            return x
+
+        t = Tool(fn, max_retries=7)
+        ts.add_tool(t)
+        tools = await ts.get_tools(_ctx())
+        assert tools["fn"].max_retries == 7
+
+
+# ---------------------------------------------------------------------------
+# MCPToolset
+# ---------------------------------------------------------------------------
+
+
+class TestMCPToolsetConstructors:
+    """Tests for MCPToolset class methods (no live server needed)."""
+
+    def test_from_http_stores_url(self):
+        ts = MCPToolset.from_http("http://localhost:8001/mcp/")
+        assert ts._transport_factory() == "http://localhost:8001/mcp/"
+
+    def test_from_http_with_prefix(self):
+        ts = MCPToolset.from_http("http://localhost:8001/mcp/", prefix="svc")
+        assert ts._prefix == "svc"
+
+    def test_from_sse_raises_without_fastmcp(self):
+        ts = MCPToolset.from_sse("http://localhost:9000/sse")
+        with pytest.raises(ImportError, match="fastmcp"):
+            with patch.dict("sys.modules", {"fastmcp": None, "fastmcp.client.transports": None}):
+                ts._transport_factory()
+
+    def test_from_stdio_raises_without_fastmcp(self):
+        ts = MCPToolset.from_stdio(["npx", "some-server"])
+        with pytest.raises(ImportError, match="fastmcp"):
+            with patch.dict("sys.modules", {"fastmcp": None, "fastmcp.client.transports": None}):
+                ts._transport_factory()
+
+    def test_prefix_none_by_default(self):
+        ts = MCPToolset.from_http("http://localhost/")
+        assert ts._prefix is None
+
+
+class TestMCPToolsetGetTools:
+    """Tests for MCPToolset.get_tools() with mocked fastmcp Client."""
+
+    def _make_mcp_tool(self, name: str, description: str = "desc", schema: dict | None = None):
+        t = MagicMock()
+        t.name = name
+        t.description = description
+        t.inputSchema = schema or {}
+        return t
+
+    async def test_get_tools_returns_toolset_tools(self):
+        mcp_tools = [self._make_mcp_tool("search"), self._make_mcp_tool("summarise")]
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=mcp_tools)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("fastmcp.Client", return_value=mock_client):
+            ts = MCPToolset.from_http("http://localhost/")
+            tools = await ts.get_tools(_ctx())
+
+        assert set(tools.keys()) == {"search", "summarise"}
+        for tool in tools.values():
+            assert isinstance(tool, ToolsetTool)
+
+    async def test_get_tools_applies_prefix(self):
+        mcp_tools = [self._make_mcp_tool("read_file")]
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=mcp_tools)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("fastmcp.Client", return_value=mock_client):
+            ts = MCPToolset.from_http("http://localhost/", prefix="fs")
+            tools = await ts.get_tools(_ctx())
+
+        assert "fs__read_file" in tools
+        assert "read_file" not in tools
+
+    async def test_get_tools_raises_without_fastmcp(self):
+        ts = MCPToolset.from_http("http://localhost/")
+        with patch.dict("sys.modules", {"fastmcp": None}):
+            with pytest.raises(ImportError, match="fastmcp"):
+                await ts.get_tools(_ctx())
+
+    async def test_get_tools_stores_name_map(self):
+        mcp_tools = [self._make_mcp_tool("do_thing")]
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=mcp_tools)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("fastmcp.Client", return_value=mock_client):
+            ts = MCPToolset.from_http("http://localhost/", prefix="p")
+            await ts.get_tools(_ctx())
+
+        assert ts._name_map == {"p__do_thing": "do_thing"}
+
+
+class TestMCPToolsetCallTool:
+    """Tests for MCPToolset.call_tool() with mocked fastmcp Client."""
+
+    def _mock_result(self, data=None, content_texts: list[str] | None = None):
+        result = MagicMock()
+        result.data = data
+        if content_texts is not None:
+            parts = []
+            for t in content_texts:
+                p = MagicMock()
+                p.text = t
+                parts.append(p)
+            result.content = parts
+        else:
+            result.content = []
+        return result
+
+    async def _setup_ts_with_tool(self, tool_name: str = "search") -> MCPToolset:
+        mcp_tool = MagicMock()
+        mcp_tool.name = tool_name
+        mcp_tool.description = "desc"
+        mcp_tool.inputSchema = {}
+
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=[mcp_tool])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("fastmcp.Client", return_value=mock_client):
+            ts = MCPToolset.from_http("http://localhost/")
+            await ts.get_tools(_ctx())
+        return ts
+
+    async def test_call_tool_returns_data_when_present(self):
+        ts = await self._setup_ts_with_tool("search")
+        call_result = self._mock_result(data={"answer": 42})
+
+        mock_client = AsyncMock()
+        mock_client.call_tool = AsyncMock(return_value=call_result)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("fastmcp.Client", return_value=mock_client):
+            result = await ts.call_tool("search", {"q": "test"}, _ctx(), _make_toolset_tool("search"))
+
+        assert result == str({"answer": 42})
+
+    async def test_call_tool_joins_content_parts(self):
+        ts = await self._setup_ts_with_tool("search")
+        call_result = self._mock_result(data=None, content_texts=["Hello", "World"])
+
+        mock_client = AsyncMock()
+        mock_client.call_tool = AsyncMock(return_value=call_result)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("fastmcp.Client", return_value=mock_client):
+            result = await ts.call_tool("search", {}, _ctx(), _make_toolset_tool("search"))
+
+        assert result == "Hello\nWorld"
+
+    async def test_call_tool_uses_original_name_via_name_map(self):
+        """call_tool() resolves the prefixed name back to the original MCP tool name."""
+        mcp_tool = MagicMock()
+        mcp_tool.name = "real_name"
+        mcp_tool.description = "d"
+        mcp_tool.inputSchema = {}
+
+        list_client = AsyncMock()
+        list_client.list_tools = AsyncMock(return_value=[mcp_tool])
+        list_client.__aenter__ = AsyncMock(return_value=list_client)
+        list_client.__aexit__ = AsyncMock(return_value=False)
+
+        call_result = self._mock_result(data="ok")
+        call_client = AsyncMock()
+        call_client.call_tool = AsyncMock(return_value=call_result)
+        call_client.__aenter__ = AsyncMock(return_value=call_client)
+        call_client.__aexit__ = AsyncMock(return_value=False)
+
+        clients = iter([list_client, call_client])
+
+        with patch("fastmcp.Client", side_effect=lambda _: next(clients)):
+            ts = MCPToolset.from_http("http://localhost/", prefix="svc")
+            await ts.get_tools(_ctx())
+            await ts.call_tool("svc__real_name", {}, _ctx(), _make_toolset_tool("svc__real_name"))
+
+        call_client.call_tool.assert_called_once_with("real_name", arguments={})
+
+    async def test_call_tool_raises_without_fastmcp(self):
+        ts = MCPToolset.from_http("http://localhost/")
+        ts._name_map = {"x": "x"}
+        with patch.dict("sys.modules", {"fastmcp": None}):
+            with pytest.raises(ImportError, match="fastmcp"):
+                await ts.call_tool("x", {}, _ctx(), _make_toolset_tool("x"))


### PR DESCRIPTION
  Extends mindtrace-agents with three new capability areas: multi-agent orchestration, persistent agent memory, and
  distributed execution. All additions follow the existing pattern — abstract interfaces in core, concrete
  implementations as optional extras, no new mandatory dependencies.