### PR TITLE
Feat/camera prod allignement

### DIFF
--- a/mindtrace/hardware/README.md
+++ b/mindtrace/hardware/README.md
@@ -155,6 +155,45 @@ async def capture_one():
 asyncio.run(capture_one())
 ```
 
+### Capture groups (stage+set batching)
+
+For production-line setups with multiple cameras, use capture groups to control concurrency per camera group:
+
+```python
+async with CameraManager() as manager:
+    cameras = manager.discover()
+    opened = await manager.open(cameras)
+
+    # Configure groups: 1 stage, 2 sets, max 1 concurrent per set
+    manager.configure_capture_groups({
+        "inspection": {
+            "top_cameras": {"batch_size": 1, "cameras": cameras[:3]},
+            "side_cameras": {"batch_size": 1, "cameras": cameras[3:]},
+        }
+    })
+
+    # Batch capture with group routing
+    results = await manager.batch_capture(
+        cameras[:3], stage="inspection", set_name="top_cameras"
+    )
+```
+
+Each group creates an `asyncio.Semaphore` sized to `batch_size`, limiting how many cameras within the group can capture simultaneously. This prevents GigE bandwidth saturation when multiple cameras share a network link.
+
+### Auto-reconnection
+
+The camera manager tracks consecutive capture failures per camera. When a camera exceeds the failure threshold, it automatically:
+
+1. Exports the current camera config to disk
+2. Closes and re-opens the camera
+3. Restores the saved configuration
+
+Configure via environment variables or `HardwareConfig`:
+
+- `MINDTRACE_HW_CAMERA_MAX_CONSECUTIVE_FAILURES` (default: 5)
+- `MINDTRACE_HW_CAMERA_REINITIALIZATION_COOLDOWN` (default: 30s)
+- `MINDTRACE_HW_CAMERA_CONFIG_DIR` (default: `~/.config/mindtrace/cameras`)
+
 ### Camera backends
 
 The camera module exposes availability flags so you can check which backends are usable in the current environment:

--- a/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/basler_camera_backend.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/basler_camera_backend.py
@@ -1394,6 +1394,48 @@ class BaslerCameraBackend(CameraBackend):
                     success_count += 1
                     total_settings += 1
 
+                # Restore GigE network transport settings
+                if config_data.get("packet_size") is not None:
+                    total_settings += 1
+                    try:
+                        await self._run_blocking(
+                            self.camera.GevSCPSPacketSize.SetValue,
+                            int(config_data["packet_size"]),
+                            timeout=self._op_timeout_s,
+                        )
+                        success_count += 1
+                    except Exception as e:
+                        self.logger.warning(f"Could not restore packet size for camera '{self.camera_name}': {e}")
+
+                if config_data.get("inter_packet_delay") is not None:
+                    total_settings += 1
+                    try:
+                        await self._run_blocking(
+                            self.camera.GevSCPD.SetValue,
+                            int(config_data["inter_packet_delay"]),
+                            timeout=self._op_timeout_s,
+                        )
+                        success_count += 1
+                    except Exception as e:
+                        self.logger.warning(
+                            f"Could not restore inter-packet delay for camera '{self.camera_name}': {e}"
+                        )
+
+                if config_data.get("bandwidth_limit") is not None:
+                    total_settings += 1
+                    try:
+                        if hasattr(self.camera, "DeviceLinkThroughputLimit"):
+                            await self._run_blocking(
+                                self.camera.DeviceLinkThroughputLimit.SetValue,
+                                int(config_data["bandwidth_limit"]),
+                                timeout=self._op_timeout_s,
+                            )
+                            success_count += 1
+                    except Exception as e:
+                        self.logger.warning(
+                            f"Could not restore bandwidth limit for camera '{self.camera_name}': {e}"
+                        )
+
             self.logger.debug(
                 f"Configuration imported from '{config_path}' for camera '{self.camera_name}': "
                 f"{success_count}/{total_settings} settings applied successfully"
@@ -1514,6 +1556,34 @@ class BaslerCameraBackend(CameraBackend):
             except Exception as e:
                 self.logger.warning(f"Could not get pixel format for camera '{self.camera_name}': {e}")
 
+            # Get GigE network transport settings
+            packet_size = None
+            try:
+                packet_size = int(
+                    await self._run_blocking(self.camera.GevSCPSPacketSize.GetValue, timeout=self._op_timeout_s)
+                )
+            except Exception as e:
+                self.logger.debug(f"Could not get packet size for camera '{self.camera_name}': {e}")
+
+            inter_packet_delay = None
+            try:
+                inter_packet_delay = int(
+                    await self._run_blocking(self.camera.GevSCPD.GetValue, timeout=self._op_timeout_s)
+                )
+            except Exception as e:
+                self.logger.debug(f"Could not get inter-packet delay for camera '{self.camera_name}': {e}")
+
+            bandwidth_limit = None
+            try:
+                if hasattr(self.camera, "DeviceLinkThroughputLimit"):
+                    bandwidth_limit = float(
+                        await self._run_blocking(
+                            self.camera.DeviceLinkThroughputLimit.GetValue, timeout=self._op_timeout_s
+                        )
+                    )
+            except Exception as e:
+                self.logger.debug(f"Could not get bandwidth limit for camera '{self.camera_name}': {e}")
+
             # Create common format configuration
             config_data = {
                 "camera_type": "basler",
@@ -1531,6 +1601,9 @@ class BaslerCameraBackend(CameraBackend):
                 "retrieve_retry_count": self.retrieve_retry_count,
                 "timeout_ms": self.timeout_ms,
                 "buffer_count": getattr(self, "buffer_count", 25),
+                "packet_size": packet_size,
+                "inter_packet_delay": inter_packet_delay,
+                "bandwidth_limit": bandwidth_limit,
             }
 
             # Write config to file (run in threadpool to avoid blocking event loop)

--- a/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/basler_camera_backend.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/basler_camera_backend.py
@@ -1432,9 +1432,7 @@ class BaslerCameraBackend(CameraBackend):
                             )
                             success_count += 1
                     except Exception as e:
-                        self.logger.warning(
-                            f"Could not restore bandwidth limit for camera '{self.camera_name}': {e}"
-                        )
+                        self.logger.warning(f"Could not restore bandwidth limit for camera '{self.camera_name}': {e}")
 
             self.logger.debug(
                 f"Configuration imported from '{config_path}' for camera '{self.camera_name}': "

--- a/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera_manager.py
@@ -1,11 +1,20 @@
 """Async camera manager for Mindtrace hardware cameras."""
 
 import asyncio
+import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from mindtrace.core import Mindtrace
 from mindtrace.hardware.cameras.backends.camera_backend import CameraBackend
 from mindtrace.hardware.cameras.core.async_camera import AsyncCamera
+from mindtrace.hardware.cameras.core.capture_groups import (
+    CaptureGroup,
+    StageSetConfigDict,
+    build_capture_groups,
+    get_semaphore_for_capture,
+    validate_stage_set_configs,
+)
 from mindtrace.hardware.core.exceptions import (
     CameraConfigurationError,
     CameraConnectionError,
@@ -88,6 +97,24 @@ class AsyncCameraManager(Mindtrace):
         # Performance settings that persist across camera open/close cycles
         self._timeout_ms = self._hardware_config.cameras.timeout_ms
         self._retrieve_retry_count = self._hardware_config.cameras.retrieve_retry_count
+
+        # Stage+Set capture groups (per-group concurrency control)
+        self._capture_groups: Dict[str, CaptureGroup] = {}
+        self._camera_group_keys: Dict[str, List[str]] = {}
+
+        # Auto-reconnection / failure tracking
+        self._failure_counts: Dict[str, int] = {}
+        self._last_reinit_attempt: Dict[str, float] = {}
+        self._max_consecutive_failures = self._hardware_config.cameras.max_consecutive_failures
+        self._reinitialization_cooldown = self._hardware_config.cameras.reinitialization_cooldown
+
+        # Camera config preservation directory
+        camera_config_dir = self._hardware_config.cameras.camera_config_dir
+        if not camera_config_dir:
+            camera_config_dir = str(
+                Path(self._hardware_config.paths.config_dir).expanduser() / "cameras"
+            )
+        self._camera_config_dir = camera_config_dir
 
         self.logger.info(
             f"AsyncCameraManager initialized. Available backends: {self._discovered_backends}, "
@@ -437,6 +464,10 @@ class AsyncCameraManager(Mindtrace):
             proxy = AsyncCamera(camera, camera_name)
             self._cameras[camera_name] = proxy
             self.logger.info(f"Camera '{camera_name}' initialized successfully")
+
+            # Auto-export config for state preservation on reconnect
+            await self._auto_export_config(camera_name)
+
             return proxy
 
         # Multiple
@@ -565,7 +596,7 @@ class AsyncCameraManager(Mindtrace):
         self.logger.info(f"Retrieve retry count set to {count}")
 
     def diagnostics(self) -> Dict[str, Any]:
-        """Get diagnostics information including bandwidth management."""
+        """Get diagnostics information including bandwidth management and resilience status."""
         return {
             "max_concurrent_captures": self.max_concurrent_captures,
             "active_cameras": len(self._cameras),
@@ -576,7 +607,144 @@ class AsyncCameraManager(Mindtrace):
                 "balanced": 2,
                 "aggressive": 3,
             },
+            "failure_counts": dict(self._failure_counts),
+            "cameras_in_cooldown": [
+                name
+                for name, ts in self._last_reinit_attempt.items()
+                if time.time() - ts < self._reinitialization_cooldown
+            ],
+            "capture_groups_count": len(self._capture_groups),
         }
+
+    # ------------------------------------------------------------------ #
+    #  Capture Groups (stage+set batching)                                #
+    # ------------------------------------------------------------------ #
+
+    def configure_capture_groups(self, config: StageSetConfigDict) -> None:
+        """Configure stage+set capture groups with per-group semaphores.
+
+        Each group creates a concurrency semaphore sized to ``batch_size``,
+        limiting how many cameras within the group can capture simultaneously.
+
+        Args:
+            config: ``{stage: {set: {"batch_size": int, "cameras": [str]}}}``
+
+        Raises:
+            CameraConfigurationError: If config is invalid.
+        """
+        is_valid, error = validate_stage_set_configs(config, self.active_cameras)
+        if not is_valid:
+            raise CameraConfigurationError(f"Invalid capture group config: {error}")
+
+        groups, camera_map = build_capture_groups(config)
+        self._capture_groups = groups
+        self._camera_group_keys = camera_map
+        self.logger.info(
+            f"Configured {len(groups)} capture groups for {len(camera_map)} cameras"
+        )
+
+    def remove_capture_groups(self) -> None:
+        """Clear all capture group configurations."""
+        count = len(self._capture_groups)
+        self._capture_groups.clear()
+        self._camera_group_keys.clear()
+        self.logger.info(f"Removed {count} capture groups")
+
+    def get_capture_groups(self) -> Dict[str, Any]:
+        """Return current capture group configuration as serializable dict."""
+        return {key: group.to_dict() for key, group in self._capture_groups.items()}
+
+    # ------------------------------------------------------------------ #
+    #  Auto-Reconnection / Failure Tracking                               #
+    # ------------------------------------------------------------------ #
+
+    def _get_camera_config_path(self, camera_name: str) -> str:
+        """Return filesystem path for a camera's preserved config."""
+        safe_name = camera_name.replace(":", "_").replace("/", "_")
+        return str(Path(self._camera_config_dir) / f"{safe_name}.json")
+
+    async def _auto_export_config(self, camera_name: str) -> None:
+        """Export camera config after successful init for later restoration."""
+        try:
+            if camera_name not in self._cameras:
+                return
+            camera = self._cameras[camera_name]
+            config_path = self._get_camera_config_path(camera_name)
+            Path(config_path).parent.mkdir(parents=True, exist_ok=True)
+            await camera.save_config(config_path)
+            self.logger.debug(f"Auto-exported config for '{camera_name}' to {config_path}")
+        except Exception as e:
+            self.logger.warning(f"Failed to auto-export config for '{camera_name}': {e}")
+
+    async def _auto_import_config(self, camera_name: str) -> None:
+        """Restore camera config from previously saved file."""
+        try:
+            config_path = self._get_camera_config_path(camera_name)
+            if not Path(config_path).exists():
+                self.logger.debug(f"No saved config for '{camera_name}'")
+                return
+            if camera_name not in self._cameras:
+                return
+            camera = self._cameras[camera_name]
+            await camera.load_config(config_path)
+            self.logger.info(f"Auto-imported config for '{camera_name}' from {config_path}")
+        except Exception as e:
+            self.logger.warning(f"Failed to auto-import config for '{camera_name}': {e}")
+
+    async def _handle_camera_failure(self, camera_name: str) -> None:
+        """Handle consecutive failures: cooldown check, close, reinit, restore config."""
+        current_time = time.time()
+
+        # Cooldown check — avoid thrashing
+        last_attempt = self._last_reinit_attempt.get(camera_name, 0.0)
+        if current_time - last_attempt < self._reinitialization_cooldown:
+            remaining = self._reinitialization_cooldown - (current_time - last_attempt)
+            self.logger.info(
+                f"Reinit cooldown for '{camera_name}', {remaining:.1f}s remaining"
+            )
+            return
+
+        self.logger.warning(
+            f"Failure threshold reached for '{camera_name}' "
+            f"({self._failure_counts.get(camera_name, 0)} consecutive failures), "
+            f"attempting reinit"
+        )
+        self._last_reinit_attempt[camera_name] = current_time
+
+        # Close the camera
+        try:
+            await self.close(camera_name)
+        except Exception as e:
+            self.logger.warning(f"Error closing '{camera_name}' during reinit: {e}")
+
+        # Re-open and restore config
+        try:
+            await self.open(camera_name, test_connection=True)
+            await self._auto_import_config(camera_name)
+            # Re-export to keep the saved file fresh
+            await self._auto_export_config(camera_name)
+            self._failure_counts[camera_name] = 0
+            self.logger.info(f"Reinit successful for '{camera_name}'")
+        except Exception as e:
+            self.logger.error(f"Reinit failed for '{camera_name}': {e}")
+            # Reset counter to prevent immediate re-trigger on next capture
+            self._failure_counts[camera_name] = 0
+
+    def _record_capture_success(self, camera_name: str) -> None:
+        """Reset failure counter on successful capture."""
+        if self._failure_counts.get(camera_name, 0) > 0:
+            self._failure_counts[camera_name] = 0
+
+    async def _record_capture_failure(self, camera_name: str) -> None:
+        """Increment failure counter and trigger reinit if threshold reached."""
+        count = self._failure_counts.get(camera_name, 0) + 1
+        self._failure_counts[camera_name] = count
+        self.logger.warning(
+            f"Capture failure #{count} for '{camera_name}' "
+            f"(threshold: {self._max_consecutive_failures})"
+        )
+        if count >= self._max_consecutive_failures:
+            await self._handle_camera_failure(camera_name)
 
     async def close(self, names: Optional[Union[str, List[str]]] = None) -> None:
         """Close one, many, or all cameras.
@@ -596,6 +764,8 @@ class AsyncCameraManager(Mindtrace):
                 try:
                     await self._cameras[camera_name].close()
                     del self._cameras[camera_name]
+                    # Clean up failure tracking (but preserve group assignments — they're config, not state)
+                    self._failure_counts.pop(camera_name, None)
                     self.logger.info(f"Camera '{camera_name}' closed")
                 except Exception as e:
                     self.logger.warning(f"Failed to close '{camera_name}': {e}")
@@ -632,6 +802,8 @@ class AsyncCameraManager(Mindtrace):
         camera_names: List[str],
         save_path_pattern: Optional[str] = None,
         output_format: str = "pil",
+        stage: Optional[str] = None,
+        set_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Capture from multiple cameras with network bandwidth management.
 
@@ -639,6 +811,8 @@ class AsyncCameraManager(Mindtrace):
             camera_names: List of camera names to capture from
             save_path_pattern: Optional path pattern for saving images. Use {camera} placeholder for camera name
             output_format: Output format for images
+            stage: Optional stage name for capture group routing
+            set_name: Optional set name for capture group routing
 
         Returns:
             Dictionary mapping camera names to captured images or file paths
@@ -647,7 +821,19 @@ class AsyncCameraManager(Mindtrace):
 
         async def capture_from_camera(camera_name: str) -> Tuple[str, Any]:
             try:
-                async with self._capture_semaphore:
+                # Route to correct semaphore (group-specific or global)
+                semaphore, err = get_semaphore_for_capture(
+                    camera_name,
+                    stage,
+                    set_name,
+                    self._capture_groups,
+                    self._camera_group_keys,
+                    self._capture_semaphore,
+                )
+                if err:
+                    raise CameraConfigurationError(err)
+
+                async with semaphore:
                     if camera_name not in self._cameras:
                         raise KeyError(f"Camera '{camera_name}' is not initialized. Use open() first.")
                     camera = self._cameras[camera_name]
@@ -661,6 +847,9 @@ class AsyncCameraManager(Mindtrace):
 
                     image = await camera.capture(save_path=save_path, output_format=output_format)
 
+                    # Track success for auto-reconnection
+                    self._record_capture_success(camera_name)
+
                     # When save_path_pattern is provided, return the file path instead of image data
                     if save_path_pattern and save_path:
                         return camera_name, save_path
@@ -668,6 +857,8 @@ class AsyncCameraManager(Mindtrace):
                         return camera_name, image
             except Exception as e:
                 self.logger.error(f"Capture failed for '{camera_name}': {e}")
+                # Track failure for auto-reconnection
+                await self._record_capture_failure(camera_name)
                 return camera_name, None
 
         tasks = [capture_from_camera(name) for name in camera_names]
@@ -690,13 +881,27 @@ class AsyncCameraManager(Mindtrace):
         exposure_multiplier: float = 2.0,
         return_images: bool = True,
         output_format: str = "pil",
+        stage: Optional[str] = None,
+        set_name: Optional[str] = None,
     ) -> Dict[str, Dict[str, Any]]:
         """Capture HDR images from multiple cameras simultaneously."""
         results = {}
 
         async def capture_hdr_from_camera(camera_name: str) -> Tuple[str, Dict[str, Any]]:
             try:
-                async with self._capture_semaphore:
+                # Route to correct semaphore (group-specific or global)
+                semaphore, err = get_semaphore_for_capture(
+                    camera_name,
+                    stage,
+                    set_name,
+                    self._capture_groups,
+                    self._camera_group_keys,
+                    self._capture_semaphore,
+                )
+                if err:
+                    raise CameraConfigurationError(err)
+
+                async with semaphore:
                     if camera_name not in self._cameras:
                         raise KeyError(f"Camera '{camera_name}' is not initialized. Use open() first.")
                     camera = self._cameras[camera_name]
@@ -714,9 +919,11 @@ class AsyncCameraManager(Mindtrace):
                         output_format=output_format,
                     )
 
+                    self._record_capture_success(camera_name)
                     return camera_name, result
             except Exception as e:
                 self.logger.error(f"HDR capture failed for '{camera_name}': {e}")
+                await self._record_capture_failure(camera_name)
                 return camera_name, {
                     "success": False,
                     "images": None,

--- a/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera_manager.py
@@ -463,9 +463,6 @@ class AsyncCameraManager(Mindtrace):
             self._cameras[camera_name] = proxy
             self.logger.info(f"Camera '{camera_name}' initialized successfully")
 
-            # Auto-export config for state preservation on reconnect
-            await self._auto_export_config(camera_name)
-
             return proxy
 
         # Multiple
@@ -787,6 +784,11 @@ class AsyncCameraManager(Mindtrace):
             else:
                 camera_name, success = result
                 results[camera_name] = success
+
+        # Export config for cameras that were successfully configured
+        for camera_name, success in results.items():
+            if success:
+                await self._auto_export_config(camera_name)
 
         return results
 

--- a/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera_manager.py
@@ -111,9 +111,7 @@ class AsyncCameraManager(Mindtrace):
         # Camera config preservation directory
         camera_config_dir = self._hardware_config.cameras.camera_config_dir
         if not camera_config_dir:
-            camera_config_dir = str(
-                Path(self._hardware_config.paths.config_dir).expanduser() / "cameras"
-            )
+            camera_config_dir = str(Path(self._hardware_config.paths.config_dir).expanduser() / "cameras")
         self._camera_config_dir = camera_config_dir
 
         self.logger.info(
@@ -639,9 +637,7 @@ class AsyncCameraManager(Mindtrace):
         groups, camera_map = build_capture_groups(config)
         self._capture_groups = groups
         self._camera_group_keys = camera_map
-        self.logger.info(
-            f"Configured {len(groups)} capture groups for {len(camera_map)} cameras"
-        )
+        self.logger.info(f"Configured {len(groups)} capture groups for {len(camera_map)} cameras")
 
     def remove_capture_groups(self) -> None:
         """Clear all capture group configurations."""
@@ -699,9 +695,7 @@ class AsyncCameraManager(Mindtrace):
         last_attempt = self._last_reinit_attempt.get(camera_name, 0.0)
         if current_time - last_attempt < self._reinitialization_cooldown:
             remaining = self._reinitialization_cooldown - (current_time - last_attempt)
-            self.logger.info(
-                f"Reinit cooldown for '{camera_name}', {remaining:.1f}s remaining"
-            )
+            self.logger.info(f"Reinit cooldown for '{camera_name}', {remaining:.1f}s remaining")
             return
 
         self.logger.warning(
@@ -740,8 +734,7 @@ class AsyncCameraManager(Mindtrace):
         count = self._failure_counts.get(camera_name, 0) + 1
         self._failure_counts[camera_name] = count
         self.logger.warning(
-            f"Capture failure #{count} for '{camera_name}' "
-            f"(threshold: {self._max_consecutive_failures})"
+            f"Capture failure #{count} for '{camera_name}' " f"(threshold: {self._max_consecutive_failures})"
         )
         if count >= self._max_consecutive_failures:
             await self._handle_camera_failure(camera_name)

--- a/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera_manager.py
@@ -734,7 +734,7 @@ class AsyncCameraManager(Mindtrace):
         count = self._failure_counts.get(camera_name, 0) + 1
         self._failure_counts[camera_name] = count
         self.logger.warning(
-            f"Capture failure #{count} for '{camera_name}' " f"(threshold: {self._max_consecutive_failures})"
+            f"Capture failure #{count} for '{camera_name}' (threshold: {self._max_consecutive_failures})"
         )
         if count >= self._max_consecutive_failures:
             await self._handle_camera_failure(camera_name)

--- a/mindtrace/hardware/mindtrace/hardware/cameras/core/capture_groups.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/core/capture_groups.py
@@ -1,0 +1,229 @@
+"""Capture group management for stage+set based semaphore routing.
+
+Ported from mt-rix CameraBackend stage_set_configs pattern. Provides per-group
+concurrency control for production-line camera batching.
+
+Usage::
+
+    config = {
+        "inspection": {
+            "top_cameras": {"batch_size": 3, "cameras": ["Basler:cam1", "Basler:cam2"]},
+            "side_cameras": {"batch_size": 1, "cameras": ["Basler:cam3"]},
+        }
+    }
+    is_valid, err = validate_stage_set_configs(config, ["Basler:cam1", "Basler:cam2", "Basler:cam3"])
+    groups, camera_map = build_capture_groups(config)
+    sem, err = get_semaphore_for_capture("Basler:cam1", "inspection", "top_cameras", groups, camera_map, global_sem)
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+
+# Type alias for the nested config format from mt-rix:
+# {stage: {set: {"batch_size": int, "cameras": [str]}}}
+StageSetConfigDict = Dict[str, Dict[str, Dict[str, Union[int, List[str]]]]]
+
+
+@dataclass
+class CaptureGroup:
+    """A stage+set capture group with its own concurrency semaphore.
+
+    Each group limits how many cameras within it can capture simultaneously,
+    allowing fine-grained bandwidth management on production lines.
+    """
+
+    stage: str
+    set_name: str
+    max_concurrent: int
+    cameras: Set[str] = field(default_factory=set)
+    semaphore: asyncio.Semaphore = field(init=False, repr=False)
+
+    def __post_init__(self):
+        self.semaphore = asyncio.Semaphore(self.max_concurrent)
+
+    @property
+    def key(self) -> str:
+        """String key for this group: 'stage:set_name'."""
+        return f"{self.stage}:{self.set_name}"
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to JSON-friendly dict (excludes semaphore)."""
+        return {
+            "stage": self.stage,
+            "set_name": self.set_name,
+            "max_concurrent": self.max_concurrent,
+            "cameras": sorted(self.cameras),
+        }
+
+
+def validate_stage_set_configs(
+    config: StageSetConfigDict,
+    available_cameras: List[str],
+) -> Tuple[bool, Optional[str]]:
+    """Validate stage_set_configs nested dictionary structure.
+
+    Rules:
+        - Each stage+set entry must have ``batch_size`` (int > 0) and ``cameras`` (list[str]).
+        - All cameras must exist in *available_cameras*.
+        - A camera cannot appear in multiple sets within the same stage.
+
+    Args:
+        config: ``{stage: {set: {"batch_size": int, "cameras": [str]}}}``
+        available_cameras: Camera names that are currently initialized.
+
+    Returns:
+        ``(is_valid, error_message)`` -- *error_message* is ``None`` when valid.
+    """
+    if not config:
+        return True, None
+
+    # Track camera assignments per stage for duplicate detection
+    stage_camera_sets: Dict[str, Dict[str, List[str]]] = {}
+
+    for stage, sets_dict in config.items():
+        if not isinstance(sets_dict, dict):
+            return False, f"Expected dict of sets for stage='{stage}', got {type(sets_dict).__name__}"
+
+        if stage not in stage_camera_sets:
+            stage_camera_sets[stage] = {}
+
+        for set_name, set_config in sets_dict.items():
+            if not isinstance(set_config, dict):
+                return False, (
+                    f"Invalid config structure for stage='{stage}', set='{set_name}'. Expected dict."
+                )
+
+            if "batch_size" not in set_config or "cameras" not in set_config:
+                return False, (
+                    f"Missing 'batch_size' or 'cameras' in stage='{stage}', set='{set_name}'"
+                )
+
+            batch_size = set_config["batch_size"]
+            cameras = set_config["cameras"]
+
+            if not isinstance(batch_size, int) or batch_size <= 0:
+                return False, (
+                    f"batch_size must be a positive integer for stage='{stage}', set='{set_name}'"
+                )
+
+            if not isinstance(cameras, list):
+                return False, f"'cameras' must be a list for stage='{stage}', set='{set_name}'"
+
+            for camera in cameras:
+                if camera not in available_cameras:
+                    return False, (
+                        f"Camera '{camera}' in stage_set_configs not found in active cameras"
+                    )
+
+            if set_name not in stage_camera_sets[stage]:
+                stage_camera_sets[stage][set_name] = []
+            stage_camera_sets[stage][set_name].extend(cameras)
+
+    # Check for cameras in multiple sets within the same stage
+    for stage, sets_dict in stage_camera_sets.items():
+        all_cameras_in_stage: List[str] = []
+        for set_name, cameras in sets_dict.items():
+            for camera in cameras:
+                if camera in all_cameras_in_stage:
+                    return False, (
+                        f"Camera '{camera}' cannot be in multiple sets within "
+                        f"the same stage ('{stage}')"
+                    )
+                all_cameras_in_stage.append(camera)
+
+    return True, None
+
+
+def build_capture_groups(
+    config: StageSetConfigDict,
+) -> Tuple[Dict[str, CaptureGroup], Dict[str, List[str]]]:
+    """Build CaptureGroup objects and camera-to-group-key mapping from config.
+
+    Args:
+        config: ``{stage: {set: {"batch_size": int, "cameras": [str]}}}``
+
+    Returns:
+        ``(groups_by_key, camera_to_group_keys)``
+
+        - ``groups_by_key``: ``{"stage:set": CaptureGroup, ...}``
+        - ``camera_to_group_keys``: ``{"cam_name": ["stage:set", ...], ...}``
+    """
+    groups: Dict[str, CaptureGroup] = {}
+    camera_map: Dict[str, List[str]] = {}
+
+    for stage, sets_dict in config.items():
+        for set_name, set_config in sets_dict.items():
+            batch_size = set_config["batch_size"]
+            cameras = set_config["cameras"]
+
+            group = CaptureGroup(
+                stage=stage,
+                set_name=set_name,
+                max_concurrent=batch_size,
+                cameras=set(cameras),
+            )
+            groups[group.key] = group
+
+            for cam in cameras:
+                if cam not in camera_map:
+                    camera_map[cam] = []
+                if group.key not in camera_map[cam]:
+                    camera_map[cam].append(group.key)
+
+    return groups, camera_map
+
+
+def get_semaphore_for_capture(
+    camera_name: str,
+    stage: Optional[str],
+    set_name: Optional[str],
+    capture_groups: Dict[str, CaptureGroup],
+    camera_group_keys: Dict[str, List[str]],
+    global_semaphore: asyncio.Semaphore,
+) -> Tuple[Optional[asyncio.Semaphore], Optional[str]]:
+    """3-way semaphore routing for capture operations.
+
+    Decision tree (ported from mt-rix ``_get_semaphore_for_capture``):
+
+    1. *stage* + *set_name* provided AND camera is assigned -> group semaphore
+    2. Camera HAS group assignments but stage/set not provided -> **error**
+    3. No assignments, no stage/set -> global semaphore
+
+    Args:
+        camera_name: Camera identifier.
+        stage: Optional stage name.
+        set_name: Optional set name.
+        capture_groups: Current capture groups by key.
+        camera_group_keys: Camera-to-group-key mapping.
+        global_semaphore: Fallback global semaphore.
+
+    Returns:
+        ``(semaphore, error_message)`` -- *error_message* is ``None`` on success,
+        *semaphore* is ``None`` on error.
+    """
+    if stage is not None and set_name is not None:
+        group_key = f"{stage}:{set_name}"
+        camera_assignments = camera_group_keys.get(camera_name, [])
+
+        if group_key in camera_assignments:
+            if group_key in capture_groups:
+                return capture_groups[group_key].semaphore, None
+            else:
+                # Group key registered for camera but semaphore missing — fall back
+                return global_semaphore, None
+        else:
+            return None, (
+                f"Camera '{camera_name}' is not assigned to stage='{stage}', "
+                f"set='{set_name}'. Available assignments: {camera_assignments}"
+            )
+
+    elif camera_name in camera_group_keys and len(camera_group_keys[camera_name]) > 0:
+        available = camera_group_keys[camera_name]
+        return None, (
+            f"Camera '{camera_name}' has capture group assignments {available} but "
+            f"stage and set_name were not provided in request"
+        )
+
+    else:
+        return global_semaphore, None

--- a/mindtrace/hardware/mindtrace/hardware/cameras/core/capture_groups.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/core/capture_groups.py
@@ -118,9 +118,7 @@ def validate_stage_set_configs(
         for set_name, cameras in sets_dict.items():
             for camera in cameras:
                 if camera in all_cameras_in_stage:
-                    return False, (
-                        f"Camera '{camera}' cannot be in multiple sets within " f"the same stage ('{stage}')"
-                    )
+                    return False, (f"Camera '{camera}' cannot be in multiple sets within the same stage ('{stage}')")
                 all_cameras_in_stage.append(camera)
 
     return True, None

--- a/mindtrace/hardware/mindtrace/hardware/cameras/core/capture_groups.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/core/capture_groups.py
@@ -90,31 +90,23 @@ def validate_stage_set_configs(
 
         for set_name, set_config in sets_dict.items():
             if not isinstance(set_config, dict):
-                return False, (
-                    f"Invalid config structure for stage='{stage}', set='{set_name}'. Expected dict."
-                )
+                return False, (f"Invalid config structure for stage='{stage}', set='{set_name}'. Expected dict.")
 
             if "batch_size" not in set_config or "cameras" not in set_config:
-                return False, (
-                    f"Missing 'batch_size' or 'cameras' in stage='{stage}', set='{set_name}'"
-                )
+                return False, (f"Missing 'batch_size' or 'cameras' in stage='{stage}', set='{set_name}'")
 
             batch_size = set_config["batch_size"]
             cameras = set_config["cameras"]
 
             if not isinstance(batch_size, int) or batch_size <= 0:
-                return False, (
-                    f"batch_size must be a positive integer for stage='{stage}', set='{set_name}'"
-                )
+                return False, (f"batch_size must be a positive integer for stage='{stage}', set='{set_name}'")
 
             if not isinstance(cameras, list):
                 return False, f"'cameras' must be a list for stage='{stage}', set='{set_name}'"
 
             for camera in cameras:
                 if camera not in available_cameras:
-                    return False, (
-                        f"Camera '{camera}' in stage_set_configs not found in active cameras"
-                    )
+                    return False, (f"Camera '{camera}' in stage_set_configs not found in active cameras")
 
             if set_name not in stage_camera_sets[stage]:
                 stage_camera_sets[stage][set_name] = []
@@ -127,8 +119,7 @@ def validate_stage_set_configs(
             for camera in cameras:
                 if camera in all_cameras_in_stage:
                     return False, (
-                        f"Camera '{camera}' cannot be in multiple sets within "
-                        f"the same stage ('{stage}')"
+                        f"Camera '{camera}' cannot be in multiple sets within " f"the same stage ('{stage}')"
                     )
                 all_cameras_in_stage.append(camera)
 

--- a/mindtrace/hardware/mindtrace/hardware/core/config.py
+++ b/mindtrace/hardware/mindtrace/hardware/core/config.py
@@ -27,6 +27,11 @@ Environment Variables:
     - MINDTRACE_HW_CAMERA_WHITE_BALANCE: Default camera white balance mode
     - MINDTRACE_HW_CAMERA_TIMEOUT: Camera capture timeout in seconds
     - MINDTRACE_HW_CAMERA_MAX_CONCURRENT_CAPTURES: Maximum concurrent captures for network bandwidth management
+    - MINDTRACE_HW_CAMERA_MAX_CONSECUTIVE_FAILURES: Consecutive capture failures before auto-reinit (default: 5)
+    - MINDTRACE_HW_CAMERA_REINITIALIZATION_COOLDOWN: Seconds between reinit attempts (default: 30.0)
+    - MINDTRACE_HW_CAMERA_CONFIG_DIR: Directory for preserved camera configs
+    - MINDTRACE_HW_CAMERA_SAVE_API_URL: External save API URL for capture forwarding
+    - MINDTRACE_HW_CAMERA_SAVE_API_TIMEOUT: HTTP timeout for save API forwarding (default: 10.0)
     - MINDTRACE_HW_CAMERA_OPENCV_WIDTH: OpenCV default frame width
     - MINDTRACE_HW_CAMERA_OPENCV_HEIGHT: OpenCV default frame height
     - MINDTRACE_HW_CAMERA_OPENCV_FPS: OpenCV default frame rate
@@ -172,6 +177,15 @@ class CameraSettings:
     # Image enhancement algorithm settings
     enhancement_gamma: float = 2.2  # Gamma correction value
     enhancement_contrast: float = 1.2  # Contrast enhancement factor
+
+    # Auto-reconnection settings
+    max_consecutive_failures: int = 5  # Consecutive capture failures before attempting reinit
+    reinitialization_cooldown: float = 30.0  # Seconds between reinit attempts
+    camera_config_dir: str = ""  # Dir for preserved camera configs; empty = PathSettings.config_dir + "/cameras"
+
+    # Capture save forwarding
+    save_api_url: str = ""  # External save API URL; empty = local save only
+    save_api_timeout: float = 10.0  # HTTP timeout for save API forwarding (seconds)
 
     # OpenCV capability ranges (defines hardware limits)
     opencv_exposure_range_min: float = -13.0
@@ -648,6 +662,32 @@ class HardwareConfigManager(Mindtrace):
         if env_val := os.getenv("MINDTRACE_HW_CAMERA_MAX_CONCURRENT_CAPTURES"):
             try:
                 self._config.cameras.max_concurrent_captures = int(env_val)
+            except ValueError:
+                pass  # Keep default value on invalid input
+
+        # Auto-reconnection settings
+        if env_val := os.getenv("MINDTRACE_HW_CAMERA_MAX_CONSECUTIVE_FAILURES"):
+            try:
+                self._config.cameras.max_consecutive_failures = int(env_val)
+            except ValueError:
+                pass  # Keep default value on invalid input
+
+        if env_val := os.getenv("MINDTRACE_HW_CAMERA_REINITIALIZATION_COOLDOWN"):
+            try:
+                self._config.cameras.reinitialization_cooldown = float(env_val)
+            except ValueError:
+                pass  # Keep default value on invalid input
+
+        if env_val := os.getenv("MINDTRACE_HW_CAMERA_CONFIG_DIR"):
+            self._config.cameras.camera_config_dir = env_val
+
+        # Capture save forwarding
+        if env_val := os.getenv("MINDTRACE_HW_CAMERA_SAVE_API_URL"):
+            self._config.cameras.save_api_url = env_val
+
+        if env_val := os.getenv("MINDTRACE_HW_CAMERA_SAVE_API_TIMEOUT"):
+            try:
+                self._config.cameras.save_api_timeout = float(env_val)
             except ValueError:
                 pass  # Keep default value on invalid input
 

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/README.md
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/README.md
@@ -71,9 +71,17 @@ uv run python -m mindtrace.hardware.services.cameras.launcher --include-mocks
 ### Image Capture
 
 - `POST /cameras/capture` - Capture single image
-- `POST /cameras/capture/batch` - Capture from multiple cameras
+- `POST /cameras/capture/batch` - Capture from multiple cameras (supports `stage`/`set_name` for capture group routing)
 - `POST /cameras/capture/hdr` - Capture HDR image with multiple exposures
-- `POST /cameras/capture/hdr/batch` - Batch HDR capture
+- `POST /cameras/capture/hdr/batch` - Batch HDR capture (supports `stage`/`set_name` for capture group routing)
+
+### Capture Groups (Stage+Set Batching)
+
+Control per-group concurrency for production-line camera setups:
+
+- `POST /cameras/capture-groups/configure` - Configure stage+set capture groups
+- `GET /cameras/capture-groups` - Get current capture group configuration
+- `POST /cameras/capture-groups/remove` - Remove all capture groups
 
 ### Streaming
 
@@ -180,7 +188,12 @@ Most REST endpoints are automatically exposed as MCP tools for integration with 
 - `camera_manager_capture_image` - Capture image
 - `camera_manager_configure_camera` - Configure camera parameters
 - `camera_manager_get_camera_status` - Get camera status
-- `camera_manager_get_system_diagnostics` - Get system diagnostics
+- `camera_manager_get_system_diagnostics` - Get system diagnostics (includes failure_counts, cameras_in_cooldown, capture_groups_count)
+
+**Capture Groups:**
+- `camera_manager_configure_capture_groups` - Configure stage+set capture groups
+- `camera_manager_get_capture_groups` - Get current capture group configuration
+- `camera_manager_remove_capture_groups` - Remove all capture groups
 
 **Homography Calibration:**
 - `camera_manager_calibrate_homography_checkerboard` - Single-image calibration (live capture)
@@ -191,6 +204,84 @@ Most REST endpoints are automatically exposed as MCP tools for integration with 
 - `camera_manager_measure_homography_box` - Measure single bounding box
 - `camera_manager_measure_homography_distance` - Measure distance between two points
 - `camera_manager_measure_homography_batch` - Unified batch (boxes + distances)
+
+## Capture Groups (Stage+Set Batching)
+
+Capture groups provide per-group concurrency control for production-line setups where multiple cameras share a GigE network link. Each group creates an `asyncio.Semaphore` sized to `batch_size`, limiting how many cameras within the group can capture simultaneously.
+
+### Configuration
+
+```bash
+# Configure 1 stage with 2 sets, max 1 concurrent per set
+curl -X POST http://localhost:8002/cameras/capture-groups/configure \
+  -H "Content-Type: application/json" \
+  -d '{
+    "config": {
+      "inspection": {
+        "top_cameras": {"batch_size": 1, "cameras": ["Basler:cam0", "Basler:cam1", "Basler:cam4"]},
+        "side_cameras": {"batch_size": 1, "cameras": ["Basler:cam6", "Basler:cam7", "Basler:cam8"]}
+      }
+    }
+  }'
+```
+
+### Capture with Group Routing
+
+Once groups are configured, batch capture requests must include `stage` and `set_name`:
+
+```bash
+curl -X POST http://localhost:8002/cameras/capture/batch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "cameras": ["Basler:cam0", "Basler:cam1", "Basler:cam4"],
+    "output_format": "numpy",
+    "stage": "inspection",
+    "set_name": "top_cameras"
+  }'
+```
+
+### Semaphore Routing Logic
+
+1. **stage + set_name provided** and camera is assigned → use group semaphore
+2. **Camera has group assignments** but stage/set_name not provided → error (forces callers to be explicit)
+3. **No assignments, no stage/set_name** → fall back to global semaphore
+
+### GigE Bandwidth Considerations
+
+For GigE cameras sharing a single NIC, the `batch_size` per group must account for the link's concurrent transfer capacity. Key factors:
+
+- **Jumbo frames** (`sudo ip link set <iface> mtu 9000`) reduce packet overhead
+- **`packet_size`** (camera setting, e.g., 8164) should match the NIC's MTU
+- **`inter_packet_delay`** (camera setting, e.g., 1000 ticks) spaces out packets to prevent NIC buffer overflow
+- With 12.5MP cameras on 1Gbps, typically max 2 concurrent transfers are reliable
+
+## Auto-Reconnection
+
+The camera manager tracks consecutive capture failures per camera. When a camera exceeds the failure threshold, it automatically:
+
+1. Checks the reinitialization cooldown (prevents thrashing)
+2. Exports the current camera config to disk
+3. Closes the camera
+4. Re-opens and restores the saved configuration
+5. Resets the failure counter
+
+### Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `MINDTRACE_HW_CAMERA_MAX_CONSECUTIVE_FAILURES` | 5 | Failures before attempting reinit |
+| `MINDTRACE_HW_CAMERA_REINITIALIZATION_COOLDOWN` | 30.0 | Seconds between reinit attempts |
+| `MINDTRACE_HW_CAMERA_CONFIG_DIR` | `~/.config/mindtrace/cameras` | Directory for preserved configs |
+
+### Diagnostics
+
+Failure tracking and reconnection status are exposed via the diagnostics endpoint:
+
+```bash
+curl http://localhost:8002/system/diagnostics
+```
+
+Response includes `failure_counts`, `cameras_in_cooldown`, and `capture_groups_count`.
 
 ## Configuration Parameters
 
@@ -205,7 +296,9 @@ Can be changed dynamically without reinitialization:
 - `white_balance` - White balance setting
 - `image_quality_enhancement` - Enable CLAHE enhancement
 - `pixel_format` - Pixel format (BGR8, RGB8, Mono8, etc.)
-- Network parameters (packet_size, inter_packet_delay, bandwidth_limit)
+- `packet_size` - GigE packet size in bytes (set to match NIC MTU, e.g., 8164 for jumbo frames)
+- `inter_packet_delay` - Ticks between GigE packets (e.g., 1000 = ~8us gap)
+- `bandwidth_limit` - Bandwidth limit in Mbps
 
 ### Startup-Only Parameters
 
@@ -213,6 +306,22 @@ Require camera reinitialization (set via config.py):
 
 - `buffer_count` - Number of frame buffers (memory allocation)
 - `basler_multicast_*` - Multicast streaming settings (network reconnection)
+
+### System Configuration
+
+Set via environment variables with `MINDTRACE_HW_CAMERA_*` prefix:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MINDTRACE_HW_CAMERA_MAX_CONCURRENT_CAPTURES` | 1 | Global concurrent capture limit |
+| `MINDTRACE_HW_CAMERA_RETRY_COUNT` | 3 | Capture retry attempts |
+| `MINDTRACE_HW_CAMERA_TIMEOUT_MS` | 2000 | Capture timeout in ms |
+| `MINDTRACE_HW_CAMERA_DEFAULT_EXPOSURE` | 6000 | Default exposure in us |
+| `MINDTRACE_HW_CAMERA_TRIGGER_MODE` | trigger | Default trigger mode |
+| `MINDTRACE_HW_CAMERA_MAX_CONSECUTIVE_FAILURES` | 5 | Auto-reconnect threshold |
+| `MINDTRACE_HW_CAMERA_REINITIALIZATION_COOLDOWN` | 30.0 | Reconnect cooldown (s) |
+| `MINDTRACE_HW_CAMERA_SAVE_API_URL` | (empty) | External save API for capture forwarding |
+| `MINDTRACE_HW_CAMERA_SAVE_API_TIMEOUT` | 10.0 | Save API timeout (s) |
 
 See `/mindtrace/hardware/core/config.py` for complete configuration options.
 
