### PR TITLE
Another unit test pack

### DIFF
--- a/scripts/docker_up.sh
+++ b/scripts/docker_up.sh
@@ -26,6 +26,9 @@ until nc -z localhost 6380; do
     sleep 1
 done
 
+echo "Flushing Redis test database..."
+$DOCKER_COMPOSE_CMD -f tests/docker-compose.yml exec -T redis redis-cli -p 6380 FLUSHALL > /dev/null
+
 export MINDTRACE_MINIO__MINIO_ENDPOINT=localhost:9100
 export MINDTRACE_MINIO__MINIO_ACCESS_KEY=minioadmin
 export MINDTRACE_MINIO__MINIO_SECRET_KEY=minioadmin

--- a/tests/unit/mindtrace/agents/models/test_openai_chat.py
+++ b/tests/unit/mindtrace/agents/models/test_openai_chat.py
@@ -1,0 +1,296 @@
+"""Unit tests for the OpenAI chat model adapter."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from mindtrace.agents.events import (
+    PartDeltaEvent,
+    PartEndEvent,
+    PartStartEvent,
+    TextPartDelta,
+    ToolCallArgsDelta,
+)
+from mindtrace.agents.messages import ModelMessage, TextPart, ToolCallPart, ToolReturnPart
+from mindtrace.agents.messages._parts import SystemPromptPart
+from mindtrace.agents.models import ModelRequestParameters
+from mindtrace.agents.models.openai_chat import OpenAIChatModel
+from mindtrace.agents.profiles import ModelProfile
+from mindtrace.agents.prompts import BinaryContent, ImageUrl, UserPromptPart
+from mindtrace.agents.tools import ToolDefinition
+
+
+class _AsyncStream:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+def _make_chunk(*, content=None, tool_calls=None, include_delta=True):
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls) if include_delta else None
+    return SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+
+
+def _make_tool_call(*, tool_call_id=None, index=0, name=None, arguments=None):
+    function = None if name is None and arguments is None else SimpleNamespace(name=name, arguments=arguments)
+    return SimpleNamespace(id=tool_call_id, index=index, function=function)
+
+
+def _make_model(client=None):
+    client = client or Mock()
+    profile = ModelProfile()
+    provider = SimpleNamespace(
+        client=client,
+        name="openai",
+        base_url="https://api.example.test/v1/",
+        model_profile=Mock(return_value=profile),
+    )
+    model = OpenAIChatModel("gpt-test", provider=provider)
+    return model, provider
+
+
+def test_constructor_uses_provider_profile_and_exposes_properties():
+    client = Mock()
+    model, provider = _make_model(client=client)
+
+    provider.model_profile.assert_called_once_with("gpt-test")
+    assert model.model_name == "gpt-test"
+    assert model.system == "openai"
+    assert model.base_url == "https://api.example.test/v1/"
+    assert model.client is client
+
+
+def test_map_user_prompt_supports_text_images_and_binary_images():
+    model, _ = _make_model()
+
+    part = UserPromptPart(
+        content=[
+            "hello",
+            ImageUrl(url="https://example.test/cat.png"),
+            BinaryContent(data=b"png-bytes", media_type="image/png"),
+        ]
+    )
+
+    assert model._map_user_prompt(part) == {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "hello"},
+            {"type": "image_url", "image_url": {"url": "https://example.test/cat.png"}},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,cG5nLWJ5dGVz"},
+            },
+        ],
+    }
+
+
+def test_map_user_prompt_rejects_unsupported_content():
+    model, _ = _make_model()
+
+    with pytest.raises(RuntimeError, match="Unsupported binary content type"):
+        model._map_user_prompt(UserPromptPart(content=[BinaryContent(data=b"x", media_type="application/pdf")]))
+
+    with pytest.raises(TypeError, match="Unsupported user content type"):
+        model._map_user_prompt(UserPromptPart(content=[object()]))
+
+
+def test_model_messages_to_openai_maps_supported_and_fallback_parts():
+    model, _ = _make_model()
+    messages = [
+        ModelMessage(role="user", parts=[UserPromptPart(content="hi")]),
+        ModelMessage(role="user", parts=[TextPart(content="ignored user fallback")]),
+        ModelMessage(role="system", parts=[SystemPromptPart(content="system prompt")]),
+        ModelMessage(role="system", parts=[TextPart(content="ignored system fallback")]),
+        ModelMessage(
+            role="assistant",
+            parts=[
+                TextPart(content="thinking"),
+                ToolCallPart(tool_name="weather", tool_call_id="call-1", args='{"city":"Paris"}'),
+            ],
+        ),
+        ModelMessage(role="assistant", parts=[TextPart(content="plain answer")]),
+        ModelMessage(role="tool", parts=[ToolReturnPart(tool_call_id="call-1", content='{"temp":21}')]),
+        ModelMessage(role="tool", parts=[SystemPromptPart(content="ignored tool fallback")]),
+    ]
+
+    assert model._model_messages_to_openai(messages) == [
+        {"role": "user", "content": "hi"},
+        {"role": "user", "content": ""},
+        {"role": "system", "content": "system prompt"},
+        {"role": "system", "content": ""},
+        {
+            "role": "assistant",
+            "content": "thinking",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "weather", "arguments": '{"city":"Paris"}'},
+                }
+            ],
+        },
+        {"role": "assistant", "content": "plain answer"},
+        {"role": "tool", "tool_call_id": "call-1", "content": '{"temp":21}'},
+        {"role": "tool", "tool_call_id": "", "content": ""},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_request_builds_openai_payload_and_maps_response():
+    message = SimpleNamespace(
+        content="Result text",
+        tool_calls=[
+            SimpleNamespace(
+                id="call-1",
+                function=SimpleNamespace(name="weather", arguments='{"city":"Paris"}'),
+            )
+        ],
+    )
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="tool_calls")],
+    )
+    create = AsyncMock(return_value=response)
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    model, _ = _make_model(client=client)
+    messages = [ModelMessage(role="user", parts=[UserPromptPart(content="hi")])]
+    request_parameters = ModelRequestParameters(
+        function_tools=[
+            ToolDefinition(
+                name="weather",
+                description="Get weather",
+                parameters_json_schema={"type": "object", "properties": {"city": {"type": "string"}}},
+            )
+        ]
+    )
+
+    result = await model.request(
+        messages=messages,
+        model_settings={"temperature": 0.2, "max_tokens": 99},
+        model_request_parameters=request_parameters,
+    )
+
+    create.assert_awaited_once_with(
+        model="gpt-test",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "weather",
+                    "description": "Get weather",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                },
+            }
+        ],
+        temperature=0.2,
+        max_tokens=99,
+    )
+    assert result.text == "Result text"
+    assert result.tool_calls == [{"id": "call-1", "name": "weather", "arguments": '{"city":"Paris"}'}]
+    assert result.model_name == "gpt-test"
+    assert result.provider_name == "openai"
+    assert result.finish_reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_request_stream_emits_text_then_tool_call_events():
+    stream = _AsyncStream(
+        [
+            SimpleNamespace(choices=[]),
+            _make_chunk(content="Hello"),
+            _make_chunk(
+                tool_calls=[
+                    _make_tool_call(
+                        tool_call_id="call-1",
+                        index=0,
+                        name="weather",
+                        arguments='{"city":"Par',
+                    )
+                ]
+            ),
+            _make_chunk(
+                tool_calls=[
+                    _make_tool_call(
+                        tool_call_id="call-1",
+                        index=0,
+                        name="weather",
+                        arguments='is"}',
+                    )
+                ]
+            ),
+        ]
+    )
+    create = AsyncMock(return_value=stream)
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    model, _ = _make_model(client=client)
+
+    events = [
+        event
+        async for event in model.request_stream(
+            messages=[ModelMessage(role="user", parts=[UserPromptPart(content="hi")])],
+            model_settings=None,
+            model_request_parameters=ModelRequestParameters(),
+        )
+    ]
+
+    assert [(type(event), event.index) for event in events] == [
+        (PartStartEvent, 0),
+        (PartDeltaEvent, 0),
+        (PartEndEvent, 0),
+        (PartStartEvent, 1),
+        (PartDeltaEvent, 1),
+        (PartEndEvent, 1),
+    ]
+    assert events[0].part_kind == "text"
+    assert isinstance(events[1].delta, TextPartDelta)
+    assert events[1].delta.content_delta == "Hello"
+    assert events[2].part.content == "Hello"
+    assert events[3].part_kind == "tool_call"
+    assert events[3].part.tool_name == "weather"
+    assert events[3].part.args == '{"city":"Par'
+    assert isinstance(events[4].delta, ToolCallArgsDelta)
+    assert events[4].delta.tool_call_id == "call-1"
+    assert events[4].delta.args_delta == 'is"}'
+    assert events[5].part.args == '{"city":"Paris"}'
+    assert events[5].tool_call_id == "call-1"
+
+
+@pytest.mark.asyncio
+async def test_request_stream_closes_text_part_when_stream_ends_without_tools():
+    stream = _AsyncStream(
+        [
+            _make_chunk(include_delta=False),
+            _make_chunk(content="Hello"),
+            _make_chunk(content=" world"),
+        ]
+    )
+    create = AsyncMock(return_value=stream)
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    model, _ = _make_model(client=client)
+
+    events = [
+        event
+        async for event in model.request_stream(
+            messages=[ModelMessage(role="user", parts=[UserPromptPart(content="hi")])],
+            model_settings={"temperature": 0.0},
+            model_request_parameters=ModelRequestParameters(),
+        )
+    ]
+
+    assert [(type(event), event.index) for event in events] == [
+        (PartStartEvent, 0),
+        (PartDeltaEvent, 0),
+        (PartDeltaEvent, 0),
+        (PartEndEvent, 0),
+    ]
+    assert events[-1].part.content == "Hello world"

--- a/tests/unit/mindtrace/agents/providers/test_gemini.py
+++ b/tests/unit/mindtrace/agents/providers/test_gemini.py
@@ -1,0 +1,64 @@
+"""Unit tests for the Gemini provider."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from mindtrace.agents.providers.gemini import GeminiProvider
+
+
+def test_init_with_injected_client_uses_client_directly():
+    client = SimpleNamespace(base_url="https://gemini-proxy.test/v1/")
+
+    provider = GeminiProvider(openai_client=client)
+
+    assert provider.client is client
+    assert provider.name == "gemini"
+    assert provider.base_url == "https://gemini-proxy.test/v1/"
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected_json_schema_output"),
+    [
+        ("gemini-2.5-flash", True),
+        ("gemini-1.5-flash-latest", False),
+        ("unknown-model", False),
+    ],
+)
+def test_model_profile_selects_prefix_specific_or_default_profiles(model_name, expected_json_schema_output):
+    provider = GeminiProvider(openai_client=SimpleNamespace(base_url="https://gemini-proxy.test/v1/"))
+
+    profile = provider.model_profile(model_name)
+
+    assert profile.supports_tools is True
+    assert profile.supports_json_schema_output is expected_json_schema_output
+    assert profile.supports_json_object_output is True
+
+
+def test_init_rejects_api_key_with_injected_client():
+    with pytest.raises(ValueError, match="Cannot provide both `openai_client` and `api_key`"):
+        GeminiProvider(openai_client=object(), api_key="secret")
+
+
+def test_init_uses_env_api_key_and_default_base_url(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "env-key")
+    constructed_client = SimpleNamespace(base_url="https://generativelanguage.googleapis.com/v1beta/openai/")
+
+    with patch("mindtrace.agents.providers.gemini.AsyncOpenAI", return_value=constructed_client) as async_openai:
+        provider = GeminiProvider()
+
+    async_openai.assert_called_once_with(
+        api_key="env-key",
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+    )
+    assert provider.client is constructed_client
+
+
+def test_init_requires_api_key_when_no_client_or_env(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="GEMINI_API_KEY"):
+        GeminiProvider()

