### PR TITLE
[Datalake 12 of X]: Bug fixes

### DIFF
--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -1151,8 +1151,6 @@ class AsyncDatalake(Mindtrace):
         metadata: dict[str, Any] | None = None,
         annotation_set_ids: list[str] | None = None,
     ) -> Datum:
-        if any(not str(asset_id).strip() for asset_id in asset_refs.values()):
-            raise ValueError("Datum asset_refs must contain non-empty asset ids")
         await self._validate_asset_refs_exist(asset_refs)
         await self._validate_annotation_set_ids_exist(annotation_set_ids or [])
         datum = self._build_document(
@@ -1177,7 +1175,7 @@ class AsyncDatalake(Mindtrace):
     async def _validate_asset_refs_exist(self, asset_refs: dict[str, str]) -> None:
         for asset_id in asset_refs.values():
             if not str(asset_id).strip():
-                continue
+                raise ValueError("Datum asset_refs must contain non-empty asset ids")
             await self.get_asset(asset_id)
 
     async def _validate_annotation_set_ids_exist(self, annotation_set_ids: list[str]) -> None:

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -1207,6 +1207,8 @@ class AsyncDatalake(Mindtrace):
         existing = await self.dataset_version_database.find({"dataset_name": dataset_name, "version": version})
         if existing:
             raise ValueError(f"Dataset version already exists: {dataset_name}@{version}")
+        if len(manifest) != len(set(manifest)):
+            raise ValueError("Dataset version manifest must not contain duplicate datum ids")
         for datum_id in manifest:
             await self.get_datum(datum_id)
         dataset_version = self._build_document(

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -1151,6 +1151,8 @@ class AsyncDatalake(Mindtrace):
         metadata: dict[str, Any] | None = None,
         annotation_set_ids: list[str] | None = None,
     ) -> Datum:
+        if any(not str(asset_id).strip() for asset_id in asset_refs.values()):
+            raise ValueError("Datum asset_refs must contain non-empty asset ids")
         await self._validate_asset_refs_exist(asset_refs)
         await self._validate_annotation_set_ids_exist(annotation_set_ids or [])
         datum = self._build_document(

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -1152,8 +1152,7 @@ class AsyncDatalake(Mindtrace):
         annotation_set_ids: list[str] | None = None,
     ) -> Datum:
         await self._validate_asset_refs_exist(asset_refs)
-        for annotation_set_id in annotation_set_ids or []:
-            await self.get_annotation_set(annotation_set_id)
+        await self._validate_annotation_set_ids_exist(annotation_set_ids or [])
         datum = self._build_document(
             Datum,
             split=split,
@@ -1179,10 +1178,16 @@ class AsyncDatalake(Mindtrace):
                 continue
             await self.get_asset(asset_id)
 
+    async def _validate_annotation_set_ids_exist(self, annotation_set_ids: list[str]) -> None:
+        for annotation_set_id in annotation_set_ids:
+            await self.get_annotation_set(annotation_set_id)
+
     async def update_datum(self, datum_id: str, **changes: Any) -> Datum:
         datum = await self.get_datum(datum_id)
         if "asset_refs" in changes and changes["asset_refs"] is not None:
             await self._validate_asset_refs_exist(changes["asset_refs"])
+        if "annotation_set_ids" in changes and changes["annotation_set_ids"] is not None:
+            await self._validate_annotation_set_ids_exist(changes["annotation_set_ids"])
         for key, value in changes.items():
             setattr(datum, key, value)
         datum.updated_at = self._utc_now()

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -591,6 +591,9 @@ class AsyncDatalake(Mindtrace):
 
     async def delete_collection(self, collection_id: str) -> None:
         collection = await self.get_collection(collection_id)
+        collection_items = await self.collection_item_database.find({"collection_id": collection_id})
+        for collection_item in collection_items:
+            await self.collection_item_database.delete(collection_item.id)
         await self.collection_database.delete(collection.id)
 
     async def create_collection_item(

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -1207,6 +1207,8 @@ class AsyncDatalake(Mindtrace):
         existing = await self.dataset_version_database.find({"dataset_name": dataset_name, "version": version})
         if existing:
             raise ValueError(f"Dataset version already exists: {dataset_name}@{version}")
+        for datum_id in manifest:
+            await self.get_datum(datum_id)
         dataset_version = self._build_document(
             DatasetVersion,
             dataset_name=dataset_name,

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -545,6 +545,9 @@ class AsyncDatalake(Mindtrace):
 
     async def delete_asset(self, asset_id: str) -> None:
         asset = await self.get_asset(asset_id)
+        datums = await self.list_datums()
+        if any(asset_id in getattr(datum, "asset_refs", {}).values() for datum in datums):
+            raise ValueError(f"Asset {asset_id} is still referenced by one or more datums")
         alias_rows = await self.asset_alias_database.find({"asset_id": asset_id})
         for row in alias_rows:
             await self.asset_alias_database.delete(row.id)
@@ -883,6 +886,9 @@ class AsyncDatalake(Mindtrace):
     ) -> AnnotationSet:
         if annotation_schema_id is not None:
             await self.get_annotation_schema(annotation_schema_id)
+        datum = None
+        if datum_id is not None:
+            datum = await self.get_datum(datum_id)
         annotation_set = self._build_document(
             AnnotationSet,
             name=name,
@@ -895,12 +901,18 @@ class AsyncDatalake(Mindtrace):
             updated_at=self._utc_now(),
         )
         inserted = await self.annotation_set_database.insert(annotation_set)
-        if datum_id is not None:
-            datum = await self.get_datum(datum_id)
+        if datum is not None:
             if inserted.annotation_set_id not in datum.annotation_set_ids:
                 datum.annotation_set_ids.append(inserted.annotation_set_id)
                 datum.updated_at = self._utc_now()
-                await self.datum_database.update(datum)
+                try:
+                    await self.datum_database.update(datum)
+                except Exception:
+                    try:
+                        await self.annotation_set_database.delete(inserted.id)
+                    except Exception:
+                        pass
+                    raise
         return inserted
 
     async def get_annotation_set(self, annotation_set_id: str) -> AnnotationSet:
@@ -1133,6 +1145,7 @@ class AsyncDatalake(Mindtrace):
         metadata: dict[str, Any] | None = None,
         annotation_set_ids: list[str] | None = None,
     ) -> Datum:
+        await self._validate_asset_refs_exist(asset_refs)
         datum = self._build_document(
             Datum,
             split=split,
@@ -1152,8 +1165,16 @@ class AsyncDatalake(Mindtrace):
     async def list_datums(self, filters: dict[str, Any] | None = None) -> list[Datum]:
         return await self.datum_database.find(filters or {})
 
+    async def _validate_asset_refs_exist(self, asset_refs: dict[str, str]) -> None:
+        for asset_id in asset_refs.values():
+            if not str(asset_id).strip():
+                continue
+            await self.get_asset(asset_id)
+
     async def update_datum(self, datum_id: str, **changes: Any) -> Datum:
         datum = await self.get_datum(datum_id)
+        if "asset_refs" in changes and changes["asset_refs"] is not None:
+            await self._validate_asset_refs_exist(changes["asset_refs"])
         for key, value in changes.items():
             setattr(datum, key, value)
         datum.updated_at = self._utc_now()

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -1152,6 +1152,8 @@ class AsyncDatalake(Mindtrace):
         annotation_set_ids: list[str] | None = None,
     ) -> Datum:
         await self._validate_asset_refs_exist(asset_refs)
+        for annotation_set_id in annotation_set_ids or []:
+            await self.get_annotation_set(annotation_set_id)
         datum = self._build_document(
             Datum,
             split=split,

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -548,6 +548,9 @@ class AsyncDatalake(Mindtrace):
         datums = await self.list_datums()
         if any(asset_id in getattr(datum, "asset_refs", {}).values() for datum in datums):
             raise ValueError(f"Asset {asset_id} is still referenced by one or more datums")
+        collection_items = await self.collection_item_database.find({"asset_id": asset_id})
+        if collection_items:
+            raise ValueError(f"Asset {asset_id} is still referenced by one or more collection items")
         alias_rows = await self.asset_alias_database.find({"asset_id": asset_id})
         for row in alias_rows:
             await self.asset_alias_database.delete(row.id)

--- a/mindtrace/datalake/mindtrace/datalake/replication.py
+++ b/mindtrace/datalake/mindtrace/datalake/replication.py
@@ -30,6 +30,12 @@ def _apply_mount_map_to_storage_ref(storage_ref: StorageRef, mount_map: dict[str
     return StorageRef(mount=mapped, name=storage_ref.name, version=storage_ref.version)
 
 
+def _storage_refs_equivalent(a: StorageRef, b: StorageRef) -> bool:
+    av = a.version if a.version is not None else "latest"
+    bv = b.version if b.version is not None else "latest"
+    return a.mount == b.mount and a.name == b.name and av == bv
+
+
 def _head_object_size_bytes(meta: dict[str, Any]) -> int | None:
     for key in ("size_bytes", "size", "content_length", "ContentLength"):
         val = meta.get(key)
@@ -128,6 +134,14 @@ class ReplicationManager:
         merged["replication"] = state.model_dump(mode="json")
         return merged
 
+    @staticmethod
+    def _should_preserve_verified_payload(existing_asset: Asset, new_asset: Asset, mapped_storage_ref: StorageRef) -> bool:
+        if ReplicationManager.get_payload_status(existing_asset) != "verified":
+            return False
+        if not _storage_refs_equivalent(existing_asset.storage_ref, mapped_storage_ref):
+            return False
+        return existing_asset.checksum == new_asset.checksum and existing_asset.size_bytes == new_asset.size_bytes
+
     async def upsert_metadata_batch(self, request: ReplicationBatchRequest) -> ReplicationBatchResult:
         result = ReplicationBatchResult()
 
@@ -153,20 +167,34 @@ class ReplicationManager:
 
         for asset in request.assets:
             mapped_storage_ref = _apply_mount_map_to_storage_ref(asset.storage_ref, request.mount_map)
+            existing_asset = None
+            try:
+                existing_asset = await self.target.get_asset(asset.asset_id)
+            except DocumentNotFoundError:
+                pass
+
+            metadata_for_replication = dict(asset.metadata or {})
+            payload_status: PayloadStatus = "pending"
+            if existing_asset is not None and self._should_preserve_verified_payload(existing_asset, asset, mapped_storage_ref):
+                existing_replication = (existing_asset.metadata or {}).get("replication")
+                if isinstance(existing_replication, dict):
+                    metadata_for_replication["replication"] = dict(existing_replication)
+                payload_status = "verified"
+
             replicated = Asset.model_validate(
                 {
                     **asset.model_dump(),
                     "storage_ref": mapped_storage_ref.model_dump(),
                     "metadata": self.build_asset_replication_metadata(
-                        asset.metadata,
+                        metadata_for_replication,
                         origin_lake_id=request.origin_lake_id,
                         origin_asset_id=asset.asset_id,
                         replication_mode=request.replication_mode,
-                        payload_status="pending",
+                        payload_status=payload_status,
                     ),
                 }
             )
-            if await self._asset_exists(asset.asset_id):
+            if existing_asset is not None:
                 await self._update_asset(replicated)
                 result.updated_assets += 1
             else:

--- a/mindtrace/datalake/mindtrace/datalake/replication.py
+++ b/mindtrace/datalake/mindtrace/datalake/replication.py
@@ -135,7 +135,9 @@ class ReplicationManager:
         return merged
 
     @staticmethod
-    def _should_preserve_verified_payload(existing_asset: Asset, new_asset: Asset, mapped_storage_ref: StorageRef) -> bool:
+    def _should_preserve_verified_payload(
+        existing_asset: Asset, new_asset: Asset, mapped_storage_ref: StorageRef
+    ) -> bool:
         if ReplicationManager.get_payload_status(existing_asset) != "verified":
             return False
         if not _storage_refs_equivalent(existing_asset.storage_ref, mapped_storage_ref):
@@ -175,7 +177,9 @@ class ReplicationManager:
 
             metadata_for_replication = dict(asset.metadata or {})
             payload_status: PayloadStatus = "pending"
-            if existing_asset is not None and self._should_preserve_verified_payload(existing_asset, asset, mapped_storage_ref):
+            if existing_asset is not None and self._should_preserve_verified_payload(
+                existing_asset, asset, mapped_storage_ref
+            ):
                 existing_replication = (existing_asset.metadata or {}).get("replication")
                 if isinstance(existing_replication, dict):
                     metadata_for_replication["replication"] = dict(existing_replication)

--- a/mindtrace/registry/mindtrace/registry/__init__.py
+++ b/mindtrace/registry/mindtrace/registry/__init__.py
@@ -47,7 +47,6 @@ __all__ = [
     "RegistryBackend",
     "Store",
     "MountedRegistry",
-    "StoreMount",
     "StoreLocationNotFound",
     "StoreKeyFormatError",
     "StoreAmbiguousObjectError",

--- a/mindtrace/registry/mindtrace/registry/core/_registry_core.py
+++ b/mindtrace/registry/mindtrace/registry/core/_registry_core.py
@@ -588,8 +588,7 @@ class _RegistryCore(Mindtrace):
                 object_class = getattr(module, class_name)
             except (ImportError, AttributeError, ValueError) as exc:
                 self.logger.warning(
-                    "Failed to resolve object class '%s' for materializer '%s'; "
-                    "falling back to typing.Any: %s",
+                    "Failed to resolve object class '%s' for materializer '%s'; falling back to typing.Any: %s",
                     object_class,
                     materializer_class,
                     exc,

--- a/mindtrace/registry/mindtrace/registry/core/_registry_core.py
+++ b/mindtrace/registry/mindtrace/registry/core/_registry_core.py
@@ -582,9 +582,19 @@ class _RegistryCore(Mindtrace):
         materializer = instantiate_target(materializer_class, uri=str(temp_dir), artifact_store=self._artifact_store)
 
         if isinstance(object_class, str):
-            module_name, class_name = object_class.rsplit(".", 1)
-            module = __import__(module_name, fromlist=[class_name])
-            object_class = getattr(module, class_name)
+            try:
+                module_name, class_name = object_class.rsplit(".", 1)
+                module = __import__(module_name, fromlist=[class_name])
+                object_class = getattr(module, class_name)
+            except (ImportError, AttributeError, ValueError) as exc:
+                self.logger.warning(
+                    "Failed to resolve object class '%s' for materializer '%s'; "
+                    "falling back to typing.Any: %s",
+                    object_class,
+                    materializer_class,
+                    exc,
+                )
+                object_class = Any
 
         return materializer.load(data_type=object_class, **init_params)
 

--- a/mindtrace/registry/mindtrace/registry/core/store.py
+++ b/mindtrace/registry/mindtrace/registry/core/store.py
@@ -568,7 +568,9 @@ class Store(Mindtrace):
         saved = self.copy(source, target=target, source_version=source_version, target_version=target_version)
 
         mount, name, key_version = self.parse_key(source)
-        resolved_source_version = source_version if source_version not in (None, "latest") else (key_version or source_version)
+        resolved_source_version = (
+            source_version if source_version not in (None, "latest") else (key_version or source_version)
+        )
         resolved_mount = mount or self._resolve_load_location(name, resolved_source_version)
 
         delete_version = resolved_source_version

--- a/mindtrace/registry/mindtrace/registry/core/store.py
+++ b/mindtrace/registry/mindtrace/registry/core/store.py
@@ -567,13 +567,15 @@ class Store(Mindtrace):
     ) -> str:
         saved = self.copy(source, target=target, source_version=source_version, target_version=target_version)
 
-        delete_version = source_version
-        if source_version == "latest":
-            mount, name, key_version = self.parse_key(source)
-            resolved_mount = mount or self._resolve_load_location(name, key_version or "latest")
+        mount, name, key_version = self.parse_key(source)
+        resolved_source_version = source_version if source_version not in (None, "latest") else (key_version or source_version)
+        resolved_mount = mount or self._resolve_load_location(name, resolved_source_version)
+
+        delete_version = resolved_source_version
+        if delete_version in (None, "latest"):
             delete_version = self.get_mount(resolved_mount).registry.list_versions(name)[-1]
 
-        self.delete(source, version=delete_version)
+        self.delete(self.build_key(resolved_mount, name), version=delete_version)
         return saved
 
     def __getitem__(self, key: str | list[str]) -> Any:

--- a/tests/integration/mindtrace/datalake/test_async_datalake_integration.py
+++ b/tests/integration/mindtrace/datalake/test_async_datalake_integration.py
@@ -159,6 +159,7 @@ async def test_async_datalake_end_to_end(async_datalake: AsyncDatalake):
     assert created_from_object.subject.id == asset.asset_id
 
     await async_datalake.delete_annotation_record(annotation_record.annotation_id)
+    await async_datalake.update_datum(datum.datum_id, asset_refs={})
     await async_datalake.delete_asset(created_from_object.asset_id)
     await async_datalake.delete_asset(asset.asset_id)
 

--- a/tests/integration/mindtrace/datalake/test_datalake_integration.py
+++ b/tests/integration/mindtrace/datalake/test_datalake_integration.py
@@ -156,6 +156,7 @@ def test_datalake_end_to_end(sync_datalake: Datalake):
     assert created_from_object.subject.id == asset.asset_id
 
     sync_datalake.delete_annotation_record(annotation_record.annotation_id)
+    sync_datalake.update_datum(datum.datum_id, asset_refs={})
     sync_datalake.delete_asset(created_from_object.asset_id)
     sync_datalake.delete_asset(asset.asset_id)
 

--- a/tests/integration/mindtrace/datalake/test_integrity_integration.py
+++ b/tests/integration/mindtrace/datalake/test_integrity_integration.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from mindtrace.database.core.exceptions import DocumentNotFoundError
+from mindtrace.datalake import AsyncDatalake
+
+
+async def _create_image_asset(datalake: AsyncDatalake, *, name: str):
+    image_bytes = Path("tests/resources/hopper.png").read_bytes()
+    storage_ref = await datalake.put_object(name=name, obj=image_bytes, metadata={"integration": "integrity"})
+    return await datalake.create_asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=storage_ref,
+        size_bytes=len(image_bytes),
+        metadata={"integration": "integrity", "name": name},
+        created_by="pytest-integrity",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_datum_rejects_missing_asset_refs(async_datalake: AsyncDatalake):
+    assert await async_datalake.list_datums() == []
+
+    with pytest.raises(DocumentNotFoundError):
+        await async_datalake.create_datum(asset_refs={"image": "missing_asset"}, split="train")
+
+    assert await async_datalake.list_datums() == []
+
+
+@pytest.mark.asyncio
+async def test_update_datum_rejects_missing_asset_refs(async_datalake: AsyncDatalake):
+    asset = await _create_image_asset(async_datalake, name=f"integrity/update/{uuid4().hex}.png")
+    datum = await async_datalake.create_datum(
+        asset_refs={"image": asset.asset_id},
+        split="train",
+        metadata={"integration": "integrity"},
+    )
+
+    with pytest.raises(DocumentNotFoundError):
+        await async_datalake.update_datum(datum.datum_id, asset_refs={"image": "missing_asset"})
+
+    refreshed = await async_datalake.get_datum(datum.datum_id)
+    assert refreshed.asset_refs == {"image": asset.asset_id}
+
+
+@pytest.mark.asyncio
+async def test_delete_asset_rejects_when_still_referenced_by_datum(async_datalake: AsyncDatalake):
+    asset = await _create_image_asset(async_datalake, name=f"integrity/delete/{uuid4().hex}.png")
+    datum = await async_datalake.create_datum(
+        asset_refs={"image": asset.asset_id},
+        split="train",
+        metadata={"integration": "integrity"},
+    )
+
+    with pytest.raises(ValueError, match="still referenced"):
+        await async_datalake.delete_asset(asset.asset_id)
+
+    refreshed_asset = await async_datalake.get_asset(asset.asset_id)
+    refreshed_datum = await async_datalake.get_datum(datum.datum_id)
+    assert refreshed_asset.asset_id == asset.asset_id
+    assert refreshed_datum.asset_refs["image"] == asset.asset_id
+
+
+@pytest.mark.asyncio
+async def test_create_annotation_set_with_missing_datum_is_atomic(async_datalake: AsyncDatalake):
+    assert await async_datalake.list_annotation_sets() == []
+
+    with pytest.raises(DocumentNotFoundError):
+        await async_datalake.create_annotation_set(
+            name="orphan-guard",
+            purpose="ground_truth",
+            source_type="human",
+            datum_id="missing_datum",
+        )
+
+    assert await async_datalake.list_annotation_sets() == []
+
+
+@pytest.mark.asyncio
+async def test_create_annotation_set_links_to_datum_exactly_once(async_datalake: AsyncDatalake):
+    asset = await _create_image_asset(async_datalake, name=f"integrity/annotation-set/{uuid4().hex}.png")
+    datum = await async_datalake.create_datum(
+        asset_refs={"image": asset.asset_id},
+        split="train",
+        metadata={"integration": "integrity"},
+    )
+
+    annotation_set = await async_datalake.create_annotation_set(
+        name="linked-set",
+        purpose="ground_truth",
+        source_type="human",
+        datum_id=datum.datum_id,
+        metadata={"integration": "integrity"},
+    )
+
+    refreshed = await async_datalake.get_datum(datum.datum_id)
+    fetched_set = await async_datalake.get_annotation_set(annotation_set.annotation_set_id)
+
+    assert refreshed.annotation_set_ids.count(annotation_set.annotation_set_id) == 1
+    assert fetched_set.annotation_set_id == annotation_set.annotation_set_id

--- a/tests/integration/mindtrace/datalake/test_integrity_integration.py
+++ b/tests/integration/mindtrace/datalake/test_integrity_integration.py
@@ -101,3 +101,156 @@ async def test_create_annotation_set_links_to_datum_exactly_once(async_datalake:
 
     assert refreshed.annotation_set_ids.count(annotation_set.annotation_set_id) == 1
     assert fetched_set.annotation_set_id == annotation_set.annotation_set_id
+
+
+@pytest.mark.asyncio
+async def test_delete_collection_cascades_collection_items(async_datalake: AsyncDatalake):
+    asset = await _create_image_asset(async_datalake, name=f"integrity/collection-orphan/{uuid4().hex}.png")
+    collection = await async_datalake.create_collection(
+        name=f"integrity-collection-{uuid4().hex[:8]}",
+        metadata={"integration": "integrity"},
+        created_by="pytest-integrity",
+    )
+    collection_item = await async_datalake.create_collection_item(
+        collection_id=collection.collection_id,
+        asset_id=asset.asset_id,
+        split="train",
+        metadata={"integration": "integrity"},
+        added_by="pytest-integrity",
+    )
+
+    await async_datalake.delete_collection(collection.collection_id)
+
+    with pytest.raises(DocumentNotFoundError, match="Collection with collection_id"):
+        await async_datalake.get_collection(collection.collection_id)
+
+    with pytest.raises(DocumentNotFoundError, match="CollectionItem with collection_item_id"):
+        await async_datalake.get_collection_item(collection_item.collection_item_id)
+
+    assert await async_datalake.list_collection_items({"collection_id": collection.collection_id}) == []
+
+
+@pytest.mark.asyncio
+async def test_delete_asset_rejects_when_still_referenced_by_collection_item(async_datalake: AsyncDatalake):
+    asset = await _create_image_asset(async_datalake, name=f"integrity/asset-orphan/{uuid4().hex}.png")
+    collection = await async_datalake.create_collection(
+        name=f"integrity-collection-{uuid4().hex[:8]}",
+        metadata={"integration": "integrity"},
+        created_by="pytest-integrity",
+    )
+    collection_item = await async_datalake.create_collection_item(
+        collection_id=collection.collection_id,
+        asset_id=asset.asset_id,
+        split="train",
+        metadata={"integration": "integrity"},
+        added_by="pytest-integrity",
+    )
+
+    with pytest.raises(ValueError, match="still referenced"):
+        await async_datalake.delete_asset(asset.asset_id)
+
+    refreshed_asset = await async_datalake.get_asset(asset.asset_id)
+    refreshed_item = await async_datalake.get_collection_item(collection_item.collection_item_id)
+    assert refreshed_asset.asset_id == asset.asset_id
+    assert refreshed_item.asset_id == asset.asset_id
+
+
+@pytest.mark.asyncio
+async def test_create_datum_rejects_missing_annotation_set_ids(async_datalake: AsyncDatalake):
+    asset = await _create_image_asset(async_datalake, name=f"integrity/missing-ann-set-create/{uuid4().hex}.png")
+
+    assert await async_datalake.list_datums() == []
+
+    with pytest.raises(DocumentNotFoundError, match="AnnotationSet with annotation_set_id"):
+        await async_datalake.create_datum(
+            asset_refs={"image": asset.asset_id},
+            split="train",
+            metadata={"integration": "integrity"},
+            annotation_set_ids=["missing_annotation_set"],
+        )
+
+    assert await async_datalake.list_datums() == []
+
+
+@pytest.mark.asyncio
+async def test_update_datum_rejects_missing_annotation_set_ids(async_datalake: AsyncDatalake):
+    asset = await _create_image_asset(async_datalake, name=f"integrity/missing-ann-set-update/{uuid4().hex}.png")
+    datum = await async_datalake.create_datum(
+        asset_refs={"image": asset.asset_id},
+        split="train",
+        metadata={"integration": "integrity"},
+    )
+
+    with pytest.raises(DocumentNotFoundError, match="AnnotationSet with annotation_set_id"):
+        await async_datalake.update_datum(datum.datum_id, annotation_set_ids=["missing_annotation_set"])
+
+    persisted = await async_datalake.get_datum(datum.datum_id)
+    assert persisted.annotation_set_ids == []
+
+
+@pytest.mark.asyncio
+async def test_create_dataset_version_rejects_missing_manifest_datum_ids(async_datalake: AsyncDatalake):
+    dataset_name = f"integrity-missing-datum-{uuid4().hex[:10]}"
+
+    with pytest.raises(DocumentNotFoundError, match="Datum with datum_id missing_datum not found"):
+        await async_datalake.create_dataset_version(
+            dataset_name=dataset_name,
+            version="1.0.0",
+            manifest=["missing_datum"],
+            metadata={"integration": "integrity"},
+            created_by="pytest-integrity",
+        )
+
+    assert await async_datalake.list_dataset_versions(dataset_name=dataset_name) == []
+
+
+@pytest.mark.asyncio
+async def test_create_dataset_version_rejects_duplicate_manifest_datum_ids(async_datalake: AsyncDatalake):
+    asset = await _create_image_asset(async_datalake, name=f"integrity/duplicate-manifest/{uuid4().hex}.png")
+    datum = await async_datalake.create_datum(
+        asset_refs={"image": asset.asset_id},
+        split="train",
+        metadata={"integration": "integrity"},
+    )
+    dataset_name = f"integrity-duplicate-manifest-{uuid4().hex[:10]}"
+
+    with pytest.raises(ValueError):
+        await async_datalake.create_dataset_version(
+            dataset_name=dataset_name,
+            version="1.0.0",
+            manifest=[datum.datum_id, datum.datum_id],
+            metadata={"integration": "integrity"},
+            created_by="pytest-integrity",
+        )
+
+    assert await async_datalake.list_dataset_versions(dataset_name=dataset_name) == []
+
+
+@pytest.mark.asyncio
+async def test_create_datum_rejects_blank_asset_ref(async_datalake: AsyncDatalake):
+    assert await async_datalake.list_datums() == []
+
+    with pytest.raises(ValueError, match="non-empty"):
+        await async_datalake.create_datum(
+            asset_refs={"image": ""},
+            split="train",
+            metadata={"integration": "integrity"},
+        )
+
+    assert await async_datalake.list_datums() == []
+
+
+@pytest.mark.asyncio
+async def test_update_datum_rejects_blank_asset_ref(async_datalake: AsyncDatalake):
+    asset = await _create_image_asset(async_datalake, name=f"integrity/blank-asset-ref-update/{uuid4().hex}.png")
+    datum = await async_datalake.create_datum(
+        asset_refs={"image": asset.asset_id},
+        split="train",
+        metadata={"integration": "integrity"},
+    )
+
+    with pytest.raises(ValueError, match="non-empty"):
+        await async_datalake.update_datum(datum.datum_id, asset_refs={"image": "   "})
+
+    persisted = await async_datalake.get_datum(datum.datum_id)
+    assert persisted.asset_refs == {"image": asset.asset_id}

--- a/tests/integration/mindtrace/datalake/test_replication_integration.py
+++ b/tests/integration/mindtrace/datalake/test_replication_integration.py
@@ -121,6 +121,28 @@ async def _assert_target_bytes_match_source(
         assert tgt_asset.checksum == src_asset.checksum
 
 
+async def _replicate_asset_to_verified(
+    *,
+    source: AsyncDatalake,
+    target: AsyncDatalake,
+    manager: ReplicationManager,
+    asset_name: str,
+):
+    asset = await _create_image_asset(source, name=asset_name)
+    await manager.upsert_metadata_batch(
+        ReplicationBatchRequest(
+            assets=[asset],
+            origin_lake_id=source.mongo_db_name,
+            mount_map=_MOUNT_MAP_LOCAL_TO_MINIO,
+        )
+    )
+    await manager.reconcile_pending_payloads(ReplicationReconcileRequest(mount_map=_MOUNT_MAP_LOCAL_TO_MINIO))
+    await _drain_pending_payloads(manager, _MOUNT_MAP_LOCAL_TO_MINIO)
+    target_asset = await target.get_asset(asset.asset_id)
+    assert ReplicationManager.get_payload_status(target_asset) == "verified"
+    return asset, target_asset
+
+
 def test_mongodb_secondary_container_accept_connections() -> None:
     """Sanity-check the compose ``mongodb_secondary`` service used by the MinIO-on-secondary-Mongo fixture."""
     if not _mongo_secondary_reachable():
@@ -220,6 +242,73 @@ async def test_replication_concurrent_hydration_gather_local_to_minio(
 
 
 @pytest.mark.asyncio
+async def test_replication_reupsert_preserves_verified_payload_state(
+    async_datalake: AsyncDatalake,
+    async_datalake_minio_secondary_mongo: AsyncDatalake,
+):
+    source = async_datalake
+    target = async_datalake_minio_secondary_mongo
+    manager = ReplicationManager(source, target)
+
+    asset, verified_target_asset = await _replicate_asset_to_verified(
+        source=source,
+        target=target,
+        manager=manager,
+        asset_name=f"replication/reupsert/state_{uuid4().hex}.png",
+    )
+    verified_storage_ref = verified_target_asset.storage_ref
+    verified_bytes = await target.get_object(verified_storage_ref)
+
+    await manager.upsert_metadata_batch(
+        ReplicationBatchRequest(
+            assets=[asset],
+            origin_lake_id=source.mongo_db_name,
+            mount_map=_MOUNT_MAP_LOCAL_TO_MINIO,
+        )
+    )
+
+    refreshed_target_asset = await target.get_asset(asset.asset_id)
+    assert ReplicationManager.get_payload_status(refreshed_target_asset) == "verified"
+    assert ReplicationManager.is_payload_available(refreshed_target_asset) is True
+    assert refreshed_target_asset.storage_ref == verified_storage_ref
+    assert await target.get_object(refreshed_target_asset.storage_ref) == verified_bytes
+
+
+@pytest.mark.asyncio
+async def test_replication_reconcile_after_reupsert_skips_verified_asset(
+    async_datalake: AsyncDatalake,
+    async_datalake_minio_secondary_mongo: AsyncDatalake,
+):
+    source = async_datalake
+    target = async_datalake_minio_secondary_mongo
+    manager = ReplicationManager(source, target)
+
+    asset, _ = await _replicate_asset_to_verified(
+        source=source,
+        target=target,
+        manager=manager,
+        asset_name=f"replication/reupsert/reconcile_{uuid4().hex}.png",
+    )
+
+    await manager.upsert_metadata_batch(
+        ReplicationBatchRequest(
+            assets=[asset],
+            origin_lake_id=source.mongo_db_name,
+            mount_map=_MOUNT_MAP_LOCAL_TO_MINIO,
+        )
+    )
+
+    reconcile_result = await manager.reconcile_pending_payloads(
+        ReplicationReconcileRequest(asset_ids=[asset.asset_id], mount_map=_MOUNT_MAP_LOCAL_TO_MINIO)
+    )
+
+    assert reconcile_result.attempted_asset_ids == []
+    assert reconcile_result.verified_asset_ids == []
+    assert reconcile_result.failed_asset_ids == []
+    assert reconcile_result.skipped_asset_ids == [asset.asset_id]
+
+
+@pytest.mark.asyncio
 async def test_replication_mark_local_delete_eligible_requires_verified_target_payload(
     async_datalake: AsyncDatalake,
     async_datalake_minio_secondary_mongo: AsyncDatalake,
@@ -288,3 +377,35 @@ async def test_replication_reclaim_verified_payloads_tombstones_source_and_keeps
 
     status = await manager.status()
     assert asset.asset_id in status.metadata["local_deleted_asset_ids"]
+
+
+@pytest.mark.asyncio
+async def test_replication_reclaim_is_idempotent_after_source_tombstoned(
+    async_datalake: AsyncDatalake,
+    async_datalake_minio_secondary_mongo: AsyncDatalake,
+):
+    source = async_datalake
+    target = async_datalake_minio_secondary_mongo
+    manager = ReplicationManager(source, target)
+
+    asset, target_asset = await _replicate_asset_to_verified(
+        source=source,
+        target=target,
+        manager=manager,
+        asset_name=f"replication/reclaim/idempotent_{uuid4().hex}.png",
+    )
+    target_bytes = await target.get_object(target_asset.storage_ref)
+
+    first = await manager.reclaim_verified_payloads(ReplicationReclaimRequest(asset_ids=[asset.asset_id], limit=1))
+    second = await manager.reclaim_verified_payloads(ReplicationReclaimRequest(asset_ids=[asset.asset_id], limit=1))
+
+    assert first.reclaimed_asset_ids == [asset.asset_id]
+    assert second.attempted_asset_ids == []
+    assert second.reclaimed_asset_ids == []
+    assert second.failed_asset_ids == []
+    assert second.skipped_asset_ids == [asset.asset_id]
+
+    source_asset = await source.get_asset(asset.asset_id)
+    assert source_asset.storage_ref == LOCAL_PAYLOAD_TOMBSTONE_STORAGE_REF
+    assert ReplicationManager.is_local_deleted(source_asset) is True
+    assert await target.get_object(target_asset.storage_ref) == target_bytes

--- a/tests/integration/mindtrace/datalake/test_replication_integration.py
+++ b/tests/integration/mindtrace/datalake/test_replication_integration.py
@@ -27,7 +27,13 @@ import pytest
 from pymongo import MongoClient
 
 from mindtrace.datalake import AsyncDatalake, ReplicationManager
-from mindtrace.datalake.replication_types import ReplicationBatchRequest, ReplicationReconcileRequest
+from mindtrace.datalake.replication import LOCAL_PAYLOAD_TOMBSTONE_STORAGE_REF
+from mindtrace.datalake.replication_types import (
+    ReplicationBatchRequest,
+    ReplicationReclaimRequest,
+    ReplicationReconcileRequest,
+)
+from mindtrace.registry import StoreLocationNotFound
 from tests.integration.mindtrace.datalake.conftest import MONGO_URL, MONGO_URL_SECONDARY
 
 _MOUNT_MAP_LOCAL_TO_MINIO = {"local": "minio"}
@@ -211,3 +217,74 @@ async def test_replication_concurrent_hydration_gather_local_to_minio(
 
     await _drain_pending_payloads(manager, _MOUNT_MAP_LOCAL_TO_MINIO)
     await _assert_target_bytes_match_source(source=source, target=target, asset_ids=[a.asset_id for a in assets])
+
+
+@pytest.mark.asyncio
+async def test_replication_mark_local_delete_eligible_requires_verified_target_payload(
+    async_datalake: AsyncDatalake,
+    async_datalake_minio_secondary_mongo: AsyncDatalake,
+):
+    source = async_datalake
+    target = async_datalake_minio_secondary_mongo
+    manager = ReplicationManager(source, target)
+
+    asset = await _create_image_asset(source, name=f"replication/reclaim/pending_{uuid4().hex}.png")
+    await manager.upsert_metadata_batch(
+        ReplicationBatchRequest(
+            assets=[asset],
+            origin_lake_id=source.mongo_db_name,
+            mount_map=_MOUNT_MAP_LOCAL_TO_MINIO,
+        )
+    )
+
+    target_asset = await target.get_asset(asset.asset_id)
+    assert ReplicationManager.get_payload_status(target_asset) == "pending"
+
+    with pytest.raises(RuntimeError, match="not delete-eligible until target payload is verified"):
+        await manager.mark_local_delete_eligible(asset.asset_id)
+
+
+@pytest.mark.asyncio
+async def test_replication_reclaim_verified_payloads_tombstones_source_and_keeps_target_readable(
+    async_datalake: AsyncDatalake,
+    async_datalake_minio_secondary_mongo: AsyncDatalake,
+):
+    source = async_datalake
+    target = async_datalake_minio_secondary_mongo
+    manager = ReplicationManager(source, target)
+
+    asset = await _create_image_asset(source, name=f"replication/reclaim/verified_{uuid4().hex}.png")
+    source_bytes = await source.get_object(asset.storage_ref)
+
+    await manager.upsert_metadata_batch(
+        ReplicationBatchRequest(
+            assets=[asset],
+            origin_lake_id=source.mongo_db_name,
+            mount_map=_MOUNT_MAP_LOCAL_TO_MINIO,
+        )
+    )
+    await manager.reconcile_pending_payloads(ReplicationReconcileRequest(mount_map=_MOUNT_MAP_LOCAL_TO_MINIO))
+    await _drain_pending_payloads(manager, _MOUNT_MAP_LOCAL_TO_MINIO)
+
+    reclaim_result = await manager.reclaim_verified_payloads(
+        ReplicationReclaimRequest(asset_ids=[asset.asset_id], limit=1)
+    )
+
+    assert reclaim_result.attempted_asset_ids == [asset.asset_id]
+    assert reclaim_result.reclaimed_asset_ids == [asset.asset_id]
+    assert reclaim_result.failed_asset_ids == []
+
+    source_asset = await source.get_asset(asset.asset_id)
+    assert source_asset.storage_ref == LOCAL_PAYLOAD_TOMBSTONE_STORAGE_REF
+    assert ReplicationManager.is_local_deleted(source_asset) is True
+
+    with pytest.raises(StoreLocationNotFound):
+        await source.get_object(source_asset.storage_ref)
+
+    target_asset = await target.get_asset(asset.asset_id)
+    assert ReplicationManager.get_payload_status(target_asset) == "verified"
+    target_bytes = await target.get_object(target_asset.storage_ref)
+    assert target_bytes == source_bytes
+
+    status = await manager.status()
+    assert asset.asset_id in status.metadata["local_deleted_asset_ids"]

--- a/tests/integration/mindtrace/datalake/test_service_integration.py
+++ b/tests/integration/mindtrace/datalake/test_service_integration.py
@@ -499,6 +499,11 @@ class TestDatalakeServiceIntegration:
             )
             is None
         )
+        detached_datum = datalake_service_local_manager.datums_update(
+            datum_id=datum.datum.datum_id,
+            changes={"asset_refs": {}},
+        )
+        assert detached_datum.datum.asset_refs == {}
         assert datalake_service_local_manager.assets_delete(id=created_from_object.asset.asset_id) is None
         assert datalake_service_local_manager.assets_delete(id=asset.asset.asset_id) is None
 

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -455,6 +455,7 @@ class TestAsyncDatalakeUnit:
         assert await async_datalake.list_assets({"kind": "image"}) == [asset]
         updated = await async_datalake.update_asset_metadata(asset.asset_id, {"source": "demo"})
         assert updated.metadata == {"source": "demo"}
+        async_datalake.list_datums = AsyncMock(return_value=[])
         await async_datalake.delete_asset(asset.asset_id)
         mock_odm.delete.assert_awaited_with("db-id")
 
@@ -479,9 +480,7 @@ class TestAsyncDatalakeUnit:
 
         annotation_set = AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
         annotation_set.annotation_record_ids = []
-        self._patch_datum_find_for_annotation_set_merge(
-            mock_odm, annotation_set.annotation_set_id, image_asset_id="asset_123"
-        )
+        self._patch_datum_find_for_annotation_set_merge(mock_odm, annotation_set.annotation_set_id, image_asset_id="asset_123")
         async_datalake.get_annotation_set = AsyncMock(return_value=annotation_set)
         inserted_model = AnnotationRecord(
             kind="bbox", label="dent", source={"type": "human", "name": "review-ui"}, geometry={}
@@ -501,6 +500,24 @@ class TestAsyncDatalakeUnit:
         )
         assert inserted == [inserted_model, inserted_dict]
         assert annotation_set.annotation_record_ids == ["annotation_model", "annotation_dict"]
+
+    @pytest.mark.asyncio
+    async def test_create_annotation_set_rolls_back_when_datum_update_fails(self, async_datalake, mock_odm):
+        datum = Datum(asset_refs={"image": "asset_123"})
+        datum.annotation_set_ids = []
+        async_datalake.get_datum = AsyncMock(return_value=datum)
+        async_datalake.annotation_set_database.delete = AsyncMock()
+        async_datalake.datum_database.update = AsyncMock(side_effect=RuntimeError("datum update failed"))
+
+        with pytest.raises(RuntimeError, match="datum update failed"):
+            await async_datalake.create_annotation_set(
+                name="gt",
+                purpose="ground_truth",
+                source_type="human",
+                datum_id=datum.datum_id,
+            )
+
+        async_datalake.annotation_set_database.delete.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_add_annotation_records_without_set_requires_asset_subject(self, async_datalake, mock_odm):
@@ -773,6 +790,9 @@ class TestAsyncDatalakeUnit:
 
     @pytest.mark.asyncio
     async def test_datum_crud_async(self, async_datalake, mock_odm):
+        async_datalake.get_asset = AsyncMock(
+            return_value=Asset(kind="image", media_type="image/png", storage_ref=StorageRef(mount="temp", name="x"))
+        )
         datum = await async_datalake.create_datum(
             asset_refs={"image": "asset_1"}, split="train", metadata={"source": "demo"}, annotation_set_ids=["set_1"]
         )
@@ -783,6 +803,29 @@ class TestAsyncDatalakeUnit:
         assert await async_datalake.list_datums({"split": "train"}) == [datum]
         updated = await async_datalake.update_datum(datum.datum_id, metadata={"source": "updated"})
         assert updated.metadata == {"source": "updated"}
+
+    @pytest.mark.asyncio
+    async def test_update_datum_validates_asset_refs(self, async_datalake):
+        datum = Datum(asset_refs={"image": "asset_1"})
+        async_datalake.get_datum = AsyncMock(return_value=datum)
+        async_datalake.get_asset = AsyncMock(
+            return_value=Asset(kind="image", media_type="image/png", storage_ref=StorageRef(mount="temp", name="x"))
+        )
+
+        await async_datalake.update_datum(datum.datum_id, asset_refs={"image": "asset_2"})
+
+        async_datalake.get_asset.assert_awaited_once_with("asset_2")
+
+    @pytest.mark.asyncio
+    async def test_delete_asset_raises_when_still_referenced_by_datum(self, async_datalake):
+        asset = Asset(kind="image", media_type="image/png", storage_ref=StorageRef(mount="temp", name="x"))
+        asset.id = "db-asset"
+        datum = Datum(asset_refs={"image": asset.asset_id})
+        async_datalake.get_asset = AsyncMock(return_value=asset)
+        async_datalake.list_datums = AsyncMock(return_value=[datum])
+
+        with pytest.raises(ValueError, match="still referenced"):
+            await async_datalake.delete_asset(asset.asset_id)
 
     @pytest.mark.asyncio
     async def test_get_datum_raises_when_missing(self, async_datalake, mock_odm):
@@ -1052,9 +1095,7 @@ class TestAsyncDatalakeUnit:
             )
 
     @pytest.mark.asyncio
-    async def test_add_annotation_records_is_atomic_when_schema_validation_fails_mid_batch(
-        self, async_datalake, mock_odm
-    ):
+    async def test_add_annotation_records_is_atomic_when_schema_validation_fails_mid_batch(self, async_datalake, mock_odm):
         schema = AnnotationSchema(
             name="bbox-demo",
             version="1.0.0",
@@ -1444,9 +1485,7 @@ class TestAsyncDatalakeUnit:
         async_datalake.annotation_record_database.delete.assert_awaited_once_with("db-success")
 
     @pytest.mark.asyncio
-    async def test_add_annotation_records_set_without_datum_link_requires_explicit_subject(
-        self, async_datalake, mock_odm
-    ):
+    async def test_add_annotation_records_set_without_datum_link_requires_explicit_subject(self, async_datalake, mock_odm):
         annotation_set = AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
         async_datalake.get_annotation_set = AsyncMock(return_value=annotation_set)
         mock_odm.find = AsyncMock(return_value=[])
@@ -1568,9 +1607,7 @@ class TestAsyncDatalakeUnit:
         annotation_set = AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
         async_datalake.get_annotation_set = AsyncMock(return_value=annotation_set)
         self._patch_datum_find_for_annotation_set_merge(
-            mock_odm,
-            annotation_set.annotation_set_id,
-            image_asset_id="datum_default_image",
+            mock_odm, annotation_set.annotation_set_id, image_asset_id="datum_default_image",
         )
         explicit = SubjectRef(kind="asset", id="user_chosen")
         inserted_dict = AnnotationRecord(

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -482,7 +482,9 @@ class TestAsyncDatalakeUnit:
 
         annotation_set = AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
         annotation_set.annotation_record_ids = []
-        self._patch_datum_find_for_annotation_set_merge(mock_odm, annotation_set.annotation_set_id, image_asset_id="asset_123")
+        self._patch_datum_find_for_annotation_set_merge(
+            mock_odm, annotation_set.annotation_set_id, image_asset_id="asset_123"
+        )
         async_datalake.get_annotation_set = AsyncMock(return_value=annotation_set)
         inserted_model = AnnotationRecord(
             kind="bbox", label="dent", source={"type": "human", "name": "review-ui"}, geometry={}
@@ -1106,7 +1108,9 @@ class TestAsyncDatalakeUnit:
             )
 
     @pytest.mark.asyncio
-    async def test_add_annotation_records_is_atomic_when_schema_validation_fails_mid_batch(self, async_datalake, mock_odm):
+    async def test_add_annotation_records_is_atomic_when_schema_validation_fails_mid_batch(
+        self, async_datalake, mock_odm
+    ):
         schema = AnnotationSchema(
             name="bbox-demo",
             version="1.0.0",
@@ -1496,7 +1500,9 @@ class TestAsyncDatalakeUnit:
         async_datalake.annotation_record_database.delete.assert_awaited_once_with("db-success")
 
     @pytest.mark.asyncio
-    async def test_add_annotation_records_set_without_datum_link_requires_explicit_subject(self, async_datalake, mock_odm):
+    async def test_add_annotation_records_set_without_datum_link_requires_explicit_subject(
+        self, async_datalake, mock_odm
+    ):
         annotation_set = AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
         async_datalake.get_annotation_set = AsyncMock(return_value=annotation_set)
         mock_odm.find = AsyncMock(return_value=[])
@@ -1618,7 +1624,9 @@ class TestAsyncDatalakeUnit:
         annotation_set = AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
         async_datalake.get_annotation_set = AsyncMock(return_value=annotation_set)
         self._patch_datum_find_for_annotation_set_merge(
-            mock_odm, annotation_set.annotation_set_id, image_asset_id="datum_default_image",
+            mock_odm,
+            annotation_set.annotation_set_id,
+            image_asset_id="datum_default_image",
         )
         explicit = SubjectRef(kind="asset", id="user_chosen")
         inserted_dict = AnnotationRecord(

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -455,7 +455,9 @@ class TestAsyncDatalakeUnit:
         assert await async_datalake.list_assets({"kind": "image"}) == [asset]
         updated = await async_datalake.update_asset_metadata(asset.asset_id, {"source": "demo"})
         assert updated.metadata == {"source": "demo"}
+        async_datalake.get_asset = AsyncMock(return_value=asset)
         async_datalake.list_datums = AsyncMock(return_value=[])
+        async_datalake.collection_item_database.find = AsyncMock(return_value=[])
         await async_datalake.delete_asset(asset.asset_id)
         mock_odm.delete.assert_awaited_with("db-id")
 
@@ -480,9 +482,7 @@ class TestAsyncDatalakeUnit:
 
         annotation_set = AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
         annotation_set.annotation_record_ids = []
-        self._patch_datum_find_for_annotation_set_merge(
-            mock_odm, annotation_set.annotation_set_id, image_asset_id="asset_123"
-        )
+        self._patch_datum_find_for_annotation_set_merge(mock_odm, annotation_set.annotation_set_id, image_asset_id="asset_123")
         async_datalake.get_annotation_set = AsyncMock(return_value=annotation_set)
         inserted_model = AnnotationRecord(
             kind="bbox", label="dent", source={"type": "human", "name": "review-ui"}, geometry={}
@@ -795,6 +795,9 @@ class TestAsyncDatalakeUnit:
         async_datalake.get_asset = AsyncMock(
             return_value=Asset(kind="image", media_type="image/png", storage_ref=StorageRef(mount="temp", name="x"))
         )
+        async_datalake.get_annotation_set = AsyncMock(
+            return_value=AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
+        )
         datum = await async_datalake.create_datum(
             asset_refs={"image": "asset_1"}, split="train", metadata={"source": "demo"}, annotation_set_ids=["set_1"]
         )
@@ -838,6 +841,12 @@ class TestAsyncDatalakeUnit:
     @pytest.mark.asyncio
     async def test_dataset_version_async(self, async_datalake, mock_odm):
         mock_odm.find.return_value = []
+        async_datalake.get_datum = AsyncMock(
+            side_effect=[
+                Datum(asset_refs={"image": "asset_1"}),
+                Datum(asset_refs={"image": "asset_2"}),
+            ]
+        )
         created = await async_datalake.create_dataset_version(
             dataset_name="demo", version="0.1.0", manifest=["datum_1", "datum_2"]
         )
@@ -1097,9 +1106,7 @@ class TestAsyncDatalakeUnit:
             )
 
     @pytest.mark.asyncio
-    async def test_add_annotation_records_is_atomic_when_schema_validation_fails_mid_batch(
-        self, async_datalake, mock_odm
-    ):
+    async def test_add_annotation_records_is_atomic_when_schema_validation_fails_mid_batch(self, async_datalake, mock_odm):
         schema = AnnotationSchema(
             name="bbox-demo",
             version="1.0.0",
@@ -1489,9 +1496,7 @@ class TestAsyncDatalakeUnit:
         async_datalake.annotation_record_database.delete.assert_awaited_once_with("db-success")
 
     @pytest.mark.asyncio
-    async def test_add_annotation_records_set_without_datum_link_requires_explicit_subject(
-        self, async_datalake, mock_odm
-    ):
+    async def test_add_annotation_records_set_without_datum_link_requires_explicit_subject(self, async_datalake, mock_odm):
         annotation_set = AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
         async_datalake.get_annotation_set = AsyncMock(return_value=annotation_set)
         mock_odm.find = AsyncMock(return_value=[])
@@ -1613,9 +1618,7 @@ class TestAsyncDatalakeUnit:
         annotation_set = AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
         async_datalake.get_annotation_set = AsyncMock(return_value=annotation_set)
         self._patch_datum_find_for_annotation_set_merge(
-            mock_odm,
-            annotation_set.annotation_set_id,
-            image_asset_id="datum_default_image",
+            mock_odm, annotation_set.annotation_set_id, image_asset_id="datum_default_image",
         )
         explicit = SubjectRef(kind="asset", id="user_chosen")
         inserted_dict = AnnotationRecord(

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -480,7 +480,9 @@ class TestAsyncDatalakeUnit:
 
         annotation_set = AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
         annotation_set.annotation_record_ids = []
-        self._patch_datum_find_for_annotation_set_merge(mock_odm, annotation_set.annotation_set_id, image_asset_id="asset_123")
+        self._patch_datum_find_for_annotation_set_merge(
+            mock_odm, annotation_set.annotation_set_id, image_asset_id="asset_123"
+        )
         async_datalake.get_annotation_set = AsyncMock(return_value=annotation_set)
         inserted_model = AnnotationRecord(
             kind="bbox", label="dent", source={"type": "human", "name": "review-ui"}, geometry={}
@@ -1095,7 +1097,9 @@ class TestAsyncDatalakeUnit:
             )
 
     @pytest.mark.asyncio
-    async def test_add_annotation_records_is_atomic_when_schema_validation_fails_mid_batch(self, async_datalake, mock_odm):
+    async def test_add_annotation_records_is_atomic_when_schema_validation_fails_mid_batch(
+        self, async_datalake, mock_odm
+    ):
         schema = AnnotationSchema(
             name="bbox-demo",
             version="1.0.0",
@@ -1485,7 +1489,9 @@ class TestAsyncDatalakeUnit:
         async_datalake.annotation_record_database.delete.assert_awaited_once_with("db-success")
 
     @pytest.mark.asyncio
-    async def test_add_annotation_records_set_without_datum_link_requires_explicit_subject(self, async_datalake, mock_odm):
+    async def test_add_annotation_records_set_without_datum_link_requires_explicit_subject(
+        self, async_datalake, mock_odm
+    ):
         annotation_set = AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
         async_datalake.get_annotation_set = AsyncMock(return_value=annotation_set)
         mock_odm.find = AsyncMock(return_value=[])
@@ -1607,7 +1613,9 @@ class TestAsyncDatalakeUnit:
         annotation_set = AnnotationSet(name="gt", purpose="ground_truth", source_type="human")
         async_datalake.get_annotation_set = AsyncMock(return_value=annotation_set)
         self._patch_datum_find_for_annotation_set_merge(
-            mock_odm, annotation_set.annotation_set_id, image_asset_id="datum_default_image",
+            mock_odm,
+            annotation_set.annotation_set_id,
+            image_asset_id="datum_default_image",
         )
         explicit = SubjectRef(kind="asset", id="user_chosen")
         inserted_dict = AnnotationRecord(

--- a/tests/unit/mindtrace/datalake/test_replication.py
+++ b/tests/unit/mindtrace/datalake/test_replication.py
@@ -222,6 +222,54 @@ class TestReplicationManager:
         assert existing_asset.metadata["replication"]["payload_status"] == "pending"
 
     @pytest.mark.asyncio
+    async def test_upsert_metadata_batch_preserves_verified_payload_for_unchanged_asset(
+        self, source_datalake, target_datalake, replication_objects
+    ):
+        verified_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        existing_asset = Asset.model_validate(
+            {
+                **replication_objects.asset.model_dump(),
+                "storage_ref": {"mount": "remote", "name": "images/cat.jpg", "version": "v1"},
+                "checksum": replication_objects.asset.checksum,
+                "size_bytes": replication_objects.asset.size_bytes,
+                "metadata": {
+                    "legacy": True,
+                    "replication": {
+                        "origin_lake_id": "source-lake",
+                        "origin_asset_id": replication_objects.asset.asset_id,
+                        "replication_mode": "metadata_first",
+                        "payload_status": "verified",
+                        "payload_available": True,
+                        "payload_verified_at": verified_at,
+                    },
+                },
+            }
+        )
+        target_datalake.get_asset = AsyncMock(return_value=existing_asset)
+        target_datalake.asset_database.find = AsyncMock(return_value=[existing_asset])
+
+        manager = ReplicationManager(source_datalake, target_datalake)
+        result = await manager.upsert_metadata_batch(
+            ReplicationBatchRequest(
+                assets=[
+                    Asset.model_validate(
+                        {
+                            **replication_objects.asset.model_dump(),
+                            "storage_ref": {"mount": "source", "name": "images/cat.jpg", "version": "v1"},
+                        }
+                    )
+                ],
+                origin_lake_id="source-lake",
+                mount_map={"source": "remote"},
+            )
+        )
+
+        assert result.updated_assets == 1
+        assert existing_asset.metadata["replication"]["payload_status"] == "verified"
+        assert existing_asset.metadata["replication"]["payload_available"] is True
+        assert existing_asset.metadata["replication"]["payload_verified_at"] == "2026-01-01T00:00:00Z"
+
+    @pytest.mark.asyncio
     async def test_status_counts_payload_states(self, source_datalake, target_datalake, replication_objects):
         pending_asset = Asset.model_validate(
             {

--- a/tests/unit/mindtrace/datalake/test_vault_serialization.py
+++ b/tests/unit/mindtrace/datalake/test_vault_serialization.py
@@ -57,6 +57,17 @@ def test_materialize_payload_with_hints_bytes(tmp_path: Path):
     assert out == raw
 
 
+def test_materialize_payload_with_hints_uses_any_for_stale_class_path(tmp_path: Path):
+    reg = Registry(tmp_path / "reg", version_objects=False, mutable=True)
+    raw = b"hello-bytes"
+    block = direct_bytes_serialization_block()
+    block["class"] = "missing.module.Type"
+
+    out = materialize_payload_with_hints(reg, raw, block)
+
+    assert out == raw
+
+
 def test_data_vault_load_materializes_with_mock_backend(tmp_path: Path):
     reg = Registry(tmp_path / "reg", version_objects=False, mutable=True)
     asset = Asset(

--- a/tests/unit/mindtrace/registry/core/test_mount.py
+++ b/tests/unit/mindtrace/registry/core/test_mount.py
@@ -460,3 +460,12 @@ def test_registry_package_lazily_exports_gcp_backend():
     gcp_backend = getattr(reloaded, "GCPRegistryBackend")
 
     assert gcp_backend.__name__ == "GCPRegistryBackend"
+
+
+def test_registry_package_star_import_succeeds():
+    reloaded = importlib.reload(registry_package)
+    namespace: dict[str, Any] = {}
+
+    exec("from mindtrace.registry import *", namespace, namespace)
+
+    assert namespace["MountedRegistry"] is reloaded.MountedRegistry

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -531,8 +531,7 @@ def test_registry_load_bytes_artifact_with_stale_class_metadata(registry, test_b
 
 
 def test_registry_load_cloudpickle_artifact_with_stale_class_metadata(registry):
-    def func(x):
-        return x + 1
+    func = lambda x: x + 1  # noqa: E731 - intentional lambda regression case
 
     registry.register_materializer(type(func), CloudpickleMaterializer)
 

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from pydantic import BaseModel
+from zenml.materializers import CloudpickleMaterializer
 
 from mindtrace.core import Config, compute_dir_hash
 from mindtrace.registry import LocalRegistryBackend, Registry, S3RegistryBackend
@@ -475,6 +476,61 @@ def test_load_without_class_metadata(registry, test_config):
     # Attempt to load the object with corrupted metadata - now raises KeyError
     with pytest.raises(KeyError, match="class"):
         registry.load("test:config", version="1.0.0")
+
+
+def _rewrite_registry_metadata(registry, name: str, version: str, **updates):
+    metadata_result = registry.backend.fetch_metadata(name, version)
+    metadata = dict(metadata_result[(name, version)].metadata)
+    metadata.update(updates)
+
+    import yaml
+
+    meta_path = registry.backend._object_metadata_path(name, version)
+    with open(meta_path, "w") as f:
+        yaml.safe_dump(metadata, f)
+
+
+def test_materialize_from_bytes_uses_any_when_class_path_is_not_importable(registry):
+    raw = b"hello-bytes"
+
+    out = registry._core.materialize_from_bytes(
+        raw,
+        object_class="missing.module.Type",
+        materializer="zenml.materializers.BytesMaterializer",
+    )
+
+    assert out == raw
+
+
+def test_registry_load_bytes_artifact_with_stale_class_metadata(registry, test_bytes):
+    registry.save("test:bytes", test_bytes, version="1.0.0")
+    _rewrite_registry_metadata(registry, "test:bytes", "1.0.0", **{"class": "missing.module.Type"})
+
+    assert registry.load("test:bytes", version="1.0.0") == test_bytes
+
+
+def test_registry_load_cloudpickle_artifact_with_stale_class_metadata(registry):
+    registry.register_materializer(type(lambda x: x), CloudpickleMaterializer)
+    func = lambda x: x + 1
+
+    registry.save("test:lambda", func, version="1.0.0")
+    _rewrite_registry_metadata(registry, "test:lambda", "1.0.0", **{"class": "missing.module.Type"})
+
+    loaded = registry.load("test:lambda", version="1.0.0")
+    assert loaded(1) == 2
+
+
+def test_registry_load_still_raises_when_materializer_cannot_be_imported(registry, test_bytes):
+    registry.save("test:bytes", test_bytes, version="1.0.0")
+    _rewrite_registry_metadata(
+        registry,
+        "test:bytes",
+        "1.0.0",
+        **{"materializer": "missing.module.Materializer"},
+    )
+
+    with pytest.raises(ModuleNotFoundError, match="missing"):
+        registry.load("test:bytes", version="1.0.0")
 
 
 def test_load_directory_with_contents(registry):

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -531,8 +531,10 @@ def test_registry_load_bytes_artifact_with_stale_class_metadata(registry, test_b
 
 
 def test_registry_load_cloudpickle_artifact_with_stale_class_metadata(registry):
-    registry.register_materializer(type(lambda x: x), CloudpickleMaterializer)
-    func = lambda x: x + 1
+    def func(x):
+        return x + 1
+
+    registry.register_materializer(type(func), CloudpickleMaterializer)
 
     registry.save("test:lambda", func, version="1.0.0")
     _rewrite_registry_metadata(registry, "test:lambda", "1.0.0", **{"class": "missing.module.Type"})

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -114,6 +114,27 @@ def test_registry_initialization(registry, temp_registry_dir):
     assert Path(temp_registry_dir).exists()
 
 
+def test_registry_serialization_hints_for_object_uses_core_materializer_lookup(registry, test_bytes):
+    hints = registry.serialization_hints_for_object(test_bytes)
+
+    assert hints == {
+        "class": "builtins.bytes",
+        "materializer": "zenml.materializers.BytesMaterializer",
+    }
+
+
+def test_registry_materialize_from_bytes_delegates_to_core(registry):
+    raw = b"hello-bytes"
+
+    out = registry.materialize_from_bytes(
+        raw,
+        object_class="builtins.bytes",
+        materializer="zenml.materializers.BytesMaterializer",
+    )
+
+    assert out == raw
+
+
 def test_registry_default_directory():
     """Test that Registry uses the default directory from config when registry_dir is None."""
     # Create a registry without specifying registry_dir

--- a/tests/unit/mindtrace/registry/core/test_store.py
+++ b/tests/unit/mindtrace/registry/core/test_store.py
@@ -25,6 +25,19 @@ def basic_store():
         yield store
 
 
+@pytest.fixture
+def versioned_store():
+    with TemporaryDirectory() as d1, TemporaryDirectory() as d2:
+        store = Store(
+            mounts={
+                "a": Registry(backend=Path(d1), version_objects=True, mutable=True),
+                "b": Registry(backend=Path(d2), version_objects=True, mutable=True),
+            },
+            default_mount="a",
+        )
+        yield store
+
+
 def test_parse_key_with_and_without_mount(basic_store):
     assert basic_store.parse_key("a/foo@1") == ("a", "foo", "1")
     assert basic_store.parse_key("foo@2") == (None, "foo", "2")
@@ -105,6 +118,43 @@ def test_copy_and_move_between_mounts(basic_store):
     assert basic_store.load("a/moved")["v"] == 1
     with pytest.raises(RegistryObjectNotFound):
         basic_store.load("b/copied")
+
+
+def test_move_unqualified_source_deletes_from_resolved_mount(basic_store):
+    basic_store.save("b/original", {"v": "from-b"})
+
+    moved_version = basic_store.move("original", target="a/moved")
+
+    assert moved_version is not None
+    assert basic_store.load("a/moved")["v"] == "from-b"
+    with pytest.raises(RegistryObjectNotFound):
+        basic_store.load("b/original")
+
+
+def test_move_unqualified_source_with_explicit_version_deletes_from_resolved_mount(versioned_store):
+    versioned_store.save("b/versioned", {"v": "v1"}, version="1.0.0")
+    versioned_store.save("b/versioned", {"v": "v2"}, version="1.0.1")
+
+    moved_version = versioned_store.move("versioned", target="a/moved-versioned", source_version="1.0.0")
+
+    assert moved_version is not None
+    assert versioned_store.load("a/moved-versioned")["v"] == "v1"
+    with pytest.raises(RegistryObjectNotFound):
+        versioned_store.load("b/versioned", version="1.0.0")
+    assert versioned_store.load("b/versioned", version="1.0.1")["v"] == "v2"
+
+
+def test_move_unqualified_source_with_key_version_deletes_loaded_version(versioned_store):
+    versioned_store.save("b/key-versioned", {"v": "v1"}, version="1.0.0")
+    versioned_store.save("b/key-versioned", {"v": "v2"}, version="1.0.1")
+
+    moved_version = versioned_store.move("key-versioned@1.0.0", target="a/moved-key-version")
+
+    assert moved_version is not None
+    assert versioned_store.load("a/moved-key-version")["v"] == "v1"
+    with pytest.raises(RegistryObjectNotFound):
+        versioned_store.load("b/key-versioned", version="1.0.0")
+    assert versioned_store.load("b/key-versioned", version="1.0.1")["v"] == "v2"
 
 
 def test_dict_like_helpers(basic_store):


### PR DESCRIPTION
## Summary

This PR contains a focused set of bug fixes that came out of the Datalake bug hunt, plus three small follow-up fixes in the registry package.

The main changes are:

- harden `AsyncDatalake` around collection, datum, asset, and dataset-version integrity
- preserve verified replication payload state when unchanged assets are re-upserted
- make registry materialization tolerant of stale serialized class metadata
- fix `Store.move()` deletion semantics for unqualified cross-mount moves
- remove a stale `StoreMount` export that broke `from mindtrace.registry import *`

## What changed

### Datalake integrity

Adds targeted integrity checks and cleanup behavior in `AsyncDatalake`:

- cascade-delete `CollectionItem` rows when deleting a collection
- block asset deletion while the asset is still referenced by collection items
- validate datum `asset_refs` on create and update
- reject blank / whitespace-only datum asset refs
- validate datum `annotation_set_ids` on create and update
- block asset deletion while the asset is still referenced by one or more datums
- make `create_annotation_set(...)` resolve/link the datum safely and roll back the inserted annotation set if datum linkage fails
- validate dataset-version manifests against stored datum ids
- reject duplicate datum ids in one dataset-version manifest

This closes a set of real write-boundary integrity gaps that previously allowed dangling references or semantically invalid memberships to be persisted and only fail later during resolution.

### Replication state preservation

Fixes re-upsert behavior in the replication manager so unchanged assets that are already verified do not regress back to `pending`.

Specifically, when the target asset already exists and the effective storage ref, checksum, and size still match, the existing verified replication metadata is preserved. This avoids unnecessary payload re-hydration and keeps reconcile flows from reprocessing assets that are already good.

### Registry stale metadata fallback

Makes registry materialization degrade gracefully when serialized `metadata["class"]` points at a class path that is no longer importable.

Instead of failing outright, the registry now:

- keeps using the stored materializer
- falls back to `typing.Any` for the object class

This preserves materialization behavior for artifacts whose historical class path has gone stale.

### Store.move() source deletion fix

Fixes `Store.move()` for unqualified cross-mount moves so deletion happens against the resolved source mount and the version that was actually loaded/moved.

This prevents the move path from copying from one mount and then deleting from the wrong place.

### Registry package exports

Removes the stale `StoreMount` entry from `mindtrace.registry.__all__` so package star-imports reflect the real exported API and no longer fail on a missing symbol.

## Issues reviewed / fixed

### Datalake integrity

- #437 — Collection deletion: cascade delete collection membership rows
- #438 — Asset deletion: reject deletes while collection items still reference the asset
- #439 — Datum creation: validate referenced annotation_set_ids exist
- #440 — Datum update: validate referenced annotation_set_ids exist
- #441 — Datum creation: reject blank asset refs
- #442 — Datum update: reject blank or whitespace-only asset refs
- #443 — Dataset version creation: reject manifests with missing datum ids
- #444 — Dataset version creation: reject duplicate datum ids in one manifest
- #435 — AsyncDatalake: enforce datum/asset reference integrity and annotation-set atomicity
- #436 — Replication: preserve verified payload state for unchanged asset re-upserts

### Registry follow-ups

- #431 — Registry materialization: handle non-importable class paths more gracefully
- #430 — Store.move(): resolve mount/version before deleting during move
- #429 — Registry: remove or reconcile stale StoreMount export

## Verification

Targeted regressions and fixes were added for each bug-hunt item, including:

- datalake integrity regressions around collection membership cleanup, missing datum asset refs, referenced asset deletion, datum annotation-set validation, dataset manifest validation, duplicate datum ids in manifests, and annotation-set atomicity
- replication regressions covering verified-state preservation on re-upsert
- registry regressions for stale class metadata fallback behavior
- store regressions for unqualified cross-mount move deletion semantics
- a package-surface regression for `from mindtrace.registry import *`

Additionally, the registry follow-up work was verified with:

```bash
tests/unit/mindtrace/registry/core/test_store.py

ds test: registry --unit
```

And the latest datalake integrity additions were reported verified with:

```bash
tests/integration/mindtrace/datalake/test_integrity_integration.py
```

Current reported result for that file:

- 13 passed

Current reported registry result:

- 552 passed
- 100% registry suite coverage

## Notable commits

- `310e3e9e` — `fix(datalake): enforce datum and annotation set integrity`
- `1a96b006` — `fix(replication): preserve verified assets on re-upsert`
- `332d64b5` — `test(integration): add datalake integrity regression coverage`
- `af4862cf` — `fix(datalake): cascade collection membership deletes`
- `c40ba12d` — `fix(datalake): block asset deletes from collection membership`
- `5caf788d` — `fix(datalake): validate annotation set ids on datum create`
- `c387150e` — `fix(datalake): validate annotation set ids on datum update`
- `59a15ad2` — `fix(datalake): validate dataset manifests against stored datums`
- `db44fc25` — `fix(datalake): reject duplicate datum ids in dataset manifests`
- `c1633cdf` — `fix(datalake): reject blank asset refs on datum create`
- `c3d06efb` — `fix(datalake): reject blank asset refs on datum update`
- `b2d1fd1c` — `test(registry): cover stale class metadata fallbacks`
- `168757d9` — `fix(registry): fallback to Any for stale class hints`
- `eb08e114` — `test(store): cover unqualified move delete semantics`
- `4249afe7` — `fix(store): delete moved objects from resolved source mount`
- `1a3c4448` — `test(registry): cover package star import exports`
- `7a5de1f8` — `fix(registry): drop stale StoreMount export`
- `3fd50dda` — `test(registry): cover facade serialization helpers`

## Notes

- This PR is intentionally narrow: it focuses on correctness / regression coverage rather than new Datalake features.
- The registry fixes were folded in here because they were discovered and resolved during follow-up review of related behavior.