### PR TITLE
Fix camera workspace Docker stubs and datalake compose healthcheck

### DIFF
--- a/docker/datalake/docker-compose.yml
+++ b/docker/datalake/docker-compose.yml
@@ -61,7 +61,20 @@ services:
     ports:
       - "8080:8080"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8080/health"]
+      # DatalakeService registers /health as a POST endpoint (Mindtrace Service default methods).
+      test:
+        [
+          "CMD",
+          "curl",
+          "-fsS",
+          "-X",
+          "POST",
+          "-H",
+          "Content-Type: application/json",
+          "-d",
+          "{}",
+          "http://localhost:8080/health",
+        ]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docker/hardware/camera/Dockerfile
+++ b/docker/hardware/camera/Dockerfile
@@ -137,7 +137,8 @@ COPY mindtrace/hardware/pyproject.toml ./mindtrace/hardware/
 COPY mindtrace/storage/pyproject.toml ./mindtrace/storage/
 
 # Create stub pyproject.toml for unused workspace members
-RUN for pkg in apps automation cluster database datalake jobs models registry ui; do \
+# Keep this list in sync with root `pyproject.toml` workspace members.
+RUN for pkg in apps agents automation cluster database datalake jobs models registry ui; do \
     mkdir -p mindtrace/$pkg && \
     printf '[project]\nname = "mindtrace-%s"\nversion = "0.0.0"\n' "$pkg" > mindtrace/$pkg/pyproject.toml; \
     done
@@ -163,7 +164,8 @@ COPY mindtrace/hardware ./mindtrace/hardware
 COPY mindtrace/storage ./mindtrace/storage
 
 # Create stub pyproject.toml for other workspace members to satisfy workspace structure
-RUN for pkg in apps automation cluster database datalake jobs models registry ui; do \
+# Keep this list in sync with root `pyproject.toml` workspace members.
+RUN for pkg in apps agents automation cluster database datalake jobs models registry ui; do \
     mkdir -p mindtrace/$pkg && \
     printf '[project]\nname = "mindtrace-%s"\nversion = "0.0.0"\n' "$pkg" > mindtrace/$pkg/pyproject.toml; \
     done


### PR DESCRIPTION
## Summary

- **Camera image:** generate stub `pyproject.toml` files for the `agents` workspace member during the hardware camera Docker build so the layout matches the root `pyproject.toml` workspace.
- **Datalake stack:** update the MinIO sidecar / datalake service healthcheck in `docker/datalake/docker-compose.yml` to call `/health` with **POST** and a JSON body, consistent with Mindtrace service defaults.

## Why

- Omitting `agents` from the stub loop can break `uv` / workspace resolution when building `docker/hardware/camera/Dockerfile`.
- `DatalakeService` registers `/health` as a POST endpoint; a GET-only healthcheck causes Docker to mark the container unhealthy.

## How to test

- Build the camera image (or the CI job that builds `docker/hardware/camera/Dockerfile`).
- From `docker/datalake/`, bring up the stack and confirm the service healthcheck passes (`docker compose ps` shows healthy once the service is up).

## Notes

- Other local changes (e.g. unstaged camera Dockerfile edits) are not part of this PR unless pushed in a later commit.