--- a/tests/unit/mindtrace/agents/providers/test_ollama.py
+++ b/tests/unit/mindtrace/agents/providers/test_ollama.py
@@ -1,0 +1,57 @@
+"""Unit tests for the Ollama provider."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from mindtrace.agents.providers.ollama import OllamaProvider
+
+
+def test_init_with_injected_client_uses_client_directly():
+    client = SimpleNamespace(base_url="http://ollama.test:11434/v1/")
+
+    provider = OllamaProvider(openai_client=client)
+
+    assert provider.client is client
+    assert provider.name == "ollama"
+    assert provider.base_url == "http://ollama.test:11434/v1/"
+    assert provider.model_profile("llama3").supports_tools is True
+    assert provider.model_profile("llama3").supports_json_schema_output is False
+
+
+def test_init_rejects_client_with_explicit_connection_settings():
+    with pytest.raises(ValueError, match="Cannot provide both `openai_client`"):
+        OllamaProvider(openai_client=object(), base_url="http://ollama.test:11434")
+
+
+def test_init_uses_env_base_url_and_default_api_key(monkeypatch):
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://ollama.test:11434/v1/")
+    monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+    constructed_client = SimpleNamespace(base_url="http://ollama.test:11434/v1/")
+
+    with patch("mindtrace.agents.providers.ollama.AsyncOpenAI", return_value=constructed_client) as async_openai:
+        provider = OllamaProvider()
+
+    async_openai.assert_called_once_with(base_url="http://ollama.test:11434/v1/", api_key="api-key-not-set")
+    assert provider.client is constructed_client
+
+
+def test_init_prefers_explicit_api_key_over_env(monkeypatch):
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://ollama.test:11434/v1/")
+    monkeypatch.setenv("OLLAMA_API_KEY", "env-key")
+    constructed_client = SimpleNamespace(base_url="http://ollama.test:11434/v1/")
+
+    with patch("mindtrace.agents.providers.ollama.AsyncOpenAI", return_value=constructed_client) as async_openai:
+        OllamaProvider(api_key="explicit-key")
+
+    async_openai.assert_called_once_with(base_url="http://ollama.test:11434/v1/", api_key="explicit-key")
+
+
+def test_init_requires_base_url_when_no_client_or_env(monkeypatch):
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+
+    with pytest.raises(ValueError, match="OLLAMA_BASE_URL"):
+        OllamaProvider()

--- a/tests/unit/mindtrace/agents/providers/test_openai.py
+++ b/tests/unit/mindtrace/agents/providers/test_openai.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/mindtrace/agents/providers/test_openai.py
+++ b/tests/unit/mindtrace/agents/providers/test_openai.py
@@ -1,0 +1,45 @@
+"""Unit tests for the OpenAI provider."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mindtrace.agents.providers.openai import OpenAIProvider
+
+
+def test_init_with_injected_client_uses_client_directly():
+    client = SimpleNamespace(base_url="https://api.openai.test/v1/")
+
+    provider = OpenAIProvider(openai_client=client)
+
+    assert provider.client is client
+    assert provider.name == "openai"
+    assert provider.base_url == "https://api.openai.test/v1/"
+    assert provider.model_profile("gpt-test").supports_json_schema_output is True
+    assert provider.model_profile("gpt-test").supports_json_object_output is True
+
+
+def test_init_rejects_client_with_explicit_credentials():
+    with pytest.raises(ValueError, match="Cannot provide both `openai_client`"):
+        OpenAIProvider(openai_client=object(), api_key="secret")
+
+
+def test_init_uses_env_api_key_and_optional_base_url(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    constructed_client = SimpleNamespace(base_url="https://proxy.openai.test/v1/")
+
+    with patch("mindtrace.agents.providers.openai.AsyncOpenAI", return_value=constructed_client) as async_openai:
+        provider = OpenAIProvider(base_url="https://proxy.openai.test/v1/")
+
+    async_openai.assert_called_once_with(api_key="env-key", base_url="https://proxy.openai.test/v1/")
+    assert provider.client is constructed_client
+
+
+def test_init_requires_api_key_when_no_client_or_env(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+        OpenAIProvider()

--- a/tests/unit/mindtrace/agents/test_messages.py
+++ b/tests/unit/mindtrace/agents/test_messages.py
@@ -3,12 +3,14 @@
 import pytest
 
 from mindtrace.agents.messages import (
+    MessagesBuilder,
     ModelMessage,
     SystemPromptPart,
     TextPart,
     ToolCallPart,
     ToolReturnPart,
 )
+from mindtrace.agents.prompts import UserPromptPart
 
 
 class TestMessageParts:
@@ -95,3 +97,61 @@ class TestModelMessage:
         parts = [TextPart(content="a"), TextPart(content="b")]
         msg = ModelMessage(role="assistant", parts=parts)
         assert len(msg.parts) == 2
+
+    def test_requires_at_least_one_part(self):
+        """ModelMessage rejects empty part lists."""
+        with pytest.raises(ValueError, match="at least one part"):
+            ModelMessage(role="user", parts=[])
+
+
+class TestMessagesBuilder:
+    """Tests for fluent message construction."""
+
+    def test_builder_chains_all_message_types(self):
+        builder = MessagesBuilder()
+
+        result = (
+            builder.add_user("hello")
+            .add_system("be helpful")
+            .add_assistant_text("working on it")
+            .add_assistant_tool_calls([("tc-1", "search", '{"q":"cats"}')])
+            .add_tool_return("tc-1", "done")
+        )
+
+        assert result is builder
+        messages = builder.messages
+        assert len(messages) == 5
+        assert messages[0].role == "user"
+        assert isinstance(messages[0].parts[0], UserPromptPart)
+        assert messages[0].parts[0].content == "hello"
+        assert messages[1].role == "system"
+        assert messages[2].parts[0].content == "working on it"
+        assert isinstance(messages[3].parts[0], ToolCallPart)
+        assert messages[3].parts[0].tool_name == "search"
+        assert messages[4].role == "tool"
+        assert messages[4].parts[0].content == "done"
+
+    def test_builder_adds_multiple_tool_calls_in_single_message(self):
+        builder = MessagesBuilder()
+
+        builder.add_assistant_tool_calls(
+            [
+                ("tc-1", "search", '{"q":"cats"}'),
+                ("tc-2", "lookup", '{"id":42}'),
+            ]
+        )
+
+        message = builder.messages[0]
+        assert message.role == "assistant"
+        assert [part.tool_name for part in message.parts] == ["search", "lookup"]
+        assert [part.tool_call_id for part in message.parts] == ["tc-1", "tc-2"]
+
+    def test_messages_property_returns_copy_of_internal_list(self):
+        builder = MessagesBuilder()
+        builder.add_user("hello")
+
+        first_snapshot = builder.messages
+        first_snapshot.append(ModelMessage(role="assistant", parts=[TextPart(content="injected")]))
+
+        assert len(first_snapshot) == 2
+        assert len(builder.messages) == 1

--- a/tests/unit/mindtrace/agents/test_prompts.py
+++ b/tests/unit/mindtrace/agents/test_prompts.py
@@ -1,0 +1,127 @@
+"""Unit tests for `mindtrace.agents.prompts`."""
+
+from __future__ import annotations
+
+import builtins
+import sys
+from types import ModuleType
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mindtrace.agents.prompts import BinaryContent, ImageUrl, UserPromptPart
+
+
+def _install_fake_google_cloud(monkeypatch) -> None:
+    storage_module = ModuleType("google.cloud.storage")
+    cloud_module = ModuleType("google.cloud")
+    google_module = ModuleType("google")
+    cloud_module.storage = storage_module
+    google_module.cloud = cloud_module
+    monkeypatch.setitem(sys.modules, "google", google_module)
+    monkeypatch.setitem(sys.modules, "google.cloud", cloud_module)
+    monkeypatch.setitem(sys.modules, "google.cloud.storage", storage_module)
+
+
+class TestBinaryContent:
+    def test_properties_encode_bytes_and_detect_images(self):
+        content = BinaryContent(data=b"hello", media_type="image/png")
+
+        assert content.base64 == "aGVsbG8="
+        assert content.data_uri == "data:image/png;base64,aGVsbG8="
+        assert content.is_image is True
+
+    def test_non_image_media_type_is_not_image(self):
+        content = BinaryContent(data=b"hello", media_type="application/pdf")
+
+        assert content.is_image is False
+
+    def test_from_path_reads_bytes_and_guesses_media_type(self, tmp_path):
+        path = tmp_path / "sample.txt"
+        path.write_text("example", encoding="utf-8")
+
+        content = BinaryContent.from_path(path)
+
+        assert content.data == b"example"
+        assert content.media_type == "text/plain"
+
+    def test_from_path_falls_back_to_octet_stream(self, tmp_path):
+        path = tmp_path / "sample.unknownext"
+        path.write_bytes(b"\x00\x01")
+
+        content = BinaryContent.from_path(path)
+
+        assert content.data == b"\x00\x01"
+        assert content.media_type == "application/octet-stream"
+
+    def test_from_path_raises_for_missing_file(self, tmp_path):
+        missing = tmp_path / "missing.png"
+
+        with pytest.raises(FileNotFoundError, match="File not found"):
+            BinaryContent.from_path(missing)
+
+    def test_from_gcs_uses_provided_client_and_explicit_media_type(self, monkeypatch):
+        _install_fake_google_cloud(monkeypatch)
+        blob = Mock(content_type="image/png")
+        blob.download_as_bytes.return_value = b"gcs-bytes"
+        bucket = Mock()
+        bucket.blob.return_value = blob
+        client = Mock()
+        client.bucket.return_value = bucket
+
+        content = BinaryContent.from_gcs("my-bucket", "folder/item.bin", client=client, media_type="application/json")
+
+        client.bucket.assert_called_once_with("my-bucket")
+        bucket.blob.assert_called_once_with("folder/item.bin")
+        blob.download_as_bytes.assert_called_once_with()
+        assert content.data == b"gcs-bytes"
+        assert content.media_type == "application/json"
+
+    def test_from_gcs_uses_blob_content_type_before_guessing(self, monkeypatch):
+        _install_fake_google_cloud(monkeypatch)
+        blob = Mock(content_type="image/jpeg")
+        blob.download_as_bytes.return_value = b"jpeg-bytes"
+        bucket = Mock()
+        bucket.blob.return_value = blob
+        client = Mock()
+        client.bucket.return_value = bucket
+
+        content = BinaryContent.from_gcs("my-bucket", "folder/item.jpg", client=client)
+
+        assert content.media_type == "image/jpeg"
+
+    def test_from_gcs_guesses_type_and_then_falls_back_to_octet_stream(self, monkeypatch):
+        _install_fake_google_cloud(monkeypatch)
+        blob = Mock(content_type=None)
+        blob.download_as_bytes.return_value = b"archive-bytes"
+        bucket = Mock()
+        bucket.blob.return_value = blob
+        client = Mock()
+        client.bucket.return_value = bucket
+
+        guessed = BinaryContent.from_gcs("my-bucket", "archive.tar.gz", client=client)
+        unknown = BinaryContent.from_gcs("my-bucket", "archive.nope", client=client)
+
+        assert guessed.media_type == "application/x-tar"
+        assert unknown.media_type == "application/octet-stream"
+
+    def test_from_gcs_raises_helpful_error_when_google_cloud_storage_is_missing(self):
+        real_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "google.cloud":
+                raise ImportError("missing google.cloud")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            with pytest.raises(ImportError, match="google-cloud-storage is required"):
+                BinaryContent.from_gcs("bucket", "blob")
+
+
+class TestPromptTypes:
+    def test_image_url_and_user_prompt_part_store_content(self):
+        image = ImageUrl(url="https://example.test/image.png")
+        prompt = UserPromptPart(content=["hello", image])
+
+        assert image.url == "https://example.test/image.png"
+        assert prompt.content == ["hello", image]

--- a/tests/unit/mindtrace/core/utils/test_system_metrics_collector.py
+++ b/tests/unit/mindtrace/core/utils/test_system_metrics_collector.py
@@ -171,14 +171,19 @@ class TestSystemMetricsCollectorContextManager:
 
     def test_context_manager_with_interval(self):
         """Test context manager with interval."""
-        with SystemMetricsCollector(interval=0.1) as collector:
-            time.sleep(0.15)
+        with SystemMetricsCollector(interval=0.02) as collector:
+            deadline = time.monotonic() + 0.2
+            while collector.metrics_cache is None and time.monotonic() < deadline:
+                time.sleep(0.005)
+
             metrics = collector()
             assert isinstance(metrics, dict)
             assert collector.metrics_cache is not None
 
         # After exit, thread should be stopped
-        time.sleep(0.2)
+        deadline = time.monotonic() + 0.1
+        while collector._thread.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.005)
         assert not collector._thread.is_alive()
 
     def test_context_manager_stops_on_exception(self):

--- a/tests/unit/mindtrace/hardware/cameras/backends/basler/test_mock_basler_camera_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/basler/test_mock_basler_camera_backend.py
@@ -264,15 +264,13 @@ class TestMockBaslerImageGeneration:
     @pytest.mark.asyncio
     async def test_auto_pattern_rotation(self):
         """Test automatic pattern rotation in auto mode."""
-        camera = MockBaslerCameraBackend("test_cam", synthetic_pattern="auto")
+        camera = MockBaslerCameraBackend("test_cam", synthetic_pattern="auto", fast_mode=True)
         await camera.initialize()
 
         # Capture multiple images to test pattern rotation
-        images = []
         image_stats = []
-        for i in range(8):  # Capture more images to ensure we see rotation
+        for i in range(4):
             image = await camera.capture()
-            images.append(image)
             # Track statistics to detect pattern changes
             stats = (image.mean(), image.std(), image.min(), image.max())
             image_stats.append(stats)

--- a/tests/unit/mindtrace/hardware/cameras/backends/genicam/test_genicam_camera_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/genicam/test_genicam_camera_backend.py
@@ -766,8 +766,12 @@ class TestDiscoveryAndHelperMethods:
         from mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend import GenICamCameraBackend
 
         with (
-            patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.os.getenv", return_value="/env.cti"),
-            patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.os.path.exists", return_value=True),
+            patch(
+                "mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.os.getenv", return_value="/env.cti"
+            ),
+            patch(
+                "mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.os.path.exists", return_value=True
+            ),
         ):
             assert GenICamCameraBackend._detect_cti_path() == "/env.cti"
 
@@ -776,9 +780,17 @@ class TestDiscoveryAndHelperMethods:
 
         with (
             patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.os.getenv", return_value=None),
-            patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.os.path.exists", return_value=False),
-            patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.platform.system", return_value="Linux"),
-            patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.platform.machine", return_value="x86_64"),
+            patch(
+                "mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.os.path.exists", return_value=False
+            ),
+            patch(
+                "mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.platform.system",
+                return_value="Linux",
+            ),
+            patch(
+                "mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.platform.machine",
+                return_value="x86_64",
+            ),
         ):
             with pytest.raises(CameraConfigurationError, match="GenTL Producer not found"):
                 GenICamCameraBackend._detect_cti_path()
@@ -965,7 +977,9 @@ class TestAdditionalGenICamOperations:
         async def raise_from_to_thread(_func):
             raise RuntimeError("boom")
 
-        monkeypatch.setattr("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.asyncio.to_thread", raise_from_to_thread)
+        monkeypatch.setattr(
+            "mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.asyncio.to_thread", raise_from_to_thread
+        )
 
         with pytest.raises(CameraCaptureError, match="Image enhancement failed"):
             await backend._enhance_image(np.zeros((2, 2, 3), dtype=np.uint8))
@@ -1006,7 +1020,9 @@ class TestAdditionalGenICamOperations:
         assert wb_node.value == "Once"
 
     @pytest.mark.asyncio
-    async def test_import_config_supports_legacy_exposure_and_genicam_nodes(self, genicam_backend_uninitialized, tmp_path):
+    async def test_import_config_supports_legacy_exposure_and_genicam_nodes(
+        self, genicam_backend_uninitialized, tmp_path
+    ):
         backend = attach_mock_acquirer(genicam_backend_uninitialized)
         backend.set_exposure = AsyncMock()
         backend.set_gain = AsyncMock()

--- a/tests/unit/mindtrace/hardware/cameras/backends/genicam/test_genicam_camera_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/genicam/test_genicam_camera_backend.py
@@ -1,4 +1,5 @@
-from unittest.mock import Mock, patch
+import json
+from unittest.mock import AsyncMock, Mock, patch
 
 import numpy as np
 import pytest
@@ -350,6 +351,22 @@ async def genicam_backend_uninitialized(mock_harvester_module):
     )
 
     yield backend
+
+
+def attach_mock_acquirer(backend, node_map=None, *, vendor="Keyence", model="CV-X420"):
+    """Attach a simple mocked image acquirer and synchronous _run_blocking helper."""
+    backend.initialized = True
+    backend.device_info = {"vendor": vendor, "model": model}
+    backend.image_acquirer = MockImageAcquirer(
+        MockDeviceInfo(serial_number=backend.camera_name, vendor=vendor, model=model),
+        node_map=node_map or MockNodeMap(),
+    )
+
+    async def run_blocking(func, timeout=None):
+        return func()
+
+    backend._run_blocking = AsyncMock(side_effect=run_blocking)
+    return backend
 
 
 # Tests for singleton Harvester pattern
@@ -729,3 +746,363 @@ class TestCameraInfo:
     async def test_camera_name_property(self, genicam_backend):
         """Test camera_name property."""
         assert genicam_backend.camera_name == "12345678"