@@ -227,72 +336,80 @@ Once the service is running, visit:
 
 The service follows a 4-layer architecture:
 
-1. **API Layer** (`api/cameras/service.py`) - REST endpoints and MCP tools
-2. **Manager Layer** (`cameras/core/async_camera_manager.py`) - Multi-camera orchestration
+1. **API Layer** (`services/cameras/service.py`) - REST endpoints and MCP tools
+2. **Manager Layer** (`cameras/core/async_camera_manager.py`) - Multi-camera orchestration, capture groups, auto-reconnection
 3. **Camera Layer** (`cameras/core/async_camera.py`) - Unified async camera interface
 4. **Backend Layer** (`cameras/backends/`) - Hardware-specific implementations
 
+Supporting modules:
+- `cameras/core/capture_groups.py` - Stage+set semaphore routing (CaptureGroup dataclass, validation, 3-way routing)
+- `core/config.py` - HardwareConfig with CameraSettings (auto-reconnection, save forwarding, GigE tuning)
+
 ## Usage Examples
 
-### Discover and Open Camera
+### Discover and Open Cameras
 
 ```bash
-# Discover Basler cameras
+# Discover all cameras
 curl -X POST http://localhost:8002/cameras/discover \
-  -H "Content-Type: application/json" \
-  -d '{"backend": "basler"}'
+  -H "Content-Type: application/json" -d '{}'
 
-# Open discovered camera
+# Open a camera (format: "Backend:device_name")
 curl -X POST http://localhost:8002/cameras/open \
   -H "Content-Type: application/json" \
-  -d '{"camera_name": "BaslerCamera_001", "backend": "basler"}'
+  -d '{"camera": "Basler:cam0", "test_connection": false}'
+
+# Open multiple cameras
+curl -X POST http://localhost:8002/cameras/open/batch \
+  -H "Content-Type: application/json" \
+  -d '{"cameras": ["Basler:cam0", "Basler:cam1", "Basler:cam4"], "test_connection": false}'
 ```
 
 ### Configure and Capture
 
 ```bash
-# Configure camera settings
+# Configure camera (trigger mode, exposure, GigE tuning)
 curl -X POST http://localhost:8002/cameras/configure \
   -H "Content-Type: application/json" \
   -d '{
-    "camera": "BaslerCamera_001",
+    "camera": "Basler:cam0",
     "properties": {
-      "exposure_time": 2000,
-      "gain": 1.5,
-      "timeout_ms": 3000
+      "trigger_mode": "trigger",
+      "exposure_time": 10000,
+      "packet_size": 8164,
+      "inter_packet_delay": 1000
     }
   }'
 
 # Capture image
 curl -X POST http://localhost:8002/cameras/capture \
   -H "Content-Type: application/json" \
-  -d '{
-    "camera_name": "BaslerCamera_001",
-    "file_path": "/tmp/capture.png"
-  }'
+  -d '{"camera": "Basler:cam0", "save_path": "/tmp/capture.jpg", "output_format": "numpy"}'
 ```
 
