### PR TITLE
feat(services): add /class_name endpoint to Service

### DIFF
--- a/mindtrace/services/mindtrace/services/__init__.py
+++ b/mindtrace/services/mindtrace/services/__init__.py
@@ -1,6 +1,7 @@
 from mindtrace.services.core.connection_manager import ConnectionManager
 from mindtrace.services.core.service import Service
 from mindtrace.services.core.types import (
+    ClassNameSchema,
     EndpointsSchema,
     Heartbeat,
     HeartbeatSchema,
@@ -18,6 +19,7 @@ from mindtrace.services.samples.echo_service import EchoService
 
 __all__ = [
     "AppConfig",
+    "ClassNameSchema",
     "ConnectionManager",
     "EchoService",
     "EndpointsSchema",

--- a/mindtrace/services/mindtrace/services/core/service.py
+++ b/mindtrace/services/mindtrace/services/core/service.py
@@ -27,6 +27,7 @@ from mindtrace.core.logging.logger import track_operation
 from mindtrace.services.core.connection_manager import ConnectionManager
 from mindtrace.services.core.mcp_client_manager import MCPClientManager
 from mindtrace.services.core.types import (
+    ClassNameSchema,
     EndpointsSchema,
     Heartbeat,
     HeartbeatSchema,
@@ -153,6 +154,7 @@ class Service(Mindtrace):
         self.add_endpoint(
             path="/server_id", func=named_lambda("server_id", lambda: {"server_id": self.id}), schema=ServerIDSchema
         )
+        self.add_endpoint(path="/class_name", func=self.class_name_func, schema=ClassNameSchema)
         self.add_endpoint(
             path="/pid_file", func=named_lambda("pid_file", lambda: {"pid_file": self.pid_file}), schema=PIDFileSchema
         )
@@ -172,6 +174,10 @@ class Service(Mindtrace):
     def status_func(self):
         """Get the current status of the service."""
         return {"status": self.status.value}
+
+    def class_name_func(self):
+        """Return the name of the concrete class of this service instance."""
+        return {"class_name": self.__class__.__name__}
 
     def heartbeat_func(self):
         """Perform a heartbeat check for the service."""

--- a/mindtrace/services/mindtrace/services/core/types.py
+++ b/mindtrace/services/mindtrace/services/core/types.py
@@ -78,6 +78,13 @@ class ServerIDOutput(BaseModel):
 ServerIDSchema = TaskSchema(name="server_id", output_schema=ServerIDOutput)
 
 
+class ClassNameOutput(BaseModel):
+    class_name: str
+
+
+ClassNameSchema = TaskSchema(name="class_name", output_schema=ClassNameOutput)
+
+
 class PIDFileOutput(BaseModel):
     pid_file: str
 

--- a/tests/integration/mindtrace/services/test_simple_integration.py
+++ b/tests/integration/mindtrace/services/test_simple_integration.py
@@ -8,7 +8,14 @@ from mcp.client.streamable_http import streamablehttp_client
 from urllib3.util.url import parse_url
 
 from mindtrace.services import generate_connection_manager
-from mindtrace.services.core.types import EndpointsOutput, HeartbeatOutput, PIDFileOutput, ServerIDOutput, StatusOutput
+from mindtrace.services.core.types import (
+    ClassNameOutput,
+    EndpointsOutput,
+    HeartbeatOutput,
+    PIDFileOutput,
+    ServerIDOutput,
+    StatusOutput,
+)
 from mindtrace.services.samples.echo_service import EchoInput, EchoOutput, EchoService
 
 
@@ -99,7 +106,15 @@ class TestServiceIntegration:
         assert "echo" in endpoints_result.endpoints  # Our custom endpoint
 
         # Default endpoints should also be present
-        default_endpoint_names = ["endpoints", "status", "heartbeat", "server_id", "pid_file", "shutdown"]
+        default_endpoint_names = [
+            "endpoints",
+            "status",
+            "heartbeat",
+            "server_id",
+            "class_name",
+            "pid_file",
+            "shutdown",
+        ]
         for endpoint_name in default_endpoint_names:
             assert endpoint_name in endpoints_result.endpoints, f"Missing default endpoint: {endpoint_name}"
 
@@ -138,6 +153,16 @@ class TestServiceIntegration:
         aserver_id_result = await echo_service_manager.aserver_id()
         assert isinstance(aserver_id_result, ServerIDOutput)
         assert aserver_id_result.server_id == server_id_result.server_id
+
+        # Test class_name endpoint (sync)
+        class_name_result = echo_service_manager.class_name()
+        assert isinstance(class_name_result, ClassNameOutput)
+        assert class_name_result.class_name == "EchoService"
+
+        # Test class_name endpoint (async)
+        aclass_name_result = await echo_service_manager.aclass_name()
+        assert isinstance(aclass_name_result, ClassNameOutput)
+        assert aclass_name_result.class_name == class_name_result.class_name
 
         # Test pid_file endpoint (sync)
         pid_file_result = echo_service_manager.pid_file()

--- a/tests/unit/mindtrace/services/core/test_service.py
+++ b/tests/unit/mindtrace/services/core/test_service.py
@@ -279,6 +279,7 @@ class TestServiceProperties:
         assert "test_task" in endpoints
         assert "echo" in endpoints
         assert "status" in endpoints
+        assert "class_name" in endpoints
 
     def test_status_property(self):
         """Test status property returns current status."""
@@ -316,6 +317,14 @@ class TestServiceProperties:
         assert isinstance(result, dict)
         assert "status" in result
         assert result["status"] == service.status.value
+
+    def test_class_name_func(self):
+        """Test class_name_func returns the concrete service class name."""
+        service = SampleService()
+        result = service.class_name_func()
+
+        assert isinstance(result, dict)
+        assert result == {"class_name": "SampleService"}
 
     def test_heartbeat_func(self):
         """Test heartbeat_func method."""

--- a/tests/unit/mindtrace/services/core/test_types.py
+++ b/tests/unit/mindtrace/services/core/test_types.py
@@ -4,6 +4,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from mindtrace.services.core.types import (
+    ClassNameOutput,
     EndpointsOutput,
     Heartbeat,
     HeartbeatOutput,
@@ -209,6 +210,13 @@ class TestOutputModels:
 
         assert output.server_id == server_id
         assert isinstance(output.server_id, UUID)
+
+    def test_class_name_output(self):
+        """Test ClassNameOutput model."""
+        output = ClassNameOutput(class_name="EchoService")
+
+        assert output.class_name == "EchoService"
+        assert isinstance(output.class_name, str)
 
     def test_pid_file_output(self):
         """Test PIDFileOutput model."""


### PR DESCRIPTION
## Summary
Adds a standard Service HTTP endpoint that returns the concrete Python class name of the running instance (`__class__.__name__`), so clients can identify which service implementation they are talking to (e.g. `EchoService` vs `Service`).

## Changes
- New `POST /class_name` route returning `{"class_name": "..."}`
- `ClassNameOutput` / `ClassNameSchema` in `mindtrace.services.core.types`
- `ClassNameSchema` re-exported from `mindtrace.services`
- `generate_connection_manager` picks up `class_name()` / `aclass_name()` automatically

## Motivation
Lets callers discover the service implementation class without relying on URL or custom metadata.

## Breaking changes
None. New endpoint only.

## How to test
```bash
ruff check && ruff format --check
ds test: tests/unit/mindtrace/services/core/test_service.py::TestServiceProperties
ds test: tests/unit/mindtrace/services/core/test_types.py
```
Integration (when echo service is up): `ds test: tests/integration/mindtrace/services/test_simple_integration.py::TestServiceIntegration::test_default_service_endpoints`

## Checklist
- [x] Feature: class name endpoint
- [ ] Bug fix
- [x] Unit tests added/updated
- [x] Manual: `ruff` + focused `ds test` paths above

Made with [Cursor](https://cursor.com)