+
+
+class TestDiscoveryAndHelperMethods:
+    @pytest.mark.asyncio
+    async def test_discover_async_uses_to_thread(self, mock_harvester_module):
+        from mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend import GenICamCameraBackend
+
+        with patch(
+            "mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.asyncio.to_thread",
+            new=AsyncMock(return_value=["12345678"]),
+        ) as to_thread:
+            result = await GenICamCameraBackend.discover_async(include_details=False)
+
+        assert result == ["12345678"]
+        to_thread.assert_awaited_once_with(GenICamCameraBackend.get_available_cameras, False)
+
+    def test_detect_cti_path_prefers_env_var(self, mock_harvester_module):
+        from mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend import GenICamCameraBackend
+
+        with (
+            patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.os.getenv", return_value="/env.cti"),
+            patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.os.path.exists", return_value=True),
+        ):
+            assert GenICamCameraBackend._detect_cti_path() == "/env.cti"
+
+    def test_detect_cti_path_raises_when_not_found(self, mock_harvester_module):
+        from mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend import GenICamCameraBackend
+
+        with (
+            patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.os.getenv", return_value=None),
+            patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.os.path.exists", return_value=False),
+            patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.platform.system", return_value="Linux"),
+            patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.platform.machine", return_value="x86_64"),
+        ):
+            with pytest.raises(CameraConfigurationError, match="GenTL Producer not found"):
+                GenICamCameraBackend._detect_cti_path()
+
+    def test_get_available_cameras_returns_empty_when_cti_missing(self, mock_harvester_module):
+        from mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend import GenICamCameraBackend
+
+        with patch.object(GenICamCameraBackend, "_detect_cti_path", side_effect=CameraConfigurationError("missing")):
+            assert GenICamCameraBackend.get_available_cameras() == []
+            assert GenICamCameraBackend.get_available_cameras(include_details=True) == {}
+
+    @pytest.mark.asyncio
+    async def test_cleanup_on_failure_clears_resources(self, genicam_backend_uninitialized):
+        backend = attach_mock_acquirer(genicam_backend_uninitialized)
+        backend.harvester = Mock()
+        backend.image_acquirer.start()
+        backend._cleanup_executor = AsyncMock()
+
+        await backend._cleanup_on_failure()
+
+        assert backend.image_acquirer is None
+        assert backend.harvester is None
+        assert backend.initialized is False
+        backend._cleanup_executor.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("vendor", "expected_integer"),
+        [("Keyence", True), ("Basler", False), ("Other", False)],
+    )
+    async def test_detect_vendor_quirks_sets_expected_flags(
+        self, genicam_backend_uninitialized, vendor, expected_integer
+    ):
+        backend = genicam_backend_uninitialized
+        backend.device_info = {"vendor": vendor}
+        backend._detect_trigger_mode_capability = AsyncMock()
+
+        await backend._detect_vendor_quirks()
+
+        assert backend.vendor_quirks["use_integer_exposure"] is expected_integer
+        backend._detect_trigger_mode_capability.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_detect_trigger_mode_capability_handles_missing_node(self, genicam_backend_uninitialized):
+        backend = attach_mock_acquirer(genicam_backend_uninitialized, MockNodeMap())
+
+        await backend._detect_trigger_mode_capability()
+
+        assert backend.vendor_quirks["trigger_mode_writable"] is False
+        assert backend.vendor_quirks["trigger_mode_at_init"] == "unknown"
+        assert backend.triggermode == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_detect_trigger_mode_capability_falls_back_on_error(self, genicam_backend_uninitialized):
+        backend = attach_mock_acquirer(genicam_backend_uninitialized)
+        backend.logger.warning = Mock()
+        backend._run_blocking = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await backend._detect_trigger_mode_capability()
+
+        assert backend.vendor_quirks["trigger_mode_writable"] is True
+        assert backend.vendor_quirks["trigger_mode_at_init"] == "continuous"
+        backend.logger.warning.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_get_node_value_uses_fallback_names(self, genicam_backend_uninitialized):
+        node_map = MockNodeMap(ExposureTimeAbs=MockGenICamNode(123.0))
+        backend = attach_mock_acquirer(genicam_backend_uninitialized, node_map)
+
+        value = await backend._get_node_value("ExposureTime", ["ExposureTimeAbs"])
+
+        assert value == 123.0
+
+    @pytest.mark.asyncio
+    async def test_set_node_value_uses_integer_exposure_conversion(self, genicam_backend_uninitialized):
+        node_map = MockNodeMap(ExposureTime=MockGenICamNode(0))
+        backend = attach_mock_acquirer(genicam_backend_uninitialized, node_map)
+        backend.vendor_quirks["use_integer_exposure"] = True
+
+        await backend._set_node_value("ExposureTime", 12.9)
+
+        assert node_map.ExposureTime.value == 12
+
+    @pytest.mark.asyncio
+    async def test_configure_camera_sets_buffer_count_and_acquisition_mode(self, genicam_backend_uninitialized):
+        node_map = MockNodeMap(AcquisitionMode=MockEnumNode("SingleFrame", ["SingleFrame", "Continuous"]))
+        backend = attach_mock_acquirer(genicam_backend_uninitialized, node_map)
+        backend.buffer_count = 7
+
+        await backend._configure_camera()
+
+        assert backend.image_acquirer.num_buffers == 7
+        assert node_map.AcquisitionMode.value == "Continuous"
+
+    @pytest.mark.asyncio
+    async def test_start_acquisition_starts_when_not_running(self, genicam_backend_uninitialized):
+        backend = attach_mock_acquirer(genicam_backend_uninitialized)
+
+        await backend._start_acquisition()
+
+        assert backend.image_acquirer.is_acquiring() is True
+
+
+class TestAdditionalGenICamOperations:
+    @pytest.mark.asyncio
+    async def test_initialize_imports_existing_config(self, mock_harvester_module, tmp_path):
+        from mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend import GenICamCameraBackend
+
+        config_path = tmp_path / "camera.json"
+        config_path.write_text("{}")
+        backend = GenICamCameraBackend("12345678", cti_path="/mock/path/to/gentl.cti", camera_config=str(config_path))
+        backend.import_config = AsyncMock()
+
+        await backend.initialize()
+
+        backend.import_config.assert_awaited_once_with(str(config_path))
+
+    @pytest.mark.asyncio
+    async def test_get_width_and_height_ranges_default_when_nodes_missing(self, genicam_backend_uninitialized):
+        backend = attach_mock_acquirer(genicam_backend_uninitialized, MockNodeMap())
+
+        assert await backend.get_width_range() == [1, 9999]
+        assert await backend.get_height_range() == [1, 9999]
+
+    @pytest.mark.asyncio
+    async def test_get_trigger_mode_falls_back_when_trigger_source_unreadable(self, genicam_backend_uninitialized):
+        node_map = MockNodeMap(
+            TriggerMode=MockEnumNode("On", ["Off", "On"], readable=True),
+            TriggerSource=MockEnumNode("Software", ["Software"], readable=False),
+        )
+        backend = attach_mock_acquirer(genicam_backend_uninitialized, node_map)
+
+        assert await backend.get_triggermode() == "trigger"
+
+    @pytest.mark.asyncio
+    async def test_set_trigger_mode_restarts_acquisition_and_updates_nodes(self, genicam_backend):
+        await genicam_backend.set_triggermode("trigger")
+        node_map = genicam_backend.image_acquirer.remote_device.node_map
+
+        assert node_map.TriggerSelector.value == "FrameStart"
+        assert node_map.TriggerMode.value == "On"
+        assert node_map.TriggerSource.value == "Software"
+        assert genicam_backend.image_acquirer.is_acquiring() is True
+
+    @pytest.mark.asyncio
+    async def test_capture_in_trigger_mode_requires_software_trigger_command(self, genicam_backend_uninitialized):
+        node_map = MockNodeMap(
+            TriggerMode=MockEnumNode("On", ["Off", "On"]),
+            TriggerSource=MockEnumNode("Software", ["Software"]),
+        )
+        backend = attach_mock_acquirer(genicam_backend_uninitialized, node_map)
+        backend.triggermode = "trigger"
+
+        with pytest.raises(CameraCaptureError, match="No software trigger command found"):
+            await backend.capture()
+
+    @pytest.mark.asyncio
+    async def test_capture_converts_mono8_to_bgr(self, genicam_backend_uninitialized):
+        backend = attach_mock_acquirer(genicam_backend_uninitialized)
+        backend.triggermode = "continuous"
+        backend.image_acquirer.fetch = lambda timeout=1.0: MockBuffer(width=4, height=3, pixel_format="Mono8")
+
+        image = await backend.capture()
+
+        assert image.shape == (3, 4, 3)
+        assert image.dtype == np.uint8
+
+    @pytest.mark.asyncio
+    async def test_capture_uses_image_enhancement_when_enabled(self, genicam_backend_uninitialized):
+        backend = attach_mock_acquirer(genicam_backend_uninitialized)
+        backend.triggermode = "continuous"
+        backend.img_quality_enhancement = True
+        backend._enhance_image = AsyncMock(return_value=np.ones((1080, 1920, 3), dtype=np.uint8))
+
+        image = await backend.capture()
+
+        backend._enhance_image.assert_awaited_once()
+        assert image.shape == (1080, 1920, 3)
+
+    @pytest.mark.asyncio
+    async def test_enhance_image_wraps_failures(self, genicam_backend_uninitialized, monkeypatch):
+        backend = attach_mock_acquirer(genicam_backend_uninitialized)
+
+        async def raise_from_to_thread(_func):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.asyncio.to_thread", raise_from_to_thread)
+
+        with pytest.raises(CameraCaptureError, match="Image enhancement failed"):
+            await backend._enhance_image(np.zeros((2, 2, 3), dtype=np.uint8))
+
+    @pytest.mark.asyncio
+    async def test_check_connection_returns_false_when_vendor_node_missing(self, genicam_backend_uninitialized):
+        backend = attach_mock_acquirer(genicam_backend_uninitialized, MockNodeMap())
+        backend.image_acquirer.start()
+
+        assert await backend.check_connection() is False
+
+    @pytest.mark.asyncio
+    async def test_close_cleans_up_image_acquirer_and_executor(self, genicam_backend_uninitialized):
+        backend = attach_mock_acquirer(genicam_backend_uninitialized)
+        backend.harvester = Mock()
+        backend.image_acquirer.start()
+        backend._cleanup_executor = AsyncMock()
+
+        await backend.close()
+
+        assert backend.image_acquirer is None
+        assert backend.harvester is None
+        assert backend.initialized is False
+        backend._cleanup_executor.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_white_balance_helpers_cover_common_paths(self, genicam_backend_uninitialized):
+        wb_node = Mock()
+        wb_node.value = "Continuous"
+        wb_node.symbolics = ["Continuous", "Off", "Once"]
+        node_map = MockNodeMap(BalanceWhiteAuto=wb_node)
+        backend = attach_mock_acquirer(genicam_backend_uninitialized, node_map)
+
+        assert await backend.get_wb() == "auto"
+        assert await backend.get_wb_range() == ["auto", "manual", "once"]
+
+        await backend.set_auto_wb_once("mystery")
+        assert wb_node.value == "Once"
+
+    @pytest.mark.asyncio
+    async def test_import_config_supports_legacy_exposure_and_genicam_nodes(self, genicam_backend_uninitialized, tmp_path):
+        backend = attach_mock_acquirer(genicam_backend_uninitialized)
+        backend.set_exposure = AsyncMock()
+        backend.set_gain = AsyncMock()
+        backend.set_triggermode = AsyncMock()
+        backend.set_auto_wb_once = AsyncMock()
+        backend.set_ROI = AsyncMock()
+        backend._apply_genicam_nodes = AsyncMock()
+        config_path = tmp_path / "camera.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "exposure": 1500,
+                    "gain": 2.5,
+                    "triggermode": "trigger",
+                    "white_balance": "once",
+                    "roi": {"x": 1, "y": 2, "width": 100, "height": 50},
+                    "genicam_nodes": {"PixelFormat": "Mono8"},
+                }
+            )
+        )
+
+        await backend.import_config(str(config_path))
+
+        backend.set_exposure.assert_awaited_once_with(1500)
+        backend.set_gain.assert_awaited_once_with(2.5)
+        backend.set_triggermode.assert_awaited_once_with("trigger")
+        backend.set_auto_wb_once.assert_awaited_once_with("once")
+        backend.set_ROI.assert_awaited_once_with(1, 2, 100, 50)
+        backend._apply_genicam_nodes.assert_awaited_once_with({"PixelFormat": "Mono8"})
+
+    @pytest.mark.asyncio
+    async def test_export_config_writes_current_values(self, genicam_backend_uninitialized, tmp_path):
+        backend = attach_mock_acquirer(genicam_backend_uninitialized)
+        backend.get_exposure = AsyncMock(return_value=1000.0)
+        backend.get_gain = AsyncMock(return_value=2.0)
+        backend.get_triggermode = AsyncMock(return_value="trigger")
+        backend.get_wb = AsyncMock(return_value="auto")
+        backend.get_ROI = AsyncMock(return_value={"x": 1, "y": 2, "width": 100, "height": 50})
+        backend.get_exposure_range = AsyncMock(return_value=[10.0, 10000.0])
+        backend.get_gain_range = AsyncMock(return_value=[0.0, 24.0])
+        backend.get_wb_range = AsyncMock(return_value=["auto", "once"])
+        backend._export_genicam_nodes = AsyncMock(return_value={"PixelFormat": "Mono8"})
+        config_path = tmp_path / "nested" / "camera.json"
+
+        with patch("mindtrace.hardware.cameras.backends.genicam.genicam_camera_backend.time.time", return_value=123.0):
+            await backend.export_config(str(config_path))
+
+        config = json.loads(config_path.read_text())
+        assert config["camera_name"] == "12345678"
+        assert config["vendor"] == "Keyence"
+        assert config["exported_timestamp"] == 123.0
+        assert config["exposure_time"] == 1000.0
+        assert config["roi"] == {"x": 1, "y": 2, "width": 100, "height": 50}
+        assert config["genicam_nodes"] == {"PixelFormat": "Mono8"}
+
+    @pytest.mark.asyncio
+    async def test_apply_and_export_genicam_nodes_use_available_values(self, genicam_backend_uninitialized):
+        reverse_x = MockGenICamNode(False)
+        pixel_format = MockEnumNode("RGB8", ["RGB8", "Mono8"])
+        node_map = MockNodeMap(PixelFormat=pixel_format, ReverseX=reverse_x)
+        backend = attach_mock_acquirer(genicam_backend_uninitialized, node_map)
+
+        await backend._apply_genicam_nodes({"PixelFormat": "Mono8", "Missing": 1, "ReverseX": True})
+        exported = await backend._export_genicam_nodes()
+
+        assert pixel_format.value == "Mono8"
+        assert reverse_x.value is True
+        assert exported["PixelFormat"] == "Mono8"
+        assert exported["ReverseX"] is True
+
+    @pytest.mark.asyncio
+    async def test_region_of_interest_methods_cover_region_nodes_and_defaults(self, genicam_backend_uninitialized):
+        node_map = MockNodeMap(
+            RegionOffsetX=MockGenICamNode(0, min_val=0, max_val=10),
+            RegionOffsetY=MockGenICamNode(0, min_val=0, max_val=10),
+            RegionWidth=MockGenICamNode(640, min_val=1, max_val=1280),
+            RegionHeight=MockGenICamNode(480, min_val=1, max_val=960),
+        )
+        backend = attach_mock_acquirer(genicam_backend_uninitialized, node_map)
+
+        await backend.set_ROI(5, 6, 320, 240)
+        roi = await backend.get_ROI()
+        await backend.reset_ROI()
+
+        assert roi == {"x": 5, "y": 6, "width": 320, "height": 240}
+        assert node_map.RegionOffsetX.value == 0
+        assert node_map.RegionOffsetY.value == 0
+        assert node_map.RegionWidth.value == 1280
+        assert node_map.RegionHeight.value == 960
+
+    @pytest.mark.asyncio
+    async def test_capture_timeout_round_trip(self, genicam_backend_uninitialized):
+        backend = genicam_backend_uninitialized
+
+        await backend.set_capture_timeout(250)
+
+        assert await backend.get_capture_timeout() == 250
+        with pytest.raises(ValueError, match="non-negative"):
+            await backend.set_capture_timeout(-1)

--- a/tests/unit/mindtrace/hardware/cameras/backends/genicam/test_mock_genicam_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/genicam/test_mock_genicam_backend.py
@@ -499,7 +499,9 @@ class TestGainRoiTimeoutAndConfig:
         await cam.set_triggermode("trigger")
         await cam.set_ROI(1, 1, 4, 4)
 
-        with patch("mindtrace.hardware.cameras.backends.genicam.mock_genicam_camera_backend.time.time", return_value=123.0):
+        with patch(
+            "mindtrace.hardware.cameras.backends.genicam.mock_genicam_camera_backend.time.time", return_value=123.0
+        ):
             await cam.export_config(str(config_path))
 
         config_data = json.loads(config_path.read_text())

--- a/tests/unit/mindtrace/hardware/cameras/backends/genicam/test_mock_genicam_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/genicam/test_mock_genicam_backend.py
@@ -1,9 +1,36 @@
 """Focused tests for MockGenICamCameraBackend behavior."""
 
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
 import pytest
 