-### Batch Operations
+### Batch Capture with Capture Groups
 
 ```bash
-# Open multiple cameras
-curl -X POST http://localhost:8002/cameras/open/batch \
+# Configure capture groups
+curl -X POST http://localhost:8002/cameras/capture-groups/configure \
   -H "Content-Type: application/json" \
   -d '{
-    "cameras": [
-      {"camera_name": "Camera_001", "backend": "basler"},
-      {"camera_name": "Camera_002", "backend": "basler"}
-    ]
+    "config": {
+      "production": {
+        "left": {"batch_size": 1, "cameras": ["Basler:cam0", "Basler:cam1"]},
+        "right": {"batch_size": 1, "cameras": ["Basler:cam4", "Basler:cam6"]}
+      }
+    }
   }'
 
-# Batch capture
+# Batch capture with group routing
 curl -X POST http://localhost:8002/cameras/capture/batch \
   -H "Content-Type: application/json" \
   -d '{
-    "captures": [
-      {"camera_name": "Camera_001", "file_path": "/tmp/cam1.png"},
-      {"camera_name": "Camera_002", "file_path": "/tmp/cam2.png"}
-    ]
+    "cameras": ["Basler:cam0", "Basler:cam1"],
+    "output_format": "numpy",
+    "stage": "production",
+    "set_name": "left"
   }'
 ```
 

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/connection_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/connection_manager.py
@@ -411,9 +411,7 @@ class CameraManagerConnectionManager(ConnectionManager):
 
     # Capture Groups (stage+set batching)
 
-    async def configure_capture_groups(
-        self, config: Dict[str, Dict[str, Dict[str, Any]]]
-    ) -> bool:
+    async def configure_capture_groups(self, config: Dict[str, Dict[str, Dict[str, Any]]]) -> bool:
         """Configure stage+set capture groups with per-group concurrency semaphores.
 
         Args:

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/connection_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/connection_manager.py
@@ -27,6 +27,7 @@ from mindtrace.hardware.services.cameras.models import (
     CaptureImageRequest,
     ConfigFileExportRequest,
     ConfigFileImportRequest,
+    ConfigureCaptureGroupsRequest,
 )
 from mindtrace.services.core.connection_manager import ConnectionManager
 
@@ -406,4 +407,39 @@ class CameraManagerConnectionManager(ConnectionManager):
             Network diagnostics data
         """
         response = await self.get("/network/diagnostics")
+        return response["data"]
+
+    # Capture Groups (stage+set batching)
+
+    async def configure_capture_groups(
+        self, config: Dict[str, Dict[str, Dict[str, Any]]]
+    ) -> bool:
+        """Configure stage+set capture groups with per-group concurrency semaphores.
+
+        Args:
+            config: ``{stage: {set: {"batch_size": int, "cameras": [str]}}}``
+
+        Returns:
+            True if successful
+        """
+        request = ConfigureCaptureGroupsRequest(config=config)
+        response = await self.post("/cameras/capture-groups/configure", request.model_dump())
+        return response["data"]
+
+    async def get_capture_groups(self) -> Dict[str, Any]:
+        """Get current capture group configuration.
+
+        Returns:
+            Dictionary of capture groups keyed by ``"stage:set_name"``
+        """
+        response = await self.get("/cameras/capture-groups")
+        return response["data"]
+
+    async def remove_capture_groups(self) -> bool:
+        """Remove all capture group configurations.
+
+        Returns:
+            True if successful
+        """
+        response = await self.post("/cameras/capture-groups/remove", {})
         return response["data"]

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/launcher.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/launcher.py
@@ -18,12 +18,14 @@ def main():
     # Create service with mock support if requested
     service = CameraManagerService(include_mocks=args.include_mocks)
 