+import mindtrace.hardware.cameras.backends.genicam.mock_genicam_camera_backend as mock_genicam_module
 from mindtrace.hardware.cameras.backends.genicam.mock_genicam_camera_backend import MockGenICamCameraBackend
-from mindtrace.hardware.core.exceptions import CameraConfigurationError, CameraConnectionError, CameraNotFoundError
+from mindtrace.hardware.core.exceptions import (
+    CameraCaptureError,
+    CameraConfigurationError,
+    CameraConnectionError,
+    CameraInitializationError,
+    CameraNotFoundError,
+    CameraTimeoutError,
+)
+
+
+@pytest.fixture(autouse=True)
+def fast_backend_sleep(monkeypatch):
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr(mock_genicam_module.asyncio, "sleep", _sleep)
+
+
+def make_camera(camera_name="MOCK_KEYENCE_001", **kwargs):
+    kwargs.setdefault("synthetic_width", 8)
+    kwargs.setdefault("synthetic_height", 6)
+    kwargs.setdefault("synthetic_overlay_text", False)
+    return MockGenICamCameraBackend(camera_name, **kwargs)
 
 
 def test_available_cameras_formats():
@@ -15,36 +42,482 @@ def test_available_cameras_formats():
     assert details["MOCK_KEYENCE_001"]["vendor"] == "KEYENCE"
 
 
-@pytest.mark.asyncio
-async def test_initialize_missing_camera_raises():
-    cam = MockGenICamCameraBackend("does_not_exist")
-    with pytest.raises(CameraNotFoundError):
-        await cam.initialize()
-
-
-@pytest.mark.asyncio
-async def test_set_exposure_requires_initialization():
-    cam = MockGenICamCameraBackend("MOCK_KEYENCE_001")
-    with pytest.raises(CameraConnectionError):
-        await cam.set_exposure(1000)
-
-
-@pytest.mark.asyncio
-async def test_keyence_exposure_casts_to_int():
-    cam = MockGenICamCameraBackend("MOCK_KEYENCE_001", vendor="KEYENCE")
-    await cam.initialize()
-    await cam.set_exposure(1234.9)
-    assert cam.exposure_time == 1234.0
-
-
-@pytest.mark.asyncio
-async def test_exposure_out_of_range_raises():
-    cam = MockGenICamCameraBackend("MOCK_BASLER_001", vendor="BASLER")
-    await cam.initialize()
-    with pytest.raises(CameraConfigurationError):
-        await cam.set_exposure(2_000_000)
+@pytest.mark.parametrize(
+    ("vendor", "expected_integer_exposure"),
+    [("KEYENCE", True), ("BASLER", False), ("FLIR", False)],
+)
+def test_vendor_quirks_match_vendor(vendor, expected_integer_exposure):
+    cam = make_camera(vendor=vendor)
+    assert cam.vendor_quirks["use_integer_exposure"] is expected_integer_exposure
+    assert cam.vendor_quirks["exposure_node_name"] == "ExposureTime"
+    assert cam.vendor_quirks["gain_node_name"] == "Gain"
 
 
 def test_invalid_buffer_count_rejected():
     with pytest.raises(CameraConfigurationError):
         MockGenICamCameraBackend("MOCK_KEYENCE_001", buffer_count=0)