-    # Launch the camera service
+    # Launch the camera service (include_mocks must be passed through launch() so gunicorn
+    # workers receive it via --init-params; the pre-launch `service` instance is not reused.)
     connection_manager = service.launch(
         host=args.host,
         port=args.port,
         wait_for_launch=True,
         block=True,  # Keep the service running
+        include_mocks=args.include_mocks,
     )
 
     return connection_manager

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/models/__init__.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/models/__init__.py
@@ -22,10 +22,9 @@ from mindtrace.hardware.services.cameras.models.requests import (
     CaptureHDRRequest,
     # Image Capture
     CaptureImageRequest,
-    CaptureSaveRequest,
     ConfigFileExportRequest,
     ConfigFileImportRequest,
-    # Capture Groups & Save
+    # Capture Groups
     ConfigureCaptureGroupsRequest,
     # Specific Parameters
     ExposureRequest,
@@ -77,13 +76,12 @@ from mindtrace.hardware.services.cameras.models.responses import (
     CameraPerformanceSettingsResponse,
     CameraStatus,
     CameraStatusResponse,
-    # Capture Groups & Save
+    # Capture Groups
     CaptureGroupInfo,
     CaptureGroupsResponse,
     CaptureResponse,
     # Capture Operations
     CaptureResult,
-    CaptureSaveResponse,
     # Configuration Files
     ConfigFileOperationResult,
     ConfigFileResponse,
@@ -161,7 +159,6 @@ __all__ = [
     "HomographyMeasureBatchRequest",
     "HomographyMeasureDistanceRequest",
     "ConfigureCaptureGroupsRequest",
-    "CaptureSaveRequest",
     # Responses
     "BaseResponse",
     "BoolResponse",
@@ -219,7 +216,6 @@ __all__ = [
     "HomographyDistanceResponse",
     "CaptureGroupInfo",
     "CaptureGroupsResponse",
-    "CaptureSaveResponse",
     "HealthCheckResponse",
     "ServiceStatus",
 ]

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/models/__init__.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/models/__init__.py
@@ -27,6 +27,9 @@ from mindtrace.hardware.services.cameras.models.requests import (
     # Specific Parameters
     ExposureRequest,
     GainRequest,
+    # Capture Groups & Save
+    ConfigureCaptureGroupsRequest,
+    CaptureSaveRequest,
     # Homography
     HomographyCalibrateCheckerboardRequest,
     HomographyCalibrateCorrespondencesRequest,
@@ -63,6 +66,10 @@ from mindtrace.hardware.services.cameras.models.responses import (
     # Batch Operations
     BatchOperationResult,
     BoolResponse,
+    # Capture Groups & Save
+    CaptureGroupInfo,
+    CaptureGroupsResponse,
+    CaptureSaveResponse,
     CameraCapabilities,
     CameraCapabilitiesResponse,
     CameraConfiguration,
@@ -153,6 +160,8 @@ __all__ = [
     "HomographyMeasureBoundingBoxRequest",
     "HomographyMeasureBatchRequest",
     "HomographyMeasureDistanceRequest",
+    "ConfigureCaptureGroupsRequest",
+    "CaptureSaveRequest",
     # Responses
     "BaseResponse",
     "BoolResponse",
@@ -208,6 +217,9 @@ __all__ = [
     "HomographyBatchMeasurementResponse",
     "HomographyDistanceResult",
     "HomographyDistanceResponse",
+    "CaptureGroupInfo",
+    "CaptureGroupsResponse",
+    "CaptureSaveResponse",
     "HealthCheckResponse",
     "ServiceStatus",
 ]

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/models/__init__.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/models/__init__.py
@@ -22,14 +22,14 @@ from mindtrace.hardware.services.cameras.models.requests import (
     CaptureHDRRequest,
     # Image Capture
     CaptureImageRequest,
+    CaptureSaveRequest,
     ConfigFileExportRequest,
     ConfigFileImportRequest,
+    # Capture Groups & Save
+    ConfigureCaptureGroupsRequest,
     # Specific Parameters
     ExposureRequest,
     GainRequest,
-    # Capture Groups & Save
-    ConfigureCaptureGroupsRequest,
-    CaptureSaveRequest,
     # Homography
     HomographyCalibrateCheckerboardRequest,
     HomographyCalibrateCorrespondencesRequest,
@@ -66,10 +66,6 @@ from mindtrace.hardware.services.cameras.models.responses import (
     # Batch Operations
     BatchOperationResult,
     BoolResponse,
-    # Capture Groups & Save
-    CaptureGroupInfo,
-    CaptureGroupsResponse,
-    CaptureSaveResponse,
     CameraCapabilities,
     CameraCapabilitiesResponse,
     CameraConfiguration,
@@ -81,9 +77,13 @@ from mindtrace.hardware.services.cameras.models.responses import (
     CameraPerformanceSettingsResponse,
     CameraStatus,
     CameraStatusResponse,
+    # Capture Groups & Save
+    CaptureGroupInfo,
+    CaptureGroupsResponse,
     CaptureResponse,
     # Capture Operations
     CaptureResult,
+    CaptureSaveResponse,
     # Configuration Files
     ConfigFileOperationResult,
     ConfigFileResponse,

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/models/requests.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/models/requests.py
@@ -111,6 +111,8 @@ class CaptureImageRequest(BaseModel):
     camera: str = Field(..., description="Camera name in format 'Backend:device_name'")
     save_path: Optional[str] = Field(None, description="Optional path to save the captured image")
     output_format: str = Field("pil", description="Output format for returned image ('numpy' or 'pil')")
+    stage: Optional[str] = Field(None, description="Stage name for capture group routing")
+    set_name: Optional[str] = Field(None, description="Set name for capture group routing")
 
     @field_validator("output_format")
     @classmethod
@@ -563,16 +565,3 @@ class ConfigureCaptureGroupsRequest(BaseModel):
         ...,
         description=("Stage+set config: {stage: {set: {'batch_size': int, 'cameras': [str]}}}"),
     )
-
-
-# Capture Save Operations
-class CaptureSaveRequest(BaseModel):
-    """Request model for capture-and-save operation.
-
-    Captures an image and saves it locally or forwards to an external API.
-    """
-
-    camera: str = Field(..., description="Camera name in format 'Backend:device_name'")
-    save_path: str = Field(..., description="File path or remote key for saving the image")
-    stage: Optional[str] = Field(None, description="Stage name for capture group routing")
-    set_name: Optional[str] = Field(None, description="Set name for capture group routing")

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/models/requests.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/models/requests.py
@@ -561,9 +561,7 @@ class ConfigureCaptureGroupsRequest(BaseModel):
 
     config: Dict[str, Dict[str, Dict[str, Any]]] = Field(
         ...,
-        description=(
-            "Stage+set config: {stage: {set: {'batch_size': int, 'cameras': [str]}}}"
-        ),
+        description=("Stage+set config: {stage: {set: {'batch_size': int, 'cameras': [str]}}}"),
     )
 
 

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/models/requests.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/models/requests.py
@@ -137,6 +137,8 @@ class CaptureBatchRequest(BaseModel):
         None, description="Optional path pattern for saving images. Use {camera} placeholder for camera name"
     )
     output_format: str = Field("pil", description="Output format for returned images ('numpy' or 'pil')")
+    stage: Optional[str] = Field(None, description="Stage name for capture group routing")
+    set_name: Optional[str] = Field(None, description="Set name for capture group routing")
 
     @field_validator("output_format")
     @classmethod
@@ -220,6 +222,8 @@ class CaptureHDRBatchRequest(BaseModel):
     )
     return_images: bool = Field(True, description="Whether to return captured images in response")
     output_format: str = Field("pil", description="Output format for returned images ('numpy' or 'pil')")
+    stage: Optional[str] = Field(None, description="Stage name for capture group routing")
+    set_name: Optional[str] = Field(None, description="Set name for capture group routing")
 
     @field_validator("exposure_levels")
     @classmethod
@@ -545,3 +549,32 @@ class HomographyCalibrateMultiViewRequest(BaseModel):
                 f"Number of images ({len(self.image_paths)}) must match number of positions ({len(self.positions)})"
             )
         return self
+
+
+# Capture Group Operations
+class ConfigureCaptureGroupsRequest(BaseModel):
+    """Request model for configuring stage+set capture groups.
+
+    Each group creates a concurrency semaphore sized to ``batch_size``,
+    limiting how many cameras within the group can capture simultaneously.
+    """
+
+    config: Dict[str, Dict[str, Dict[str, Any]]] = Field(
+        ...,
+        description=(
+            "Stage+set config: {stage: {set: {'batch_size': int, 'cameras': [str]}}}"
+        ),
+    )
+
+
+# Capture Save Operations
+class CaptureSaveRequest(BaseModel):
+    """Request model for capture-and-save operation.
+
+    Captures an image and saves it locally or forwards to an external API.
+    """
+
+    camera: str = Field(..., description="Camera name in format 'Backend:device_name'")
+    save_path: str = Field(..., description="File path or remote key for saving the image")
+    stage: Optional[str] = Field(None, description="Stage name for capture group routing")
+    set_name: Optional[str] = Field(None, description="Set name for capture group routing")

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/models/responses.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/models/responses.py
@@ -491,12 +491,6 @@ class CaptureGroupsResponse(BaseResponse):
     data: Dict[str, CaptureGroupInfo]
 
 
-class CaptureSaveResponse(BaseResponse):
-    """Response model for capture-and-save operation."""
-
-    data: CaptureResult
-
-
 # Health Check
 class HealthCheckResponse(BaseModel):
     """Health check response model."""

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/models/responses.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/models/responses.py
@@ -233,6 +233,9 @@ class SystemDiagnostics(BaseModel):
     backend_status: Dict[str, bool]
     memory_usage_mb: Optional[float] = None
     uptime_seconds: Optional[float] = None
+    failure_counts: Optional[Dict[str, int]] = None
+    cameras_in_cooldown: Optional[List[str]] = None
+    capture_groups_count: Optional[int] = None
 
 
 class SystemDiagnosticsResponse(BaseResponse):
@@ -470,6 +473,28 @@ class HomographyBatchMeasurementResponse(BaseResponse):
     """Response model for unified batch homography measurements."""
 
     data: HomographyBatchMeasurementData
+
+
+# Capture Groups
+class CaptureGroupInfo(BaseModel):
+    """Capture group information model."""
+
+    stage: str
+    set_name: str
+    max_concurrent: int
+    cameras: List[str]
+
+
+class CaptureGroupsResponse(BaseResponse):
+    """Response model for capture groups."""
+
+    data: Dict[str, CaptureGroupInfo]
+
+
+class CaptureSaveResponse(BaseResponse):
+    """Response model for capture-and-save operation."""
+
+    data: CaptureResult
 
 
 # Health Check

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/schemas/__init__.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/schemas/__init__.py
@@ -6,6 +6,11 @@ from mindtrace.hardware.services.cameras.schemas.backend_schemas import (
     DiscoverCamerasSchema,
     GetBackendInfoSchema,
 )
+from mindtrace.hardware.services.cameras.schemas.capture_group_schemas import (
+    ConfigureCaptureGroupsSchema,
+    GetCaptureGroupsSchema,
+    RemoveCaptureGroupsSchema,
+)
 from mindtrace.hardware.services.cameras.schemas.capture_schemas import (
     CaptureHDRImagesBatchSchema,
     CaptureHDRImageSchema,
@@ -83,6 +88,10 @@ ALL_SCHEMAS = {
     "get_camera_configuration": GetCameraConfigurationSchema,
     "import_camera_config": ImportCameraConfigSchema,
     "export_camera_config": ExportCameraConfigSchema,
+    # Capture Groups
+    "configure_capture_groups": ConfigureCaptureGroupsSchema,
+    "get_capture_groups": GetCaptureGroupsSchema,
+    "remove_capture_groups": RemoveCaptureGroupsSchema,
     # Image Capture
     "capture_image": CaptureImageSchema,
     "capture_images_batch": CaptureImagesBatchSchema,
@@ -132,6 +141,10 @@ __all__ = [
     "GetCameraConfigurationSchema",
     "ImportCameraConfigSchema",
     "ExportCameraConfigSchema",
+    # Capture Groups
+    "ConfigureCaptureGroupsSchema",
+    "GetCaptureGroupsSchema",
+    "RemoveCaptureGroupsSchema",
     # Image Capture
     "CaptureImageSchema",
     "CaptureImagesBatchSchema",

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/schemas/capture_group_schemas.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/schemas/capture_group_schemas.py
@@ -1,0 +1,32 @@
+"""Capture Group TaskSchemas for stage+set batching."""
+
+from mindtrace.core import TaskSchema
+from mindtrace.hardware.services.cameras.models import (
+    BoolResponse,
+    CaptureGroupsResponse,
+    ConfigureCaptureGroupsRequest,
+)
+
+ConfigureCaptureGroupsSchema = TaskSchema(
+    name="configure_capture_groups",
+    input_schema=ConfigureCaptureGroupsRequest,
+    output_schema=BoolResponse,
+)
+
+GetCaptureGroupsSchema = TaskSchema(
+    name="get_capture_groups",
+    input_schema=None,
+    output_schema=CaptureGroupsResponse,
+)
+
+RemoveCaptureGroupsSchema = TaskSchema(
+    name="remove_capture_groups",
+    input_schema=None,
+    output_schema=BoolResponse,
+)
+
+__all__ = [
+    "ConfigureCaptureGroupsSchema",
+    "GetCaptureGroupsSchema",
+    "RemoveCaptureGroupsSchema",
+]

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/service.py
@@ -54,12 +54,15 @@ from mindtrace.hardware.services.cameras.models import (
     CameraStatus,
     CameraStatusResponse,
     CaptureBatchRequest,
+    CaptureGroupInfo,
+    CaptureGroupsResponse,
     CaptureHDRBatchRequest,
     CaptureHDRRequest,
     CaptureImageRequest,
     CaptureResponse,
     CaptureResult,
     ConfigFileExportRequest,
+    ConfigureCaptureGroupsRequest,
     ConfigFileImportRequest,
     ConfigFileOperationResult,
     ConfigFileResponse,
@@ -241,6 +244,27 @@ class CameraManagerService(Service):
             "cameras/capture/hdr/batch",
             self.capture_hdr_images_batch,
             ALL_SCHEMAS["capture_hdr_images_batch"],
+            as_tool=True,
+        )
+
+        # Capture Groups (stage+set batching)
+        self.add_endpoint(
+            "cameras/capture-groups/configure",
+            self.configure_capture_groups,
+            ALL_SCHEMAS["configure_capture_groups"],
+            as_tool=True,
+        )
+        self.add_endpoint(
+            "cameras/capture-groups",
+            self.get_capture_groups,
+            ALL_SCHEMAS["get_capture_groups"],
+            methods=["GET"],
+            as_tool=True,
+        )
+        self.add_endpoint(
+            "cameras/capture-groups/remove",
+            self.remove_capture_groups,
+            ALL_SCHEMAS["remove_capture_groups"],
             as_tool=True,
         )
 
@@ -958,6 +982,8 @@ class CameraManagerService(Service):
                 request.cameras,
                 save_path_pattern=request.save_path_pattern,
                 output_format=request.output_format,
+                stage=request.stage,
+                set_name=request.set_name,
             )
 
             capture_results = {}
@@ -1068,6 +1094,8 @@ class CameraManagerService(Service):
                 exposure_multiplier=request.exposure_multiplier,
                 return_images=request.return_images,
                 output_format=request.output_format,
+                stage=request.stage,
+                set_name=request.set_name,
             )
 
             hdr_results = {}
@@ -1269,6 +1297,56 @@ class CameraManagerService(Service):
             return BoolResponse(success=True, message=message, data=True)
         except Exception as e:
             self.logger.error(f"Failed to set performance settings: {e}")
+            raise
+
+    # Capture Group Operations (stage+set batching)
+    async def configure_capture_groups(self, request: ConfigureCaptureGroupsRequest) -> BoolResponse:
+        """Configure stage+set capture groups with per-group concurrency semaphores."""
+        try:
+            manager = await self._get_camera_manager()
+            manager.configure_capture_groups(request.config)
+            groups = manager.get_capture_groups()
+            return BoolResponse(
+                success=True,
+                message=f"Configured {len(groups)} capture groups",
+                data=True,
+            )
+        except CameraConfigurationError as e:
+            self.logger.error(f"Invalid capture group config: {e}")
+            raise
+        except Exception as e:
+            self.logger.error(f"Failed to configure capture groups: {e}")
+            raise
+
+    async def get_capture_groups(self) -> CaptureGroupsResponse:
+        """Get current capture group configuration."""
+        try:
+            manager = await self._get_camera_manager()
+            groups = manager.get_capture_groups()
+            data = {
+                key: CaptureGroupInfo(**info) for key, info in groups.items()
+            }
+            return CaptureGroupsResponse(
+                success=True,
+                message=f"Retrieved {len(data)} capture groups",
+                data=data,
+            )
+        except Exception as e:
+            self.logger.error(f"Failed to get capture groups: {e}")
+            raise
+
+    async def remove_capture_groups(self) -> BoolResponse:
+        """Remove all capture group configurations."""
+        try:
+            manager = await self._get_camera_manager()
+            manager.remove_capture_groups()
+            return BoolResponse(
+                success=True,
+                message="All capture groups removed",
+                data=True,
+            )
+        except Exception as e:
+            self.logger.error(f"Failed to remove capture groups: {e}")
             raise
 
     # Streaming Operations
@@ -1982,6 +2060,9 @@ class CameraManagerService(Service):
                 recommended_settings=diagnostics_data["recommended_settings"],
                 backend_status={backend: True for backend in manager.backends()},
                 uptime_seconds=uptime_seconds,
+                failure_counts=diagnostics_data.get("failure_counts"),
+                cameras_in_cooldown=diagnostics_data.get("cameras_in_cooldown"),
+                capture_groups_count=diagnostics_data.get("capture_groups_count"),
             )
 
             return SystemDiagnosticsResponse(

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/service.py
@@ -62,10 +62,10 @@ from mindtrace.hardware.services.cameras.models import (
     CaptureResponse,
     CaptureResult,
     ConfigFileExportRequest,
-    ConfigureCaptureGroupsRequest,
     ConfigFileImportRequest,
     ConfigFileOperationResult,
     ConfigFileResponse,
+    ConfigureCaptureGroupsRequest,
     HDRCaptureResponse,
     HDRCaptureResult,
     HealthCheckResponse,
@@ -1323,9 +1323,7 @@ class CameraManagerService(Service):
         try:
             manager = await self._get_camera_manager()
             groups = manager.get_capture_groups()
-            data = {
-                key: CaptureGroupInfo(**info) for key, info in groups.items()
-            }
+            data = {key: CaptureGroupInfo(**info) for key, info in groups.items()}
             return CaptureGroupsResponse(
                 success=True,
                 message=f"Retrieved {len(data)} capture groups",

--- a/tests/unit/mindtrace/hardware/services/cameras/test_service.py
+++ b/tests/unit/mindtrace/hardware/services/cameras/test_service.py
@@ -819,12 +819,15 @@ class TestCameraManagerServiceCaptureAndHomography:
         CameraManagerService._register_endpoints(service)
 
         endpoint_paths = [entry.args[0] for entry in service.add_endpoint.call_args_list]
-        assert service.add_endpoint.call_count == 38
+        assert service.add_endpoint.call_count == 41
         assert "health" in endpoint_paths
         assert "cameras/capture" in endpoint_paths
         assert "cameras/stream/start" in endpoint_paths
         assert "stream/{camera_name}" in endpoint_paths
         assert "cameras/homography/measure/distance" in endpoint_paths
+        assert "cameras/capture-groups/configure" in endpoint_paths
+        assert "cameras/capture-groups" in endpoint_paths
+        assert "cameras/capture-groups/remove" in endpoint_paths
 
     @pytest.mark.asyncio
     async def test_configure_cameras_batch_formats_partial_results(self, service_with_mock_manager):


### PR DESCRIPTION
## Capture groups, auto-reconnection, and GigE config persistence

### Problem

The camera service lacked production-line features present in the mt-rix camera backend:

- No way to control capture concurrency per camera group — all cameras shared a single global semaphore, making it impossible to model stage+set layouts on a production line.
- No automatic recovery when a camera fails — consecutive capture failures left cameras in a broken state until manual intervention.
- GigE transport settings (packet_size, inter_packet_delay, bandwidth_limit) were not persisted, so any camera reconnect reverted to defaults and broke multi-camera setups sharing a single NIC.

### Changes

**Capture groups (stage+set batching)**

- New `capture_groups.py` module with `CaptureGroup` dataclass, validation, and 3-way semaphore routing.
- `AsyncCameraManager` gains `configure_capture_groups()`, `remove_capture_groups()`, `get_capture_groups()`.
- `batch_capture()` and `batch_capture_hdr()` accept `stage` and `set_name` parameters to route through per-group semaphores.
- Three new REST/MCP endpoints: `POST /cameras/capture-groups/configure`, `GET /cameras/capture-groups`, `POST /cameras/capture-groups/remove`.
- Connection manager client methods for all three.

**Auto-reconnection**

- Per-camera failure counter with configurable threshold (`max_consecutive_failures`) and cooldown (`reinitialization_cooldown`).
- On threshold: export config to disk, close, reopen, import config, reset counter.
- Config preserved as JSON in `camera_config_dir`, restored on reconnect.
- Capture group assignments survive close/reopen (treated as configuration, not state).

**GigE transport config persistence**

- Basler backend `export_config` now includes `packet_size`, `inter_packet_delay`, and `bandwidth_limit`.
- Basler backend `import_config` restores these on reconnect.
- Without this, auto-reconnected cameras revert to default packet size (1500) and zero inter-packet delay, causing `buffer was incompletely grabbed` errors on shared GigE links.

**Configuration**

New `CameraSettings` fields with environment variable support:

| Variable | Default | Purpose |
|----------|---------|---------|
| `MINDTRACE_HW_CAMERA_MAX_CONSECUTIVE_FAILURES` | 5 | Failure threshold before auto-reinit |
| `MINDTRACE_HW_CAMERA_REINITIALIZATION_COOLDOWN` | 30.0 | Seconds between reinit attempts |
| `MINDTRACE_HW_CAMERA_CONFIG_DIR` | `~/.config/mindtrace/cameras` | Preserved config directory |
| `MINDTRACE_HW_CAMERA_SAVE_API_URL` | (empty) | External save API for capture forwarding |
| `MINDTRACE_HW_CAMERA_SAVE_API_TIMEOUT` | 10.0 | Save API timeout |

**Diagnostics**

`GET /system/diagnostics` now includes `failure_counts`, `cameras_in_cooldown`, and `capture_groups_count`.

### Testing

- 100-round stress test with 7 Basler GigE cameras (3536x3536, trigger mode, 10ms exposure) split across 2 capture groups with `max_concurrent=1` per set.
- 700/700 captures successful (100%) at 5.9 captures/sec with jumbo frames and inter-packet delay configured.
- Verified auto-reconnect restores full config including GigE transport settings.
- Verified capture group assignments persist across camera close/reopen cycles.
- Verified semaphore routing: cameras with group assignments reject captures without explicit stage/set, cameras without assignments fall back to global semaphore.