+
+
+def test_invalid_timeout_rejected():
+    with pytest.raises(CameraConfigurationError, match="Timeout must be at least 100ms"):
+        MockGenICamCameraBackend("MOCK_KEYENCE_001", timeout_ms=99)
+
+
+class TestInitialization:
+    @pytest.mark.asyncio
+    async def test_initialize_missing_camera_raises(self):
+        cam = make_camera("does_not_exist")
+        with pytest.raises(CameraNotFoundError):
+            await cam.initialize()
+
+    @pytest.mark.asyncio
+    async def test_initialize_fail_init_raises(self):
+        cam = make_camera("MOCK_KEYENCE_001", simulate_fail_init=True)
+        with pytest.raises(CameraInitializationError, match="Simulated initialization failure"):
+            await cam.initialize()
+
+    @pytest.mark.asyncio
+    async def test_initialize_success_returns_mock_objects(self):
+        cam = make_camera("MOCK_KEYENCE_001", vendor="KEYENCE")
+
+        success, camera_object, device_info = await cam.initialize()
+
+        assert success is True
+        assert cam.initialized is True
+        assert camera_object == {"type": "mock_genicam", "name": "MOCK_KEYENCE_001"}
+        assert device_info["serial_number"] == cam.serial_number
+        assert device_info["vendor"] == "KEYENCE"
+
+    @pytest.mark.asyncio
+    async def test_initialize_imports_existing_config_file(self, tmp_path):
+        config_path = tmp_path / "camera.json"
+        config_path.write_text("{}")
+        cam = make_camera("MOCK_KEYENCE_001", camera_config=str(config_path))
+        cam.import_config = AsyncMock()
+
+        await cam.initialize()
+
+        cam.import_config.assert_awaited_once_with(str(config_path))
+
+
+class TestExposureAndTrigger:
+    @pytest.mark.asyncio
+    async def test_get_exposure_range_requires_initialization(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(CameraConnectionError):
+            await cam.get_exposure_range()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("vendor", "expected_range"),
+        [
+            ("KEYENCE", [10.0, 10000000.0]),
+            ("BASLER", [1.0, 1000000.0]),
+            ("FLIR", [1.0, 5000000.0]),
+        ],
+    )
+    async def test_get_exposure_range_matches_vendor(self, vendor, expected_range):
+        cam = make_camera("MOCK_KEYENCE_001", vendor=vendor)
+        await cam.initialize()
+        assert await cam.get_exposure_range() == expected_range
+
+    @pytest.mark.asyncio
+    async def test_set_exposure_requires_initialization(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(CameraConnectionError):
+            await cam.set_exposure(1000)
+
+    @pytest.mark.asyncio
+    async def test_get_exposure_requires_initialization(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(CameraConnectionError):
+            await cam.get_exposure()
+
+    @pytest.mark.asyncio
+    async def test_keyence_exposure_casts_to_int(self):
+        cam = make_camera("MOCK_KEYENCE_001", vendor="KEYENCE")
+        await cam.initialize()
+
+        await cam.set_exposure(1234.9)
+
+        assert cam.exposure_time == 1234.0
+        assert await cam.get_exposure() == 1234.0
+
+    @pytest.mark.asyncio
+    async def test_non_keyence_exposure_keeps_float(self):
+        cam = make_camera("MOCK_BASLER_001", vendor="BASLER")
+        await cam.initialize()
+
+        await cam.set_exposure(1234.9)
+
+        assert cam.exposure_time == 1234.9
+        assert await cam.get_exposure() == 1234.9
+
+    @pytest.mark.asyncio
+    async def test_exposure_out_of_range_raises(self):
+        cam = make_camera("MOCK_BASLER_001", vendor="BASLER")
+        await cam.initialize()
+        with pytest.raises(CameraConfigurationError):
+            await cam.set_exposure(2_000_000)
+
+    @pytest.mark.asyncio
+    async def test_get_triggermode_defaults_before_init(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        assert await cam.get_triggermode() == "continuous"
+
+    @pytest.mark.asyncio
+    async def test_set_triggermode_requires_initialization(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(CameraConnectionError):
+            await cam.set_triggermode("trigger")
+
+    @pytest.mark.asyncio
+    async def test_set_triggermode_rejects_invalid_mode(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+        with pytest.raises(CameraConfigurationError, match="Invalid trigger mode"):
+            await cam.set_triggermode("invalid")
+
+    @pytest.mark.asyncio
+    async def test_set_triggermode_updates_mode(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+
+        await cam.set_triggermode("trigger")
+
+        assert await cam.get_triggermode() == "trigger"
+
+
+class TestCaptureAndImages:
+    @pytest.mark.asyncio
+    async def test_capture_requires_initialization(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(CameraConnectionError):
+            await cam.capture()
+
+    @pytest.mark.asyncio
+    async def test_capture_fail_capture_raises(self):
+        cam = make_camera("MOCK_KEYENCE_001", simulate_fail_capture=True)
+        await cam.initialize()
+        with pytest.raises(CameraCaptureError, match="Simulated capture failure"):
+            await cam.capture()
+
+    @pytest.mark.asyncio
+    async def test_capture_timeout_raises(self):
+        cam = make_camera("MOCK_KEYENCE_001", simulate_timeout=True)
+        await cam.initialize()
+        with pytest.raises(CameraTimeoutError, match="Simulated timeout"):
+            await cam.capture()
+
+    @pytest.mark.asyncio
+    async def test_capture_returns_image_and_increments_counter(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+
+        image = await cam.capture()
+
+        assert image.shape == (6, 8, 3)
+        assert image.dtype == np.uint8
+        assert cam.image_counter == 1
+
+    @pytest.mark.asyncio
+    async def test_capture_uses_enhancement_when_enabled(self):
+        cam = make_camera("MOCK_KEYENCE_001", img_quality_enhancement=True)
+        await cam.initialize()
+        base_image = np.zeros((6, 8, 3), dtype=np.uint8)
+        enhanced_image = np.ones((6, 8, 3), dtype=np.uint8)
+        cam._generate_synthetic_image = AsyncMock(return_value=base_image)
+        cam._enhance_image = AsyncMock(return_value=enhanced_image)
+
+        image = await cam.capture()
+
+        assert np.array_equal(image, enhanced_image)
+        cam._enhance_image.assert_awaited_once_with(base_image)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("pattern", ["gradient", "checkerboard", "circular", "noise"])
+    async def test_generate_synthetic_image_supports_explicit_patterns(self, pattern):
+        width = 60 if pattern == "checkerboard" else 8
+        height = 60 if pattern == "checkerboard" else 6
+        cam = make_camera("MOCK_KEYENCE_001", synthetic_pattern=pattern, synthetic_width=width, synthetic_height=height)
+        image = await cam._generate_synthetic_image()
+
+        assert image.shape == (height, width, 3)
+        assert image.dtype == np.uint8
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("vendor", ["KEYENCE", "BASLER", "FLIR"])
+    async def test_generate_synthetic_image_auto_mode_handles_vendor_colors(self, vendor):
+        cam = make_camera("MOCK_KEYENCE_001", vendor=vendor, synthetic_pattern="auto")
+
+        image = await cam._generate_synthetic_image()
+
+        assert image.shape == (6, 8, 3)
+        assert image.dtype == np.uint8
+
+    @pytest.mark.asyncio
+    async def test_generate_synthetic_image_with_overlay_text(self):
+        cam = make_camera("MOCK_KEYENCE_001", synthetic_pattern="gradient", synthetic_overlay_text=True)
+
+        image = await cam._generate_synthetic_image()
+
+        assert image.shape == (6, 8, 3)
+
+    @pytest.mark.asyncio
+    async def test_enhance_image_returns_enhanced_image(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        image = np.zeros((6, 8, 3), dtype=np.uint8)
+
+        enhanced = await cam._enhance_image(image)
+
+        assert enhanced.shape == image.shape
+        assert enhanced.dtype == image.dtype
+
+    @pytest.mark.asyncio
+    async def test_enhance_image_returns_original_on_failure(self, monkeypatch):
+        cam = make_camera("MOCK_KEYENCE_001")
+        cam.logger.error = MagicMock()
+        image = np.zeros((6, 8, 3), dtype=np.uint8)
+
+        async def raise_from_to_thread(_func):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(mock_genicam_module.asyncio, "to_thread", raise_from_to_thread)
+
+        result = await cam._enhance_image(image)
+
+        assert result is image
+        cam.logger.error.assert_called_once()
+
+
+class TestConnectionAndLifecycle:
+    @pytest.mark.asyncio
+    async def test_check_connection_false_when_uninitialized(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        assert await cam.check_connection() is False
+
+    @pytest.mark.asyncio
+    async def test_check_connection_true_with_valid_capture(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+        cam.capture = AsyncMock(return_value=np.zeros((2, 2, 3), dtype=np.uint8))
+
+        assert await cam.check_connection() is True
+
+    @pytest.mark.asyncio
+    async def test_check_connection_false_when_capture_raises(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+        cam.capture = AsyncMock(side_effect=CameraCaptureError("boom"))
+        cam.logger.warning = MagicMock()
+
+        assert await cam.check_connection() is False
+        cam.logger.warning.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_resets_initialized_state(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+
+        await cam.close()
+
+        assert cam.initialized is False
+
+    @pytest.mark.asyncio
+    async def test_close_is_noop_when_uninitialized(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.close()
+        assert cam.initialized is False
+
+
+class TestGainRoiTimeoutAndConfig:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("vendor", "expected_range"),
+        [("KEYENCE", [1.0, 7.0]), ("BASLER", [0.0, 48.0]), ("FLIR", [1.0, 16.0])],
+    )
+    async def test_get_gain_range_matches_vendor(self, vendor, expected_range):
+        cam = make_camera("MOCK_KEYENCE_001", vendor=vendor)
+        assert await cam.get_gain_range() == expected_range
+
+    @pytest.mark.asyncio
+    async def test_get_gain_requires_initialization(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(CameraConnectionError):
+            await cam.get_gain()
+
+    @pytest.mark.asyncio
+    async def test_set_gain_requires_initialization(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(CameraConnectionError):
+            await cam.set_gain(2.0)
+
+    @pytest.mark.asyncio
+    async def test_set_gain_rejects_out_of_range_value(self):
+        cam = make_camera("MOCK_KEYENCE_001", vendor="KEYENCE")
+        await cam.initialize()
+        with pytest.raises(CameraConfigurationError, match="outside valid range"):
+            await cam.set_gain(10.0)
+
+    @pytest.mark.asyncio
+    async def test_set_gain_updates_gain(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+
+        await cam.set_gain(3.5)
+
+        assert await cam.get_gain() == 3.5
+
+    @pytest.mark.asyncio
+    async def test_set_roi_requires_initialization(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(CameraConnectionError):
+            await cam.set_ROI(0, 0, 4, 4)
+
+    @pytest.mark.asyncio
+    async def test_set_roi_rejects_invalid_dimensions(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+        with pytest.raises(CameraConfigurationError, match="Invalid ROI dimensions"):
+            await cam.set_ROI(0, 0, 0, 4)
+
+    @pytest.mark.asyncio
+    async def test_set_roi_rejects_invalid_offsets(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+        with pytest.raises(CameraConfigurationError, match="Invalid ROI offsets"):
+            await cam.set_ROI(-1, 0, 4, 4)
+
+    @pytest.mark.asyncio
+    async def test_set_roi_rejects_out_of_bounds_region(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+        with pytest.raises(CameraConfigurationError, match="exceeds sensor bounds"):
+            await cam.set_ROI(6, 4, 4, 4)
+
+    @pytest.mark.asyncio
+    async def test_get_roi_requires_initialization(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(CameraConnectionError):
+            await cam.get_ROI()
+
+    @pytest.mark.asyncio
+    async def test_set_and_get_roi(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+
+        await cam.set_ROI(1, 1, 4, 4)
+        roi = await cam.get_ROI()
+        roi["x"] = 99
+
+        assert cam.roi == {"x": 1, "y": 1, "width": 4, "height": 4}
+
+    @pytest.mark.asyncio
+    async def test_reset_roi_requires_initialization(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(CameraConnectionError):
+            await cam.reset_ROI()
+
+    @pytest.mark.asyncio
+    async def test_reset_roi_restores_full_sensor(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+        await cam.set_ROI(1, 1, 4, 4)
+
+        await cam.reset_ROI()
+
+        assert cam.roi == {"x": 0, "y": 0, "width": 8, "height": 6}
+
+    @pytest.mark.asyncio
+    async def test_set_capture_timeout_rejects_negative_value(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(ValueError, match="non-negative"):
+            await cam.set_capture_timeout(-1)
+
+    @pytest.mark.asyncio
+    async def test_capture_timeout_round_trip(self):
+        cam = make_camera("MOCK_KEYENCE_001")
+
+        await cam.set_capture_timeout(250)
+
+        assert await cam.get_capture_timeout() == 250
+
+    @pytest.mark.asyncio
+    async def test_import_config_missing_file_raises(self, tmp_path):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(CameraConfigurationError, match="Configuration file not found"):
+            await cam.import_config(str(tmp_path / "missing.json"))
+
+    @pytest.mark.asyncio
+    async def test_import_config_updates_camera_settings(self, tmp_path):
+        config_path = tmp_path / "camera.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "exposure_time": 1200,
+                    "gain": 3.0,
+                    "trigger_mode": "trigger",
+                    "roi": {"x": 1, "y": 2, "width": 4, "height": 3},
+                    "image_enhancement": True,
+                }
+            )
+        )
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+
+        await cam.import_config(str(config_path))
+
+        assert cam.exposure_time == 1200.0
+        assert cam.gain == 3.0
+        assert cam.triggermode == "trigger"
+        assert cam.roi == {"x": 1, "y": 2, "width": 4, "height": 3}
+        assert cam.img_quality_enhancement is True
+
+    @pytest.mark.asyncio
+    async def test_import_config_wraps_invalid_json(self, tmp_path):
+        config_path = tmp_path / "invalid.json"
+        config_path.write_text("{invalid json")
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+
+        with pytest.raises(CameraConfigurationError, match="Failed to import configuration"):
+            await cam.import_config(str(config_path))
+
+    @pytest.mark.asyncio
+    async def test_export_config_requires_initialization(self, tmp_path):
+        cam = make_camera("MOCK_KEYENCE_001")
+        with pytest.raises(CameraConnectionError):
+            await cam.export_config(str(tmp_path / "camera.json"))
+
+    @pytest.mark.asyncio
+    async def test_export_config_writes_expected_json(self, tmp_path):
+        config_path = tmp_path / "nested" / "camera.json"
+        cam = make_camera("MOCK_KEYENCE_001", vendor="KEYENCE")
+        await cam.initialize()
+        await cam.set_gain(4.0)
+        await cam.set_exposure(1500)
+        await cam.set_triggermode("trigger")
+        await cam.set_ROI(1, 1, 4, 4)
+
+        with patch("mindtrace.hardware.cameras.backends.genicam.mock_genicam_camera_backend.time.time", return_value=123.0):
+            await cam.export_config(str(config_path))
+
+        config_data = json.loads(config_path.read_text())
+        assert config_data["camera_type"] == "mock_genicam"
+        assert config_data["camera_name"] == "MOCK_KEYENCE_001"
+        assert config_data["vendor"] == "KEYENCE"
+        assert config_data["timestamp"] == 123.0
+        assert config_data["exposure_time"] == 1500.0
+        assert config_data["gain"] == 4.0
+        assert config_data["trigger_mode"] == "trigger"
+        assert config_data["roi"] == {"x": 1, "y": 1, "width": 4, "height": 4}
+
+    @pytest.mark.asyncio
+    async def test_export_config_wraps_write_errors(self, tmp_path):
+        config_path = tmp_path / "camera.json"
+        cam = make_camera("MOCK_KEYENCE_001")
+        await cam.initialize()
+
+        with patch("builtins.open", side_effect=OSError("disk full")):
+            with pytest.raises(CameraConfigurationError, match="Failed to export configuration"):
+                await cam.export_config(str(config_path))

--- a/tests/unit/mindtrace/hardware/cameras/backends/test_camera_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/test_camera_backend.py
@@ -1,7 +1,8 @@
+import asyncio
 import logging
 import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
@@ -11,6 +12,8 @@ from mindtrace.hardware.core.exceptions import (
     CameraConnectionError,
     CameraInitializationError,
     CameraNotFoundError,
+    CameraTimeoutError,
+    HardwareOperationError,
 )
 
 
@@ -128,6 +131,12 @@ class MinimalConcreteBackend(CameraBackend):
         return ["test_camera"]
 
 
+class MinimalThreadAffinityBackend(MinimalConcreteBackend):
+    """Concrete backend that requires thread affinity for SDK calls."""
+
+    REQUIRES_THREAD_AFFINITY = True
+
+
 class TestCameraBackendConstructor:
     """Test camera backend constructor and initialization."""
 
@@ -209,6 +218,130 @@ class TestCameraBackendConstructor:
         # Should use config values when not explicitly provided
         assert backend.img_quality_enhancement is False
         assert backend.retrieve_retry_count == 7
+
+
+class TestCameraBackendBlockingExecution:
+    """Test blocking SDK execution helpers."""
+
+    @patch("mindtrace.hardware.cameras.backends.camera_backend.get_camera_config")
+    @pytest.mark.asyncio
+    async def test_run_blocking_uses_to_thread_when_thread_affinity_not_required(self, mock_get_config):
+        mock_config_obj = MagicMock()
+        mock_config_obj.cameras.image_quality_enhancement = True
+        mock_config_obj.cameras.retrieve_retry_count = 3
+        mock_get_config.return_value.get_config.return_value = mock_config_obj
+
+        backend = MinimalConcreteBackend(camera_name="cam-1")
+        backend._op_timeout_s = 1.25
+
+        with patch(
+            "mindtrace.hardware.cameras.backends.camera_backend.asyncio.to_thread",
+            AsyncMock(return_value="done"),
+        ) as to_thread:
+            result = await backend._run_blocking(str.upper, "abc")
+
+        to_thread.assert_called_once_with(str.upper, "abc")
+        assert result == "done"
+
+    @patch("mindtrace.hardware.cameras.backends.camera_backend.get_camera_config")
+    @pytest.mark.asyncio
+    async def test_run_blocking_uses_single_thread_executor_when_affinity_required(self, mock_get_config):
+        mock_config_obj = MagicMock()
+        mock_config_obj.cameras.image_quality_enhancement = True
+        mock_config_obj.cameras.retrieve_retry_count = 3
+        mock_get_config.return_value.get_config.return_value = mock_config_obj
+
+        backend = MinimalThreadAffinityBackend(camera_name="affinity-cam")
+        loop = MagicMock()
+        future = asyncio.Future()
+        future.set_result("done")
+        loop.run_in_executor.return_value = future
+
+        with (
+            patch("mindtrace.hardware.cameras.backends.camera_backend.asyncio.get_running_loop", return_value=loop),
+            patch("mindtrace.hardware.cameras.backends.camera_backend.ThreadPoolExecutor") as executor_cls,
+        ):
+            result = await backend._run_blocking(str.upper, "abc", timeout=2.0)
+
+        executor_cls.assert_called_once_with(max_workers=1, thread_name_prefix="MinimalThreadAffinityBackend_affinity-cam")
+        loop.run_in_executor.assert_called_once()
+        assert result == "done"
+        assert backend._sdk_executor is executor_cls.return_value
+
+    @patch("mindtrace.hardware.cameras.backends.camera_backend.get_camera_config")
+    @pytest.mark.asyncio
+    async def test_run_blocking_wraps_timeouts(self, mock_get_config):
+        mock_config_obj = MagicMock()
+        mock_config_obj.cameras.image_quality_enhancement = True
+        mock_config_obj.cameras.retrieve_retry_count = 3
+        mock_get_config.return_value.get_config.return_value = mock_config_obj
+
+        backend = MinimalConcreteBackend(camera_name="cam-1")
+
+        with (
+            patch("mindtrace.hardware.cameras.backends.camera_backend.asyncio.to_thread", return_value=object()),
+            patch(
+                "mindtrace.hardware.cameras.backends.camera_backend.asyncio.wait_for",
+                side_effect=asyncio.TimeoutError,
+            ),
+        ):
+            with pytest.raises(CameraTimeoutError, match="timed out after 5.00s"):
+                await backend._run_blocking(lambda: None)
+
+    @patch("mindtrace.hardware.cameras.backends.camera_backend.get_camera_config")
+    @pytest.mark.asyncio
+    async def test_run_blocking_wraps_generic_errors(self, mock_get_config):
+        mock_config_obj = MagicMock()
+        mock_config_obj.cameras.image_quality_enhancement = True
+        mock_config_obj.cameras.retrieve_retry_count = 3
+        mock_get_config.return_value.get_config.return_value = mock_config_obj
+
+        backend = MinimalConcreteBackend(camera_name="cam-1")
+
+        with (
+            patch("mindtrace.hardware.cameras.backends.camera_backend.asyncio.to_thread", return_value=object()),
+            patch(
+                "mindtrace.hardware.cameras.backends.camera_backend.asyncio.wait_for",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            with pytest.raises(HardwareOperationError, match="SDK operation failed for camera 'cam-1': boom"):
+                await backend._run_blocking(lambda: None)
+
+    @patch("mindtrace.hardware.cameras.backends.camera_backend.get_camera_config")
+    @pytest.mark.asyncio
+    async def test_cleanup_executor_shuts_down_and_clears_executor(self, mock_get_config):
+        mock_config_obj = MagicMock()
+        mock_config_obj.cameras.image_quality_enhancement = True
+        mock_config_obj.cameras.retrieve_retry_count = 3
+        mock_get_config.return_value.get_config.return_value = mock_config_obj
+
+        backend = MinimalConcreteBackend(camera_name="cam-1")
+        executor = MagicMock()
+        backend._sdk_executor = executor
+
+        await backend._cleanup_executor()
+
+        executor.shutdown.assert_called_once_with(wait=False, cancel_futures=True)
+        assert backend._sdk_executor is None
+
+    @patch("mindtrace.hardware.cameras.backends.camera_backend.get_camera_config")
+    @pytest.mark.asyncio
+    async def test_cleanup_executor_logs_warning_on_shutdown_error(self, mock_get_config):
+        mock_config_obj = MagicMock()
+        mock_config_obj.cameras.image_quality_enhancement = True
+        mock_config_obj.cameras.retrieve_retry_count = 3
+        mock_get_config.return_value.get_config.return_value = mock_config_obj
+
+        backend = MinimalConcreteBackend(camera_name="cam-1")
+        backend._sdk_executor = MagicMock()
+        backend._sdk_executor.shutdown.side_effect = RuntimeError("shutdown failed")
+        backend.logger.warning = MagicMock()
+
+        await backend._cleanup_executor()
+
+        backend.logger.warning.assert_called_once()
+        assert backend._sdk_executor is None
 
 
 class TestCameraBackendLogging:
@@ -696,7 +829,7 @@ class TestCameraBackendCleanup:
     """Test resource cleanup and destructor behavior."""
 
     @patch("mindtrace.hardware.cameras.backends.camera_backend.get_camera_config")
-    def test_destructor_with_camera_warns(self, mock_get_config, caplog):
+    def test_destructor_with_camera_warns(self, mock_get_config):
         """Test destructor warns when camera not properly cleaned up."""
         mock_config_obj = MagicMock()
         mock_config_obj.cameras.image_quality_enhancement = True
@@ -705,21 +838,14 @@ class TestCameraBackendCleanup:
 
         backend = MinimalConcreteBackend()
         backend.camera = "mock_camera"  # Simulate uncleaned camera
+        backend.logger.warning = MagicMock()
 
-        # Temporarily lower handler levels to capture warnings
-        original_levels, original_propagate = enable_log_capture(backend, logging.WARNING)
+        backend.__del__()
 
-        with caplog.at_level(logging.WARNING):
-            backend.__del__()
-
-        # Restore original handler levels
-        restore_log_settings(backend, original_levels, original_propagate)
-
-        # Should warn about improper cleanup
-        # Check log records instead of text for more reliable capture
-        log_messages = [record.message for record in caplog.records]
-        assert any("destroyed without proper cleanup" in msg for msg in log_messages)
-        assert any("Use 'async with camera' or call 'await camera.close()'" in msg for msg in log_messages)
+        backend.logger.warning.assert_called_once()
+        warning_message = backend.logger.warning.call_args.args[0]
+        assert "destroyed without proper cleanup" in warning_message
+        assert "Use 'async with camera' or call 'await camera.close()'" in warning_message
 
     @patch("mindtrace.hardware.cameras.backends.camera_backend.get_camera_config")
     def test_destructor_without_camera_no_warning(self, mock_get_config, caplog):

--- a/tests/unit/mindtrace/hardware/cameras/backends/test_camera_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/test_camera_backend.py
@@ -263,7 +263,9 @@ class TestCameraBackendBlockingExecution:
         ):
             result = await backend._run_blocking(str.upper, "abc", timeout=2.0)
 
-        executor_cls.assert_called_once_with(max_workers=1, thread_name_prefix="MinimalThreadAffinityBackend_affinity-cam")
+        executor_cls.assert_called_once_with(
+            max_workers=1, thread_name_prefix="MinimalThreadAffinityBackend_affinity-cam"
+        )
         loop.run_in_executor.assert_called_once()
         assert result == "done"
         assert backend._sdk_executor is executor_cls.return_value

--- a/tests/unit/mindtrace/hardware/cameras/core/test_async_camera.py
+++ b/tests/unit/mindtrace/hardware/cameras/core/test_async_camera.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import AsyncMock
 
 import numpy as np
 import pytest
@@ -772,10 +773,14 @@ async def test_async_camera_capture_connection_error_retry(monkeypatch):
             cam._backend.capture = connection_error_capture
             cam._backend.retrieve_retry_count = 2  # Set retry count on backend
 
-            # This should retry and succeed
+            retry_sleep = AsyncMock()
+            monkeypatch.setattr("mindtrace.hardware.cameras.core.async_camera.asyncio.sleep", retry_sleep)
+
+            # This should retry and succeed without incurring a real backoff delay.
             result = await cam.capture()
             assert result is not None
             assert call_count == 2
+            retry_sleep.assert_awaited_once()
     finally:
         await manager.close(None)
 

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_base.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_base.py
@@ -1,0 +1,226 @@
+"""Unit tests for the BasePLC helper behavior."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from mindtrace.hardware.core.exceptions import PLCTagError
+from mindtrace.hardware.plcs.backends.base import BasePLC
+
+
+class MinimalPLC(BasePLC):
+    def __init__(self, *args, **kwargs):
+        self._connected = False
+        super().__init__(*args, **kwargs)
+
+    async def initialize(self):
+        self.initialized = True
+        return True, object(), object()
+
+    async def connect(self) -> bool:
+        self._connected = True
+        return True
+
+    async def disconnect(self) -> bool:
+        self._connected = False
+        return True
+
+    async def is_connected(self) -> bool:
+        return self._connected
+
+    async def read_tag(self, tags):
+        return {"Tag1": 1} if isinstance(tags, str) else {tag: index for index, tag in enumerate(tags)}
+
+    async def write_tag(self, tags):
+        if isinstance(tags, tuple):
+            return {tags[0]: True}
+        return {tag_name: True for tag_name, _ in tags}
+
+    async def get_all_tags(self):
+        return ["Tag1", "Tag2"]
+
+    async def get_tag_info(self, tag_name: str):
+        return {"name": tag_name, "type": "int"}
+
+    @staticmethod
+    def get_available_plcs():
+        return ["Mock:PLC1"]
+
+    @staticmethod
+    def get_backend_info():
+        return {"name": "MockPLC"}
+
+
+def _mock_hardware_config():
+    return SimpleNamespace(
+        plcs=SimpleNamespace(
+            connection_timeout=1.5,
+            read_timeout=2.5,
+            write_timeout=3.5,
+            retry_count=3,
+            retry_delay=0.01,
+        )
+    )
+
+
+class TestBasePLCInitialization:
+    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
+    def test_constructor_uses_config_defaults(self, mock_get_hardware_config):
+        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
+
+        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
+
+        assert plc.plc_name == "PLC1"
+        assert plc.ip_address == "192.168.1.100"
+        assert plc.connection_timeout == 1.5
+        assert plc.read_timeout == 2.5
+        assert plc.write_timeout == 3.5
+        assert plc.retry_count == 3
+        assert plc.retry_delay == 0.01
+        assert plc.initialized is False
+
+    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
+    def test_constructor_respects_explicit_overrides(self, mock_get_hardware_config):
+        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
+
+        plc = MinimalPLC(
+            plc_name="PLC1",
+            ip_address="192.168.1.100",
+            connection_timeout=10.0,
+            read_timeout=20.0,
+            write_timeout=30.0,
+            retry_count=4,
+            retry_delay=0.5,
+        )
+
+        assert plc.connection_timeout == 10.0
+        assert plc.read_timeout == 20.0
+        assert plc.write_timeout == 30.0
+        assert plc.retry_count == 4
+        assert plc.retry_delay == 0.5
+
+    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
+    def test_logger_formatting_is_configured(self, mock_get_hardware_config):
+        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
+
+        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
+
+        assert plc.logger.propagate is False
+        assert plc.logger.level <= logging.INFO
+        assert plc.logger.handlers
+        formatter = plc.logger.handlers[0].formatter
+        assert "%(message)s" in formatter._fmt
+        assert formatter is not None
+
+
+class TestBasePLCRetryHelpers:
+    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
+    @pytest.mark.asyncio
+    async def test_reconnect_disconnects_sleeps_and_reconnects(self, mock_get_hardware_config):
+        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
+        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
+        plc.disconnect = AsyncMock(return_value=True)
+        plc.connect = AsyncMock(return_value=True)
+
+        with patch("mindtrace.hardware.plcs.backends.base.asyncio.sleep", AsyncMock()) as sleep:
+            result = await plc.reconnect()
+
+        plc.disconnect.assert_awaited_once_with()
+        sleep.assert_awaited_once_with(plc.retry_delay)
+        plc.connect.assert_awaited_once_with()
+        assert result is True
+
+    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
+    @pytest.mark.asyncio
+    async def test_reconnect_returns_false_when_disconnect_fails(self, mock_get_hardware_config):
+        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
+        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
+        plc.disconnect = AsyncMock(side_effect=RuntimeError("boom"))
+        plc.logger.error = Mock()
+
+        result = await plc.reconnect()
+
+        assert result is False
+        plc.logger.error.assert_called_once()
+
+    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
+    @pytest.mark.asyncio
+    async def test_read_tag_with_retry_retries_and_reconnects(self, mock_get_hardware_config):
+        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
+        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
+        plc.read_tag = AsyncMock(side_effect=[RuntimeError("fail once"), {"Tag1": 123}])
+        plc.is_connected = AsyncMock(return_value=False)
+        plc.reconnect = AsyncMock(return_value=True)
+
+        with patch("mindtrace.hardware.plcs.backends.base.asyncio.sleep", AsyncMock()) as sleep:
+            result = await plc.read_tag_with_retry("Tag1")
+
+        assert result == {"Tag1": 123}
+        assert plc.read_tag.await_count == 2
+        plc.reconnect.assert_awaited_once_with()
+        sleep.assert_awaited_once_with(plc.retry_delay)
+
+    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
+    @pytest.mark.asyncio
+    async def test_read_tag_with_retry_raises_after_exhausting_attempts(self, mock_get_hardware_config):
+        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
+        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
+        plc.read_tag = AsyncMock(side_effect=RuntimeError("still failing"))
+        plc.is_connected = AsyncMock(return_value=True)
+        plc.reconnect = AsyncMock()
+
+        with patch("mindtrace.hardware.plcs.backends.base.asyncio.sleep", AsyncMock()):
+            with pytest.raises(PLCTagError, match="Failed to read tags after 3 attempts"):
+                await plc.read_tag_with_retry("Tag1")
+
+        assert plc.read_tag.await_count == 3
+        plc.reconnect.assert_not_called()
+
+    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
+    @pytest.mark.asyncio
+    async def test_write_tag_with_retry_retries_and_reconnects(self, mock_get_hardware_config):
+        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
+        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
+        plc.write_tag = AsyncMock(side_effect=[RuntimeError("fail once"), {"Tag1": True}])
+        plc.is_connected = AsyncMock(return_value=False)
+        plc.reconnect = AsyncMock(return_value=True)
+
+        with patch("mindtrace.hardware.plcs.backends.base.asyncio.sleep", AsyncMock()) as sleep:
+            result = await plc.write_tag_with_retry(("Tag1", 100))
+
+        assert result == {"Tag1": True}
+        assert plc.write_tag.await_count == 2
+        plc.reconnect.assert_awaited_once_with()
+        sleep.assert_awaited_once_with(plc.retry_delay)
+
+    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
+    @pytest.mark.asyncio
+    async def test_write_tag_with_retry_raises_after_exhausting_attempts(self, mock_get_hardware_config):
+        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
+        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
+        plc.write_tag = AsyncMock(side_effect=RuntimeError("still failing"))
+        plc.is_connected = AsyncMock(return_value=True)
+        plc.reconnect = AsyncMock()
+
+        with patch("mindtrace.hardware.plcs.backends.base.asyncio.sleep", AsyncMock()):
+            with pytest.raises(PLCTagError, match="Failed to write tags after 3 attempts"):
+                await plc.write_tag_with_retry(("Tag1", 100))
+
+        assert plc.write_tag.await_count == 3
+        plc.reconnect.assert_not_called()
+
+
+@patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
+def test_string_representations_include_identity(mock_get_hardware_config):
+    mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
+
+    plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
+    plc.initialized = True
+
+    assert str(plc) == "MinimalPLC(PLC1@192.168.1.100)"
+    assert "plc_name='PLC1'" in repr(plc)
+    assert "initialized=True" in repr(plc)

--- a/tests/unit/mindtrace/hardware/scanners_3d/backends/test_scanner_3d_backend.py
+++ b/tests/unit/mindtrace/hardware/scanners_3d/backends/test_scanner_3d_backend.py
@@ -1,0 +1,142 @@
+"""Unit tests for the Scanner3DBackend base class."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mindtrace.hardware.core.exceptions import CameraTimeoutError, HardwareOperationError
+from mindtrace.hardware.scanners_3d.backends.scanner_3d_backend import Scanner3DBackend
+
+
+class MinimalScannerBackend(Scanner3DBackend):
+    @staticmethod
+    def discover():
+        return ["SN-1", "SN-2"]
+
+    async def initialize(self) -> bool:
+        self._is_open = True
+        return True
+
+    async def capture(self, **kwargs):
+        return {"captured": True, "kwargs": kwargs}
+
+    async def close(self) -> None:
+        self._is_open = False
+
+    @property
+    def name(self) -> str:
+        return f"Minimal:{self.serial_number}"
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_returns_function_result():
+    backend = MinimalScannerBackend(serial_number="SN-1", op_timeout_s=1.5)
+
+    result = await backend._run_blocking(lambda x, y: x + y, 2, 3)
+
+    assert result == 5
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_wraps_timeout():
+    backend = MinimalScannerBackend(serial_number="SN-1", op_timeout_s=1.5)
+
+    with (
+        patch("mindtrace.hardware.scanners_3d.backends.scanner_3d_backend.asyncio.to_thread", return_value=object()),
+        patch(
+            "mindtrace.hardware.scanners_3d.backends.scanner_3d_backend.asyncio.wait_for",
+            side_effect=asyncio.TimeoutError,
+        ),
+    ):
+        with pytest.raises(CameraTimeoutError, match="timed out after 1.50s"):
+            await backend._run_blocking(lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_preserves_domain_error():
+    backend = MinimalScannerBackend(serial_number="SN-1")
+
+    with patch(
+        "mindtrace.hardware.scanners_3d.backends.scanner_3d_backend.asyncio.to_thread",
+        AsyncMock(side_effect=HardwareOperationError("already wrapped")),
+    ):
+        with pytest.raises(HardwareOperationError, match="already wrapped"):
+            await backend._run_blocking(lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_run_blocking_wraps_generic_error():
+    backend = MinimalScannerBackend(serial_number="SN-1")
+
+    with patch(
+        "mindtrace.hardware.scanners_3d.backends.scanner_3d_backend.asyncio.to_thread",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        with pytest.raises(HardwareOperationError, match="3D scanner operation failed: boom"):
+            await backend._run_blocking(lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_discover_async_uses_subclass_discover():
+    result = await MinimalScannerBackend.discover_async()
+
+    assert result == ["SN-1", "SN-2"]
+
+
+@pytest.mark.asyncio
+async def test_discover_detailed_helpers_use_base_discover_hook():
+    with patch.object(Scanner3DBackend, "discover", return_value=["SN-1", "SN-2"]):
+        detailed = Scanner3DBackend.discover_detailed()
+        detailed_async = await Scanner3DBackend.discover_detailed_async()
+
+    assert detailed == [{"serial_number": "SN-1"}, {"serial_number": "SN-2"}]
+    assert detailed_async == detailed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "args", "expected_message"),
+    [
+        ("capture_point_cloud", (), "capture_point_cloud not implemented"),
+        ("get_capabilities", (), "get_capabilities not implemented"),
+        ("get_configuration", (), "get_configuration not implemented"),
+        ("set_configuration", (object(),), "set_configuration not implemented"),
+        ("set_exposure_time", (10.0,), "set_exposure_time not supported"),
+        ("get_trigger_mode", (), "get_trigger_mode not supported"),
+    ],
+)
+async def test_optional_methods_raise_not_implemented(method_name, args, expected_message):
+    backend = MinimalScannerBackend(serial_number="SN-1")
+
+    with pytest.raises(NotImplementedError, match=expected_message):
+        await getattr(backend, method_name)(*args)
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_initializes_and_closes():
+    backend = MinimalScannerBackend(serial_number="SN-1")
+    backend.initialize = AsyncMock(return_value=True)
+    backend.close = AsyncMock(return_value=None)
+
+    async with backend as entered:
+        assert entered is backend
+
+    backend.initialize.assert_awaited_once_with()
+    backend.close.assert_awaited_once_with()
+
+
+def test_properties_repr_and_destructor_warning(caplog):
+    backend = MinimalScannerBackend(serial_number="SN-1")
+
+    assert backend.is_open is False
+    assert backend.device_info is None
+    assert "status=closed" in repr(backend)
+
+    backend._is_open = True
+    with caplog.at_level("WARNING"):
+        backend.__del__()
+
+    assert "destroyed without proper cleanup" in caplog.text

--- a/tests/unit/mindtrace/hardware/scanners_3d/core/test_async_scanner_3d.py
+++ b/tests/unit/mindtrace/hardware/scanners_3d/core/test_async_scanner_3d.py
@@ -1,0 +1,180 @@
+"""Unit tests for the AsyncScanner3D wrapper."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from mindtrace.hardware.core.exceptions import CameraConnectionError
+from mindtrace.hardware.scanners_3d.core.async_scanner_3d import AsyncScanner3D
+
+
+def _install_backend_module(monkeypatch, module_path: str, class_name: str, factory: Mock) -> None:
+    module = ModuleType(module_path)
+    setattr(module, class_name, factory)
+    monkeypatch.setitem(sys.modules, module_path, module)
+
+
+def _make_scanner():
+    backend = Mock()
+    backend.name = "Photoneo:ABC123"
+    backend.is_open = True
+    scanner = AsyncScanner3D(backend)
+    return scanner, backend
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("name", "module_path", "class_name", "expected_serial"),
+    [
+        (None, "mindtrace.hardware.scanners_3d.backends.photoneo.photoneo_backend", "PhotoneoBackend", None),
+        ("ABC123", "mindtrace.hardware.scanners_3d.backends.photoneo.photoneo_backend", "PhotoneoBackend", "ABC123"),
+        (
+            "MockPhotoneo:MOCK-001",
+            "mindtrace.hardware.scanners_3d.backends.photoneo.mock_photoneo_backend",
+            "MockPhotoneoBackend",
+            "MOCK-001",
+        ),
+    ],
+)
+async def test_open_selects_backend_parses_name_and_initializes(monkeypatch, name, module_path, class_name, expected_serial):
+    backend = Mock()
+    backend.initialize = AsyncMock(return_value=True)
+    factory = Mock(return_value=backend)
+    _install_backend_module(monkeypatch, module_path, class_name, factory)
+
+    scanner = await AsyncScanner3D.open(name)
+
+    factory.assert_called_once_with(serial_number=expected_serial)
+    backend.initialize.assert_awaited_once_with()
+    assert isinstance(scanner, AsyncScanner3D)
+    assert scanner._backend is backend
+
+
+@pytest.mark.asyncio
+async def test_open_supports_backend_name_without_serial(monkeypatch):
+    backend = Mock()
+    backend.initialize = AsyncMock(return_value=True)
+    factory = Mock(return_value=backend)
+    _install_backend_module(
+        monkeypatch,
+        "mindtrace.hardware.scanners_3d.backends.photoneo.mock_photoneo_backend",
+        "MockPhotoneoBackend",
+        factory,
+    )
+
+    scanner = await AsyncScanner3D.open("mockphotoneo")
+
+    factory.assert_called_once_with(serial_number=None)
+    assert scanner._backend is backend
+
+
+@pytest.mark.asyncio
+async def test_open_raises_for_unknown_backend():
+    with pytest.raises(ValueError, match="Unknown scanner backend type"):
+        await AsyncScanner3D.open("UnknownBackend:123")
+
+
+@pytest.mark.asyncio
+async def test_open_raises_when_backend_initialization_fails(monkeypatch):
+    backend = Mock()
+    backend.initialize = AsyncMock(return_value=False)
+    factory = Mock(return_value=backend)
+    _install_backend_module(
+        monkeypatch,
+        "mindtrace.hardware.scanners_3d.backends.photoneo.photoneo_backend",
+        "PhotoneoBackend",
+        factory,
+    )
+
+    with pytest.raises(CameraConnectionError, match="Failed to open scanner"):
+        await AsyncScanner3D.open("Photoneo:ABC123")
+
+
+@pytest.mark.asyncio
+async def test_capture_delegates_flags_to_backend():
+    scanner, backend = _make_scanner()
+    backend.capture = AsyncMock(return_value="scan-result")
+
+    result = await scanner.capture(
+        timeout_ms=321,
+        enable_range=False,
+        enable_intensity=True,
+        enable_confidence=True,
+        enable_normal=True,
+        enable_color=True,
+    )
+
+    backend.capture.assert_awaited_once_with(
+        timeout_ms=321,
+        enable_range=False,
+        enable_intensity=True,
+        enable_confidence=True,
+        enable_normal=True,
+        enable_color=True,
+    )
+    assert result == "scan-result"
+
+
+@pytest.mark.asyncio
+async def test_capture_point_cloud_downsamples_when_requested():
+    scanner, backend = _make_scanner()
+    point_cloud = Mock()
+    downsampled = Mock()
+    point_cloud.downsample.return_value = downsampled
+    backend.capture_point_cloud = AsyncMock(return_value=point_cloud)
+
+    result = await scanner.capture_point_cloud(
+        include_colors=False,
+        include_confidence=True,
+        downsample_factor=4,
+        timeout_ms=222,
+    )
+
+    backend.capture_point_cloud.assert_awaited_once_with(
+        include_colors=False,
+        include_confidence=True,
+        timeout_ms=222,
+    )
+    point_cloud.downsample.assert_called_once_with(4)
+    assert result is downsampled
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "args", "expected_return"),
+    [
+        ("close", (), None),
+        ("get_capabilities", (), {"modes": ["fast"]}),
+        ("get_configuration", (), {"exposure_time": 12.5}),
+        ("set_configuration", ({"exposure_time": 12.5},), None),
+        ("set_exposure_time", (5.5,), None),
+        ("get_exposure_time", (), 5.5),
+        ("set_trigger_mode", ("Software",), None),
+        ("get_trigger_mode", (), "Software"),
+    ],
+)
+async def test_wrapper_methods_delegate_to_backend(method_name, args, expected_return):
+    scanner, backend = _make_scanner()
+    backend_method = AsyncMock(return_value=expected_return)
+    setattr(backend, method_name, backend_method)
+
+    result = await getattr(scanner, method_name)(*args)
+
+    backend_method.assert_awaited_once_with(*args)
+    assert result == expected_return
+
+
+def test_properties_and_repr_proxy_to_backend():
+    scanner, backend = _make_scanner()
+
+    assert scanner.name == "Photoneo:ABC123"
+    assert scanner.is_open is True
+    assert "Photoneo:ABC123" in repr(scanner)
+    assert "open" in repr(scanner)
+
+    backend.is_open = False
+    assert "closed" in repr(scanner)

--- a/tests/unit/mindtrace/hardware/scanners_3d/core/test_async_scanner_3d.py
+++ b/tests/unit/mindtrace/hardware/scanners_3d/core/test_async_scanner_3d.py
@@ -40,7 +40,9 @@ def _make_scanner():
         ),
     ],
 )
-async def test_open_selects_backend_parses_name_and_initializes(monkeypatch, name, module_path, class_name, expected_serial):
+async def test_open_selects_backend_parses_name_and_initializes(
+    monkeypatch, name, module_path, class_name, expected_serial
+):
     backend = Mock()
     backend.initialize = AsyncMock(return_value=True)
     factory = Mock(return_value=backend)

--- a/tests/unit/mindtrace/hardware/scanners_3d/core/test_scanner_3d.py
+++ b/tests/unit/mindtrace/hardware/scanners_3d/core/test_scanner_3d.py
@@ -1,0 +1,191 @@
+"""Unit tests for the synchronous Scanner3D wrapper."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+from mindtrace.hardware.scanners_3d.core.scanner_3d import AsyncScanner3D, Scanner3D
+
+
+def _make_sync_wrapper():
+    scanner = Scanner3D.__new__(Scanner3D)
+    scanner._backend = Mock()
+    scanner._backend.name = "Photoneo:SYNC-123"
+    scanner._backend.is_open = True
+    scanner._owns_loop_thread = False
+    scanner._loop = None
+    scanner._loop_thread = None
+
+    def _submit(coro):
+        return asyncio.run(coro)
+
+    scanner._submit = _submit
+    return scanner
+
+
+def test_init_uses_provided_async_scanner_and_loop():
+    backend = Mock()
+    loop = Mock()
+
+    scanner = Scanner3D(async_scanner=backend, loop=loop)
+
+    assert scanner._backend is backend
+    assert scanner._loop is loop
+    assert scanner._owns_loop_thread is False
+    assert scanner._loop_thread is None
+
+
+def test_init_creates_loop_thread_and_opens_async_scanner():
+    opened_scanner = Mock(spec=AsyncScanner3D)
+    loop = Mock()
+    thread = Mock()
+
+    def _run_threadsafe(coro, target_loop):
+        future = Mock()
+        future.result.side_effect = lambda: asyncio.run(coro)
+        assert target_loop is loop
+        return future
+
+    with (
+        patch("mindtrace.hardware.scanners_3d.core.scanner_3d.asyncio.new_event_loop", return_value=loop) as new_loop,
+        patch("mindtrace.hardware.scanners_3d.core.scanner_3d.threading.Thread", return_value=thread) as thread_cls,
+        patch(
+            "mindtrace.hardware.scanners_3d.core.scanner_3d.asyncio.run_coroutine_threadsafe",
+            side_effect=_run_threadsafe,
+        ) as run_threadsafe,
+        patch.object(AsyncScanner3D, "open", AsyncMock(return_value=opened_scanner)) as open_async_scanner,
+    ):
+        scanner = Scanner3D(name="Photoneo:SYNC-123")
+
+    new_loop.assert_called_once_with()
+    thread_cls.assert_called_once()
+    thread.start.assert_called_once_with()
+    run_threadsafe.assert_called_once()
+    open_async_scanner.assert_awaited_once_with("Photoneo:SYNC-123")
+    assert scanner._backend is opened_scanner
+    assert scanner._loop is loop
+    assert scanner._owns_loop_thread is True
+
+
+def test_property_proxies():
+    scanner = _make_sync_wrapper()
+
+    assert scanner.name == "Photoneo:SYNC-123"
+    assert scanner.is_open is True
+
+
+def test_submit_uses_run_coroutine_threadsafe():
+    scanner = Scanner3D.__new__(Scanner3D)
+    scanner._loop = Mock()
+    future = Mock()
+    future.result.return_value = "done"
+
+    async def _sample():
+        return "value"
+
+    coro = _sample()
+    try:
+        with patch("asyncio.run_coroutine_threadsafe", return_value=future) as run_threadsafe:
+            assert scanner._submit(coro) == "done"
+
+        run_threadsafe.assert_called_once_with(coro, scanner._loop)
+        future.result.assert_called_once_with()
+    finally:
+        coro.close()
+
+
+def test_close_stops_owned_loop_and_joins_thread():
+    scanner = _make_sync_wrapper()
+    scanner._backend.close = AsyncMock(return_value=None)
+    scanner._owns_loop_thread = True
+    scanner._loop = Mock()
+    scanner._loop_thread = Mock()
+
+    scanner.close()
+
+    scanner._backend.close.assert_awaited_once_with()
+    scanner._loop.call_soon_threadsafe.assert_called_once_with(scanner._loop.stop)
+    scanner._loop_thread.join.assert_called_once_with(timeout=2)
+
+
+def test_context_manager_closes_on_exit():
+    scanner = _make_sync_wrapper()
+
+    with patch.object(scanner, "close") as close:
+        assert scanner.__enter__() is scanner
+        scanner.__exit__(None, None, None)
+
+    close.assert_called_once_with()
+
+
+def test_capture_delegates_flags_to_backend():
+    scanner = _make_sync_wrapper()
+    scanner._backend.capture = AsyncMock(return_value="scan-result")
+
+    result = scanner.capture(
+        timeout_ms=123,
+        enable_range=False,
+        enable_intensity=True,
+        enable_confidence=True,
+        enable_normal=True,
+        enable_color=True,
+    )
+
+    scanner._backend.capture.assert_awaited_once_with(
+        timeout_ms=123,
+        enable_range=False,
+        enable_intensity=True,
+        enable_confidence=True,
+        enable_normal=True,
+        enable_color=True,
+    )
+    assert result == "scan-result"
+
+
+def test_capture_point_cloud_delegates_all_arguments():
+    scanner = _make_sync_wrapper()
+    scanner._backend.capture_point_cloud = AsyncMock(return_value="point-cloud")
+
+    result = scanner.capture_point_cloud(
+        include_colors=False,
+        include_confidence=True,
+        downsample_factor=3,
+        timeout_ms=250,
+    )
+
+    scanner._backend.capture_point_cloud.assert_awaited_once_with(
+        include_colors=False,
+        include_confidence=True,
+        downsample_factor=3,
+        timeout_ms=250,
+    )
+    assert result == "point-cloud"
+
+
+def test_configuration_methods_delegate_to_backend():
+    scanner = _make_sync_wrapper()
+    scanner._backend.set_exposure_time = AsyncMock(return_value=None)
+    scanner._backend.get_exposure_time = AsyncMock(return_value=2500.0)
+    scanner._backend.set_trigger_mode = AsyncMock(return_value=None)
+    scanner._backend.get_trigger_mode = AsyncMock(return_value="Software")
+
+    scanner.set_exposure_time(2500.0)
+    assert scanner.get_exposure_time() == 2500.0
+    scanner.set_trigger_mode("Software")
+    assert scanner.get_trigger_mode() == "Software"
+
+    scanner._backend.set_exposure_time.assert_awaited_once_with(2500.0)
+    scanner._backend.get_exposure_time.assert_awaited_once_with()
+    scanner._backend.set_trigger_mode.assert_awaited_once_with("Software")
+    scanner._backend.get_trigger_mode.assert_awaited_once_with()
+
+
+def test_repr_uses_status():
+    scanner = _make_sync_wrapper()
+
+    assert "Photoneo:SYNC-123" in repr(scanner)
+    assert "status=open" in repr(scanner)
+
+    scanner._backend.is_open = False
+    assert "status=closed" in repr(scanner)

--- a/tests/unit/mindtrace/hardware/services/cameras/test_connection_manager.py
+++ b/tests/unit/mindtrace/hardware/services/cameras/test_connection_manager.py
@@ -73,7 +73,9 @@ class TestGetWrappers:
             ("get_network_diagnostics", "/network/diagnostics", {"latency_ms": 4.2}),
         ],
     )
-    async def test_get_wrappers_return_response_data(self, cm, monkeypatch, method_name, expected_endpoint, expected_data):
+    async def test_get_wrappers_return_response_data(
+        self, cm, monkeypatch, method_name, expected_endpoint, expected_data
+    ):
         monkeypatch.setattr(cm, "get", AsyncMock(return_value={"data": expected_data}))
 
         result = await getattr(cm, method_name)()
@@ -97,9 +99,25 @@ class TestPostWrappers:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("method_name", "args", "kwargs", "expected_endpoint", "expected_subset", "expected_timeout", "expected_result"),
+        (
+            "method_name",
+            "args",
+            "kwargs",
+            "expected_endpoint",
+            "expected_subset",
+            "expected_timeout",
+            "expected_result",
+        ),
         [
-            ("open_camera", ("Basler:cam",), {"test_connection": True}, "/cameras/open", {"camera": "Basler:cam", "test_connection": True}, None, True),
+            (
+                "open_camera",
+                ("Basler:cam",),
+                {"test_connection": True},
+                "/cameras/open",
+                {"camera": "Basler:cam", "test_connection": True},
+                None,
+                True,
+            ),
             (
                 "open_cameras_batch",
                 (["Basler:cam", "GenICam:cam"],),
@@ -120,8 +138,24 @@ class TestPostWrappers:
                 {"closed": 2},
             ),
             ("close_all_cameras", (), {}, "/cameras/close/all", {}, None, True),
-            ("get_camera_status", ("Basler:cam",), {}, "/cameras/status", {"camera": "Basler:cam"}, None, {"open": True}),
-            ("get_camera_info", ("Basler:cam",), {}, "/cameras/info", {"camera": "Basler:cam"}, None, {"serial": "123"}),
+            (
+                "get_camera_status",
+                ("Basler:cam",),
+                {},
+                "/cameras/status",
+                {"camera": "Basler:cam"},
+                None,
+                {"open": True},
+            ),
+            (
+                "get_camera_info",
+                ("Basler:cam",),
+                {},
+                "/cameras/info",
+                {"camera": "Basler:cam"},
+                None,
+                {"serial": "123"},
+            ),
             (
                 "get_camera_capabilities",
                 ("Basler:cam",),

--- a/tests/unit/mindtrace/hardware/services/cameras/test_connection_manager.py
+++ b/tests/unit/mindtrace/hardware/services/cameras/test_connection_manager.py
@@ -1,6 +1,8 @@
 """Unit tests for CameraManagerConnectionManager request wrappers."""
 
-from unittest.mock import AsyncMock
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -12,47 +14,264 @@ def cm():
     return CameraManagerConnectionManager(url="http://localhost:8000")
 
 
-@pytest.mark.asyncio
-async def test_discover_backends(cm, monkeypatch):
-    monkeypatch.setattr(cm, "get", AsyncMock(return_value={"data": ["A", "B"]}))
-    assert await cm.discover_backends() == ["A", "B"]
-    cm.get.assert_awaited_once_with("/backends")
+def _make_async_client(response):
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+    client.post = AsyncMock(return_value=response)
+    context_manager = AsyncMock()
+    context_manager.__aenter__.return_value = client
+    context_manager.__aexit__.return_value = None
+    return client, context_manager
 
 
-@pytest.mark.asyncio
-async def test_discover_cameras_with_backend(cm, monkeypatch):
-    monkeypatch.setattr(cm, "post", AsyncMock(return_value={"data": ["Basler:1"]}))
-    result = await cm.discover_cameras("Basler")
-    assert result == ["Basler:1"]
-    cm.post.assert_awaited_once()
-    endpoint, payload = cm.post.await_args.args[0], cm.post.await_args.args[1]
-    assert endpoint == "/cameras/discover"
-    assert payload["backend"] == "Basler"
+class TestHttpHelpers:
+    @pytest.mark.asyncio
+    async def test_get_uses_httpx_async_client(self, cm):
+        response = Mock()
+        response.json.return_value = {"data": {"healthy": True}}
+        client, context_manager = _make_async_client(response)
+
+        with patch(
+            "mindtrace.hardware.services.cameras.connection_manager.httpx.AsyncClient",
+            return_value=context_manager,
+        ) as async_client:
+            result = await cm.get("/system/diagnostics", http_timeout=12.5)
+
+        async_client.assert_called_once_with(timeout=12.5)
+        client.get.assert_awaited_once_with("http://localhost:8000/system/diagnostics")
+        response.raise_for_status.assert_called_once_with()
+        assert result == {"data": {"healthy": True}}
+
+    @pytest.mark.asyncio
+    async def test_post_uses_httpx_async_client(self, cm):
+        response = Mock()
+        response.json.return_value = {"data": {"ok": True}}
+        client, context_manager = _make_async_client(response)
+
+        with patch(
+            "mindtrace.hardware.services.cameras.connection_manager.httpx.AsyncClient",
+            return_value=context_manager,
+        ) as async_client:
+            result = await cm.post("/cameras/open", {"camera": "Basler:1"}, http_timeout=20.0)
+
+        async_client.assert_called_once_with(timeout=20.0)
+        client.post.assert_awaited_once_with("http://localhost:8000/cameras/open", json={"camera": "Basler:1"})
+        response.raise_for_status.assert_called_once_with()
+        assert result == {"data": {"ok": True}}
 
 
-@pytest.mark.asyncio
-async def test_open_camera_payload(cm, monkeypatch):
-    monkeypatch.setattr(cm, "post", AsyncMock(return_value={"data": True}))
-    assert await cm.open_camera("Basler:cam", test_connection=True) is True
-    endpoint, payload = cm.post.await_args.args[0], cm.post.await_args.args[1]
-    assert endpoint == "/cameras/open"
-    assert payload["camera"] == "Basler:cam"
-    assert payload["test_connection"] is True
+class TestGetWrappers:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "expected_endpoint", "expected_data"),
+        [
+            ("discover_backends", "/backends", ["Basler", "GenICam"]),
+            ("get_backend_info", "/backends/info", {"Basler": {"vendor": "Basler"}}),
+            ("get_active_cameras", "/cameras/active", ["Basler:cam-1"]),
+            ("get_system_diagnostics", "/system/diagnostics", {"cpu": 0.2}),
+            ("get_bandwidth_settings", "/network/bandwidth", {"max_concurrent_captures": 2}),
+            ("get_network_diagnostics", "/network/diagnostics", {"latency_ms": 4.2}),
+        ],
+    )
+    async def test_get_wrappers_return_response_data(self, cm, monkeypatch, method_name, expected_endpoint, expected_data):
+        monkeypatch.setattr(cm, "get", AsyncMock(return_value={"data": expected_data}))
+
+        result = await getattr(cm, method_name)()
+
+        cm.get.assert_awaited_once_with(expected_endpoint)
+        assert result == expected_data
 
 
-@pytest.mark.asyncio
-async def test_capture_hdr_image_uses_long_timeout(cm, monkeypatch):
-    monkeypatch.setattr(cm, "post", AsyncMock(return_value={"data": {"ok": True}}))
-    result = await cm.capture_hdr_image("Basler:cam", exposure_levels=4)
-    assert result == {"ok": True}
-    assert cm.post.await_args.args[0] == "/cameras/capture/hdr"
-    assert cm.post.await_args.kwargs["http_timeout"] == 180.0
+class TestPostWrappers:
+    @pytest.mark.asyncio
+    async def test_discover_cameras_with_backend(self, cm, monkeypatch):
+        monkeypatch.setattr(cm, "post", AsyncMock(return_value={"data": ["Basler:1"]}))
 
+        result = await cm.discover_cameras("Basler")
 
-@pytest.mark.asyncio
-async def test_set_bandwidth_limit(cm, monkeypatch):
-    monkeypatch.setattr(cm, "post", AsyncMock(return_value={"data": True}))
-    assert await cm.set_bandwidth_limit(3) is True
-    endpoint, payload = cm.post.await_args.args[0], cm.post.await_args.args[1]
-    assert endpoint == "/network/bandwidth/limit"
-    assert payload["max_concurrent_captures"] == 3
+        assert result == ["Basler:1"]
+        cm.post.assert_awaited_once()
+        endpoint, payload = cm.post.await_args.args
+        assert endpoint == "/cameras/discover"
+        assert payload["backend"] == "Basler"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "args", "kwargs", "expected_endpoint", "expected_subset", "expected_timeout", "expected_result"),
+        [
+            ("open_camera", ("Basler:cam",), {"test_connection": True}, "/cameras/open", {"camera": "Basler:cam", "test_connection": True}, None, True),
+            (
+                "open_cameras_batch",
+                (["Basler:cam", "GenICam:cam"],),
+                {"test_connection": False},
+                "/cameras/open/batch",
+                {"cameras": ["Basler:cam", "GenICam:cam"], "test_connection": False},
+                None,
+                {"opened": 2},
+            ),
+            ("close_camera", ("Basler:cam",), {}, "/cameras/close", {"camera": "Basler:cam"}, None, True),
+            (
+                "close_cameras_batch",
+                (["Basler:cam", "GenICam:cam"],),
+                {},
+                "/cameras/close/batch",
+                {"cameras": ["Basler:cam", "GenICam:cam"]},
+                None,
+                {"closed": 2},
+            ),
+            ("close_all_cameras", (), {}, "/cameras/close/all", {}, None, True),
+            ("get_camera_status", ("Basler:cam",), {}, "/cameras/status", {"camera": "Basler:cam"}, None, {"open": True}),
+            ("get_camera_info", ("Basler:cam",), {}, "/cameras/info", {"camera": "Basler:cam"}, None, {"serial": "123"}),
+            (
+                "get_camera_capabilities",
+                ("Basler:cam",),
+                {},
+                "/cameras/capabilities",
+                {"camera": "Basler:cam"},
+                None,
+                {"supports_hdr": True},
+            ),
+            (
+                "configure_camera",
+                ("Basler:cam", {"ExposureTime": 1000}),
+                {},
+                "/cameras/configure",
+                {"camera": "Basler:cam", "properties": {"ExposureTime": 1000}},
+                None,
+                True,
+            ),
+            (
+                "configure_cameras_batch",
+                ({"Basler:cam": {"ExposureTime": 1000}},),
+                {},
+                "/cameras/configure/batch",
+                {"configurations": {"Basler:cam": {"ExposureTime": 1000}}},
+                None,
+                {"configured": 1},
+            ),
+            (
+                "get_camera_configuration",
+                ("Basler:cam",),
+                {},
+                "/cameras/configuration",
+                {"camera": "Basler:cam"},
+                None,
+                {"ExposureTime": 1000},
+            ),
+            (
+                "import_camera_config",
+                ("Basler:cam", "/tmp/cam.pfs"),
+                {},
+                "/cameras/config/import",
+                {"camera": "Basler:cam", "config_path": "/tmp/cam.pfs"},
+                None,
+                {"imported": True},
+            ),
+            (
+                "export_camera_config",
+                ("Basler:cam", "/tmp/cam.pfs"),
+                {},
+                "/cameras/config/export",
+                {"camera": "Basler:cam", "config_path": "/tmp/cam.pfs"},
+                120.0,
+                {"exported": True},
+            ),
+            (
+                "capture_image",
+                ("Basler:cam",),
+                {"save_path": "/tmp/frame.png", "output_format": "numpy"},
+                "/cameras/capture",
+                {"camera": "Basler:cam", "save_path": "/tmp/frame.png", "output_format": "numpy"},
+                120.0,
+                {"image": "bytes"},
+            ),
+            (
+                "capture_images_batch",
+                (["Basler:cam", "GenICam:cam"],),
+                {"output_format": "numpy"},
+                "/cameras/capture/batch",
+                {"cameras": ["Basler:cam", "GenICam:cam"], "output_format": "numpy"},
+                120.0,
+                {"images": 2},
+            ),
+            (
+                "capture_hdr_image",
+                ("Basler:cam",),
+                {
+                    "save_path_pattern": "/tmp/frame_{exposure}.png",
+                    "exposure_levels": 4,
+                    "exposure_multiplier": 3.0,
+                    "return_images": False,
+                    "output_format": "numpy",
+                },
+                "/cameras/capture/hdr",
+                {
+                    "camera": "Basler:cam",
+                    "save_path_pattern": "/tmp/frame_{exposure}.png",
+                    "exposure_levels": 4,
+                    "exposure_multiplier": 3.0,
+                    "return_images": False,
+                    "output_format": "numpy",
+                },
+                180.0,
+                {"hdr": True},
+            ),
+            (
+                "capture_hdr_images_batch",
+                (["Basler:cam", "GenICam:cam"],),
+                {
+                    "save_path_pattern": "/tmp/frame_{exposure}.png",
+                    "exposure_levels": 5,
+                    "exposure_multiplier": 2.5,
+                    "return_images": False,
+                    "output_format": "numpy",
+                },
+                "/cameras/capture/hdr/batch",
+                {
+                    "cameras": ["Basler:cam", "GenICam:cam"],
+                    "save_path_pattern": "/tmp/frame_{exposure}.png",
+                    "exposure_levels": 5,
+                    "exposure_multiplier": 2.5,
+                    "return_images": False,
+                    "output_format": "numpy",
+                },
+                180.0,
+                {"hdr_batches": 2},
+            ),
+            (
+                "set_bandwidth_limit",
+                (3,),
+                {},
+                "/network/bandwidth/limit",
+                {"max_concurrent_captures": 3},
+                None,
+                True,
+            ),
+        ],
+    )
+    async def test_post_wrappers_build_expected_payloads(
+        self,
+        cm,
+        monkeypatch,
+        method_name,
+        args,
+        kwargs,
+        expected_endpoint,
+        expected_subset,
+        expected_timeout,
+        expected_result,
+    ):
+        monkeypatch.setattr(cm, "post", AsyncMock(return_value={"data": expected_result}))
+
+        result = await getattr(cm, method_name)(*args, **kwargs)
+
+        call_args = cm.post.await_args
+        endpoint, payload = call_args.args
+        assert endpoint == expected_endpoint
+        for key, value in expected_subset.items():
+            assert payload[key] == value
+        if expected_timeout is None:
+            assert "http_timeout" not in call_args.kwargs
+        else:
+            assert call_args.kwargs["http_timeout"] == expected_timeout
+        assert result == expected_result

--- a/tests/unit/mindtrace/registry/backends/test_gcp_registry_backend.py
+++ b/tests/unit/mindtrace/registry/backends/test_gcp_registry_backend.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Tuple
+from unittest.mock import patch
 from urllib.parse import quote
 
 import pytest
@@ -645,14 +646,25 @@ def test_acquire_lock_success(backend):
 def test_acquire_lock_already_held(backend):
     """Test lock acquisition times out when lock is already held."""
     key = "test:object@1.0.0"
+    current_time = [1000.0]
 
-    # First lock succeeds (long TTL so it won't expire during test)
-    result1 = backend._acquire_lock(key, "lock-1", timeout=30)
-    assert result1 is True
+    def fake_time() -> float:
+        return current_time[0]
 
-    # Second lock times out (short timeout < first lock's TTL)
-    result2 = backend._acquire_lock(key, "lock-2", timeout=1)
-    assert result2 is False
+    def fake_sleep(seconds: float) -> None:
+        current_time[0] += seconds
+
+    with (
+        patch("mindtrace.registry.backends.gcp_registry_backend.time.time", side_effect=fake_time),
+        patch("mindtrace.registry.backends.gcp_registry_backend.time.sleep", side_effect=fake_sleep),
+    ):
+        # First lock succeeds (long TTL so it won't expire during test)
+        result1 = backend._acquire_lock(key, "lock-1", timeout=30)
+        assert result1 is True
+
+        # Second lock times out (short timeout < first lock's TTL)
+        result2 = backend._acquire_lock(key, "lock-2", timeout=1)
+        assert result2 is False
 
 
 def test_release_lock(backend):

--- a/tests/unit/mindtrace/registry/backends/test_local_registry_backend.py
+++ b/tests/unit/mindtrace/registry/backends/test_local_registry_backend.py
@@ -708,7 +708,7 @@ def test_internal_lock_raises_on_acquisition_failure(backend):
     # Context manager itself should still raise LockAcquisitionError
     # (the backend methods catch this and return failed results)
     with pytest.raises(LockAcquisitionError, match="lock"):
-        with backend._internal_lock(lock_key):
+        with backend._internal_lock(lock_key, timeout=0.01):
             pass  # Should never reach here
 
     # Clean up
@@ -729,6 +729,9 @@ def test_push_blocked_by_active_lock(backend, sample_object_dir):
     exclusive_path = backend._exclusive_lock_path(lock_key)
     with open(exclusive_path, "w") as f:
         json.dump({"lock_id": lock_id, "expires_at": time.time() + 60}, f)
+
+    # Use a tiny lock timeout so contention is detected quickly in tests.
+    backend._lock_timeout = 0.01
 
     # Push should return failed result because lock is held
     result = backend.push(["test:object"], ["1.0.0"], [sample_object_dir], [{"test": True}])
@@ -757,6 +760,9 @@ def test_delete_blocked_by_active_lock(backend, sample_object_dir):
     exclusive_path = backend._exclusive_lock_path(lock_key)
     with open(exclusive_path, "w") as f:
         json.dump({"lock_id": lock_id, "expires_at": time.time() + 60}, f)
+
+    # Use a tiny lock timeout so contention is detected quickly in tests.
+    backend._lock_timeout = 0.01
 
     # Delete should return failed result because lock is held
     result = backend.delete(["test:object"], ["1.0.0"])

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -2228,7 +2228,7 @@ def test_backend_internal_lock_contention(registry):
         assert not registry.backend._acquire_internal_lock(lock_key, other_lock_id, timeout=30)
 
         with pytest.raises(LockAcquisitionError):
-            with registry.backend._internal_lock(lock_key, timeout=0.5):
+            with registry.backend._internal_lock(lock_key, timeout=0.01):
                 pass
     finally:
         # Release the lock


### PR DESCRIPTION
This PR adds another focused pack of unit tests for the `mindtrace` package. No production library code has been changed.

`ds test --unit` before this PR:
```
Name                           Stmts   Miss  Cover   
TOTAL                          28793   4113    86%
=== 5674 passed, 7 skipped in 90.71s (0:01:30) ===
```

`ds test --unit` after this PR:
```
Name                           Stmts   Miss  Cover   
TOTAL                          28793   3236    89%
=== 5880 passed, 7 skipped in 100.32 (0:01:40) ===
```

## Summary

This PR expands unit coverage across the `agents` and `hardware` packages, with additional targeted coverage for provider configuration, message/prompt helpers, camera and scanner wrapper orchestration, PLC retry/config helpers, and GenICam/camera backend edge cases. It also includes a small pass to speed up several slow unit tests.

## What Tests Were Added or Expanded

- Added provider and model coverage for:
  - `tests/unit/mindtrace/agents/models/test_openai_chat.py`
  - `tests/unit/mindtrace/agents/providers/test_openai.py`
  - `tests/unit/mindtrace/agents/providers/test_ollama.py`
  - `tests/unit/mindtrace/agents/providers/test_gemini.py`

- Expanded agent helper coverage for:
  - `tests/unit/mindtrace/agents/test_messages.py`
  - `tests/unit/mindtrace/agents/test_prompts.py`

- Added scanner backend and wrapper coverage for:
  - `tests/unit/mindtrace/hardware/scanners_3d/backends/test_scanner_3d_backend.py`
  - `tests/unit/mindtrace/hardware/scanners_3d/core/test_async_scanner_3d.py`
  - `tests/unit/mindtrace/hardware/scanners_3d/core/test_scanner_3d.py`

- Expanded camera service and backend coverage for:
  - `tests/unit/mindtrace/hardware/services/cameras/test_connection_manager.py`
  - `tests/unit/mindtrace/hardware/cameras/backends/test_camera_backend.py`
  - `tests/unit/mindtrace/hardware/cameras/backends/genicam/test_genicam_camera_backend.py`
  - `tests/unit/mindtrace/hardware/cameras/backends/genicam/test_mock_genicam_backend.py`

- Added PLC backend helper coverage for:
  - `tests/unit/mindtrace/hardware/plcs/backends/test_base.py`

- Improved runtime of slower unit suites in:
  - `tests/unit/mindtrace/core/utils/test_system_metrics_collector.py`
  - `tests/unit/mindtrace/hardware/cameras/backends/basler/test_mock_basler_camera_backend.py`
  - `tests/unit/mindtrace/hardware/cameras/core/test_async_camera.py`
  - `tests/unit/mindtrace/registry/backends/test_gcp_registry_backend.py`
  - `tests/unit/mindtrace/registry/backends/test_local_registry_backend.py`
  - `tests/unit/mindtrace/registry/core/test_registry.py`

## Notable Areas Covered

- OpenAI chat message mapping behavior
- OpenAI, Ollama, and Gemini provider configuration branches
- Agent message builder paths and prompt binary content helpers
- Scanner 3D backend helper branches and sync/async wrapper delegation flows
- Camera connection manager request handling
- PLC base retry and configuration helper branches
- Camera backend blocking helper behavior
- GenICam backend lifecycle and mock backend branches
- Unit test runtime reductions in a handful of slower suites

## Cluster integration test fix

The branch also includes a small cluster integration test fix in `scripts/docker_up.sh`. Two new lines were added at the start of the integration test suite setup to flush the Redis DB (`FLUSHALL`) before launch. This prevents malformed jobs left over from earlier runs from corrupting Redis state and causing later cluster integration suite runs to fail when launching the cluster.

