### PR TITLE
[Datalake 14 of X]: DataVault datasets and snapshot-based export

### DIFF
--- a/mindtrace/datalake/mindtrace/datalake/__init__.py
+++ b/mindtrace/datalake/mindtrace/datalake/__init__.py
@@ -22,7 +22,7 @@ from .async_datalake import (
     SlowOperationWarning,
     SlowOpsPolicy,
 )
-from .data_vault import AsyncDataVault, DataVault
+from .data_vault import AsyncDataVault, DataVault, VaultDataset
 from .data_vault_backends import (
     AsyncDataVaultBackend,
     DatalakeServiceAsyncDataVaultBackend,
@@ -113,6 +113,7 @@ __all__ = [
     "AssetAlias",
     "AsyncDataVault",
     "AsyncDataVaultBackend",
+    "VaultDataset",
     "SlowOperationDisabledError",
     "SlowOperationWarning",
     "SlowOpsPolicy",

--- a/mindtrace/datalake/mindtrace/datalake/__init__.py
+++ b/mindtrace/datalake/mindtrace/datalake/__init__.py
@@ -32,6 +32,7 @@ from .data_vault_backends import (
     LocalDataVaultBackend,
 )
 from .datalake import Datalake
+from .exporters import ExportableDataset, ExportableItem, ExportResult, export_dataset_to_format, get_dataset_exporter
 from .pagination_types import (
     CursorEnvelope,
     CursorPage,
@@ -114,6 +115,11 @@ __all__ = [
     "AsyncDataVault",
     "AsyncDataVaultBackend",
     "VaultDataset",
+    "ExportResult",
+    "ExportableDataset",
+    "ExportableItem",
+    "export_dataset_to_format",
+    "get_dataset_exporter",
     "SlowOperationDisabledError",
     "SlowOperationWarning",
     "SlowOpsPolicy",

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -472,9 +472,7 @@ class AsyncDatalake(Mindtrace):
         resolved_limit = self._default_page_limit() if limit is None else limit
         max_page_limit = self._max_page_limit()
         if resolved_limit < 1 or resolved_limit > max_page_limit:
-            raise ValueError(
-                f"Page limit must be between 1 and {max_page_limit}, got {resolved_limit}."
-            )
+            raise ValueError(f"Page limit must be between 1 and {max_page_limit}, got {resolved_limit}.")
         return resolved_limit
 
     async def _paginate_database(
@@ -2169,6 +2167,37 @@ class AsyncDatalake(Mindtrace):
         dataset_version = await self.get_dataset_version(dataset_name, version)
         datums = [await self.resolve_datum(datum_id) for datum_id in dataset_version.manifest]
         return ResolvedDatasetVersion(dataset_version=dataset_version, datums=datums)
+
+    async def export_dataset_version_to_format(
+        self,
+        dataset_name: str,
+        version: str,
+        *,
+        format: str,
+        destination: str | Path,
+        include_media: bool = True,
+        overwrite: bool = False,
+        split_map: dict[str, str] | None = None,
+        exporter_options: dict[str, Any] | None = None,
+    ):
+        """Export an immutable dataset version to a named external format."""
+        from mindtrace.datalake.exporters import export_dataset_to_format
+        from mindtrace.datalake.exporters.base import build_exportable_dataset_from_resolved_version_async
+
+        resolved_dataset_version = await self.resolve_dataset_version(dataset_name, version)
+        exportable_dataset = await build_exportable_dataset_from_resolved_version_async(
+            self,
+            resolved_dataset_version,
+            split_map=split_map,
+        )
+        return export_dataset_to_format(
+            exportable_dataset,
+            format=format,
+            destination=destination,
+            include_media=include_media,
+            overwrite=overwrite,
+            exporter_options=exporter_options,
+        )
 
     async def create_asset_from_object(
         self,

--- a/mindtrace/datalake/mindtrace/datalake/data_vault.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault.py
@@ -49,13 +49,16 @@ from __future__ import annotations
 
 import re
 from collections.abc import AsyncIterator, Iterator, Sequence
+from datetime import datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Any
 
 from PIL import Image
+from pydantic import BaseModel, Field
 from zenml.materializers.base_materializer import BaseMaterializer
 
+from mindtrace.database.core.exceptions import DocumentNotFoundError
 from mindtrace.datalake.annotations import AnnotationVariants, annotation_from_record
 from mindtrace.datalake.async_datalake import AsyncDatalake
 from mindtrace.datalake.data_vault_backends import (
@@ -73,7 +76,15 @@ from mindtrace.datalake.data_vault_backends import (
 from mindtrace.datalake.datalake import Datalake
 from mindtrace.datalake.pagination_types import CursorPage
 from mindtrace.datalake.service import DatalakeService
-from mindtrace.datalake.types import AnnotationRecord, Asset, DuplicateAliasError, SubjectRef
+from mindtrace.datalake.types import (
+    AnnotationRecord,
+    AnnotationSet,
+    Asset,
+    Collection,
+    CollectionItem,
+    DuplicateAliasError,
+    SubjectRef,
+)
 from mindtrace.datalake.vault_serialization import (
     augment_asset_metadata_for_vault_save,
     extract_serialization_block,
@@ -82,6 +93,98 @@ from mindtrace.datalake.vault_serialization import (
 from mindtrace.registry import Registry
 
 _SYNC_VAULT_METHODS = _SYNC_VAULT_METHOD_NAMES
+_DATA_VAULT_METADATA_QUERY_PREFIX = "metadata.mindtrace.data_vault"
+
+
+class VaultDataset(BaseModel):
+    """Human-facing mutable dataset descriptor backed by a datalake collection."""
+
+    dataset_id: str
+    name: str
+    description: str | None = None
+    status: str = "active"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    asset_count: int = 0
+    created_at: datetime
+    created_by: str | None = None
+    updated_at: datetime
+
+
+def _dataset_filters(filters: dict[str, Any] | None = None) -> dict[str, Any]:
+    merged = dict(filters or {})
+    merged.setdefault("status", "active")
+    return merged
+
+
+def _build_vault_dataset(collection: Collection, *, asset_count: int) -> VaultDataset:
+    return VaultDataset(
+        dataset_id=collection.collection_id,
+        name=collection.name,
+        description=collection.description,
+        status=collection.status,
+        metadata=dict(collection.metadata or {}),
+        asset_count=asset_count,
+        created_at=collection.created_at,
+        created_by=collection.created_by,
+        updated_at=collection.updated_at,
+    )
+
+
+def _dataset_annotation_set_metadata(collection: Collection, asset_id: str) -> dict[str, Any]:
+    return {
+        "mindtrace": {
+            "data_vault": {
+                "dataset_collection_id": collection.collection_id,
+                "dataset_name": collection.name,
+                "asset_id": asset_id,
+            }
+        }
+    }
+
+
+def _dataset_annotation_set_filters(collection_id: str, *, asset_id: str | None = None) -> dict[str, Any]:
+    filters: dict[str, Any] = {
+        f"{_DATA_VAULT_METADATA_QUERY_PREFIX}.dataset_collection_id": collection_id,
+        "status": "active",
+    }
+    if asset_id is not None:
+        filters[f"{_DATA_VAULT_METADATA_QUERY_PREFIX}.asset_id"] = asset_id
+    return filters
+
+
+def _coerce_annotation_payload(annotation: AnnotationRecord | AnnotationVariants | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(annotation, AnnotationRecord):
+        return annotation.model_dump(mode="json")
+    if isinstance(annotation, dict):
+        return dict(annotation)
+    if hasattr(annotation, "to_payload"):
+        return dict(annotation.to_payload())
+    raise TypeError("annotation must be a dict, AnnotationRecord, or typed annotation model with to_payload()")
+
+
+def _extract_annotation_asset_id(payload: dict[str, Any]) -> str | None:
+    subject = payload.get("subject")
+    if isinstance(subject, SubjectRef):
+        return subject.id if subject.kind == "asset" else None
+    if isinstance(subject, dict) and subject.get("kind") == "asset":
+        asset_id = subject.get("id")
+        return str(asset_id) if asset_id is not None else None
+    return None
+
+
+def _annotation_source_type(payload: dict[str, Any]) -> str:
+    source = payload.get("source")
+    if isinstance(source, dict):
+        source_type = source.get("type")
+        if source_type in {"human", "machine", "mixed"}:
+            return str(source_type)
+    return "mixed"
+
+
+def _annotation_id(annotation: str | AnnotationRecord) -> str:
+    if isinstance(annotation, AnnotationRecord):
+        return annotation.annotation_id
+    return annotation
 
 
 def _pil_image_to_png_bytes(image: Image.Image) -> bytes:
@@ -228,6 +331,95 @@ class AsyncDataVault:
         safe = _sanitize_object_name_component(alias)
         return f"{self._object_name_prefix}/{safe}"
 
+    async def _resolve_asset_id(self, asset: str | Asset) -> str:
+        if isinstance(asset, Asset):
+            return asset.asset_id
+        try:
+            return (await self._backend.get_asset(asset)).asset_id
+        except DocumentNotFoundError:
+            return (await self._backend.get_asset_by_alias(asset)).asset_id
+
+    async def _get_dataset_collection(self, dataset: str | VaultDataset) -> Collection:
+        if isinstance(dataset, VaultDataset):
+            matches = await self._backend.list_collections({"collection_id": dataset.dataset_id})
+        else:
+            matches = await self._backend.list_collections(_dataset_filters({"name": dataset}))
+        if not matches:
+            raise DocumentNotFoundError(f"Dataset {dataset!r} not found")
+        if len(matches) > 1:
+            raise ValueError(f"Multiple active datasets matched {dataset!r}; use a unique dataset name.")
+        return matches[0]
+
+    async def _dataset_asset_count(self, collection_id: str) -> int:
+        items = await self._backend.list_collection_items({"collection_id": collection_id, "status": "active"})
+        return len({item.asset_id for item in items})
+
+    async def _build_dataset_summary(self, collection: Collection) -> VaultDataset:
+        return _build_vault_dataset(collection, asset_count=await self._dataset_asset_count(collection.collection_id))
+
+    async def _ensure_collection_item(
+        self,
+        collection: Collection,
+        asset_id: str,
+        *,
+        split: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        added_by: str | None = None,
+    ) -> CollectionItem:
+        items = await self._backend.list_collection_items(
+            {"collection_id": collection.collection_id, "asset_id": asset_id}
+        )
+        active_items = [item for item in items if item.status == "active"]
+        if active_items:
+            item = active_items[0]
+            changes: dict[str, Any] = {}
+            if split is not None and item.split != split:
+                changes["split"] = split
+            if metadata:
+                changes["metadata"] = {**item.metadata, **metadata}
+            if changes:
+                item = await self._backend.update_collection_item(item.collection_item_id, **changes)
+            return item
+        if items:
+            item = items[0]
+            return await self._backend.update_collection_item(
+                item.collection_item_id,
+                status="active",
+                split=split if split is not None else item.split,
+                metadata={**item.metadata, **(metadata or {})},
+            )
+        return await self._backend.create_collection_item(
+            collection_id=collection.collection_id,
+            asset_id=asset_id,
+            split=split,
+            status="active",
+            metadata=metadata,
+            added_by=added_by,
+        )
+
+    async def _get_or_create_dataset_annotation_set(
+        self,
+        collection: Collection,
+        asset_id: str,
+        *,
+        created_by: str | None = None,
+        annotation_schema_id: str | None = None,
+        source_type: str = "mixed",
+    ) -> AnnotationSet:
+        filters = _dataset_annotation_set_filters(collection.collection_id, asset_id=asset_id)
+        matches = await self._backend.list_annotation_sets(filters)
+        if matches:
+            return matches[0]
+        return await self._backend.create_annotation_set(
+            name=f"{collection.name}:{asset_id}",
+            purpose="other",
+            source_type=source_type,
+            status="active",
+            metadata=_dataset_annotation_set_metadata(collection, asset_id),
+            created_by=created_by,
+            annotation_schema_id=annotation_schema_id,
+        )
+
     async def list_assets(self, filters: dict[str, Any] | None = None) -> list[Asset]:
         """List assets eagerly; prefer :meth:`iter_assets` or :meth:`list_assets_page` for scalable discovery."""
         return await self._backend.list_assets(filters)
@@ -295,6 +487,178 @@ class AsyncDataVault:
     async def get_asset(self, asset_id: str) -> Asset:
         """Load :class:`~mindtrace.datalake.types.Asset` metadata by canonical ``asset_id``."""
         return await self._backend.get_asset(asset_id)
+
+    async def list_datasets(self, filters: dict[str, Any] | None = None) -> list[VaultDataset]:
+        """List mutable human-facing datasets backed by active datalake collections."""
+        collections = await self._backend.list_collections(_dataset_filters(filters))
+        return [await self._build_dataset_summary(collection) for collection in collections]
+
+    async def list_datasets_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "updated_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[VaultDataset]:
+        page = await self._backend.list_collections_page(
+            filters=_dataset_filters(filters),
+            sort=sort,
+            limit=limit,
+            cursor=cursor,
+            include_total=include_total,
+        )
+        return CursorPage(items=[await self._build_dataset_summary(item) for item in page.items], page=page.page)
+
+    async def iter_datasets(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "updated_desc",
+        batch_size: int | None = None,
+    ) -> AsyncIterator[VaultDataset]:
+        async for collection in self._backend.iter_collections(
+            filters=_dataset_filters(filters),
+            sort=sort,
+            batch_size=batch_size,
+        ):
+            yield await self._build_dataset_summary(collection)
+
+    async def get_dataset(self, name: str) -> VaultDataset:
+        """Return one mutable dataset by its human-readable name."""
+        return await self._build_dataset_summary(await self._get_dataset_collection(name))
+
+    async def create_dataset(
+        self,
+        name: str,
+        *,
+        description: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> VaultDataset:
+        """Create a new mutable dataset backed by a datalake collection."""
+        existing = await self._backend.list_collections(_dataset_filters({"name": name}))
+        if existing:
+            raise ValueError(f"Dataset {name!r} already exists")
+        collection = await self._backend.create_collection(
+            name=name,
+            description=description,
+            status="active",
+            metadata=metadata,
+            created_by=created_by,
+        )
+        return _build_vault_dataset(collection, asset_count=0)
+
+    async def add_asset(
+        self,
+        dataset: str | VaultDataset,
+        asset: str | Asset,
+        *,
+        split: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        added_by: str | None = None,
+    ) -> Asset:
+        """Ensure an asset belongs to a dataset, creating or reactivating membership as needed."""
+        collection = await self._get_dataset_collection(dataset)
+        asset_id = await self._resolve_asset_id(asset)
+        await self._ensure_collection_item(collection, asset_id, split=split, metadata=metadata, added_by=added_by)
+        return await self._backend.get_asset(asset_id)
+
+    async def remove_asset(self, dataset: str | VaultDataset, asset: str | Asset, *, missing_ok: bool = False) -> None:
+        """Remove an asset from a dataset without deleting the asset itself."""
+        collection = await self._get_dataset_collection(dataset)
+        asset_id = await self._resolve_asset_id(asset)
+        items = await self._backend.list_collection_items(
+            {"collection_id": collection.collection_id, "asset_id": asset_id}
+        )
+        if not items and not missing_ok:
+            raise DocumentNotFoundError(f"Asset {asset_id!r} is not part of dataset {collection.name!r}")
+        for item in items:
+            await self._backend.delete_collection_item(item.collection_item_id)
+
+    async def list_dataset_assets(self, dataset: str | VaultDataset) -> list[Asset]:
+        """List unique active assets that belong to a dataset."""
+        collection = await self._get_dataset_collection(dataset)
+        items = await self._backend.list_collection_items(
+            {"collection_id": collection.collection_id, "status": "active"}
+        )
+        assets: list[Asset] = []
+        seen: set[str] = set()
+        for item in items:
+            if item.asset_id in seen:
+                continue
+            seen.add(item.asset_id)
+            assets.append(await self._backend.get_asset(item.asset_id))
+        return assets
+
+    async def add_annotation(
+        self,
+        dataset: str | VaultDataset,
+        annotation: AnnotationRecord | AnnotationVariants | dict[str, Any],
+        *,
+        asset: str | Asset | None = None,
+        annotation_schema_id: str | None = None,
+        created_by: str | None = None,
+    ) -> AnnotationRecord:
+        """Add one annotation to a dataset, implicitly adding its asset membership when needed."""
+        collection = await self._get_dataset_collection(dataset)
+        payload = _coerce_annotation_payload(annotation)
+        asset_id = await self._resolve_asset_id(asset) if asset is not None else _extract_annotation_asset_id(payload)
+        if asset_id is None:
+            raise ValueError("Annotation must reference an asset subject, or asset= must be provided.")
+        await self._ensure_collection_item(collection, asset_id)
+        payload["subject"] = {"kind": "asset", "id": asset_id}
+        annotation_set = await self._get_or_create_dataset_annotation_set(
+            collection,
+            asset_id,
+            created_by=created_by,
+            annotation_schema_id=annotation_schema_id,
+            source_type=_annotation_source_type(payload),
+        )
+        records = await self._backend.add_annotation_records(
+            [payload],
+            annotation_set_id=annotation_set.annotation_set_id,
+            annotation_schema_id=annotation_schema_id,
+        )
+        return records[0]
+
+    async def remove_annotation(
+        self,
+        dataset: str | VaultDataset,
+        annotation: str | AnnotationRecord,
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Remove a dataset-scoped annotation record from the dataset without removing its asset."""
+        collection = await self._get_dataset_collection(dataset)
+        annotation_id = _annotation_id(annotation)
+        annotation_sets = await self._backend.list_annotation_sets(
+            _dataset_annotation_set_filters(collection.collection_id)
+        )
+        if not any(annotation_id in annotation_set.annotation_record_ids for annotation_set in annotation_sets):
+            if missing_ok:
+                return
+            raise DocumentNotFoundError(f"Annotation {annotation_id!r} is not part of dataset {collection.name!r}")
+        await self._backend.delete_annotation_record(annotation_id)
+
+    async def list_dataset_annotations(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        asset: str | Asset | None = None,
+    ) -> list[AnnotationRecord]:
+        """List dataset-scoped annotations, optionally filtered to one asset."""
+        collection = await self._get_dataset_collection(dataset)
+        asset_id = await self._resolve_asset_id(asset) if asset is not None else None
+        annotation_sets = await self._backend.list_annotation_sets(
+            _dataset_annotation_set_filters(collection.collection_id, asset_id=asset_id)
+        )
+        annotations: list[AnnotationRecord] = []
+        for annotation_set in annotation_sets:
+            for annotation_id in annotation_set.annotation_record_ids:
+                annotations.append(await self._backend.get_annotation_record(annotation_id))
+        return annotations
 
     async def load(
         self,
@@ -540,6 +904,93 @@ class DataVault:
         safe = _sanitize_object_name_component(alias)
         return f"{self._object_name_prefix}/{safe}"
 
+    def _resolve_asset_id(self, asset: str | Asset) -> str:
+        if isinstance(asset, Asset):
+            return asset.asset_id
+        try:
+            return self._backend.get_asset(asset).asset_id
+        except DocumentNotFoundError:
+            return self._backend.get_asset_by_alias(asset).asset_id
+
+    def _get_dataset_collection(self, dataset: str | VaultDataset) -> Collection:
+        if isinstance(dataset, VaultDataset):
+            matches = self._backend.list_collections({"collection_id": dataset.dataset_id})
+        else:
+            matches = self._backend.list_collections(_dataset_filters({"name": dataset}))
+        if not matches:
+            raise DocumentNotFoundError(f"Dataset {dataset!r} not found")
+        if len(matches) > 1:
+            raise ValueError(f"Multiple active datasets matched {dataset!r}; use a unique dataset name.")
+        return matches[0]
+
+    def _dataset_asset_count(self, collection_id: str) -> int:
+        items = self._backend.list_collection_items({"collection_id": collection_id, "status": "active"})
+        return len({item.asset_id for item in items})
+
+    def _build_dataset_summary(self, collection: Collection) -> VaultDataset:
+        return _build_vault_dataset(collection, asset_count=self._dataset_asset_count(collection.collection_id))
+
+    def _ensure_collection_item(
+        self,
+        collection: Collection,
+        asset_id: str,
+        *,
+        split: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        added_by: str | None = None,
+    ) -> CollectionItem:
+        items = self._backend.list_collection_items({"collection_id": collection.collection_id, "asset_id": asset_id})
+        active_items = [item for item in items if item.status == "active"]
+        if active_items:
+            item = active_items[0]
+            changes: dict[str, Any] = {}
+            if split is not None and item.split != split:
+                changes["split"] = split
+            if metadata:
+                changes["metadata"] = {**item.metadata, **metadata}
+            if changes:
+                item = self._backend.update_collection_item(item.collection_item_id, **changes)
+            return item
+        if items:
+            item = items[0]
+            return self._backend.update_collection_item(
+                item.collection_item_id,
+                status="active",
+                split=split if split is not None else item.split,
+                metadata={**item.metadata, **(metadata or {})},
+            )
+        return self._backend.create_collection_item(
+            collection_id=collection.collection_id,
+            asset_id=asset_id,
+            split=split,
+            status="active",
+            metadata=metadata,
+            added_by=added_by,
+        )
+
+    def _get_or_create_dataset_annotation_set(
+        self,
+        collection: Collection,
+        asset_id: str,
+        *,
+        created_by: str | None = None,
+        annotation_schema_id: str | None = None,
+        source_type: str = "mixed",
+    ) -> AnnotationSet:
+        filters = _dataset_annotation_set_filters(collection.collection_id, asset_id=asset_id)
+        matches = self._backend.list_annotation_sets(filters)
+        if matches:
+            return matches[0]
+        return self._backend.create_annotation_set(
+            name=f"{collection.name}:{asset_id}",
+            purpose="other",
+            source_type=source_type,
+            status="active",
+            metadata=_dataset_annotation_set_metadata(collection, asset_id),
+            created_by=created_by,
+            annotation_schema_id=annotation_schema_id,
+        )
+
     def list_assets(self, filters: dict[str, Any] | None = None) -> list[Asset]:
         """List assets eagerly; prefer :meth:`iter_assets` or :meth:`list_assets_page` for scalable discovery."""
         return self._backend.list_assets(filters)
@@ -605,6 +1056,172 @@ class DataVault:
     def get_asset(self, asset_id: str) -> Asset:
         """Load :class:`~mindtrace.datalake.types.Asset` metadata by canonical ``asset_id``."""
         return self._backend.get_asset(asset_id)
+
+    def list_datasets(self, filters: dict[str, Any] | None = None) -> list[VaultDataset]:
+        """List mutable human-facing datasets backed by active datalake collections."""
+        collections = self._backend.list_collections(_dataset_filters(filters))
+        return [self._build_dataset_summary(collection) for collection in collections]
+
+    def list_datasets_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "updated_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[VaultDataset]:
+        page = self._backend.list_collections_page(
+            filters=_dataset_filters(filters),
+            sort=sort,
+            limit=limit,
+            cursor=cursor,
+            include_total=include_total,
+        )
+        return CursorPage(items=[self._build_dataset_summary(item) for item in page.items], page=page.page)
+
+    def iter_datasets(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "updated_desc",
+        batch_size: int | None = None,
+    ) -> Iterator[VaultDataset]:
+        for collection in self._backend.iter_collections(
+            filters=_dataset_filters(filters),
+            sort=sort,
+            batch_size=batch_size,
+        ):
+            yield self._build_dataset_summary(collection)
+
+    def get_dataset(self, name: str) -> VaultDataset:
+        """Return one mutable dataset by its human-readable name."""
+        return self._build_dataset_summary(self._get_dataset_collection(name))
+
+    def create_dataset(
+        self,
+        name: str,
+        *,
+        description: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> VaultDataset:
+        """Create a new mutable dataset backed by a datalake collection."""
+        existing = self._backend.list_collections(_dataset_filters({"name": name}))
+        if existing:
+            raise ValueError(f"Dataset {name!r} already exists")
+        collection = self._backend.create_collection(
+            name=name,
+            description=description,
+            status="active",
+            metadata=metadata,
+            created_by=created_by,
+        )
+        return _build_vault_dataset(collection, asset_count=0)
+
+    def add_asset(
+        self,
+        dataset: str | VaultDataset,
+        asset: str | Asset,
+        *,
+        split: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        added_by: str | None = None,
+    ) -> Asset:
+        """Ensure an asset belongs to a dataset, creating or reactivating membership as needed."""
+        collection = self._get_dataset_collection(dataset)
+        asset_id = self._resolve_asset_id(asset)
+        self._ensure_collection_item(collection, asset_id, split=split, metadata=metadata, added_by=added_by)
+        return self._backend.get_asset(asset_id)
+
+    def remove_asset(self, dataset: str | VaultDataset, asset: str | Asset, *, missing_ok: bool = False) -> None:
+        """Remove an asset from a dataset without deleting the asset itself."""
+        collection = self._get_dataset_collection(dataset)
+        asset_id = self._resolve_asset_id(asset)
+        items = self._backend.list_collection_items({"collection_id": collection.collection_id, "asset_id": asset_id})
+        if not items and not missing_ok:
+            raise DocumentNotFoundError(f"Asset {asset_id!r} is not part of dataset {collection.name!r}")
+        for item in items:
+            self._backend.delete_collection_item(item.collection_item_id)
+
+    def list_dataset_assets(self, dataset: str | VaultDataset) -> list[Asset]:
+        """List unique active assets that belong to a dataset."""
+        collection = self._get_dataset_collection(dataset)
+        items = self._backend.list_collection_items({"collection_id": collection.collection_id, "status": "active"})
+        assets: list[Asset] = []
+        seen: set[str] = set()
+        for item in items:
+            if item.asset_id in seen:
+                continue
+            seen.add(item.asset_id)
+            assets.append(self._backend.get_asset(item.asset_id))
+        return assets
+
+    def add_annotation(
+        self,
+        dataset: str | VaultDataset,
+        annotation: AnnotationRecord | AnnotationVariants | dict[str, Any],
+        *,
+        asset: str | Asset | None = None,
+        annotation_schema_id: str | None = None,
+        created_by: str | None = None,
+    ) -> AnnotationRecord:
+        """Add one annotation to a dataset, implicitly adding its asset membership when needed."""
+        collection = self._get_dataset_collection(dataset)
+        payload = _coerce_annotation_payload(annotation)
+        asset_id = self._resolve_asset_id(asset) if asset is not None else _extract_annotation_asset_id(payload)
+        if asset_id is None:
+            raise ValueError("Annotation must reference an asset subject, or asset= must be provided.")
+        self._ensure_collection_item(collection, asset_id)
+        payload["subject"] = {"kind": "asset", "id": asset_id}
+        annotation_set = self._get_or_create_dataset_annotation_set(
+            collection,
+            asset_id,
+            created_by=created_by,
+            annotation_schema_id=annotation_schema_id,
+            source_type=_annotation_source_type(payload),
+        )
+        records = self._backend.add_annotation_records(
+            [payload],
+            annotation_set_id=annotation_set.annotation_set_id,
+            annotation_schema_id=annotation_schema_id,
+        )
+        return records[0]
+
+    def remove_annotation(
+        self,
+        dataset: str | VaultDataset,
+        annotation: str | AnnotationRecord,
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        """Remove a dataset-scoped annotation record from the dataset without removing its asset."""
+        collection = self._get_dataset_collection(dataset)
+        annotation_id = _annotation_id(annotation)
+        annotation_sets = self._backend.list_annotation_sets(_dataset_annotation_set_filters(collection.collection_id))
+        if not any(annotation_id in annotation_set.annotation_record_ids for annotation_set in annotation_sets):
+            if missing_ok:
+                return
+            raise DocumentNotFoundError(f"Annotation {annotation_id!r} is not part of dataset {collection.name!r}")
+        self._backend.delete_annotation_record(annotation_id)
+
+    def list_dataset_annotations(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        asset: str | Asset | None = None,
+    ) -> list[AnnotationRecord]:
+        """List dataset-scoped annotations, optionally filtered to one asset."""
+        collection = self._get_dataset_collection(dataset)
+        asset_id = self._resolve_asset_id(asset) if asset is not None else None
+        annotation_sets = self._backend.list_annotation_sets(
+            _dataset_annotation_set_filters(collection.collection_id, asset_id=asset_id)
+        )
+        annotations: list[AnnotationRecord] = []
+        for annotation_set in annotation_sets:
+            for annotation_id in annotation_set.annotation_record_ids:
+                annotations.append(self._backend.get_annotation_record(annotation_id))
+        return annotations
 
     def load(
         self,

--- a/mindtrace/datalake/mindtrace/datalake/data_vault.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault.py
@@ -47,7 +47,10 @@ passing the connection manager to :class:`DataVault` — see :meth:`DataVault.fr
 
 from __future__ import annotations
 
+import base64
+import json
 import re
+import warnings
 from collections.abc import AsyncIterator, Iterator, Sequence
 from datetime import UTC, datetime
 from io import BytesIO
@@ -61,7 +64,12 @@ from zenml.materializers.base_materializer import BaseMaterializer
 
 from mindtrace.database.core.exceptions import DocumentNotFoundError
 from mindtrace.datalake.annotations import AnnotationVariants, annotation_from_record
-from mindtrace.datalake.async_datalake import AsyncDatalake
+from mindtrace.datalake.async_datalake import (
+    AsyncDatalake,
+    SlowOperationDisabledError,
+    SlowOperationWarning,
+    SlowOpsPolicy,
+)
 from mindtrace.datalake.data_vault_backends import (
     _ASYNC_VAULT_METHOD_NAMES,
     _SYNC_VAULT_METHOD_NAMES,
@@ -75,7 +83,7 @@ from mindtrace.datalake.data_vault_backends import (
     looks_like_datalake_service_sync_client,
 )
 from mindtrace.datalake.datalake import Datalake
-from mindtrace.datalake.pagination_types import CursorPage
+from mindtrace.datalake.pagination_types import CursorPage, PageInfo
 from mindtrace.datalake.service import DatalakeService
 from mindtrace.datalake.types import (
     AnnotationRecord,
@@ -99,6 +107,8 @@ from mindtrace.registry import Registry
 
 _SYNC_VAULT_METHODS = _SYNC_VAULT_METHOD_NAMES
 _DATA_VAULT_METADATA_QUERY_PREFIX = "metadata.mindtrace.data_vault"
+_DATASET_ASSETS_CURSOR_KIND = "dataset_assets_v1"
+_DATASET_ANNOTATIONS_CURSOR_KIND = "dataset_annotations_v1"
 
 
 class VaultDataset(BaseModel):
@@ -119,6 +129,47 @@ def _dataset_filters(filters: dict[str, Any] | None = None) -> dict[str, Any]:
     merged = dict(filters or {})
     merged.setdefault("status", "active")
     return merged
+
+
+def _resolve_slow_ops_policy(backend: Any, explicit: SlowOpsPolicy | str | None) -> SlowOpsPolicy:
+    if explicit is not None:
+        return SlowOpsPolicy(explicit)
+    candidate = getattr(backend, "slow_ops_policy", None)
+    if candidate is None:
+        candidate = getattr(getattr(backend, "_datalake", None), "slow_ops_policy", None)
+    if candidate is None or not isinstance(candidate, (SlowOpsPolicy, str)):
+        return SlowOpsPolicy.WARN
+    return SlowOpsPolicy(candidate)
+
+
+def _guard_slow_list_operation(policy: SlowOpsPolicy, operation_name: str, *, alternatives: str) -> None:
+    if policy == SlowOpsPolicy.ALLOW:
+        return
+    message = (
+        f"{operation_name}() eagerly materializes an unbounded result set and may not scale. "
+        f"Use {alternatives} instead."
+    )
+    if policy == SlowOpsPolicy.WARN:
+        warnings.warn(message, SlowOperationWarning, stacklevel=2)
+        return
+    raise SlowOperationDisabledError(message)
+
+
+def _encode_dataset_cursor(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def _decode_dataset_cursor(cursor: str | None, *, expected_kind: str) -> dict[str, Any]:
+    if cursor is None:
+        return {}
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8"))
+    except Exception as exc:
+        raise ValueError("Invalid dataset page cursor") from exc
+    if not isinstance(payload, dict) or payload.get("kind") != expected_kind:
+        raise ValueError("Invalid dataset page cursor")
+    return payload
 
 
 def _build_vault_dataset(collection: Collection, *, asset_count: int) -> VaultDataset:
@@ -473,10 +524,12 @@ class AsyncDataVault:
         *,
         object_name_prefix: str = "vault",
         registry: Registry | None = None,
+        slow_ops_policy: SlowOpsPolicy | str | None = None,
     ) -> None:
         self._backend = _normalize_async_backend(backend)
         self._object_name_prefix = object_name_prefix.strip("/").strip() or "vault"
         self._registry = registry
+        self.slow_ops_policy = _resolve_slow_ops_policy(backend, slow_ops_policy)
 
     @classmethod
     def from_url(
@@ -486,6 +539,7 @@ class AsyncDataVault:
         timeout: int = 60,
         object_name_prefix: str = "vault",
         registry: Registry | None = None,
+        slow_ops_policy: SlowOpsPolicy | str | None = None,
     ) -> AsyncDataVault:
         """Connect to a running :class:`~mindtrace.datalake.service.DatalakeService` and return a vault.
 
@@ -493,7 +547,7 @@ class AsyncDataVault:
         (including async task methods when exposed by the client).
         """
         cm = DatalakeService.connect(url=url, timeout=timeout)
-        return cls(cm, object_name_prefix=object_name_prefix, registry=registry)
+        return cls(cm, object_name_prefix=object_name_prefix, registry=registry, slow_ops_policy=slow_ops_policy)
 
     def _object_name(self, alias: str) -> str:
         safe = _sanitize_object_name_component(alias)
@@ -524,6 +578,30 @@ class AsyncDataVault:
 
     async def _build_dataset_summary(self, collection: Collection) -> VaultDataset:
         return _build_vault_dataset(collection, asset_count=await self._dataset_asset_count(collection.collection_id))
+
+    async def _count_dataset_assets(self, collection_id: str) -> int:
+        seen: set[str] = set()
+        cursor: str | None = None
+        while True:
+            page = await self._backend.list_collection_items_page(
+                filters={"collection_id": collection_id, "status": "active"},
+                cursor=cursor,
+            )
+            seen.update(item.asset_id for item in page.items)
+            if not page.page.has_more or page.page.next_cursor is None:
+                return len(seen)
+            cursor = page.page.next_cursor
+
+    async def _count_dataset_annotations(self, collection_id: str, asset_id: str | None) -> int:
+        total = 0
+        cursor: str | None = None
+        filters = _dataset_annotation_set_filters(collection_id, asset_id=asset_id)
+        while True:
+            page = await self._backend.list_annotation_sets_page(filters=filters, cursor=cursor)
+            total += sum(len(annotation_set.annotation_record_ids) for annotation_set in page.items)
+            if not page.page.has_more or page.page.next_cursor is None:
+                return total
+            cursor = page.page.next_cursor
 
     async def _ensure_collection_item(
         self,
@@ -746,7 +824,12 @@ class AsyncDataVault:
             await self._backend.delete_collection_item(item.collection_item_id)
 
     async def list_dataset_assets(self, dataset: str | VaultDataset) -> list[Asset]:
-        """List unique active assets that belong to a dataset."""
+        """List unique active assets that belong to a dataset eagerly."""
+        _guard_slow_list_operation(
+            self.slow_ops_policy,
+            "list_dataset_assets",
+            alternatives="iter_dataset_assets() or list_dataset_assets_page()",
+        )
         collection = await self._get_dataset_collection(dataset)
         items = await self._backend.list_collection_items(
             {"collection_id": collection.collection_id, "status": "active"}
@@ -759,6 +842,105 @@ class AsyncDataVault:
             seen.add(item.asset_id)
             assets.append(await self._backend.get_asset(item.asset_id))
         return assets
+
+    async def list_dataset_assets_page(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[Asset]:
+        collection = await self._get_dataset_collection(dataset)
+        state = _decode_dataset_cursor(cursor, expected_kind=_DATASET_ASSETS_CURSOR_KIND)
+        if state and state.get("collection_id") != collection.collection_id:
+            raise ValueError("Dataset asset cursor does not match the requested dataset")
+        if state and state.get("sort") != sort:
+            raise ValueError("Dataset asset cursor does not match the requested sort order")
+
+        resolved_limit = int(state["limit"]) if state.get("limit") is not None else limit
+        items_cursor = state.get("items_cursor")
+        seen: set[str] = set(state.get("seen_asset_ids", []))
+        pending_asset_ids: list[str] = list(state.get("pending_asset_ids", []))
+        items: list[Asset] = []
+        has_more = False
+
+        while resolved_limit is None or len(items) < resolved_limit:
+            while pending_asset_ids and (resolved_limit is None or len(items) < resolved_limit):
+                asset_id = pending_asset_ids.pop(0)
+                if asset_id in seen:
+                    continue
+                seen.add(asset_id)
+                items.append(await self._backend.get_asset(asset_id))
+            if resolved_limit is not None and len(items) >= resolved_limit:
+                has_more = bool(pending_asset_ids) or items_cursor is not None
+                break
+            if items and not pending_asset_ids and items_cursor is None and not has_more:
+                break
+
+            page = await self._backend.list_collection_items_page(
+                filters={"collection_id": collection.collection_id, "status": "active"},
+                sort=sort,
+                limit=limit,
+                cursor=items_cursor,
+                include_total=False,
+            )
+            if resolved_limit is None:
+                resolved_limit = page.page.limit
+            raw_asset_ids = [item.asset_id for item in page.items]
+            items_cursor = page.page.next_cursor
+            has_more = page.page.has_more and items_cursor is not None
+            if not raw_asset_ids and not has_more:
+                break
+            pending_asset_ids = raw_asset_ids
+            if not has_more and items_cursor is None and len(items) + len(pending_asset_ids) < resolved_limit:
+                while pending_asset_ids:
+                    asset_id = pending_asset_ids.pop(0)
+                    if asset_id in seen:
+                        continue
+                    seen.add(asset_id)
+                    items.append(await self._backend.get_asset(asset_id))
+                break
+
+        next_cursor: str | None = None
+        if pending_asset_ids or has_more:
+            next_cursor = _encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ASSETS_CURSOR_KIND,
+                    "collection_id": collection.collection_id,
+                    "sort": sort,
+                    "limit": resolved_limit,
+                    "items_cursor": items_cursor,
+                    "seen_asset_ids": list(seen),
+                    "pending_asset_ids": pending_asset_ids,
+                }
+            )
+
+        total_count = await self._count_dataset_assets(collection.collection_id) if include_total else None
+        page_limit = resolved_limit if resolved_limit is not None else max(len(items), 1)
+        return CursorPage(
+            items=items,
+            page=PageInfo(
+                limit=page_limit, next_cursor=next_cursor, has_more=next_cursor is not None, total_count=total_count
+            ),
+        )
+
+    async def iter_dataset_assets(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        sort: str = "created_desc",
+        batch_size: int | None = None,
+    ) -> AsyncIterator[Asset]:
+        cursor: str | None = None
+        while True:
+            page = await self.list_dataset_assets_page(dataset, sort=sort, limit=batch_size, cursor=cursor)
+            for asset in page.items:
+                yield asset
+            if not page.page.has_more or page.page.next_cursor is None:
+                break
+            cursor = page.page.next_cursor
 
     async def add_annotation(
         self,
@@ -816,7 +998,12 @@ class AsyncDataVault:
         *,
         asset: str | Asset | None = None,
     ) -> list[AnnotationRecord]:
-        """List dataset-scoped annotations, optionally filtered to one asset."""
+        """List dataset-scoped annotations eagerly, optionally filtered to one asset."""
+        _guard_slow_list_operation(
+            self.slow_ops_policy,
+            "list_dataset_annotations",
+            alternatives="iter_dataset_annotations() or list_dataset_annotations_page()",
+        )
         collection = await self._get_dataset_collection(dataset)
         asset_id = await self._resolve_asset_id(asset) if asset is not None else None
         annotation_sets = await self._backend.list_annotation_sets(
@@ -827,6 +1014,111 @@ class AsyncDataVault:
             for annotation_id in annotation_set.annotation_record_ids:
                 annotations.append(await self._backend.get_annotation_record(annotation_id))
         return annotations
+
+    async def list_dataset_annotations_page(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        asset: str | Asset | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[AnnotationRecord]:
+        collection = await self._get_dataset_collection(dataset)
+        asset_id = await self._resolve_asset_id(asset) if asset is not None else None
+        state = _decode_dataset_cursor(cursor, expected_kind=_DATASET_ANNOTATIONS_CURSOR_KIND)
+        if state and state.get("collection_id") != collection.collection_id:
+            raise ValueError("Dataset annotation cursor does not match the requested dataset")
+        if state and state.get("sort") != sort:
+            raise ValueError("Dataset annotation cursor does not match the requested sort order")
+        if state and state.get("asset_id") != asset_id:
+            raise ValueError("Dataset annotation cursor does not match the requested asset filter")
+
+        resolved_limit = int(state["limit"]) if state.get("limit") is not None else limit
+        annotation_sets_cursor = state.get("annotation_sets_cursor")
+        pending_annotation_ids: list[str] = list(state.get("pending_annotation_ids", []))
+        items: list[AnnotationRecord] = []
+        has_more = False
+        filters = _dataset_annotation_set_filters(collection.collection_id, asset_id=asset_id)
+
+        while resolved_limit is None or len(items) < resolved_limit:
+            while pending_annotation_ids and (resolved_limit is None or len(items) < resolved_limit):
+                items.append(await self._backend.get_annotation_record(pending_annotation_ids.pop(0)))
+            if resolved_limit is not None and len(items) >= resolved_limit:
+                has_more = bool(pending_annotation_ids) or annotation_sets_cursor is not None
+                break
+            if items and not pending_annotation_ids and annotation_sets_cursor is None and not has_more:
+                break
+
+            page = await self._backend.list_annotation_sets_page(
+                filters=filters,
+                sort=sort,
+                limit=limit,
+                cursor=annotation_sets_cursor,
+                include_total=False,
+            )
+            if resolved_limit is None:
+                resolved_limit = page.page.limit
+            pending_annotation_ids = [
+                annotation_id for annotation_set in page.items for annotation_id in annotation_set.annotation_record_ids
+            ]
+            annotation_sets_cursor = page.page.next_cursor
+            has_more = page.page.has_more and annotation_sets_cursor is not None
+            if not pending_annotation_ids and not has_more:
+                break
+            if (
+                not has_more
+                and annotation_sets_cursor is None
+                and len(items) + len(pending_annotation_ids) < resolved_limit
+            ):
+                while pending_annotation_ids:
+                    items.append(await self._backend.get_annotation_record(pending_annotation_ids.pop(0)))
+                break
+
+        next_cursor: str | None = None
+        if pending_annotation_ids or has_more:
+            next_cursor = _encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ANNOTATIONS_CURSOR_KIND,
+                    "collection_id": collection.collection_id,
+                    "asset_id": asset_id,
+                    "sort": sort,
+                    "limit": resolved_limit,
+                    "annotation_sets_cursor": annotation_sets_cursor,
+                    "pending_annotation_ids": pending_annotation_ids,
+                }
+            )
+
+        total_count = (
+            await self._count_dataset_annotations(collection.collection_id, asset_id) if include_total else None
+        )
+        page_limit = resolved_limit if resolved_limit is not None else max(len(items), 1)
+        return CursorPage(
+            items=items,
+            page=PageInfo(
+                limit=page_limit, next_cursor=next_cursor, has_more=next_cursor is not None, total_count=total_count
+            ),
+        )
+
+    async def iter_dataset_annotations(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        asset: str | Asset | None = None,
+        sort: str = "created_desc",
+        batch_size: int | None = None,
+    ) -> AsyncIterator[AnnotationRecord]:
+        cursor: str | None = None
+        while True:
+            page = await self.list_dataset_annotations_page(
+                dataset, asset=asset, sort=sort, limit=batch_size, cursor=cursor
+            )
+            for annotation in page.items:
+                yield annotation
+            if not page.page.has_more or page.page.next_cursor is None:
+                break
+            cursor = page.page.next_cursor
 
     async def _prepare_import_target_dataset(
         self,
@@ -1332,10 +1624,12 @@ class DataVault:
         *,
         object_name_prefix: str = "vault",
         registry: Registry | None = None,
+        slow_ops_policy: SlowOpsPolicy | str | None = None,
     ) -> None:
         self._backend = _normalize_sync_backend(backend)
         self._object_name_prefix = object_name_prefix.strip("/").strip() or "vault"
         self._registry = registry
+        self.slow_ops_policy = _resolve_slow_ops_policy(backend, slow_ops_policy)
 
     @classmethod
     def from_url(
@@ -1345,13 +1639,14 @@ class DataVault:
         timeout: int = 60,
         object_name_prefix: str = "vault",
         registry: Registry | None = None,
+        slow_ops_policy: SlowOpsPolicy | str | None = None,
     ) -> DataVault:
         """Connect to a running :class:`~mindtrace.datalake.service.DatalakeService` and return a vault.
 
         Equivalent to ``DataVault(DatalakeService.connect(url=url, timeout=timeout), ...)``.
         """
         cm = DatalakeService.connect(url=url, timeout=timeout)
-        return cls(cm, object_name_prefix=object_name_prefix, registry=registry)
+        return cls(cm, object_name_prefix=object_name_prefix, registry=registry, slow_ops_policy=slow_ops_policy)
 
     def _object_name(self, alias: str) -> str:
         safe = _sanitize_object_name_component(alias)
@@ -1382,6 +1677,30 @@ class DataVault:
 
     def _build_dataset_summary(self, collection: Collection) -> VaultDataset:
         return _build_vault_dataset(collection, asset_count=self._dataset_asset_count(collection.collection_id))
+
+    def _count_dataset_assets(self, collection_id: str) -> int:
+        seen: set[str] = set()
+        cursor: str | None = None
+        while True:
+            page = self._backend.list_collection_items_page(
+                filters={"collection_id": collection_id, "status": "active"},
+                cursor=cursor,
+            )
+            seen.update(item.asset_id for item in page.items)
+            if not page.page.has_more or page.page.next_cursor is None:
+                return len(seen)
+            cursor = page.page.next_cursor
+
+    def _count_dataset_annotations(self, collection_id: str, asset_id: str | None) -> int:
+        total = 0
+        cursor: str | None = None
+        filters = _dataset_annotation_set_filters(collection_id, asset_id=asset_id)
+        while True:
+            page = self._backend.list_annotation_sets_page(filters=filters, cursor=cursor)
+            total += sum(len(annotation_set.annotation_record_ids) for annotation_set in page.items)
+            if not page.page.has_more or page.page.next_cursor is None:
+                return total
+            cursor = page.page.next_cursor
 
     def _ensure_collection_item(
         self,
@@ -1598,7 +1917,12 @@ class DataVault:
             self._backend.delete_collection_item(item.collection_item_id)
 
     def list_dataset_assets(self, dataset: str | VaultDataset) -> list[Asset]:
-        """List unique active assets that belong to a dataset."""
+        """List unique active assets that belong to a dataset eagerly."""
+        _guard_slow_list_operation(
+            self.slow_ops_policy,
+            "list_dataset_assets",
+            alternatives="iter_dataset_assets() or list_dataset_assets_page()",
+        )
         collection = self._get_dataset_collection(dataset)
         items = self._backend.list_collection_items({"collection_id": collection.collection_id, "status": "active"})
         assets: list[Asset] = []
@@ -1609,6 +1933,104 @@ class DataVault:
             seen.add(item.asset_id)
             assets.append(self._backend.get_asset(item.asset_id))
         return assets
+
+    def list_dataset_assets_page(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[Asset]:
+        collection = self._get_dataset_collection(dataset)
+        state = _decode_dataset_cursor(cursor, expected_kind=_DATASET_ASSETS_CURSOR_KIND)
+        if state and state.get("collection_id") != collection.collection_id:
+            raise ValueError("Dataset asset cursor does not match the requested dataset")
+        if state and state.get("sort") != sort:
+            raise ValueError("Dataset asset cursor does not match the requested sort order")
+
+        resolved_limit = int(state["limit"]) if state.get("limit") is not None else limit
+        items_cursor = state.get("items_cursor")
+        seen: set[str] = set(state.get("seen_asset_ids", []))
+        pending_asset_ids: list[str] = list(state.get("pending_asset_ids", []))
+        items: list[Asset] = []
+        has_more = False
+
+        while resolved_limit is None or len(items) < resolved_limit:
+            while pending_asset_ids and (resolved_limit is None or len(items) < resolved_limit):
+                asset_id = pending_asset_ids.pop(0)
+                if asset_id in seen:
+                    continue
+                seen.add(asset_id)
+                items.append(self._backend.get_asset(asset_id))
+            if resolved_limit is not None and len(items) >= resolved_limit:
+                has_more = bool(pending_asset_ids) or items_cursor is not None
+                break
+            if items and not pending_asset_ids and items_cursor is None and not has_more:
+                break
+
+            page = self._backend.list_collection_items_page(
+                filters={"collection_id": collection.collection_id, "status": "active"},
+                sort=sort,
+                limit=limit,
+                cursor=items_cursor,
+                include_total=False,
+            )
+            if resolved_limit is None:
+                resolved_limit = page.page.limit
+            raw_asset_ids = [item.asset_id for item in page.items]
+            items_cursor = page.page.next_cursor
+            has_more = page.page.has_more and items_cursor is not None
+            if not raw_asset_ids and not has_more:
+                break
+            pending_asset_ids = raw_asset_ids
+            if not has_more and items_cursor is None and len(items) + len(pending_asset_ids) < resolved_limit:
+                while pending_asset_ids:
+                    asset_id = pending_asset_ids.pop(0)
+                    if asset_id in seen:
+                        continue
+                    seen.add(asset_id)
+                    items.append(self._backend.get_asset(asset_id))
+                break
+
+        next_cursor: str | None = None
+        if pending_asset_ids or has_more:
+            next_cursor = _encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ASSETS_CURSOR_KIND,
+                    "collection_id": collection.collection_id,
+                    "sort": sort,
+                    "limit": resolved_limit,
+                    "items_cursor": items_cursor,
+                    "seen_asset_ids": list(seen),
+                    "pending_asset_ids": pending_asset_ids,
+                }
+            )
+
+        total_count = self._count_dataset_assets(collection.collection_id) if include_total else None
+        page_limit = resolved_limit if resolved_limit is not None else max(len(items), 1)
+        return CursorPage(
+            items=items,
+            page=PageInfo(
+                limit=page_limit, next_cursor=next_cursor, has_more=next_cursor is not None, total_count=total_count
+            ),
+        )
+
+    def iter_dataset_assets(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        sort: str = "created_desc",
+        batch_size: int | None = None,
+    ) -> Iterator[Asset]:
+        cursor: str | None = None
+        while True:
+            page = self.list_dataset_assets_page(dataset, sort=sort, limit=batch_size, cursor=cursor)
+            yield from page.items
+            if not page.page.has_more or page.page.next_cursor is None:
+                break
+            cursor = page.page.next_cursor
 
     def add_annotation(
         self,
@@ -1664,7 +2086,12 @@ class DataVault:
         *,
         asset: str | Asset | None = None,
     ) -> list[AnnotationRecord]:
-        """List dataset-scoped annotations, optionally filtered to one asset."""
+        """List dataset-scoped annotations eagerly, optionally filtered to one asset."""
+        _guard_slow_list_operation(
+            self.slow_ops_policy,
+            "list_dataset_annotations",
+            alternatives="iter_dataset_annotations() or list_dataset_annotations_page()",
+        )
         collection = self._get_dataset_collection(dataset)
         asset_id = self._resolve_asset_id(asset) if asset is not None else None
         annotation_sets = self._backend.list_annotation_sets(
@@ -1675,6 +2102,106 @@ class DataVault:
             for annotation_id in annotation_set.annotation_record_ids:
                 annotations.append(self._backend.get_annotation_record(annotation_id))
         return annotations
+
+    def list_dataset_annotations_page(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        asset: str | Asset | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[AnnotationRecord]:
+        collection = self._get_dataset_collection(dataset)
+        asset_id = self._resolve_asset_id(asset) if asset is not None else None
+        state = _decode_dataset_cursor(cursor, expected_kind=_DATASET_ANNOTATIONS_CURSOR_KIND)
+        if state and state.get("collection_id") != collection.collection_id:
+            raise ValueError("Dataset annotation cursor does not match the requested dataset")
+        if state and state.get("sort") != sort:
+            raise ValueError("Dataset annotation cursor does not match the requested sort order")
+        if state and state.get("asset_id") != asset_id:
+            raise ValueError("Dataset annotation cursor does not match the requested asset filter")
+
+        resolved_limit = int(state["limit"]) if state.get("limit") is not None else limit
+        annotation_sets_cursor = state.get("annotation_sets_cursor")
+        pending_annotation_ids: list[str] = list(state.get("pending_annotation_ids", []))
+        items: list[AnnotationRecord] = []
+        has_more = False
+        filters = _dataset_annotation_set_filters(collection.collection_id, asset_id=asset_id)
+
+        while resolved_limit is None or len(items) < resolved_limit:
+            while pending_annotation_ids and (resolved_limit is None or len(items) < resolved_limit):
+                items.append(self._backend.get_annotation_record(pending_annotation_ids.pop(0)))
+            if resolved_limit is not None and len(items) >= resolved_limit:
+                has_more = bool(pending_annotation_ids) or annotation_sets_cursor is not None
+                break
+            if items and not pending_annotation_ids and annotation_sets_cursor is None and not has_more:
+                break
+
+            page = self._backend.list_annotation_sets_page(
+                filters=filters,
+                sort=sort,
+                limit=limit,
+                cursor=annotation_sets_cursor,
+                include_total=False,
+            )
+            if resolved_limit is None:
+                resolved_limit = page.page.limit
+            pending_annotation_ids = [
+                annotation_id for annotation_set in page.items for annotation_id in annotation_set.annotation_record_ids
+            ]
+            annotation_sets_cursor = page.page.next_cursor
+            has_more = page.page.has_more and annotation_sets_cursor is not None
+            if not pending_annotation_ids and not has_more:
+                break
+            if (
+                not has_more
+                and annotation_sets_cursor is None
+                and len(items) + len(pending_annotation_ids) < resolved_limit
+            ):
+                while pending_annotation_ids:
+                    items.append(self._backend.get_annotation_record(pending_annotation_ids.pop(0)))
+                break
+
+        next_cursor: str | None = None
+        if pending_annotation_ids or has_more:
+            next_cursor = _encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ANNOTATIONS_CURSOR_KIND,
+                    "collection_id": collection.collection_id,
+                    "asset_id": asset_id,
+                    "sort": sort,
+                    "limit": resolved_limit,
+                    "annotation_sets_cursor": annotation_sets_cursor,
+                    "pending_annotation_ids": pending_annotation_ids,
+                }
+            )
+
+        total_count = self._count_dataset_annotations(collection.collection_id, asset_id) if include_total else None
+        page_limit = resolved_limit if resolved_limit is not None else max(len(items), 1)
+        return CursorPage(
+            items=items,
+            page=PageInfo(
+                limit=page_limit, next_cursor=next_cursor, has_more=next_cursor is not None, total_count=total_count
+            ),
+        )
+
+    def iter_dataset_annotations(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        asset: str | Asset | None = None,
+        sort: str = "created_desc",
+        batch_size: int | None = None,
+    ) -> Iterator[AnnotationRecord]:
+        cursor: str | None = None
+        while True:
+            page = self.list_dataset_annotations_page(dataset, asset=asset, sort=sort, limit=batch_size, cursor=cursor)
+            yield from page.items
+            if not page.page.has_more or page.page.next_cursor is None:
+                break
+            cursor = page.page.next_cursor
 
     def _prepare_import_target_dataset(
         self,

--- a/mindtrace/datalake/mindtrace/datalake/data_vault.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault.py
@@ -828,13 +828,6 @@ class AsyncDataVault:
                 annotations.append(await self._backend.get_annotation_record(annotation_id))
         return annotations
 
-    def _require_local_datalake(self) -> AsyncDatalake | Any:
-        if isinstance(self._backend, LocalAsyncDataVaultBackend):
-            return self._backend._datalake
-        raise NotImplementedError(
-            "DataVault dataset export currently requires a local AsyncDatalake backend when freeze is needed."
-        )
-
     async def _prepare_import_target_dataset(
         self,
         *,
@@ -848,9 +841,8 @@ class AsyncDataVault:
         if matches:
             if not overwrite:
                 raise ValueError(f"Dataset {dataset_name!r} already exists")
-            datalake = self._require_local_datalake()
             for collection in matches:
-                await datalake.update_collection(collection.collection_id, status="archived")
+                await self._backend.update_collection(collection.collection_id, status="archived")
         return await self.create_dataset(
             dataset_name,
             description=description,
@@ -870,8 +862,7 @@ class AsyncDataVault:
         created_by: str | None = None,
     ) -> VaultDataset:
         """Materialize an immutable dataset version into a mutable vault dataset."""
-        datalake = self._require_local_datalake()
-        resolved_dataset_version = await datalake.resolve_dataset_version(dataset_name, version)
+        resolved_dataset_version = await self._backend.resolve_dataset_version(dataset_name, version)
         source_dataset = resolved_dataset_version.dataset_version
         imported_dataset = await self._prepare_import_target_dataset(
             dataset_name=target_name or f"{dataset_name}-{version}",
@@ -959,7 +950,6 @@ class AsyncDataVault:
         items = await self._backend.list_collection_items(
             {"collection_id": collection.collection_id, "status": "active"}
         )
-        datalake = self._require_local_datalake()
         dataset_name = _snapshot_dataset_version_name(collection, snapshot_name)
         version = _snapshot_dataset_version_version(snapshot_version)
 
@@ -967,7 +957,7 @@ class AsyncDataVault:
             manifest: list[str] = []
             for item in items:
                 asset = await self._backend.get_asset(item.asset_id)
-                datum = await datalake.create_datum(
+                datum = await self._backend.create_datum(
                     asset_refs={_snapshot_primary_role(asset): asset.asset_id},
                     split=item.split,
                     metadata=_snapshot_datum_metadata(collection, item),
@@ -977,7 +967,7 @@ class AsyncDataVault:
                     _dataset_annotation_set_filters(collection.collection_id, asset_id=asset.asset_id)
                 )
                 for source_set in source_sets:
-                    frozen_set = await datalake.create_annotation_set(
+                    frozen_set = await self._backend.create_annotation_set(
                         name=source_set.name,
                         purpose=source_set.purpose,
                         source_type=source_set.source_type,
@@ -992,12 +982,12 @@ class AsyncDataVault:
                         for annotation_id in source_set.annotation_record_ids
                     ]
                     if source_records:
-                        await datalake.add_annotation_records(
+                        await self._backend.add_annotation_records(
                             [_snapshot_annotation_payload(record, asset.asset_id) for record in source_records],
                             annotation_set_id=frozen_set.annotation_set_id,
                             annotation_schema_id=source_set.annotation_schema_id,
                         )
-            await datalake.create_dataset_version(
+            await self._backend.create_dataset_version(
                 dataset_name=dataset_name,
                 version=version,
                 description=collection.description,
@@ -1015,7 +1005,7 @@ class AsyncDataVault:
                 ),
                 created_by=created_by,
             )
-            return await datalake.resolve_dataset_version(dataset_name, version)
+            return await self._backend.resolve_dataset_version(dataset_name, version)
 
         resolved_datums: list[ResolvedDatum] = []
         manifest: list[str] = []
@@ -1102,7 +1092,6 @@ class AsyncDataVault:
         from mindtrace.datalake.exporters import export_dataset_to_format
         from mindtrace.datalake.exporters.base import build_exportable_dataset_from_resolved_version_async
 
-        datalake = self._require_local_datalake()
         resolved_dataset_version = await self._freeze_dataset(
             dataset,
             persist_snapshot=persist_snapshot,
@@ -1111,7 +1100,7 @@ class AsyncDataVault:
             created_by=created_by,
         )
         exportable_dataset = await build_exportable_dataset_from_resolved_version_async(
-            datalake,
+            self._backend,
             resolved_dataset_version,
             split_map=split_map,
         )
@@ -1687,13 +1676,6 @@ class DataVault:
                 annotations.append(self._backend.get_annotation_record(annotation_id))
         return annotations
 
-    def _require_local_datalake(self) -> Datalake | Any:
-        if isinstance(self._backend, LocalDataVaultBackend):
-            return self._backend._datalake
-        raise NotImplementedError(
-            "DataVault dataset export currently requires a local Datalake backend when freeze is needed."
-        )
-
     def _prepare_import_target_dataset(
         self,
         *,
@@ -1707,9 +1689,8 @@ class DataVault:
         if matches:
             if not overwrite:
                 raise ValueError(f"Dataset {dataset_name!r} already exists")
-            datalake = self._require_local_datalake()
             for collection in matches:
-                datalake.update_collection(collection.collection_id, status="archived")
+                self._backend.update_collection(collection.collection_id, status="archived")
         return self.create_dataset(
             dataset_name,
             description=description,
@@ -1729,8 +1710,7 @@ class DataVault:
         created_by: str | None = None,
     ) -> VaultDataset:
         """Materialize an immutable dataset version into a mutable vault dataset."""
-        datalake = self._require_local_datalake()
-        resolved_dataset_version = datalake.resolve_dataset_version(dataset_name, version)
+        resolved_dataset_version = self._backend.resolve_dataset_version(dataset_name, version)
         source_dataset = resolved_dataset_version.dataset_version
         imported_dataset = self._prepare_import_target_dataset(
             dataset_name=target_name or f"{dataset_name}-{version}",
@@ -1816,7 +1796,6 @@ class DataVault:
     ) -> ResolvedDatasetVersion:
         collection = self._get_dataset_collection(dataset)
         items = self._backend.list_collection_items({"collection_id": collection.collection_id, "status": "active"})
-        datalake = self._require_local_datalake()
         dataset_name = _snapshot_dataset_version_name(collection, snapshot_name)
         version = _snapshot_dataset_version_version(snapshot_version)
 
@@ -1824,7 +1803,7 @@ class DataVault:
             manifest: list[str] = []
             for item in items:
                 asset = self._backend.get_asset(item.asset_id)
-                datum = datalake.create_datum(
+                datum = self._backend.create_datum(
                     asset_refs={_snapshot_primary_role(asset): asset.asset_id},
                     split=item.split,
                     metadata=_snapshot_datum_metadata(collection, item),
@@ -1834,7 +1813,7 @@ class DataVault:
                     _dataset_annotation_set_filters(collection.collection_id, asset_id=asset.asset_id)
                 )
                 for source_set in source_sets:
-                    frozen_set = datalake.create_annotation_set(
+                    frozen_set = self._backend.create_annotation_set(
                         name=source_set.name,
                         purpose=source_set.purpose,
                         source_type=source_set.source_type,
@@ -1849,12 +1828,12 @@ class DataVault:
                         for annotation_id in source_set.annotation_record_ids
                     ]
                     if source_records:
-                        datalake.add_annotation_records(
+                        self._backend.add_annotation_records(
                             [_snapshot_annotation_payload(record, asset.asset_id) for record in source_records],
                             annotation_set_id=frozen_set.annotation_set_id,
                             annotation_schema_id=source_set.annotation_schema_id,
                         )
-            datalake.create_dataset_version(
+            self._backend.create_dataset_version(
                 dataset_name=dataset_name,
                 version=version,
                 description=collection.description,
@@ -1872,7 +1851,7 @@ class DataVault:
                 ),
                 created_by=created_by,
             )
-            return datalake.resolve_dataset_version(dataset_name, version)
+            return self._backend.resolve_dataset_version(dataset_name, version)
 
         resolved_datums: list[ResolvedDatum] = []
         manifest: list[str] = []
@@ -1959,7 +1938,6 @@ class DataVault:
         from mindtrace.datalake.exporters import export_dataset_to_format
         from mindtrace.datalake.exporters.base import build_exportable_dataset_from_resolved_version_sync
 
-        datalake = self._require_local_datalake()
         resolved_dataset_version = self._freeze_dataset(
             dataset,
             persist_snapshot=persist_snapshot,
@@ -1968,7 +1946,7 @@ class DataVault:
             created_by=created_by,
         )
         exportable_dataset = build_exportable_dataset_from_resolved_version_sync(
-            datalake,
+            self._backend,
             resolved_dataset_version,
             split_map=split_map,
         )

--- a/mindtrace/datalake/mindtrace/datalake/data_vault.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault.py
@@ -49,10 +49,11 @@ from __future__ import annotations
 
 import re
 from collections.abc import AsyncIterator, Iterator, Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from PIL import Image
 from pydantic import BaseModel, Field
@@ -82,7 +83,11 @@ from mindtrace.datalake.types import (
     Asset,
     Collection,
     CollectionItem,
+    DatasetVersion,
+    Datum,
     DuplicateAliasError,
+    ResolvedDatasetVersion,
+    ResolvedDatum,
     SubjectRef,
 )
 from mindtrace.datalake.vault_serialization import (
@@ -185,6 +190,82 @@ def _annotation_id(annotation: str | AnnotationRecord) -> str:
     if isinstance(annotation, AnnotationRecord):
         return annotation.annotation_id
     return annotation
+
+
+def _merge_nested_dict(base: dict[str, Any] | None, extra: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base or {})
+    for key, value in extra.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _merge_nested_dict(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _snapshot_dataset_version_name(collection: Collection, snapshot_name: str | None) -> str:
+    return snapshot_name or collection.name
+
+
+def _snapshot_dataset_version_version(snapshot_version: str | None) -> str:
+    return snapshot_version or f"export-{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}-{uuid4().hex[:8]}"
+
+
+def _snapshot_primary_role(asset: Asset) -> str:
+    return "image" if asset.kind == "image" else "asset"
+
+
+def _snapshot_datum_metadata(collection: Collection, item: CollectionItem) -> dict[str, Any]:
+    return _merge_nested_dict(
+        item.metadata,
+        {
+            "mindtrace": {
+                "data_vault": {
+                    "source_dataset_id": collection.collection_id,
+                    "source_dataset_name": collection.name,
+                    "source_collection_item_id": item.collection_item_id,
+                }
+            }
+        },
+    )
+
+
+def _snapshot_annotation_set_metadata(
+    collection: Collection,
+    item: CollectionItem,
+    source_set: AnnotationSet,
+) -> dict[str, Any]:
+    return _merge_nested_dict(
+        source_set.metadata,
+        {
+            "mindtrace": {
+                "data_vault": {
+                    "source_dataset_id": collection.collection_id,
+                    "source_dataset_name": collection.name,
+                    "source_collection_item_id": item.collection_item_id,
+                    "source_annotation_set_id": source_set.annotation_set_id,
+                }
+            }
+        },
+    )
+
+
+def _snapshot_annotation_payload(record: AnnotationRecord, asset_id: str) -> dict[str, Any]:
+    payload = record.model_dump(
+        mode="json",
+        exclude={"annotation_id", "created_at", "updated_at"},
+    )
+    payload["subject"] = {"kind": "asset", "id": asset_id}
+    payload["metadata"] = _merge_nested_dict(
+        payload.get("metadata"),
+        {
+            "mindtrace": {
+                "data_vault": {
+                    "source_annotation_id": record.annotation_id,
+                }
+            }
+        },
+    )
+    return payload
 
 
 def _pil_image_to_png_bytes(image: Image.Image) -> bytes:
@@ -659,6 +740,191 @@ class AsyncDataVault:
             for annotation_id in annotation_set.annotation_record_ids:
                 annotations.append(await self._backend.get_annotation_record(annotation_id))
         return annotations
+
+    def _require_local_datalake(self) -> AsyncDatalake | Any:
+        if isinstance(self._backend, LocalAsyncDataVaultBackend):
+            return self._backend._datalake
+        raise NotImplementedError(
+            "DataVault dataset export currently requires a local AsyncDatalake backend when freeze is needed."
+        )
+
+    async def _freeze_dataset(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        persist_snapshot: bool = False,
+        snapshot_name: str | None = None,
+        snapshot_version: str | None = None,
+        created_by: str | None = None,
+    ) -> ResolvedDatasetVersion:
+        collection = await self._get_dataset_collection(dataset)
+        items = await self._backend.list_collection_items(
+            {"collection_id": collection.collection_id, "status": "active"}
+        )
+        datalake = self._require_local_datalake()
+        dataset_name = _snapshot_dataset_version_name(collection, snapshot_name)
+        version = _snapshot_dataset_version_version(snapshot_version)
+
+        if persist_snapshot:
+            manifest: list[str] = []
+            for item in items:
+                asset = await self._backend.get_asset(item.asset_id)
+                datum = await datalake.create_datum(
+                    asset_refs={_snapshot_primary_role(asset): asset.asset_id},
+                    split=item.split,
+                    metadata=_snapshot_datum_metadata(collection, item),
+                )
+                manifest.append(datum.datum_id)
+                source_sets = await self._backend.list_annotation_sets(
+                    _dataset_annotation_set_filters(collection.collection_id, asset_id=asset.asset_id)
+                )
+                for source_set in source_sets:
+                    frozen_set = await datalake.create_annotation_set(
+                        name=source_set.name,
+                        purpose=source_set.purpose,
+                        source_type=source_set.source_type,
+                        status=source_set.status,
+                        metadata=_snapshot_annotation_set_metadata(collection, item, source_set),
+                        created_by=created_by,
+                        datum_id=datum.datum_id,
+                        annotation_schema_id=source_set.annotation_schema_id,
+                    )
+                    source_records = [
+                        await self._backend.get_annotation_record(annotation_id)
+                        for annotation_id in source_set.annotation_record_ids
+                    ]
+                    if source_records:
+                        await datalake.add_annotation_records(
+                            [_snapshot_annotation_payload(record, asset.asset_id) for record in source_records],
+                            annotation_set_id=frozen_set.annotation_set_id,
+                            annotation_schema_id=source_set.annotation_schema_id,
+                        )
+            await datalake.create_dataset_version(
+                dataset_name=dataset_name,
+                version=version,
+                description=collection.description,
+                manifest=manifest,
+                metadata=_merge_nested_dict(
+                    collection.metadata,
+                    {
+                        "mindtrace": {
+                            "data_vault": {
+                                "source_dataset_id": collection.collection_id,
+                                "source_dataset_name": collection.name,
+                            }
+                        }
+                    },
+                ),
+                created_by=created_by,
+            )
+            return await datalake.resolve_dataset_version(dataset_name, version)
+
+        resolved_datums: list[ResolvedDatum] = []
+        manifest: list[str] = []
+        for item in items:
+            asset = await self._backend.get_asset(item.asset_id)
+            datum = Datum(
+                asset_refs={_snapshot_primary_role(asset): asset.asset_id},
+                split=item.split,
+                metadata=_snapshot_datum_metadata(collection, item),
+            )
+            source_sets = await self._backend.list_annotation_sets(
+                _dataset_annotation_set_filters(collection.collection_id, asset_id=asset.asset_id)
+            )
+            frozen_sets: list[AnnotationSet] = []
+            frozen_records: dict[str, list[AnnotationRecord]] = {}
+            for source_set in source_sets:
+                cloned_records = [
+                    AnnotationRecord(**_snapshot_annotation_payload(record, asset.asset_id))
+                    for record in [
+                        await self._backend.get_annotation_record(annotation_id)
+                        for annotation_id in source_set.annotation_record_ids
+                    ]
+                ]
+                frozen_set = AnnotationSet(
+                    name=source_set.name,
+                    purpose=source_set.purpose,
+                    source_type=source_set.source_type,
+                    status=source_set.status,
+                    annotation_schema_id=source_set.annotation_schema_id,
+                    annotation_record_ids=[record.annotation_id for record in cloned_records],
+                    metadata=_snapshot_annotation_set_metadata(collection, item, source_set),
+                    created_by=created_by,
+                )
+                frozen_sets.append(frozen_set)
+                frozen_records[frozen_set.annotation_set_id] = cloned_records
+            datum.annotation_set_ids = [annotation_set.annotation_set_id for annotation_set in frozen_sets]
+            manifest.append(datum.datum_id)
+            resolved_datums.append(
+                ResolvedDatum(
+                    datum=datum,
+                    assets={_snapshot_primary_role(asset): asset},
+                    annotation_sets=frozen_sets,
+                    annotation_records=frozen_records,
+                )
+            )
+        return ResolvedDatasetVersion(
+            dataset_version=DatasetVersion(
+                dataset_name=dataset_name,
+                version=version,
+                description=collection.description,
+                manifest=manifest,
+                metadata=_merge_nested_dict(
+                    collection.metadata,
+                    {
+                        "mindtrace": {
+                            "data_vault": {
+                                "source_dataset_id": collection.collection_id,
+                                "source_dataset_name": collection.name,
+                            }
+                        }
+                    },
+                ),
+                created_by=created_by,
+            ),
+            datums=resolved_datums,
+        )
+
+    async def export_dataset(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        format: str,
+        destination: str | Path,
+        include_media: bool = True,
+        overwrite: bool = False,
+        split_map: dict[str, str] | None = None,
+        exporter_options: dict[str, Any] | None = None,
+        persist_snapshot: bool = False,
+        snapshot_name: str | None = None,
+        snapshot_version: str | None = None,
+        created_by: str | None = None,
+    ):
+        """Export a mutable DataVault dataset to a named external format."""
+        from mindtrace.datalake.exporters import export_dataset_to_format
+        from mindtrace.datalake.exporters.base import build_exportable_dataset_from_resolved_version_async
+
+        datalake = self._require_local_datalake()
+        resolved_dataset_version = await self._freeze_dataset(
+            dataset,
+            persist_snapshot=persist_snapshot,
+            snapshot_name=snapshot_name,
+            snapshot_version=snapshot_version,
+            created_by=created_by,
+        )
+        exportable_dataset = await build_exportable_dataset_from_resolved_version_async(
+            datalake,
+            resolved_dataset_version,
+            split_map=split_map,
+        )
+        return export_dataset_to_format(
+            exportable_dataset,
+            format=format,
+            destination=destination,
+            include_media=include_media,
+            overwrite=overwrite,
+            exporter_options=exporter_options,
+        )
 
     async def load(
         self,
@@ -1222,6 +1488,189 @@ class DataVault:
             for annotation_id in annotation_set.annotation_record_ids:
                 annotations.append(self._backend.get_annotation_record(annotation_id))
         return annotations
+
+    def _require_local_datalake(self) -> Datalake | Any:
+        if isinstance(self._backend, LocalDataVaultBackend):
+            return self._backend._datalake
+        raise NotImplementedError(
+            "DataVault dataset export currently requires a local Datalake backend when freeze is needed."
+        )
+
+    def _freeze_dataset(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        persist_snapshot: bool = False,
+        snapshot_name: str | None = None,
+        snapshot_version: str | None = None,
+        created_by: str | None = None,
+    ) -> ResolvedDatasetVersion:
+        collection = self._get_dataset_collection(dataset)
+        items = self._backend.list_collection_items({"collection_id": collection.collection_id, "status": "active"})
+        datalake = self._require_local_datalake()
+        dataset_name = _snapshot_dataset_version_name(collection, snapshot_name)
+        version = _snapshot_dataset_version_version(snapshot_version)
+
+        if persist_snapshot:
+            manifest: list[str] = []
+            for item in items:
+                asset = self._backend.get_asset(item.asset_id)
+                datum = datalake.create_datum(
+                    asset_refs={_snapshot_primary_role(asset): asset.asset_id},
+                    split=item.split,
+                    metadata=_snapshot_datum_metadata(collection, item),
+                )
+                manifest.append(datum.datum_id)
+                source_sets = self._backend.list_annotation_sets(
+                    _dataset_annotation_set_filters(collection.collection_id, asset_id=asset.asset_id)
+                )
+                for source_set in source_sets:
+                    frozen_set = datalake.create_annotation_set(
+                        name=source_set.name,
+                        purpose=source_set.purpose,
+                        source_type=source_set.source_type,
+                        status=source_set.status,
+                        metadata=_snapshot_annotation_set_metadata(collection, item, source_set),
+                        created_by=created_by,
+                        datum_id=datum.datum_id,
+                        annotation_schema_id=source_set.annotation_schema_id,
+                    )
+                    source_records = [
+                        self._backend.get_annotation_record(annotation_id)
+                        for annotation_id in source_set.annotation_record_ids
+                    ]
+                    if source_records:
+                        datalake.add_annotation_records(
+                            [_snapshot_annotation_payload(record, asset.asset_id) for record in source_records],
+                            annotation_set_id=frozen_set.annotation_set_id,
+                            annotation_schema_id=source_set.annotation_schema_id,
+                        )
+            datalake.create_dataset_version(
+                dataset_name=dataset_name,
+                version=version,
+                description=collection.description,
+                manifest=manifest,
+                metadata=_merge_nested_dict(
+                    collection.metadata,
+                    {
+                        "mindtrace": {
+                            "data_vault": {
+                                "source_dataset_id": collection.collection_id,
+                                "source_dataset_name": collection.name,
+                            }
+                        }
+                    },
+                ),
+                created_by=created_by,
+            )
+            return datalake.resolve_dataset_version(dataset_name, version)
+
+        resolved_datums: list[ResolvedDatum] = []
+        manifest: list[str] = []
+        for item in items:
+            asset = self._backend.get_asset(item.asset_id)
+            datum = Datum(
+                asset_refs={_snapshot_primary_role(asset): asset.asset_id},
+                split=item.split,
+                metadata=_snapshot_datum_metadata(collection, item),
+            )
+            source_sets = self._backend.list_annotation_sets(
+                _dataset_annotation_set_filters(collection.collection_id, asset_id=asset.asset_id)
+            )
+            frozen_sets: list[AnnotationSet] = []
+            frozen_records: dict[str, list[AnnotationRecord]] = {}
+            for source_set in source_sets:
+                cloned_records = [
+                    AnnotationRecord(**_snapshot_annotation_payload(record, asset.asset_id))
+                    for record in [
+                        self._backend.get_annotation_record(annotation_id)
+                        for annotation_id in source_set.annotation_record_ids
+                    ]
+                ]
+                frozen_set = AnnotationSet(
+                    name=source_set.name,
+                    purpose=source_set.purpose,
+                    source_type=source_set.source_type,
+                    status=source_set.status,
+                    annotation_schema_id=source_set.annotation_schema_id,
+                    annotation_record_ids=[record.annotation_id for record in cloned_records],
+                    metadata=_snapshot_annotation_set_metadata(collection, item, source_set),
+                    created_by=created_by,
+                )
+                frozen_sets.append(frozen_set)
+                frozen_records[frozen_set.annotation_set_id] = cloned_records
+            datum.annotation_set_ids = [annotation_set.annotation_set_id for annotation_set in frozen_sets]
+            manifest.append(datum.datum_id)
+            resolved_datums.append(
+                ResolvedDatum(
+                    datum=datum,
+                    assets={_snapshot_primary_role(asset): asset},
+                    annotation_sets=frozen_sets,
+                    annotation_records=frozen_records,
+                )
+            )
+        return ResolvedDatasetVersion(
+            dataset_version=DatasetVersion(
+                dataset_name=dataset_name,
+                version=version,
+                description=collection.description,
+                manifest=manifest,
+                metadata=_merge_nested_dict(
+                    collection.metadata,
+                    {
+                        "mindtrace": {
+                            "data_vault": {
+                                "source_dataset_id": collection.collection_id,
+                                "source_dataset_name": collection.name,
+                            }
+                        }
+                    },
+                ),
+                created_by=created_by,
+            ),
+            datums=resolved_datums,
+        )
+
+    def export_dataset(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        format: str,
+        destination: str | Path,
+        include_media: bool = True,
+        overwrite: bool = False,
+        split_map: dict[str, str] | None = None,
+        exporter_options: dict[str, Any] | None = None,
+        persist_snapshot: bool = False,
+        snapshot_name: str | None = None,
+        snapshot_version: str | None = None,
+        created_by: str | None = None,
+    ):
+        """Export a mutable DataVault dataset to a named external format."""
+        from mindtrace.datalake.exporters import export_dataset_to_format
+        from mindtrace.datalake.exporters.base import build_exportable_dataset_from_resolved_version_sync
+
+        datalake = self._require_local_datalake()
+        resolved_dataset_version = self._freeze_dataset(
+            dataset,
+            persist_snapshot=persist_snapshot,
+            snapshot_name=snapshot_name,
+            snapshot_version=snapshot_version,
+            created_by=created_by,
+        )
+        exportable_dataset = build_exportable_dataset_from_resolved_version_sync(
+            datalake,
+            resolved_dataset_version,
+            split_map=split_map,
+        )
+        return export_dataset_to_format(
+            exportable_dataset,
+            format=format,
+            destination=destination,
+            include_media=include_media,
+            overwrite=overwrite,
+            exporter_options=exporter_options,
+        )
 
     def load(
         self,

--- a/mindtrace/datalake/mindtrace/datalake/data_vault.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault.py
@@ -268,6 +268,93 @@ def _snapshot_annotation_payload(record: AnnotationRecord, asset_id: str) -> dic
     return payload
 
 
+def _import_dataset_metadata(
+    source_dataset: DatasetVersion,
+    target_metadata: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return _merge_nested_dict(
+        source_dataset.metadata,
+        _merge_nested_dict(
+            target_metadata,
+            {
+                "mindtrace": {
+                    "source_dataset_version": {
+                        "dataset_name": source_dataset.dataset_name,
+                        "version": source_dataset.version,
+                        "dataset_version_id": source_dataset.dataset_version_id,
+                    }
+                }
+            },
+        ),
+    )
+
+
+def _imported_annotation_set_metadata(
+    source_dataset: DatasetVersion,
+    source_set: AnnotationSet,
+    asset_id: str,
+) -> dict[str, Any]:
+    return _merge_nested_dict(
+        source_set.metadata,
+        {
+            "mindtrace": {
+                "data_vault": {
+                    "source_annotation_set_id": source_set.annotation_set_id,
+                    "source_dataset_version_id": source_dataset.dataset_version_id,
+                    "asset_id": asset_id,
+                }
+            }
+        },
+    )
+
+
+def _imported_annotation_payload(
+    record: AnnotationRecord,
+    *,
+    asset_id: str,
+    source_dataset: DatasetVersion,
+    source_set: AnnotationSet,
+) -> dict[str, Any]:
+    payload = record.model_dump(
+        mode="json",
+        exclude={"annotation_id", "created_at", "updated_at"},
+    )
+    payload["subject"] = {"kind": "asset", "id": asset_id}
+    payload["metadata"] = _merge_nested_dict(
+        payload.get("metadata"),
+        {
+            "mindtrace": {
+                "source_dataset_version": {
+                    "dataset_name": source_dataset.dataset_name,
+                    "version": source_dataset.version,
+                    "dataset_version_id": source_dataset.dataset_version_id,
+                },
+                "data_vault": {
+                    "source_annotation_id": record.annotation_id,
+                    "source_annotation_set_id": source_set.annotation_set_id,
+                },
+            }
+        },
+    )
+    return payload
+
+
+def _resolved_primary_asset(resolved_datum: ResolvedDatum) -> Asset | None:
+    for role in ("image", "asset"):
+        asset = resolved_datum.assets.get(role)
+        if asset is not None:
+            return asset
+    for asset in resolved_datum.assets.values():
+        return asset
+    return None
+
+
+def _annotation_matches_asset(record: AnnotationRecord, asset_id: str) -> bool:
+    if record.subject is None:
+        return True
+    return record.subject.kind == "asset" and record.subject.id == asset_id
+
+
 def _pil_image_to_png_bytes(image: Image.Image) -> bytes:
     """Encode a PIL image as lossless PNG bytes (Mindtrace canonical wire format for images)."""
     buf = BytesIO()
@@ -747,6 +834,117 @@ class AsyncDataVault:
         raise NotImplementedError(
             "DataVault dataset export currently requires a local AsyncDatalake backend when freeze is needed."
         )
+
+    async def _prepare_import_target_dataset(
+        self,
+        *,
+        dataset_name: str,
+        description: str | None,
+        metadata: dict[str, Any],
+        overwrite: bool,
+        created_by: str | None,
+    ) -> VaultDataset:
+        matches = await self._backend.list_collections(_dataset_filters({"name": dataset_name}))
+        if matches:
+            if not overwrite:
+                raise ValueError(f"Dataset {dataset_name!r} already exists")
+            datalake = self._require_local_datalake()
+            for collection in matches:
+                await datalake.update_collection(collection.collection_id, status="archived")
+        return await self.create_dataset(
+            dataset_name,
+            description=description,
+            metadata=metadata,
+            created_by=created_by,
+        )
+
+    async def import_dataset_version(
+        self,
+        dataset_name: str,
+        version: str,
+        *,
+        target_name: str | None = None,
+        target_description: str | None = None,
+        target_metadata: dict[str, Any] | None = None,
+        overwrite: bool = False,
+        created_by: str | None = None,
+    ) -> VaultDataset:
+        """Materialize an immutable dataset version into a mutable vault dataset."""
+        datalake = self._require_local_datalake()
+        resolved_dataset_version = await datalake.resolve_dataset_version(dataset_name, version)
+        source_dataset = resolved_dataset_version.dataset_version
+        imported_dataset = await self._prepare_import_target_dataset(
+            dataset_name=target_name or f"{dataset_name}-{version}",
+            description=target_description if target_description is not None else source_dataset.description,
+            metadata=_import_dataset_metadata(source_dataset, target_metadata),
+            overwrite=overwrite,
+            created_by=created_by,
+        )
+
+        collection = await self._get_dataset_collection(imported_dataset)
+        for resolved_datum in resolved_dataset_version.datums:
+            primary_asset = _resolved_primary_asset(resolved_datum)
+            if primary_asset is None:
+                continue
+            await self._ensure_collection_item(
+                collection,
+                primary_asset.asset_id,
+                split=resolved_datum.datum.split,
+                metadata=dict(resolved_datum.datum.metadata or {}),
+                added_by=created_by,
+            )
+            for source_set in resolved_datum.annotation_sets:
+                source_records = list(resolved_datum.annotation_records.get(source_set.annotation_set_id, []))
+                matching_records = [
+                    record for record in source_records if _annotation_matches_asset(record, primary_asset.asset_id)
+                ]
+                if not matching_records:
+                    continue
+                imported_set = await self._backend.create_annotation_set(
+                    name=source_set.name,
+                    purpose=source_set.purpose,
+                    source_type=source_set.source_type,
+                    status="active",
+                    metadata=_merge_nested_dict(
+                        _dataset_annotation_set_metadata(collection, primary_asset.asset_id),
+                        _imported_annotation_set_metadata(source_dataset, source_set, primary_asset.asset_id),
+                    ),
+                    created_by=created_by,
+                    annotation_schema_id=source_set.annotation_schema_id,
+                )
+                await self._backend.add_annotation_records(
+                    [
+                        _imported_annotation_payload(
+                            record,
+                            asset_id=primary_asset.asset_id,
+                            source_dataset=source_dataset,
+                            source_set=source_set,
+                        )
+                        for record in matching_records
+                    ],
+                    annotation_set_id=imported_set.annotation_set_id,
+                    annotation_schema_id=source_set.annotation_schema_id,
+                )
+        return await self.get_dataset(imported_dataset.name)
+
+    async def freeze_dataset(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        snapshot_name: str | None = None,
+        snapshot_version: str | None = None,
+        persist: bool = True,
+        created_by: str | None = None,
+    ) -> DatasetVersion | ResolvedDatasetVersion:
+        """Freeze a mutable vault dataset into an immutable snapshot."""
+        resolved = await self._freeze_dataset(
+            dataset,
+            persist_snapshot=persist,
+            snapshot_name=snapshot_name,
+            snapshot_version=snapshot_version,
+            created_by=created_by,
+        )
+        return resolved.dataset_version if persist else resolved
 
     async def _freeze_dataset(
         self,
@@ -1495,6 +1693,117 @@ class DataVault:
         raise NotImplementedError(
             "DataVault dataset export currently requires a local Datalake backend when freeze is needed."
         )
+
+    def _prepare_import_target_dataset(
+        self,
+        *,
+        dataset_name: str,
+        description: str | None,
+        metadata: dict[str, Any],
+        overwrite: bool,
+        created_by: str | None,
+    ) -> VaultDataset:
+        matches = self._backend.list_collections(_dataset_filters({"name": dataset_name}))
+        if matches:
+            if not overwrite:
+                raise ValueError(f"Dataset {dataset_name!r} already exists")
+            datalake = self._require_local_datalake()
+            for collection in matches:
+                datalake.update_collection(collection.collection_id, status="archived")
+        return self.create_dataset(
+            dataset_name,
+            description=description,
+            metadata=metadata,
+            created_by=created_by,
+        )
+
+    def import_dataset_version(
+        self,
+        dataset_name: str,
+        version: str,
+        *,
+        target_name: str | None = None,
+        target_description: str | None = None,
+        target_metadata: dict[str, Any] | None = None,
+        overwrite: bool = False,
+        created_by: str | None = None,
+    ) -> VaultDataset:
+        """Materialize an immutable dataset version into a mutable vault dataset."""
+        datalake = self._require_local_datalake()
+        resolved_dataset_version = datalake.resolve_dataset_version(dataset_name, version)
+        source_dataset = resolved_dataset_version.dataset_version
+        imported_dataset = self._prepare_import_target_dataset(
+            dataset_name=target_name or f"{dataset_name}-{version}",
+            description=target_description if target_description is not None else source_dataset.description,
+            metadata=_import_dataset_metadata(source_dataset, target_metadata),
+            overwrite=overwrite,
+            created_by=created_by,
+        )
+
+        collection = self._get_dataset_collection(imported_dataset)
+        for resolved_datum in resolved_dataset_version.datums:
+            primary_asset = _resolved_primary_asset(resolved_datum)
+            if primary_asset is None:
+                continue
+            self._ensure_collection_item(
+                collection,
+                primary_asset.asset_id,
+                split=resolved_datum.datum.split,
+                metadata=dict(resolved_datum.datum.metadata or {}),
+                added_by=created_by,
+            )
+            for source_set in resolved_datum.annotation_sets:
+                source_records = list(resolved_datum.annotation_records.get(source_set.annotation_set_id, []))
+                matching_records = [
+                    record for record in source_records if _annotation_matches_asset(record, primary_asset.asset_id)
+                ]
+                if not matching_records:
+                    continue
+                imported_set = self._backend.create_annotation_set(
+                    name=source_set.name,
+                    purpose=source_set.purpose,
+                    source_type=source_set.source_type,
+                    status="active",
+                    metadata=_merge_nested_dict(
+                        _dataset_annotation_set_metadata(collection, primary_asset.asset_id),
+                        _imported_annotation_set_metadata(source_dataset, source_set, primary_asset.asset_id),
+                    ),
+                    created_by=created_by,
+                    annotation_schema_id=source_set.annotation_schema_id,
+                )
+                self._backend.add_annotation_records(
+                    [
+                        _imported_annotation_payload(
+                            record,
+                            asset_id=primary_asset.asset_id,
+                            source_dataset=source_dataset,
+                            source_set=source_set,
+                        )
+                        for record in matching_records
+                    ],
+                    annotation_set_id=imported_set.annotation_set_id,
+                    annotation_schema_id=source_set.annotation_schema_id,
+                )
+        return self.get_dataset(imported_dataset.name)
+
+    def freeze_dataset(
+        self,
+        dataset: str | VaultDataset,
+        *,
+        snapshot_name: str | None = None,
+        snapshot_version: str | None = None,
+        persist: bool = True,
+        created_by: str | None = None,
+    ) -> DatasetVersion | ResolvedDatasetVersion:
+        """Freeze a mutable vault dataset into an immutable snapshot."""
+        resolved = self._freeze_dataset(
+            dataset,
+            persist_snapshot=persist,
+            snapshot_name=snapshot_name,
+            snapshot_version=snapshot_version,
+            created_by=created_by,
+        )
+        return resolved.dataset_version if persist else resolved
 
     def _freeze_dataset(
         self,

--- a/mindtrace/datalake/mindtrace/datalake/data_vault_backends.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault_backends.py
@@ -20,15 +20,28 @@ from mindtrace.datalake.pagination_types import CursorPage
 from mindtrace.datalake.service_types import (
     AddAliasInput,
     AddAnnotationRecordsInput,
+    CreateAnnotationSetInput,
     CreateAssetFromObjectInput,
+    CreateCollectionInput,
+    CreateCollectionItemInput,
+    DeleteByIdInput,
     GetAssetByAliasInput,
     GetByIdInput,
     GetObjectInput,
     ListAnnotationRecordsForAssetInput,
     ListInput,
     PageInput,
+    UpdateCollectionItemInput,
 )
-from mindtrace.datalake.types import AnnotationRecord, Asset, AssetAlias, StorageRef
+from mindtrace.datalake.types import (
+    AnnotationRecord,
+    AnnotationSet,
+    Asset,
+    AssetAlias,
+    Collection,
+    CollectionItem,
+    StorageRef,
+)
 from mindtrace.services.core.connection_manager import ConnectionManager
 
 _SYNC_VAULT_METHOD_NAMES = (
@@ -42,6 +55,20 @@ _SYNC_VAULT_METHOD_NAMES = (
     "add_alias",
     "add_annotation_records",
     "list_annotation_records_for_asset",
+    "list_collections",
+    "list_collections_page",
+    "iter_collections",
+    "create_collection",
+    "list_collection_items",
+    "list_collection_items_page",
+    "create_collection_item",
+    "update_collection_item",
+    "delete_collection_item",
+    "list_annotation_sets",
+    "create_annotation_set",
+    "get_annotation_record",
+    "list_annotation_records",
+    "delete_annotation_record",
 )
 _ASYNC_VAULT_METHOD_NAMES = _SYNC_VAULT_METHOD_NAMES
 
@@ -165,6 +192,98 @@ class AsyncDataVaultBackend(ABC):
     @abstractmethod
     async def list_annotation_records_for_asset(self, asset_id: str) -> list[AnnotationRecord]: ...
 
+    @abstractmethod
+    async def list_collections(self, filters: dict[str, Any] | None = None) -> list[Collection]: ...
+
+    @abstractmethod
+    async def list_collections_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[Collection]: ...
+
+    @abstractmethod
+    async def iter_collections(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        batch_size: int | None = None,
+    ) -> AsyncIterator[Collection]: ...
+
+    @abstractmethod
+    async def create_collection(
+        self,
+        *,
+        name: str,
+        description: str | None = None,
+        status: str = "active",
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> Collection: ...
+
+    @abstractmethod
+    async def list_collection_items(self, filters: dict[str, Any] | None = None) -> list[CollectionItem]: ...
+
+    @abstractmethod
+    async def list_collection_items_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[CollectionItem]: ...
+
+    @abstractmethod
+    async def create_collection_item(
+        self,
+        *,
+        collection_id: str,
+        asset_id: str,
+        split: str | None = None,
+        status: str = "active",
+        metadata: dict[str, Any] | None = None,
+        added_by: str | None = None,
+    ) -> CollectionItem: ...
+
+    @abstractmethod
+    async def update_collection_item(self, collection_item_id: str, **changes: Any) -> CollectionItem: ...
+
+    @abstractmethod
+    async def delete_collection_item(self, collection_item_id: str) -> None: ...
+
+    @abstractmethod
+    async def list_annotation_sets(self, filters: dict[str, Any] | None = None) -> list[AnnotationSet]: ...
+
+    @abstractmethod
+    async def create_annotation_set(
+        self,
+        *,
+        name: str,
+        purpose: str,
+        source_type: str,
+        status: str = "draft",
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+        datum_id: str | None = None,
+        annotation_schema_id: str | None = None,
+    ) -> AnnotationSet: ...
+
+    @abstractmethod
+    async def get_annotation_record(self, annotation_id: str) -> AnnotationRecord: ...
+
+    @abstractmethod
+    async def list_annotation_records(self, filters: dict[str, Any] | None = None) -> list[AnnotationRecord]: ...
+
+    @abstractmethod
+    async def delete_annotation_record(self, annotation_id: str) -> None: ...
+
 
 class DataVaultBackend(ABC):
     """Blocking backend contract for :class:`~mindtrace.datalake.DataVault`."""
@@ -234,6 +353,98 @@ class DataVaultBackend(ABC):
 
     @abstractmethod
     def list_annotation_records_for_asset(self, asset_id: str) -> list[AnnotationRecord]: ...
+
+    @abstractmethod
+    def list_collections(self, filters: dict[str, Any] | None = None) -> list[Collection]: ...
+
+    @abstractmethod
+    def list_collections_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[Collection]: ...
+
+    @abstractmethod
+    def iter_collections(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        batch_size: int | None = None,
+    ) -> Iterator[Collection]: ...
+
+    @abstractmethod
+    def create_collection(
+        self,
+        *,
+        name: str,
+        description: str | None = None,
+        status: str = "active",
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> Collection: ...
+
+    @abstractmethod
+    def list_collection_items(self, filters: dict[str, Any] | None = None) -> list[CollectionItem]: ...
+
+    @abstractmethod
+    def list_collection_items_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[CollectionItem]: ...
+
+    @abstractmethod
+    def create_collection_item(
+        self,
+        *,
+        collection_id: str,
+        asset_id: str,
+        split: str | None = None,
+        status: str = "active",
+        metadata: dict[str, Any] | None = None,
+        added_by: str | None = None,
+    ) -> CollectionItem: ...
+
+    @abstractmethod
+    def update_collection_item(self, collection_item_id: str, **changes: Any) -> CollectionItem: ...
+
+    @abstractmethod
+    def delete_collection_item(self, collection_item_id: str) -> None: ...
+
+    @abstractmethod
+    def list_annotation_sets(self, filters: dict[str, Any] | None = None) -> list[AnnotationSet]: ...
+
+    @abstractmethod
+    def create_annotation_set(
+        self,
+        *,
+        name: str,
+        purpose: str,
+        source_type: str,
+        status: str = "draft",
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+        datum_id: str | None = None,
+        annotation_schema_id: str | None = None,
+    ) -> AnnotationSet: ...
+
+    @abstractmethod
+    def get_annotation_record(self, annotation_id: str) -> AnnotationRecord: ...
+
+    @abstractmethod
+    def list_annotation_records(self, filters: dict[str, Any] | None = None) -> list[AnnotationRecord]: ...
+
+    @abstractmethod
+    def delete_annotation_record(self, annotation_id: str) -> None: ...
 
 
 class LocalAsyncDataVaultBackend(AsyncDataVaultBackend):
@@ -333,6 +544,133 @@ class LocalAsyncDataVaultBackend(AsyncDataVaultBackend):
     async def list_annotation_records_for_asset(self, asset_id: str) -> list[AnnotationRecord]:
         return await self._datalake.list_annotation_records_for_asset(asset_id)
 
+    async def list_collections(self, filters: dict[str, Any] | None = None) -> list[Collection]:
+        return await self._datalake.list_collections(filters)
+
+    async def list_collections_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[Collection]:
+        return await self._datalake.list_collections_page(
+            filters=filters,
+            sort=sort,
+            limit=limit,
+            cursor=cursor,
+            include_total=include_total,
+        )
+
+    async def iter_collections(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        batch_size: int | None = None,
+    ) -> AsyncIterator[Collection]:
+        async for collection in self._datalake.iter_collections(filters=filters, sort=sort, batch_size=batch_size):
+            yield collection
+
+    async def create_collection(
+        self,
+        *,
+        name: str,
+        description: str | None = None,
+        status: str = "active",
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> Collection:
+        return await self._datalake.create_collection(
+            name=name,
+            description=description,
+            status=status,
+            metadata=metadata,
+            created_by=created_by,
+        )
+
+    async def list_collection_items(self, filters: dict[str, Any] | None = None) -> list[CollectionItem]:
+        return await self._datalake.list_collection_items(filters)
+
+    async def list_collection_items_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[CollectionItem]:
+        return await self._datalake.list_collection_items_page(
+            filters=filters,
+            sort=sort,
+            limit=limit,
+            cursor=cursor,
+            include_total=include_total,
+        )
+
+    async def create_collection_item(
+        self,
+        *,
+        collection_id: str,
+        asset_id: str,
+        split: str | None = None,
+        status: str = "active",
+        metadata: dict[str, Any] | None = None,
+        added_by: str | None = None,
+    ) -> CollectionItem:
+        return await self._datalake.create_collection_item(
+            collection_id=collection_id,
+            asset_id=asset_id,
+            split=split,
+            status=status,
+            metadata=metadata,
+            added_by=added_by,
+        )
+
+    async def update_collection_item(self, collection_item_id: str, **changes: Any) -> CollectionItem:
+        return await self._datalake.update_collection_item(collection_item_id, **changes)
+
+    async def delete_collection_item(self, collection_item_id: str) -> None:
+        await self._datalake.delete_collection_item(collection_item_id)
+
+    async def list_annotation_sets(self, filters: dict[str, Any] | None = None) -> list[AnnotationSet]:
+        return await self._datalake.list_annotation_sets(filters)
+
+    async def create_annotation_set(
+        self,
+        *,
+        name: str,
+        purpose: str,
+        source_type: str,
+        status: str = "draft",
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+        datum_id: str | None = None,
+        annotation_schema_id: str | None = None,
+    ) -> AnnotationSet:
+        return await self._datalake.create_annotation_set(
+            name=name,
+            purpose=purpose,
+            source_type=source_type,
+            status=status,
+            metadata=metadata,
+            created_by=created_by,
+            datum_id=datum_id,
+            annotation_schema_id=annotation_schema_id,
+        )
+
+    async def get_annotation_record(self, annotation_id: str) -> AnnotationRecord:
+        return await self._datalake.get_annotation_record(annotation_id)
+
+    async def list_annotation_records(self, filters: dict[str, Any] | None = None) -> list[AnnotationRecord]:
+        return await self._datalake.list_annotation_records(filters)
+
+    async def delete_annotation_record(self, annotation_id: str) -> None:
+        await self._datalake.delete_annotation_record(annotation_id)
+
 
 class LocalDataVaultBackend(DataVaultBackend):
     """Delegates to :class:`~mindtrace.datalake.Datalake` (or a compatible sync facade)."""
@@ -429,6 +767,132 @@ class LocalDataVaultBackend(DataVaultBackend):
 
     def list_annotation_records_for_asset(self, asset_id: str) -> list[AnnotationRecord]:
         return self._datalake.list_annotation_records_for_asset(asset_id)
+
+    def list_collections(self, filters: dict[str, Any] | None = None) -> list[Collection]:
+        return self._datalake.list_collections(filters)
+
+    def list_collections_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[Collection]:
+        return self._datalake.list_collections_page(
+            filters=filters,
+            sort=sort,
+            limit=limit,
+            cursor=cursor,
+            include_total=include_total,
+        )
+
+    def iter_collections(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        batch_size: int | None = None,
+    ) -> Iterator[Collection]:
+        yield from self._datalake.iter_collections(filters=filters, sort=sort, batch_size=batch_size)
+
+    def create_collection(
+        self,
+        *,
+        name: str,
+        description: str | None = None,
+        status: str = "active",
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> Collection:
+        return self._datalake.create_collection(
+            name=name,
+            description=description,
+            status=status,
+            metadata=metadata,
+            created_by=created_by,
+        )
+
+    def list_collection_items(self, filters: dict[str, Any] | None = None) -> list[CollectionItem]:
+        return self._datalake.list_collection_items(filters)
+
+    def list_collection_items_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[CollectionItem]:
+        return self._datalake.list_collection_items_page(
+            filters=filters,
+            sort=sort,
+            limit=limit,
+            cursor=cursor,
+            include_total=include_total,
+        )
+
+    def create_collection_item(
+        self,
+        *,
+        collection_id: str,
+        asset_id: str,
+        split: str | None = None,
+        status: str = "active",
+        metadata: dict[str, Any] | None = None,
+        added_by: str | None = None,
+    ) -> CollectionItem:
+        return self._datalake.create_collection_item(
+            collection_id=collection_id,
+            asset_id=asset_id,
+            split=split,
+            status=status,
+            metadata=metadata,
+            added_by=added_by,
+        )
+
+    def update_collection_item(self, collection_item_id: str, **changes: Any) -> CollectionItem:
+        return self._datalake.update_collection_item(collection_item_id, **changes)
+
+    def delete_collection_item(self, collection_item_id: str) -> None:
+        self._datalake.delete_collection_item(collection_item_id)
+
+    def list_annotation_sets(self, filters: dict[str, Any] | None = None) -> list[AnnotationSet]:
+        return self._datalake.list_annotation_sets(filters)
+
+    def create_annotation_set(
+        self,
+        *,
+        name: str,
+        purpose: str,
+        source_type: str,
+        status: str = "draft",
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+        datum_id: str | None = None,
+        annotation_schema_id: str | None = None,
+    ) -> AnnotationSet:
+        return self._datalake.create_annotation_set(
+            name=name,
+            purpose=purpose,
+            source_type=source_type,
+            status=status,
+            metadata=metadata,
+            created_by=created_by,
+            datum_id=datum_id,
+            annotation_schema_id=annotation_schema_id,
+        )
+
+    def get_annotation_record(self, annotation_id: str) -> AnnotationRecord:
+        return self._datalake.get_annotation_record(annotation_id)
+
+    def list_annotation_records(self, filters: dict[str, Any] | None = None) -> list[AnnotationRecord]:
+        return self._datalake.list_annotation_records(filters)
+
+    def delete_annotation_record(self, annotation_id: str) -> None:
+        self._datalake.delete_annotation_record(annotation_id)
 
 
 def _encode_obj_for_service(obj: Any) -> str:
@@ -592,6 +1056,172 @@ class DatalakeServiceAsyncDataVaultBackend(AsyncDataVaultBackend):
         )
         return out.annotation_records
 
+    async def list_collections(self, filters: dict[str, Any] | None = None) -> list[Collection]:
+        out = await self._call("acollections_list", input_obj=ListInput(filters=filters))
+        return out.collections
+
+    async def list_collections_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[Collection]:
+        return await self._call(
+            "acollections_list_page",
+            input_obj=PageInput(
+                filters=filters,
+                sort=sort,
+                limit=limit,
+                cursor=cursor,
+                include_total=include_total,
+            ),
+        )
+
+    async def iter_collections(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        batch_size: int | None = None,
+    ) -> AsyncIterator[Collection]:
+        cursor: str | None = None
+        page_limit = batch_size
+        while True:
+            page = await self.list_collections_page(
+                filters=filters,
+                sort=sort,
+                limit=page_limit,
+                cursor=cursor,
+            )
+            for collection in page.items:
+                yield collection
+            if not page.page.has_more or page.page.next_cursor is None:
+                break
+            cursor = page.page.next_cursor
+
+    async def create_collection(
+        self,
+        *,
+        name: str,
+        description: str | None = None,
+        status: str = "active",
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> Collection:
+        out = await self._call(
+            "acollections_create",
+            input_obj=CreateCollectionInput(
+                name=name,
+                description=description,
+                status=status,
+                metadata=metadata,
+                created_by=created_by,
+            ),
+        )
+        return out.collection
+
+    async def list_collection_items(self, filters: dict[str, Any] | None = None) -> list[CollectionItem]:
+        out = await self._call("acollection_items_list", input_obj=ListInput(filters=filters))
+        return out.collection_items
+
+    async def list_collection_items_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[CollectionItem]:
+        return await self._call(
+            "acollection_items_list_page",
+            input_obj=PageInput(
+                filters=filters,
+                sort=sort,
+                limit=limit,
+                cursor=cursor,
+                include_total=include_total,
+            ),
+        )
+
+    async def create_collection_item(
+        self,
+        *,
+        collection_id: str,
+        asset_id: str,
+        split: str | None = None,
+        status: str = "active",
+        metadata: dict[str, Any] | None = None,
+        added_by: str | None = None,
+    ) -> CollectionItem:
+        out = await self._call(
+            "acollection_items_create",
+            input_obj=CreateCollectionItemInput(
+                collection_id=collection_id,
+                asset_id=asset_id,
+                split=split,
+                status=status,
+                metadata=metadata,
+                added_by=added_by,
+            ),
+        )
+        return out.collection_item
+
+    async def update_collection_item(self, collection_item_id: str, **changes: Any) -> CollectionItem:
+        out = await self._call(
+            "acollection_items_update",
+            input_obj=UpdateCollectionItemInput(collection_item_id=collection_item_id, changes=changes),
+        )
+        return out.collection_item
+
+    async def delete_collection_item(self, collection_item_id: str) -> None:
+        await self._call("acollection_items_delete", input_obj=DeleteByIdInput(id=collection_item_id))
+
+    async def list_annotation_sets(self, filters: dict[str, Any] | None = None) -> list[AnnotationSet]:
+        out = await self._call("aannotation_sets_list", input_obj=ListInput(filters=filters))
+        return out.annotation_sets
+
+    async def create_annotation_set(
+        self,
+        *,
+        name: str,
+        purpose: str,
+        source_type: str,
+        status: str = "draft",
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+        datum_id: str | None = None,
+        annotation_schema_id: str | None = None,
+    ) -> AnnotationSet:
+        out = await self._call(
+            "aannotation_sets_create",
+            input_obj=CreateAnnotationSetInput(
+                name=name,
+                purpose=purpose,
+                source_type=source_type,
+                status=status,
+                metadata=metadata,
+                created_by=created_by,
+                datum_id=datum_id,
+                annotation_schema_id=annotation_schema_id,
+            ),
+        )
+        return out.annotation_set
+
+    async def get_annotation_record(self, annotation_id: str) -> AnnotationRecord:
+        out = await self._call("aannotation_records_get", input_obj=GetByIdInput(id=annotation_id))
+        return out.annotation_record
+
+    async def list_annotation_records(self, filters: dict[str, Any] | None = None) -> list[AnnotationRecord]:
+        out = await self._call("aannotation_records_list", input_obj=ListInput(filters=filters))
+        return out.annotation_records
+
+    async def delete_annotation_record(self, annotation_id: str) -> None:
+        await self._call("aannotation_records_delete", input_obj=DeleteByIdInput(id=annotation_id))
+
 
 class DatalakeServiceDataVaultBackend(DataVaultBackend):
     """Calls a ``DatalakeService`` connection manager's sync task methods (``assets_*``, ``objects_*``, ``aliases_*``)."""
@@ -736,3 +1366,168 @@ class DatalakeServiceDataVaultBackend(DataVaultBackend):
             input_obj=ListAnnotationRecordsForAssetInput(asset_id=asset_id),
         )
         return out.annotation_records
+
+    def list_collections(self, filters: dict[str, Any] | None = None) -> list[Collection]:
+        out = self._call("collections_list", input_obj=ListInput(filters=filters))
+        return out.collections
+
+    def list_collections_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[Collection]:
+        return self._call(
+            "collections_list_page",
+            input_obj=PageInput(
+                filters=filters,
+                sort=sort,
+                limit=limit,
+                cursor=cursor,
+                include_total=include_total,
+            ),
+        )
+
+    def iter_collections(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        batch_size: int | None = None,
+    ) -> Iterator[Collection]:
+        cursor: str | None = None
+        page_limit = batch_size
+        while True:
+            page = self.list_collections_page(
+                filters=filters,
+                sort=sort,
+                limit=page_limit,
+                cursor=cursor,
+            )
+            yield from page.items
+            if not page.page.has_more or page.page.next_cursor is None:
+                break
+            cursor = page.page.next_cursor
+
+    def create_collection(
+        self,
+        *,
+        name: str,
+        description: str | None = None,
+        status: str = "active",
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> Collection:
+        out = self._call(
+            "collections_create",
+            input_obj=CreateCollectionInput(
+                name=name,
+                description=description,
+                status=status,
+                metadata=metadata,
+                created_by=created_by,
+            ),
+        )
+        return out.collection
+
+    def list_collection_items(self, filters: dict[str, Any] | None = None) -> list[CollectionItem]:
+        out = self._call("collection_items_list", input_obj=ListInput(filters=filters))
+        return out.collection_items
+
+    def list_collection_items_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[CollectionItem]:
+        return self._call(
+            "collection_items_list_page",
+            input_obj=PageInput(
+                filters=filters,
+                sort=sort,
+                limit=limit,
+                cursor=cursor,
+                include_total=include_total,
+            ),
+        )
+
+    def create_collection_item(
+        self,
+        *,
+        collection_id: str,
+        asset_id: str,
+        split: str | None = None,
+        status: str = "active",
+        metadata: dict[str, Any] | None = None,
+        added_by: str | None = None,
+    ) -> CollectionItem:
+        out = self._call(
+            "collection_items_create",
+            input_obj=CreateCollectionItemInput(
+                collection_id=collection_id,
+                asset_id=asset_id,
+                split=split,
+                status=status,
+                metadata=metadata,
+                added_by=added_by,
+            ),
+        )
+        return out.collection_item
+
+    def update_collection_item(self, collection_item_id: str, **changes: Any) -> CollectionItem:
+        out = self._call(
+            "collection_items_update",
+            input_obj=UpdateCollectionItemInput(collection_item_id=collection_item_id, changes=changes),
+        )
+        return out.collection_item
+
+    def delete_collection_item(self, collection_item_id: str) -> None:
+        self._call("collection_items_delete", input_obj=DeleteByIdInput(id=collection_item_id))
+
+    def list_annotation_sets(self, filters: dict[str, Any] | None = None) -> list[AnnotationSet]:
+        out = self._call("annotation_sets_list", input_obj=ListInput(filters=filters))
+        return out.annotation_sets
+
+    def create_annotation_set(
+        self,
+        *,
+        name: str,
+        purpose: str,
+        source_type: str,
+        status: str = "draft",
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+        datum_id: str | None = None,
+        annotation_schema_id: str | None = None,
+    ) -> AnnotationSet:
+        out = self._call(
+            "annotation_sets_create",
+            input_obj=CreateAnnotationSetInput(
+                name=name,
+                purpose=purpose,
+                source_type=source_type,
+                status=status,
+                metadata=metadata,
+                created_by=created_by,
+                datum_id=datum_id,
+                annotation_schema_id=annotation_schema_id,
+            ),
+        )
+        return out.annotation_set
+
+    def get_annotation_record(self, annotation_id: str) -> AnnotationRecord:
+        out = self._call("annotation_records_get", input_obj=GetByIdInput(id=annotation_id))
+        return out.annotation_record
+
+    def list_annotation_records(self, filters: dict[str, Any] | None = None) -> list[AnnotationRecord]:
+        out = self._call("annotation_records_list", input_obj=ListInput(filters=filters))
+        return out.annotation_records
+
+    def delete_annotation_record(self, annotation_id: str) -> None:
+        self._call("annotation_records_delete", input_obj=DeleteByIdInput(id=annotation_id))

--- a/mindtrace/datalake/mindtrace/datalake/data_vault_backends.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault_backends.py
@@ -24,13 +24,17 @@ from mindtrace.datalake.service_types import (
     CreateAssetFromObjectInput,
     CreateCollectionInput,
     CreateCollectionItemInput,
+    CreateDatasetVersionInput,
+    CreateDatumInput,
     DeleteByIdInput,
     GetAssetByAliasInput,
     GetByIdInput,
+    GetDatasetVersionInput,
     GetObjectInput,
     ListAnnotationRecordsForAssetInput,
     ListInput,
     PageInput,
+    UpdateCollectionInput,
     UpdateCollectionItemInput,
 )
 from mindtrace.datalake.types import (
@@ -40,6 +44,9 @@ from mindtrace.datalake.types import (
     AssetAlias,
     Collection,
     CollectionItem,
+    DatasetVersion,
+    Datum,
+    ResolvedDatasetVersion,
     StorageRef,
 )
 from mindtrace.services.core.connection_manager import ConnectionManager
@@ -227,6 +234,9 @@ class AsyncDataVaultBackend(ABC):
     ) -> Collection: ...
 
     @abstractmethod
+    async def update_collection(self, collection_id: str, **changes: Any) -> Collection: ...
+
+    @abstractmethod
     async def list_collection_items(self, filters: dict[str, Any] | None = None) -> list[CollectionItem]: ...
 
     @abstractmethod
@@ -283,6 +293,32 @@ class AsyncDataVaultBackend(ABC):
 
     @abstractmethod
     async def delete_annotation_record(self, annotation_id: str) -> None: ...
+
+    @abstractmethod
+    async def create_datum(
+        self,
+        *,
+        asset_refs: dict[str, str],
+        split: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        annotation_set_ids: list[str] | None = None,
+    ) -> Datum: ...
+
+    @abstractmethod
+    async def create_dataset_version(
+        self,
+        *,
+        dataset_name: str,
+        version: str,
+        manifest: list[str],
+        description: str | None = None,
+        source_dataset_version_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> DatasetVersion: ...
+
+    @abstractmethod
+    async def resolve_dataset_version(self, dataset_name: str, version: str) -> ResolvedDatasetVersion: ...
 
 
 class DataVaultBackend(ABC):
@@ -389,6 +425,9 @@ class DataVaultBackend(ABC):
     ) -> Collection: ...
 
     @abstractmethod
+    def update_collection(self, collection_id: str, **changes: Any) -> Collection: ...
+
+    @abstractmethod
     def list_collection_items(self, filters: dict[str, Any] | None = None) -> list[CollectionItem]: ...
 
     @abstractmethod
@@ -445,6 +484,32 @@ class DataVaultBackend(ABC):
 
     @abstractmethod
     def delete_annotation_record(self, annotation_id: str) -> None: ...
+
+    @abstractmethod
+    def create_datum(
+        self,
+        *,
+        asset_refs: dict[str, str],
+        split: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        annotation_set_ids: list[str] | None = None,
+    ) -> Datum: ...
+
+    @abstractmethod
+    def create_dataset_version(
+        self,
+        *,
+        dataset_name: str,
+        version: str,
+        manifest: list[str],
+        description: str | None = None,
+        source_dataset_version_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> DatasetVersion: ...
+
+    @abstractmethod
+    def resolve_dataset_version(self, dataset_name: str, version: str) -> ResolvedDatasetVersion: ...
 
 
 class LocalAsyncDataVaultBackend(AsyncDataVaultBackend):
@@ -594,6 +659,9 @@ class LocalAsyncDataVaultBackend(AsyncDataVaultBackend):
     async def list_collection_items(self, filters: dict[str, Any] | None = None) -> list[CollectionItem]:
         return await self._datalake.list_collection_items(filters)
 
+    async def update_collection(self, collection_id: str, **changes: Any) -> Collection:
+        return await self._datalake.update_collection(collection_id, **changes)
+
     async def list_collection_items_page(
         self,
         *,
@@ -670,6 +738,45 @@ class LocalAsyncDataVaultBackend(AsyncDataVaultBackend):
 
     async def delete_annotation_record(self, annotation_id: str) -> None:
         await self._datalake.delete_annotation_record(annotation_id)
+
+    async def create_datum(
+        self,
+        *,
+        asset_refs: dict[str, str],
+        split: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        annotation_set_ids: list[str] | None = None,
+    ) -> Datum:
+        return await self._datalake.create_datum(
+            asset_refs=asset_refs,
+            split=split,
+            metadata=metadata,
+            annotation_set_ids=annotation_set_ids,
+        )
+
+    async def create_dataset_version(
+        self,
+        *,
+        dataset_name: str,
+        version: str,
+        manifest: list[str],
+        description: str | None = None,
+        source_dataset_version_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> DatasetVersion:
+        return await self._datalake.create_dataset_version(
+            dataset_name=dataset_name,
+            version=version,
+            manifest=manifest,
+            description=description,
+            source_dataset_version_id=source_dataset_version_id,
+            metadata=metadata,
+            created_by=created_by,
+        )
+
+    async def resolve_dataset_version(self, dataset_name: str, version: str) -> ResolvedDatasetVersion:
+        return await self._datalake.resolve_dataset_version(dataset_name, version)
 
 
 class LocalDataVaultBackend(DataVaultBackend):
@@ -817,6 +924,9 @@ class LocalDataVaultBackend(DataVaultBackend):
     def list_collection_items(self, filters: dict[str, Any] | None = None) -> list[CollectionItem]:
         return self._datalake.list_collection_items(filters)
 
+    def update_collection(self, collection_id: str, **changes: Any) -> Collection:
+        return self._datalake.update_collection(collection_id, **changes)
+
     def list_collection_items_page(
         self,
         *,
@@ -893,6 +1003,45 @@ class LocalDataVaultBackend(DataVaultBackend):
 
     def delete_annotation_record(self, annotation_id: str) -> None:
         self._datalake.delete_annotation_record(annotation_id)
+
+    def create_datum(
+        self,
+        *,
+        asset_refs: dict[str, str],
+        split: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        annotation_set_ids: list[str] | None = None,
+    ) -> Datum:
+        return self._datalake.create_datum(
+            asset_refs=asset_refs,
+            split=split,
+            metadata=metadata,
+            annotation_set_ids=annotation_set_ids,
+        )
+
+    def create_dataset_version(
+        self,
+        *,
+        dataset_name: str,
+        version: str,
+        manifest: list[str],
+        description: str | None = None,
+        source_dataset_version_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> DatasetVersion:
+        return self._datalake.create_dataset_version(
+            dataset_name=dataset_name,
+            version=version,
+            manifest=manifest,
+            description=description,
+            source_dataset_version_id=source_dataset_version_id,
+            metadata=metadata,
+            created_by=created_by,
+        )
+
+    def resolve_dataset_version(self, dataset_name: str, version: str) -> ResolvedDatasetVersion:
+        return self._datalake.resolve_dataset_version(dataset_name, version)
 
 
 def _encode_obj_for_service(obj: Any) -> str:
@@ -1123,6 +1272,13 @@ class DatalakeServiceAsyncDataVaultBackend(AsyncDataVaultBackend):
         )
         return out.collection
 
+    async def update_collection(self, collection_id: str, **changes: Any) -> Collection:
+        out = await self._call(
+            "acollections_update",
+            input_obj=UpdateCollectionInput(collection_id=collection_id, changes=changes),
+        )
+        return out.collection
+
     async def list_collection_items(self, filters: dict[str, Any] | None = None) -> list[CollectionItem]:
         out = await self._call("acollection_items_list", input_obj=ListInput(filters=filters))
         return out.collection_items
@@ -1221,6 +1377,57 @@ class DatalakeServiceAsyncDataVaultBackend(AsyncDataVaultBackend):
 
     async def delete_annotation_record(self, annotation_id: str) -> None:
         await self._call("aannotation_records_delete", input_obj=DeleteByIdInput(id=annotation_id))
+
+    async def create_datum(
+        self,
+        *,
+        asset_refs: dict[str, str],
+        split: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        annotation_set_ids: list[str] | None = None,
+    ) -> Datum:
+        out = await self._call(
+            "adatums_create",
+            input_obj=CreateDatumInput(
+                asset_refs=asset_refs,
+                split=split,
+                metadata=metadata,
+                annotation_set_ids=annotation_set_ids,
+            ),
+        )
+        return out.datum
+
+    async def create_dataset_version(
+        self,
+        *,
+        dataset_name: str,
+        version: str,
+        manifest: list[str],
+        description: str | None = None,
+        source_dataset_version_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> DatasetVersion:
+        out = await self._call(
+            "adataset_versions_create",
+            input_obj=CreateDatasetVersionInput(
+                dataset_name=dataset_name,
+                version=version,
+                manifest=manifest,
+                description=description,
+                source_dataset_version_id=source_dataset_version_id,
+                metadata=metadata,
+                created_by=created_by,
+            ),
+        )
+        return out.dataset_version
+
+    async def resolve_dataset_version(self, dataset_name: str, version: str) -> ResolvedDatasetVersion:
+        out = await self._call(
+            "adataset_versions_resolve",
+            input_obj=GetDatasetVersionInput(dataset_name=dataset_name, version=version),
+        )
+        return out.resolved_dataset_version
 
 
 class DatalakeServiceDataVaultBackend(DataVaultBackend):
@@ -1433,6 +1640,13 @@ class DatalakeServiceDataVaultBackend(DataVaultBackend):
         )
         return out.collection
 
+    def update_collection(self, collection_id: str, **changes: Any) -> Collection:
+        out = self._call(
+            "collections_update",
+            input_obj=UpdateCollectionInput(collection_id=collection_id, changes=changes),
+        )
+        return out.collection
+
     def list_collection_items(self, filters: dict[str, Any] | None = None) -> list[CollectionItem]:
         out = self._call("collection_items_list", input_obj=ListInput(filters=filters))
         return out.collection_items
@@ -1531,3 +1745,54 @@ class DatalakeServiceDataVaultBackend(DataVaultBackend):
 
     def delete_annotation_record(self, annotation_id: str) -> None:
         self._call("annotation_records_delete", input_obj=DeleteByIdInput(id=annotation_id))
+
+    def create_datum(
+        self,
+        *,
+        asset_refs: dict[str, str],
+        split: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        annotation_set_ids: list[str] | None = None,
+    ) -> Datum:
+        out = self._call(
+            "datums_create",
+            input_obj=CreateDatumInput(
+                asset_refs=asset_refs,
+                split=split,
+                metadata=metadata,
+                annotation_set_ids=annotation_set_ids,
+            ),
+        )
+        return out.datum
+
+    def create_dataset_version(
+        self,
+        *,
+        dataset_name: str,
+        version: str,
+        manifest: list[str],
+        description: str | None = None,
+        source_dataset_version_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> DatasetVersion:
+        out = self._call(
+            "dataset_versions_create",
+            input_obj=CreateDatasetVersionInput(
+                dataset_name=dataset_name,
+                version=version,
+                manifest=manifest,
+                description=description,
+                source_dataset_version_id=source_dataset_version_id,
+                metadata=metadata,
+                created_by=created_by,
+            ),
+        )
+        return out.dataset_version
+
+    def resolve_dataset_version(self, dataset_name: str, version: str) -> ResolvedDatasetVersion:
+        out = self._call(
+            "dataset_versions_resolve",
+            input_obj=GetDatasetVersionInput(dataset_name=dataset_name, version=version),
+        )
+        return out.resolved_dataset_version

--- a/mindtrace/datalake/mindtrace/datalake/data_vault_backends.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault_backends.py
@@ -272,6 +272,17 @@ class AsyncDataVaultBackend(ABC):
     async def list_annotation_sets(self, filters: dict[str, Any] | None = None) -> list[AnnotationSet]: ...
 
     @abstractmethod
+    async def list_annotation_sets_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[AnnotationSet]: ...
+
+    @abstractmethod
     async def create_annotation_set(
         self,
         *,
@@ -461,6 +472,17 @@ class DataVaultBackend(ABC):
 
     @abstractmethod
     def list_annotation_sets(self, filters: dict[str, Any] | None = None) -> list[AnnotationSet]: ...
+
+    @abstractmethod
+    def list_annotation_sets_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[AnnotationSet]: ...
 
     @abstractmethod
     def create_annotation_set(
@@ -706,6 +728,23 @@ class LocalAsyncDataVaultBackend(AsyncDataVaultBackend):
 
     async def list_annotation_sets(self, filters: dict[str, Any] | None = None) -> list[AnnotationSet]:
         return await self._datalake.list_annotation_sets(filters)
+
+    async def list_annotation_sets_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[AnnotationSet]:
+        return await self._datalake.list_annotation_sets_page(
+            filters=filters,
+            sort=sort,
+            limit=limit,
+            cursor=cursor,
+            include_total=include_total,
+        )
 
     async def create_annotation_set(
         self,
@@ -971,6 +1010,23 @@ class LocalDataVaultBackend(DataVaultBackend):
 
     def list_annotation_sets(self, filters: dict[str, Any] | None = None) -> list[AnnotationSet]:
         return self._datalake.list_annotation_sets(filters)
+
+    def list_annotation_sets_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[AnnotationSet]:
+        return self._datalake.list_annotation_sets_page(
+            filters=filters,
+            sort=sort,
+            limit=limit,
+            cursor=cursor,
+            include_total=include_total,
+        )
 
     def create_annotation_set(
         self,
@@ -1340,6 +1396,26 @@ class DatalakeServiceAsyncDataVaultBackend(AsyncDataVaultBackend):
         out = await self._call("aannotation_sets_list", input_obj=ListInput(filters=filters))
         return out.annotation_sets
 
+    async def list_annotation_sets_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[AnnotationSet]:
+        return await self._call(
+            "aannotation_sets_list_page",
+            input_obj=PageInput(
+                filters=filters,
+                sort=sort,
+                limit=limit,
+                cursor=cursor,
+                include_total=include_total,
+            ),
+        )
+
     async def create_annotation_set(
         self,
         *,
@@ -1707,6 +1783,26 @@ class DatalakeServiceDataVaultBackend(DataVaultBackend):
     def list_annotation_sets(self, filters: dict[str, Any] | None = None) -> list[AnnotationSet]:
         out = self._call("annotation_sets_list", input_obj=ListInput(filters=filters))
         return out.annotation_sets
+
+    def list_annotation_sets_page(
+        self,
+        *,
+        filters: dict[str, Any] | None = None,
+        sort: str = "created_desc",
+        limit: int | None = None,
+        cursor: str | None = None,
+        include_total: bool = False,
+    ) -> CursorPage[AnnotationSet]:
+        return self._call(
+            "annotation_sets_list_page",
+            input_obj=PageInput(
+                filters=filters,
+                sort=sort,
+                limit=limit,
+                cursor=cursor,
+                include_total=include_total,
+            ),
+        )
 
     def create_annotation_set(
         self,

--- a/mindtrace/datalake/mindtrace/datalake/datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/datalake.py
@@ -4,6 +4,7 @@ import asyncio
 import threading
 from collections.abc import Iterator
 from concurrent.futures import Future
+from pathlib import Path
 from typing import Any, Optional
 
 from mindtrace.core import Mindtrace
@@ -865,6 +866,31 @@ class Datalake(Mindtrace):
 
     def resolve_dataset_version(self, dataset_name: str, version: str):
         return self._submit_coro(self._backend.resolve_dataset_version(dataset_name, version))
+
+    def export_dataset_version_to_format(
+        self,
+        dataset_name: str,
+        version: str,
+        *,
+        format: str,
+        destination: str | Path,
+        include_media: bool = True,
+        overwrite: bool = False,
+        split_map: dict[str, str] | None = None,
+        exporter_options: dict[str, Any] | None = None,
+    ):
+        return self._submit_coro(
+            self._backend.export_dataset_version_to_format(
+                dataset_name,
+                version,
+                format=format,
+                destination=destination,
+                include_media=include_media,
+                overwrite=overwrite,
+                split_map=split_map,
+                exporter_options=exporter_options,
+            )
+        )
 
     def create_asset_from_object(self, **kwargs: Any):
         return self._submit_coro(self._backend.create_asset_from_object(**kwargs))

--- a/mindtrace/datalake/mindtrace/datalake/exporters/__init__.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/__init__.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from .types import ExportableDataset, ExportableItem, ExportResult
+
+ExporterFunc = Callable[..., ExportResult]
+
+
+def get_dataset_exporter(format_name: str) -> ExporterFunc:
+    """Return the exporter callable for a named format."""
+    normalized = format_name.strip().lower()
+    if normalized == "coco":
+        from .coco import export_dataset_as_coco
+
+        return export_dataset_as_coco
+    if normalized == "huggingface":
+        from .huggingface import export_dataset_as_huggingface
+
+        return export_dataset_as_huggingface
+    raise ValueError(f"Unsupported dataset export format {format_name!r}. Supported formats: 'coco', 'huggingface'.")
+
+
+def export_dataset_to_format(
+    dataset: ExportableDataset,
+    *,
+    format: str,
+    destination: str | Path,
+    include_media: bool = True,
+    overwrite: bool = False,
+    exporter_options: dict[str, Any] | None = None,
+) -> ExportResult:
+    """Dispatch a canonical export view to a concrete exporter backend."""
+    exporter = get_dataset_exporter(format)
+    return exporter(
+        dataset,
+        destination=destination,
+        include_media=include_media,
+        overwrite=overwrite,
+        options=exporter_options,
+    )
+
+
+__all__ = [
+    "ExportResult",
+    "ExportableDataset",
+    "ExportableItem",
+    "export_dataset_to_format",
+    "get_dataset_exporter",
+]

--- a/mindtrace/datalake/mindtrace/datalake/exporters/base.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/base.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import mimetypes
+import shutil
+from pathlib import Path
+from typing import Any
+
+from mindtrace.datalake.types import AnnotationRecord, AnnotationSet, Asset, ResolvedDatasetVersion, ResolvedDatum
+
+from .types import ExportableDataset, ExportableItem
+
+
+def media_suffix_for_asset(asset: Asset) -> str:
+    """Return a best-effort filename suffix for an asset media type."""
+    media_type = asset.media_type or "application/octet-stream"
+    if media_type == "image/jpeg":
+        return ".jpg"
+    guessed = mimetypes.guess_extension(media_type)
+    return guessed or ".bin"
+
+
+def default_export_filename(asset: Asset) -> str:
+    """Return a stable export filename for an asset."""
+    return f"{asset.asset_id}{media_suffix_for_asset(asset)}"
+
+
+def prepare_export_destination(destination: str | Path, *, overwrite: bool) -> Path:
+    """Create or clean the destination directory for an export."""
+    path = Path(destination)
+    if path.exists():
+        if not overwrite:
+            raise FileExistsError(f"Export destination already exists: {path}")
+        if path.is_file():
+            path.unlink()
+        else:
+            shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def write_export_file(destination: Path, relative_path: str | Path, payload: bytes) -> str:
+    """Write one file beneath an export destination and return its relative path."""
+    rel = Path(relative_path)
+    target = destination / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(payload)
+    return rel.as_posix()
+
+
+def _mapped_split(split: str | None, split_map: dict[str, str] | None) -> str | None:
+    if split is None or split_map is None:
+        return split
+    return split_map.get(split, split)
+
+
+def _annotation_subject_asset_id(annotation: AnnotationRecord) -> str | None:
+    subject = annotation.subject
+    if subject is None or subject.kind != "asset":
+        return None
+    return subject.id
+
+
+def _primary_asset_entry(resolved_datum: ResolvedDatum) -> tuple[str, Asset] | None:
+    for role in ("image", "asset"):
+        asset = resolved_datum.assets.get(role)
+        if asset is not None:
+            return role, asset
+    for role, asset in resolved_datum.assets.items():
+        return role, asset
+    return None
+
+
+def _annotation_sets_for_asset(
+    resolved_datum: ResolvedDatum, asset_id: str
+) -> tuple[list[AnnotationSet], list[AnnotationRecord], list[str]]:
+    warnings: list[str] = []
+    annotation_sets: list[AnnotationSet] = []
+    annotations: list[AnnotationRecord] = []
+    for annotation_set in resolved_datum.annotation_sets:
+        set_records = list(resolved_datum.annotation_records.get(annotation_set.annotation_set_id, []))
+        matching_records = [
+            record for record in set_records if _annotation_subject_asset_id(record) in {None, asset_id}
+        ]
+        if matching_records:
+            annotation_sets.append(annotation_set)
+            annotations.extend(matching_records)
+            skipped = [
+                record.annotation_id
+                for record in set_records
+                if _annotation_subject_asset_id(record) not in {None, asset_id}
+            ]
+            if skipped:
+                warnings.append(
+                    f"Skipped {len(skipped)} annotation(s) in set {annotation_set.annotation_set_id} because they target a non-primary asset."
+                )
+        elif set_records:
+            warnings.append(
+                f"Skipped annotation set {annotation_set.annotation_set_id} for datum {resolved_datum.datum.datum_id} because it has no records for asset {asset_id}."
+            )
+    return annotation_sets, annotations, warnings
+
+
+def _build_exportable_item(
+    resolved_datum: ResolvedDatum,
+    *,
+    payload_bytes: bytes,
+    split_map: dict[str, str] | None = None,
+) -> tuple[ExportableItem | None, list[str]]:
+    warnings: list[str] = []
+    primary_entry = _primary_asset_entry(resolved_datum)
+    if primary_entry is None:
+        return None, [f"Skipped datum {resolved_datum.datum.datum_id} because it does not reference any assets."]
+    role, asset = primary_entry
+    if len(resolved_datum.assets) > 1:
+        warnings.append(
+            f"Datum {resolved_datum.datum.datum_id} has multiple assets; exporting primary role {role!r} only."
+        )
+    annotation_sets, annotations, annotation_warnings = _annotation_sets_for_asset(resolved_datum, asset.asset_id)
+    warnings.extend(annotation_warnings)
+    return (
+        ExportableItem(
+            asset=asset,
+            split=_mapped_split(resolved_datum.datum.split, split_map),
+            metadata=dict(resolved_datum.datum.metadata or {}),
+            annotations=annotations,
+            annotation_sets=annotation_sets,
+            payload_bytes=payload_bytes,
+            source_filename=default_export_filename(asset),
+        ),
+        warnings,
+    )
+
+
+def build_exportable_dataset_from_resolved_version_sync(
+    datalake: Any,
+    resolved_dataset_version: ResolvedDatasetVersion,
+    *,
+    split_map: dict[str, str] | None = None,
+) -> ExportableDataset:
+    """Build a canonical export view from a resolved dataset snapshot."""
+    warnings: list[str] = []
+    items: list[ExportableItem] = []
+    for resolved_datum in resolved_dataset_version.datums:
+        primary_entry = _primary_asset_entry(resolved_datum)
+        if primary_entry is None:
+            warnings.append(f"Skipped datum {resolved_datum.datum.datum_id} because it does not reference any assets.")
+            continue
+        _, asset = primary_entry
+        export_item, item_warnings = _build_exportable_item(
+            resolved_datum,
+            payload_bytes=datalake.get_object(asset.storage_ref),
+            split_map=split_map,
+        )
+        warnings.extend(item_warnings)
+        if export_item is not None:
+            items.append(export_item)
+    dataset_version = resolved_dataset_version.dataset_version
+    return ExportableDataset(
+        name=dataset_version.dataset_name,
+        description=dataset_version.description,
+        metadata=dict(dataset_version.metadata or {}),
+        items=items,
+        warnings=warnings,
+    )
+
+
+async def build_exportable_dataset_from_resolved_version_async(
+    datalake: Any,
+    resolved_dataset_version: ResolvedDatasetVersion,
+    *,
+    split_map: dict[str, str] | None = None,
+) -> ExportableDataset:
+    """Build a canonical export view from a resolved dataset snapshot."""
+    warnings: list[str] = []
+    items: list[ExportableItem] = []
+    for resolved_datum in resolved_dataset_version.datums:
+        primary_entry = _primary_asset_entry(resolved_datum)
+        if primary_entry is None:
+            warnings.append(f"Skipped datum {resolved_datum.datum.datum_id} because it does not reference any assets.")
+            continue
+        _, asset = primary_entry
+        export_item, item_warnings = _build_exportable_item(
+            resolved_datum,
+            payload_bytes=await datalake.get_object(asset.storage_ref),
+            split_map=split_map,
+        )
+        warnings.extend(item_warnings)
+        if export_item is not None:
+            items.append(export_item)
+    dataset_version = resolved_dataset_version.dataset_version
+    return ExportableDataset(
+        name=dataset_version.dataset_name,
+        description=dataset_version.description,
+        metadata=dict(dataset_version.metadata or {}),
+        items=items,
+        warnings=warnings,
+    )

--- a/mindtrace/datalake/mindtrace/datalake/exporters/base.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/base.py
@@ -132,7 +132,7 @@ def _build_exportable_item(
 
 
 def build_exportable_dataset_from_resolved_version_sync(
-    datalake: Any,
+    object_loader: Any,
     resolved_dataset_version: ResolvedDatasetVersion,
     *,
     split_map: dict[str, str] | None = None,
@@ -148,7 +148,7 @@ def build_exportable_dataset_from_resolved_version_sync(
         _, asset = primary_entry
         export_item, item_warnings = _build_exportable_item(
             resolved_datum,
-            payload_bytes=datalake.get_object(asset.storage_ref),
+            payload_bytes=object_loader.get_object(asset.storage_ref),
             split_map=split_map,
         )
         warnings.extend(item_warnings)
@@ -165,7 +165,7 @@ def build_exportable_dataset_from_resolved_version_sync(
 
 
 async def build_exportable_dataset_from_resolved_version_async(
-    datalake: Any,
+    object_loader: Any,
     resolved_dataset_version: ResolvedDatasetVersion,
     *,
     split_map: dict[str, str] | None = None,
@@ -181,7 +181,7 @@ async def build_exportable_dataset_from_resolved_version_async(
         _, asset = primary_entry
         export_item, item_warnings = _build_exportable_item(
             resolved_datum,
-            payload_bytes=await datalake.get_object(asset.storage_ref),
+            payload_bytes=await object_loader.get_object(asset.storage_ref),
             split_map=split_map,
         )
         warnings.extend(item_warnings)

--- a/mindtrace/datalake/mindtrace/datalake/exporters/coco.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/coco.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+from PIL import Image
+
+from .base import prepare_export_destination, write_export_file
+from .types import ExportableDataset, ExportableItem, ExportResult
+
+
+def _polygon_bbox(vertices: list[list[float]]) -> list[float]:
+    xs = [float(v[0]) for v in vertices]
+    ys = [float(v[1]) for v in vertices]
+    return [min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys)]
+
+
+def _polygon_area(vertices: list[list[float]]) -> float:
+    if len(vertices) < 3:
+        return 0.0
+    area = 0.0
+    points = [(float(v[0]), float(v[1])) for v in vertices]
+    for idx, (x1, y1) in enumerate(points):
+        x2, y2 = points[(idx + 1) % len(points)]
+        area += (x1 * y2) - (x2 * y1)
+    return abs(area) / 2.0
+
+
+def _supported_category_records(dataset: ExportableDataset) -> list[tuple[str, str]]:
+    pairs: set[tuple[str, str]] = set()
+    for item in dataset.items:
+        for annotation in item.annotations:
+            if annotation.kind in {"bbox", "polygon"}:
+                pairs.add((annotation.kind, annotation.label))
+    return sorted(pairs, key=lambda pair: (pair[0], pair[1]))
+
+
+def _image_info(item: ExportableItem, image_id: int, file_name: str) -> dict[str, Any]:
+    if item.payload_bytes is None:
+        raise ValueError(f"COCO export requires payload bytes for asset {item.asset.asset_id}")
+    if not item.asset.media_type.startswith("image/"):
+        raise ValueError(
+            f"COCO export supports image assets only; asset {item.asset.asset_id} has media type {item.asset.media_type!r}."
+        )
+    with Image.open(BytesIO(item.payload_bytes)) as image:
+        width, height = image.size
+    return {
+        "id": image_id,
+        "file_name": file_name,
+        "width": width,
+        "height": height,
+    }
+
+
+def export_dataset_as_coco(
+    dataset: ExportableDataset,
+    *,
+    destination: str | Path,
+    include_media: bool = True,
+    overwrite: bool = False,
+    options: dict[str, Any] | None = None,
+) -> ExportResult:
+    """Export a canonical dataset view to a COCO-style directory."""
+    del options
+    destination_path = prepare_export_destination(destination, overwrite=overwrite)
+    warnings = list(dataset.warnings)
+    categories = _supported_category_records(dataset)
+    category_ids = {pair: idx + 1 for idx, pair in enumerate(categories)}
+    category_rows = [{"id": category_ids[pair], "name": pair[1], "supercategory": pair[0]} for pair in categories]
+
+    split_bundles: dict[str, dict[str, Any]] = defaultdict(lambda: {"images": [], "annotations": []})
+    files_written: list[str] = []
+    next_annotation_id = 1
+    for image_id, item in enumerate(dataset.items, start=1):
+        split_name = item.split or "default"
+        image_filename = item.source_filename or f"{item.asset.asset_id}.bin"
+        image_relative_path = (
+            Path("images") / split_name / image_filename if item.split is not None else Path("images") / image_filename
+        )
+        if include_media and item.payload_bytes is not None:
+            files_written.append(write_export_file(destination_path, image_relative_path, item.payload_bytes))
+        image_row = _image_info(item, image_id, image_relative_path.as_posix())
+        split_bundles[split_name]["images"].append(image_row)
+
+        for annotation in item.annotations:
+            category_key = (annotation.kind, annotation.label)
+            if annotation.kind == "bbox":
+                geometry = annotation.geometry or {}
+                bbox = [
+                    float(geometry["x"]),
+                    float(geometry["y"]),
+                    float(geometry["width"]),
+                    float(geometry["height"]),
+                ]
+                coco_annotation = {
+                    "id": next_annotation_id,
+                    "image_id": image_id,
+                    "category_id": category_ids[category_key],
+                    "bbox": bbox,
+                    "area": float(bbox[2] * bbox[3]),
+                    "iscrowd": 0,
+                    "segmentation": [],
+                }
+            elif annotation.kind == "polygon":
+                vertices = list(annotation.geometry.get("vertices") or annotation.geometry.get("points") or [])
+                if len(vertices) < 3:
+                    warnings.append(
+                        f"Skipped polygon annotation {annotation.annotation_id} on asset {item.asset.asset_id} because it has fewer than 3 vertices."
+                    )
+                    continue
+                flattened = [float(coord) for vertex in vertices for coord in vertex]
+                coco_annotation = {
+                    "id": next_annotation_id,
+                    "image_id": image_id,
+                    "category_id": category_ids[category_key],
+                    "bbox": _polygon_bbox(vertices),
+                    "area": _polygon_area(vertices),
+                    "iscrowd": 0,
+                    "segmentation": [flattened],
+                }
+            else:
+                warnings.append(
+                    f"Skipped unsupported COCO annotation kind {annotation.kind!r} for annotation {annotation.annotation_id}."
+                )
+                continue
+            split_bundles[split_name]["annotations"].append(coco_annotation)
+            next_annotation_id += 1
+
+    multiple_splits = {item.split for item in dataset.items if item.split is not None}
+    for split_name, payload in split_bundles.items():
+        coco_payload = {
+            "info": {"description": dataset.description or dataset.name},
+            "licenses": [],
+            "categories": category_rows,
+            "images": payload["images"],
+            "annotations": payload["annotations"],
+        }
+        if multiple_splits:
+            relative_path = Path("annotations") / f"{split_name}.json"
+        else:
+            relative_path = Path("annotations.json")
+        files_written.append(
+            write_export_file(
+                destination_path,
+                relative_path,
+                json.dumps(coco_payload, indent=2, sort_keys=True).encode("utf-8"),
+            )
+        )
+
+    summary = {
+        "format": "coco",
+        "dataset_name": dataset.name,
+        "asset_count": dataset.asset_count,
+        "annotation_count": dataset.annotation_count,
+        "warnings": warnings,
+    }
+    files_written.append(
+        write_export_file(
+            destination_path, "export_summary.json", json.dumps(summary, indent=2, sort_keys=True).encode("utf-8")
+        )
+    )
+    return ExportResult(
+        format="coco",
+        destination=destination_path,
+        dataset_name=dataset.name,
+        asset_count=dataset.asset_count,
+        annotation_count=dataset.annotation_count,
+        files_written=files_written,
+        warnings=warnings,
+    )

--- a/mindtrace/datalake/mindtrace/datalake/exporters/huggingface.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/huggingface.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+from .base import prepare_export_destination, write_export_file
+from .types import ExportableDataset, ExportResult
+
+
+def export_dataset_as_huggingface(
+    dataset: ExportableDataset,
+    *,
+    destination: str | Path,
+    include_media: bool = True,
+    overwrite: bool = False,
+    options: dict[str, Any] | None = None,
+) -> ExportResult:
+    """Export a canonical dataset view to a Hugging Face datasets directory."""
+    del options
+    try:
+        datasets_module = importlib.import_module("datasets")
+    except ImportError as exc:
+        raise ImportError(
+            "Hugging Face export requires the optional 'datasets' dependency. "
+            "Install mindtrace-datalake[export-huggingface]."
+        ) from exc
+
+    destination_path = prepare_export_destination(destination, overwrite=overwrite)
+    warnings = list(dataset.warnings)
+    files_written: list[str] = []
+    rows_by_split: dict[str, list[dict[str, Any]]] = {}
+
+    for item in dataset.items:
+        split_name = item.split or "default"
+        media_relative_path: str | None = None
+        if include_media and item.payload_bytes is not None:
+            media_path = Path("media") / split_name / (item.source_filename or f"{item.asset.asset_id}.bin")
+            media_relative_path = write_export_file(destination_path, media_path, item.payload_bytes)
+            files_written.append(media_relative_path)
+        rows_by_split.setdefault(split_name, []).append(
+            {
+                "asset_id": item.asset.asset_id,
+                "split": item.split,
+                "media_type": item.asset.media_type,
+                "image_path": media_relative_path,
+                "storage_ref": item.asset.storage_ref.model_dump(mode="json"),
+                "metadata": dict(item.metadata or {}),
+                "asset_metadata": dict(item.asset.metadata or {}),
+                "annotations": [annotation.model_dump(mode="json") for annotation in item.annotations],
+            }
+        )
+
+    dataset_payload = {split: datasets_module.Dataset.from_list(rows) for split, rows in rows_by_split.items()}
+    if len(dataset_payload) == 1 and "default" in dataset_payload:
+        hf_dataset = dataset_payload["default"]
+    else:
+        hf_dataset = datasets_module.DatasetDict(dataset_payload)
+    hf_dataset.save_to_disk(str(destination_path))
+
+    files_written.append(".")
+    return ExportResult(
+        format="huggingface",
+        destination=destination_path,
+        dataset_name=dataset.name,
+        asset_count=dataset.asset_count,
+        annotation_count=dataset.annotation_count,
+        files_written=files_written,
+        warnings=warnings,
+    )

--- a/mindtrace/datalake/mindtrace/datalake/exporters/types.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/types.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from mindtrace.datalake.types import AnnotationRecord, AnnotationSet, Asset
+
+
+class ExportableItem(BaseModel):
+    """Format-neutral dataset item prepared for exporter backends."""
+
+    asset: Asset
+    split: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    annotations: list[AnnotationRecord] = Field(default_factory=list)
+    annotation_sets: list[AnnotationSet] = Field(default_factory=list)
+    payload_bytes: bytes | None = None
+    source_filename: str | None = None
+
+
+class ExportableDataset(BaseModel):
+    """Canonical in-memory export view built from a resolved dataset snapshot."""
+
+    name: str
+    description: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    items: list[ExportableItem] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+    @property
+    def asset_count(self) -> int:
+        return len(self.items)
+
+    @property
+    def annotation_count(self) -> int:
+        return sum(len(item.annotations) for item in self.items)
+
+
+class ExportResult(BaseModel):
+    """Summary returned by dataset export operations."""
+
+    format: str
+    destination: Path
+    dataset_name: str
+    asset_count: int
+    annotation_count: int
+    files_written: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)

--- a/mindtrace/datalake/pyproject.toml
+++ b/mindtrace/datalake/pyproject.toml
@@ -20,6 +20,14 @@ dependencies = [
     "tqdm>=4.66.0",
 ]
 
+[project.optional-dependencies]
+export-huggingface = [
+    "datasets>=2.19.0",
+]
+export-all = [
+    "datasets>=2.19.0",
+]
+
 [project.scripts]
 mindtrace-datalake-import-pascal-voc = "mindtrace.datalake.importers.pascal_voc:main"
 

--- a/tests/unit/mindtrace/datalake/test___init__.py
+++ b/tests/unit/mindtrace/datalake/test___init__.py
@@ -50,3 +50,8 @@ def test_datalake_exports_sync_symbols():
     assert datalake_module.SlowOpsPolicy.__name__ == "SlowOpsPolicy"
     assert datalake_module.SlowOperationWarning.__name__ == "SlowOperationWarning"
     assert datalake_module.SlowOperationDisabledError.__name__ == "SlowOperationDisabledError"
+    assert datalake_module.ExportResult.__name__ == "ExportResult"
+    assert datalake_module.ExportableDataset.__name__ == "ExportableDataset"
+    assert datalake_module.ExportableItem.__name__ == "ExportableItem"
+    assert callable(datalake_module.export_dataset_to_format)
+    assert callable(datalake_module.get_dataset_exporter)

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -9,11 +9,20 @@ from PIL import Image
 from mindtrace.datalake.data_vault import (
     AsyncDataVault,
     DataVault,
+    VaultDataset,
     _annotations_bound_to_asset,
     _pil_image_to_png_bytes,
 )
 from mindtrace.datalake.pagination_types import CursorPage, PageInfo
-from mindtrace.datalake.types import AnnotationRecord, Asset, StorageRef, SubjectRef
+from mindtrace.datalake.types import (
+    AnnotationRecord,
+    AnnotationSet,
+    Asset,
+    Collection,
+    CollectionItem,
+    StorageRef,
+    SubjectRef,
+)
 from mindtrace.datalake.vault_serialization import (
     SERIALIZATION_METADATA_KEY,
     direct_bytes_serialization_block,
@@ -468,3 +477,198 @@ def test_sync_data_vault_load_by_asset_id_materializes_bytes(tmp_path: Path):
     backend.get_object = Mock(return_value=b"sync-payload")
     vault = DataVault(backend, registry=reg)
     assert vault.load_by_asset_id("by-id") == b"sync-payload"
+
+
+def test_sync_data_vault_create_and_list_datasets():
+    collection = Collection(name="training", collection_id="collection_1")
+    backend = Mock()
+    backend.list_collections = Mock(side_effect=[[], [collection], [collection]])
+    backend.create_collection = Mock(return_value=collection)
+    backend.list_collection_items = Mock(return_value=[])
+    backend.iter_collections = Mock(return_value=iter([collection]))
+    page = CursorPage(items=[collection], page=PageInfo(limit=1, next_cursor=None, has_more=False, total_count=1))
+    backend.list_collections_page = Mock(return_value=page)
+
+    vault = DataVault(backend)
+    created = vault.create_dataset("training", description="demo")
+    assert created == VaultDataset(
+        dataset_id="collection_1",
+        name="training",
+        description=None,
+        status="active",
+        metadata={},
+        asset_count=0,
+        created_at=collection.created_at,
+        created_by=None,
+        updated_at=collection.updated_at,
+    )
+    backend.create_collection.assert_called_once_with(
+        name="training",
+        description="demo",
+        status="active",
+        metadata=None,
+        created_by=None,
+    )
+
+    assert vault.list_datasets() == [created]
+    dataset_page = vault.list_datasets_page(limit=1, include_total=True)
+    assert dataset_page.items == [created]
+    backend.list_collections_page.assert_called_once_with(
+        filters={"status": "active"},
+        sort="updated_desc",
+        limit=1,
+        cursor=None,
+        include_total=True,
+    )
+    assert list(vault.iter_datasets()) == [created]
+
+
+def test_sync_data_vault_add_annotation_brings_asset_into_dataset():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+        status="active",
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    backend = Mock()
+    backend.list_collections = Mock(return_value=[collection])
+    backend.get_asset = Mock(return_value=asset)
+    backend.list_collection_items = Mock(return_value=[])
+    backend.create_collection_item = Mock(
+        return_value=CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    )
+    backend.list_annotation_sets = Mock(return_value=[])
+    backend.create_annotation_set = Mock(return_value=annotation_set)
+    backend.add_annotation_records = Mock(return_value=[record])
+
+    vault = DataVault(backend)
+    out = vault.add_annotation(
+        "training",
+        {"kind": "bbox", "label": "cat", "source": {"type": "human", "name": "review"}, "geometry": {}},
+        asset="asset_1",
+    )
+
+    assert out == record
+    backend.create_collection_item.assert_called_once_with(
+        collection_id="collection_1",
+        asset_id="asset_1",
+        split=None,
+        status="active",
+        metadata=None,
+        added_by=None,
+    )
+    create_set_kwargs = backend.create_annotation_set.call_args.kwargs
+    assert create_set_kwargs["name"] == "training:asset_1"
+    assert create_set_kwargs["metadata"]["mindtrace"]["data_vault"]["dataset_collection_id"] == "collection_1"
+    add_args, add_kwargs = backend.add_annotation_records.call_args
+    assert add_kwargs["annotation_set_id"] == "annotation_set_1"
+    assert add_args[0][0]["subject"] == {"kind": "asset", "id": "asset_1"}
+
+
+def test_sync_data_vault_list_assets_and_annotations_and_remove_membership():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1"],
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    backend = Mock()
+    backend.list_collections = Mock(return_value=[collection])
+    backend.list_collection_items = Mock(side_effect=[[item, item], [item]])
+    backend.get_asset = Mock(return_value=asset)
+    backend.list_annotation_sets = Mock(return_value=[annotation_set, annotation_set])
+    backend.get_annotation_record = Mock(return_value=record)
+    backend.delete_annotation_record = Mock()
+    backend.delete_collection_item = Mock()
+
+    vault = DataVault(backend)
+    assert vault.list_dataset_assets("training") == [asset]
+    assert vault.list_dataset_annotations("training") == [record, record]
+
+    vault.remove_annotation("training", "annotation_1")
+    backend.delete_annotation_record.assert_called_once_with("annotation_1")
+
+    vault.remove_asset("training", "asset_1")
+    backend.delete_collection_item.assert_called_once_with("ci_1")
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_add_annotation_brings_asset_into_dataset():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+        status="active",
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    backend = Mock()
+    backend.list_collections = AsyncMock(return_value=[collection])
+    backend.get_asset = AsyncMock(return_value=asset)
+    backend.list_collection_items = AsyncMock(return_value=[])
+    backend.create_collection_item = AsyncMock(
+        return_value=CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    )
+    backend.list_annotation_sets = AsyncMock(return_value=[])
+    backend.create_annotation_set = AsyncMock(return_value=annotation_set)
+    backend.add_annotation_records = AsyncMock(return_value=[record])
+
+    vault = AsyncDataVault(backend)
+    out = await vault.add_annotation(
+        "training",
+        {"kind": "bbox", "label": "cat", "source": {"type": "human", "name": "review"}, "geometry": {}},
+        asset="asset_1",
+    )
+
+    assert out == record
+    backend.create_collection_item.assert_awaited_once()
+    backend.create_annotation_set.assert_awaited_once()
+    backend.add_annotation_records.assert_awaited_once()

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -13,12 +13,14 @@ from mindtrace.datalake.data_vault import (
     DataVault,
     VaultDataset,
     _annotation_id,
+    _annotation_matches_asset,
     _annotation_source_type,
     _annotations_bound_to_asset,
     _coerce_annotation_payload,
     _dataset_annotation_set_filters,
     _extract_annotation_asset_id,
     _pil_image_to_png_bytes,
+    _resolved_primary_asset,
 )
 from mindtrace.datalake.pagination_types import CursorPage, PageInfo
 from mindtrace.datalake.types import (
@@ -28,7 +30,9 @@ from mindtrace.datalake.types import (
     Collection,
     CollectionItem,
     DatasetVersion,
+    Datum,
     ResolvedDatasetVersion,
+    ResolvedDatum,
     StorageRef,
     SubjectRef,
 )
@@ -1301,3 +1305,442 @@ def test_async_data_vault_export_dataset_requires_local_backend():
 
     with pytest.raises(NotImplementedError, match="local AsyncDatalake backend"):
         vault._require_local_datalake()
+
+
+def test_data_vault_import_helpers_handle_asset_selection_and_unbound_annotations():
+    asset = Asset(
+        kind="artifact",
+        media_type="application/octet-stream",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    resolved = ResolvedDatum(
+        datum=Datum(asset_refs={"other": "asset_1"}),
+        assets={"other": asset},
+        annotation_sets=[],
+        annotation_records={},
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        source={"type": "human", "name": "review"},
+        geometry={"x": 1, "y": 2, "width": 3, "height": 4},
+    )
+
+    assert _resolved_primary_asset(resolved) == asset
+    assert (
+        _resolved_primary_asset(
+            ResolvedDatum(datum=Datum(asset_refs={}), assets={}, annotation_sets=[], annotation_records={})
+        )
+        is None
+    )
+    assert _annotation_matches_asset(record, "asset_1") is True
+
+
+def test_sync_data_vault_prepare_import_target_dataset_archives_existing_collection():
+    existing = Collection(name="training", collection_id="collection_existing")
+    created = Collection(name="training", collection_id="collection_new")
+    datalake = Mock()
+    datalake.list_collections = Mock(side_effect=[[existing], []])
+    datalake.update_collection = Mock(return_value=existing)
+    datalake.create_collection = Mock(return_value=created)
+
+    dataset = DataVault(datalake)._prepare_import_target_dataset(
+        dataset_name="training",
+        description="Imported",
+        metadata={"source": "snapshot"},
+        overwrite=True,
+        created_by="tester",
+    )
+
+    assert dataset.dataset_id == "collection_new"
+    datalake.update_collection.assert_called_once_with("collection_existing", status="archived")
+
+
+def test_sync_data_vault_prepare_import_target_dataset_rejects_existing_name_without_overwrite():
+    existing = Collection(name="training", collection_id="collection_existing")
+    datalake = Mock()
+    datalake.list_collections = Mock(return_value=[existing])
+
+    with pytest.raises(ValueError, match="already exists"):
+        DataVault(datalake)._prepare_import_target_dataset(
+            dataset_name="training",
+            description="Imported",
+            metadata={"source": "snapshot"},
+            overwrite=False,
+            created_by="tester",
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_prepare_import_target_dataset_archives_existing_collection():
+    existing = Collection(name="training", collection_id="collection_existing")
+    created = Collection(name="training", collection_id="collection_new")
+    datalake = Mock()
+    datalake.list_collections = AsyncMock(side_effect=[[existing], []])
+    datalake.update_collection = AsyncMock(return_value=existing)
+    datalake.create_collection = AsyncMock(return_value=created)
+
+    dataset = await AsyncDataVault(datalake)._prepare_import_target_dataset(
+        dataset_name="training",
+        description="Imported",
+        metadata={"source": "snapshot"},
+        overwrite=True,
+        created_by="tester",
+    )
+
+    assert dataset.dataset_id == "collection_new"
+    datalake.update_collection.assert_awaited_once_with("collection_existing", status="archived")
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_prepare_import_target_dataset_rejects_existing_name_without_overwrite():
+    existing = Collection(name="training", collection_id="collection_existing")
+    datalake = Mock()
+    datalake.list_collections = AsyncMock(return_value=[existing])
+
+    with pytest.raises(ValueError, match="already exists"):
+        await AsyncDataVault(datalake)._prepare_import_target_dataset(
+            dataset_name="training",
+            description="Imported",
+            metadata={"source": "snapshot"},
+            overwrite=False,
+            created_by="tester",
+        )
+
+
+def test_sync_data_vault_import_dataset_version_materializes_mutable_dataset():
+    source_dataset = DatasetVersion(
+        dataset_name="source-dataset", version="1.0.0", dataset_version_id="dataset_version_1"
+    )
+    image_asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="image", version="1"),
+        asset_id="asset_image",
+    )
+    mask_asset = Asset(
+        kind="mask",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="mask", version="1"),
+        asset_id="asset_mask",
+    )
+    image_record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_image"),
+        source={"type": "human", "name": "review"},
+        geometry={"x": 1, "y": 2, "width": 3, "height": 4},
+    )
+    mask_record = AnnotationRecord(
+        annotation_id="annotation_2",
+        kind="bbox",
+        label="mask",
+        subject=SubjectRef(kind="asset", id="asset_mask"),
+        source={"type": "human", "name": "review"},
+        geometry={"x": 5, "y": 6, "width": 7, "height": 8},
+    )
+    source_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="source-set",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1", "annotation_2"],
+    )
+    resolved = ResolvedDatasetVersion(
+        dataset_version=source_dataset,
+        datums=[
+            ResolvedDatum(
+                datum=Datum(asset_refs={"image": "asset_image"}, split="train", metadata={"row": 1}),
+                assets={"image": image_asset, "mask": mask_asset},
+                annotation_sets=[source_set],
+                annotation_records={source_set.annotation_set_id: [image_record, mask_record]},
+            )
+        ],
+    )
+    imported_dataset = VaultDataset(
+        dataset_id="collection_1",
+        name="training-copy",
+        created_at=Collection(name="training-copy").created_at,
+        updated_at=Collection(name="training-copy").updated_at,
+    )
+    imported_set = AnnotationSet(
+        annotation_set_id="imported_set_1",
+        name="source-set",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+    )
+    datalake = Mock()
+    vault = DataVault(datalake)
+    vault._prepare_import_target_dataset = Mock(return_value=imported_dataset)
+    vault._get_dataset_collection = Mock(return_value=Collection(name="training-copy", collection_id="collection_1"))
+    vault._ensure_collection_item = Mock(
+        return_value=CollectionItem(collection_id="collection_1", asset_id="asset_image")
+    )
+    vault.get_dataset = Mock(return_value=imported_dataset)
+    datalake.resolve_dataset_version = Mock(return_value=resolved)
+    datalake.create_annotation_set = Mock(return_value=imported_set)
+    datalake.add_annotation_records = Mock(return_value=[image_record])
+
+    result = vault.import_dataset_version("source-dataset", "1.0.0", target_name="training-copy")
+
+    assert result == imported_dataset
+    vault._ensure_collection_item.assert_called_once()
+    datalake.create_annotation_set.assert_called_once()
+    added_payloads = datalake.add_annotation_records.call_args.args[0]
+    assert len(added_payloads) == 1
+    assert added_payloads[0]["subject"]["id"] == "asset_image"
+
+
+def test_sync_data_vault_import_dataset_version_skips_empty_datums_and_non_primary_records():
+    source_dataset = DatasetVersion(
+        dataset_name="source-dataset", version="1.0.0", dataset_version_id="dataset_version_1"
+    )
+    image_asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="image", version="1"),
+        asset_id="asset_image",
+    )
+    other_asset = Asset(
+        kind="mask",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="mask", version="1"),
+        asset_id="asset_mask",
+    )
+    source_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="source-set",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1"],
+    )
+    foreign_record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="mask",
+        subject=SubjectRef(kind="asset", id="asset_mask"),
+        source={"type": "human", "name": "review"},
+        geometry={"x": 5, "y": 6, "width": 7, "height": 8},
+    )
+    resolved = ResolvedDatasetVersion(
+        dataset_version=source_dataset,
+        datums=[
+            ResolvedDatum(
+                datum=Datum(asset_refs={}),
+                assets={},
+                annotation_sets=[],
+                annotation_records={},
+            ),
+            ResolvedDatum(
+                datum=Datum(asset_refs={"image": "asset_image"}, split="train"),
+                assets={"image": image_asset, "mask": other_asset},
+                annotation_sets=[source_set],
+                annotation_records={source_set.annotation_set_id: [foreign_record]},
+            ),
+        ],
+    )
+    imported_dataset = VaultDataset(
+        dataset_id="collection_1",
+        name="training-copy",
+        created_at=Collection(name="training-copy").created_at,
+        updated_at=Collection(name="training-copy").updated_at,
+    )
+    datalake = Mock()
+    vault = DataVault(datalake)
+    vault._prepare_import_target_dataset = Mock(return_value=imported_dataset)
+    vault._get_dataset_collection = Mock(return_value=Collection(name="training-copy", collection_id="collection_1"))
+    vault._ensure_collection_item = Mock(
+        return_value=CollectionItem(collection_id="collection_1", asset_id="asset_image")
+    )
+    vault.get_dataset = Mock(return_value=imported_dataset)
+    datalake.resolve_dataset_version = Mock(return_value=resolved)
+    datalake.create_annotation_set = Mock()
+    datalake.add_annotation_records = Mock()
+
+    result = vault.import_dataset_version("source-dataset", "1.0.0", target_name="training-copy")
+
+    assert result == imported_dataset
+    vault._ensure_collection_item.assert_called_once()
+    datalake.create_annotation_set.assert_not_called()
+    datalake.add_annotation_records.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_import_dataset_version_materializes_mutable_dataset():
+    source_dataset = DatasetVersion(
+        dataset_name="source-dataset", version="1.0.0", dataset_version_id="dataset_version_1"
+    )
+    image_asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="image", version="1"),
+        asset_id="asset_image",
+    )
+    image_record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_image"),
+        source={"type": "human", "name": "review"},
+        geometry={"x": 1, "y": 2, "width": 3, "height": 4},
+    )
+    source_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="source-set",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1"],
+    )
+    resolved = ResolvedDatasetVersion(
+        dataset_version=source_dataset,
+        datums=[
+            ResolvedDatum(
+                datum=Datum(asset_refs={"image": "asset_image"}, split="train", metadata={"row": 1}),
+                assets={"image": image_asset},
+                annotation_sets=[source_set],
+                annotation_records={source_set.annotation_set_id: [image_record]},
+            )
+        ],
+    )
+    imported_dataset = VaultDataset(
+        dataset_id="collection_1",
+        name="training-copy",
+        created_at=Collection(name="training-copy").created_at,
+        updated_at=Collection(name="training-copy").updated_at,
+    )
+    imported_set = AnnotationSet(
+        annotation_set_id="imported_set_1",
+        name="source-set",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+    )
+    datalake = Mock()
+    vault = AsyncDataVault(datalake)
+    vault._prepare_import_target_dataset = AsyncMock(return_value=imported_dataset)
+    vault._get_dataset_collection = AsyncMock(
+        return_value=Collection(name="training-copy", collection_id="collection_1")
+    )
+    vault._ensure_collection_item = AsyncMock(
+        return_value=CollectionItem(collection_id="collection_1", asset_id="asset_image")
+    )
+    vault.get_dataset = AsyncMock(return_value=imported_dataset)
+    datalake.resolve_dataset_version = AsyncMock(return_value=resolved)
+    datalake.create_annotation_set = AsyncMock(return_value=imported_set)
+    datalake.add_annotation_records = AsyncMock(return_value=[image_record])
+
+    result = await vault.import_dataset_version("source-dataset", "1.0.0", target_name="training-copy")
+
+    assert result == imported_dataset
+    vault._ensure_collection_item.assert_awaited_once()
+    datalake.create_annotation_set.assert_awaited_once()
+    added_payloads = datalake.add_annotation_records.await_args.args[0]
+    assert len(added_payloads) == 1
+    assert added_payloads[0]["subject"]["id"] == "asset_image"
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_import_dataset_version_skips_empty_datums_and_non_primary_records():
+    source_dataset = DatasetVersion(
+        dataset_name="source-dataset", version="1.0.0", dataset_version_id="dataset_version_1"
+    )
+    image_asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="image", version="1"),
+        asset_id="asset_image",
+    )
+    other_asset = Asset(
+        kind="mask",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="mask", version="1"),
+        asset_id="asset_mask",
+    )
+    source_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="source-set",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1"],
+    )
+    foreign_record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="mask",
+        subject=SubjectRef(kind="asset", id="asset_mask"),
+        source={"type": "human", "name": "review"},
+        geometry={"x": 5, "y": 6, "width": 7, "height": 8},
+    )
+    resolved = ResolvedDatasetVersion(
+        dataset_version=source_dataset,
+        datums=[
+            ResolvedDatum(datum=Datum(asset_refs={}), assets={}, annotation_sets=[], annotation_records={}),
+            ResolvedDatum(
+                datum=Datum(asset_refs={"image": "asset_image"}, split="train"),
+                assets={"image": image_asset, "mask": other_asset},
+                annotation_sets=[source_set],
+                annotation_records={source_set.annotation_set_id: [foreign_record]},
+            ),
+        ],
+    )
+    imported_dataset = VaultDataset(
+        dataset_id="collection_1",
+        name="training-copy",
+        created_at=Collection(name="training-copy").created_at,
+        updated_at=Collection(name="training-copy").updated_at,
+    )
+    datalake = Mock()
+    vault = AsyncDataVault(datalake)
+    vault._prepare_import_target_dataset = AsyncMock(return_value=imported_dataset)
+    vault._get_dataset_collection = AsyncMock(
+        return_value=Collection(name="training-copy", collection_id="collection_1")
+    )
+    vault._ensure_collection_item = AsyncMock(
+        return_value=CollectionItem(collection_id="collection_1", asset_id="asset_image")
+    )
+    vault.get_dataset = AsyncMock(return_value=imported_dataset)
+    datalake.resolve_dataset_version = AsyncMock(return_value=resolved)
+    datalake.create_annotation_set = AsyncMock()
+    datalake.add_annotation_records = AsyncMock()
+
+    result = await vault.import_dataset_version("source-dataset", "1.0.0", target_name="training-copy")
+
+    assert result == imported_dataset
+    vault._ensure_collection_item.assert_awaited_once()
+    datalake.create_annotation_set.assert_not_called()
+    datalake.add_annotation_records.assert_not_called()
+
+
+def test_sync_data_vault_freeze_dataset_returns_dataset_version_when_persisting():
+    resolved = ResolvedDatasetVersion(
+        dataset_version=DatasetVersion(dataset_name="training", version="1.2.3"), datums=[]
+    )
+    vault = object.__new__(DataVault)
+    vault._freeze_dataset = Mock(return_value=resolved)
+
+    result = vault.freeze_dataset("training", persist=True, snapshot_version="1.2.3")
+
+    assert result == resolved.dataset_version
+    vault._freeze_dataset.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_freeze_dataset_returns_resolved_snapshot_when_not_persisting():
+    resolved = ResolvedDatasetVersion(
+        dataset_version=DatasetVersion(dataset_name="training", version="1.2.3"), datums=[]
+    )
+    vault = object.__new__(AsyncDataVault)
+    vault._freeze_dataset = AsyncMock(return_value=resolved)
+
+    result = await vault.freeze_dataset("training", persist=False, snapshot_version="1.2.3")
+
+    assert result == resolved
+    vault._freeze_dataset.assert_awaited_once()

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -6,11 +6,17 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from PIL import Image
 
+from mindtrace.database.core.exceptions import DocumentNotFoundError
 from mindtrace.datalake.data_vault import (
     AsyncDataVault,
     DataVault,
     VaultDataset,
+    _annotation_id,
+    _annotation_source_type,
     _annotations_bound_to_asset,
+    _coerce_annotation_payload,
+    _dataset_annotation_set_filters,
+    _extract_annotation_asset_id,
     _pil_image_to_png_bytes,
 )
 from mindtrace.datalake.pagination_types import CursorPage, PageInfo
@@ -479,6 +485,381 @@ def test_sync_data_vault_load_by_asset_id_materializes_bytes(tmp_path: Path):
     assert vault.load_by_asset_id("by-id") == b"sync-payload"
 
 
+def test_data_vault_dataset_helpers_cover_annotation_shapes():
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="x",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    typed = Mock()
+    typed.to_payload.return_value = {
+        "kind": "bbox",
+        "label": "y",
+        "subject": {"kind": "asset", "id": "asset_2"},
+        "source": {"type": "machine", "name": "model"},
+        "geometry": {},
+    }
+
+    assert _coerce_annotation_payload(record)["annotation_id"] == "annotation_1"
+    assert _coerce_annotation_payload({"kind": "bbox"}) == {"kind": "bbox"}
+    assert _coerce_annotation_payload(typed)["label"] == "y"
+    with pytest.raises(TypeError, match="annotation must be a dict"):
+        _coerce_annotation_payload(object())
+
+    assert _extract_annotation_asset_id({"subject": SubjectRef(kind="asset", id="asset_1")}) == "asset_1"
+    assert _extract_annotation_asset_id({"subject": {"kind": "asset", "id": 7}}) == "7"
+    assert _extract_annotation_asset_id({"subject": {"kind": "dataset", "id": "d1"}}) is None
+    assert _annotation_source_type({"source": {"type": "human"}}) == "human"
+    assert _annotation_source_type({"source": {"type": "other"}}) == "mixed"
+    assert _annotation_id(record) == "annotation_1"
+    assert _annotation_id("annotation_2") == "annotation_2"
+    assert _dataset_annotation_set_filters("collection_1", asset_id="asset_1") == {
+        "metadata.mindtrace.data_vault.dataset_collection_id": "collection_1",
+        "metadata.mindtrace.data_vault.asset_id": "asset_1",
+        "status": "active",
+    }
+
+
+def test_sync_data_vault_get_dataset_errors():
+    backend = Mock()
+    backend.list_collections = Mock(side_effect=[[], [Collection(name="x"), Collection(name="x")]])
+    vault = DataVault(backend)
+
+    with pytest.raises(DocumentNotFoundError, match="Dataset 'missing' not found"):
+        vault.get_dataset("missing")
+    with pytest.raises(ValueError, match="Multiple active datasets matched"):
+        vault.get_dataset("duplicate")
+
+
+def test_sync_data_vault_add_asset_uses_alias_and_updates_existing_item():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    existing = CollectionItem(
+        collection_id="collection_1",
+        asset_id="asset_1",
+        collection_item_id="ci_1",
+        split="val",
+        metadata={"old": True},
+    )
+    updated = existing.model_copy(update={"split": "train", "metadata": {"old": True, "new": True}})
+    backend = Mock()
+    backend.list_collections = Mock(return_value=[collection])
+    backend.get_asset = Mock(side_effect=[DocumentNotFoundError("no direct asset"), asset])
+    backend.get_asset_by_alias = Mock(return_value=asset)
+    backend.list_collection_items = Mock(return_value=[existing])
+    backend.update_collection_item = Mock(return_value=updated)
+
+    vault = DataVault(backend)
+    out = vault.add_asset("training", "friendly-alias", split="train", metadata={"new": True})
+
+    assert out == asset
+    backend.get_asset_by_alias.assert_called_once_with("friendly-alias")
+    backend.update_collection_item.assert_called_once_with("ci_1", split="train", metadata={"old": True, "new": True})
+
+
+def test_sync_data_vault_add_asset_reactivates_existing_item():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    inactive = CollectionItem(
+        collection_id="collection_1",
+        asset_id="asset_1",
+        collection_item_id="ci_1",
+        status="removed",
+        metadata={"old": True},
+    )
+    backend = Mock()
+    backend.list_collections = Mock(return_value=[collection])
+    backend.get_asset = Mock(return_value=asset)
+    backend.list_collection_items = Mock(return_value=[inactive])
+    backend.update_collection_item = Mock(return_value=inactive.model_copy(update={"status": "active"}))
+
+    vault = DataVault(backend)
+    vault.add_asset("training", "asset_1", metadata={"new": True})
+
+    backend.update_collection_item.assert_called_once_with(
+        "ci_1",
+        status="active",
+        split=None,
+        metadata={"old": True, "new": True},
+    )
+
+
+def test_sync_data_vault_add_annotation_from_record_and_missing_subject_error():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+        status="active",
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    backend = Mock()
+    backend.list_collections = Mock(return_value=[collection])
+    backend.get_asset = Mock(return_value=asset)
+    backend.list_collection_items = Mock(return_value=[])
+    backend.create_collection_item = Mock(
+        return_value=CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    )
+    backend.list_annotation_sets = Mock(return_value=[annotation_set])
+    backend.add_annotation_records = Mock(return_value=[record])
+
+    vault = DataVault(backend)
+    assert vault.add_annotation("training", record) == record
+    add_payload = backend.add_annotation_records.call_args.args[0][0]
+    assert add_payload["subject"] == {"kind": "asset", "id": "asset_1"}
+
+    with pytest.raises(ValueError, match="must reference an asset subject"):
+        vault.add_annotation(
+            "training",
+            {"kind": "bbox", "label": "cat", "source": {"type": "human", "name": "review"}, "geometry": {}},
+        )
+
+
+def test_sync_data_vault_remove_annotation_missing_ok_and_filtered_annotation_listing():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1"],
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    backend = Mock()
+    backend.list_collections = Mock(side_effect=[[collection], [collection], [collection]])
+    backend.get_asset = Mock(side_effect=DocumentNotFoundError("no direct asset"))
+    backend.get_asset_by_alias = Mock(return_value=asset)
+    backend.list_annotation_sets = Mock(side_effect=[[], [annotation_set], [annotation_set]])
+    backend.get_annotation_record = Mock(return_value=record)
+    backend.delete_annotation_record = Mock()
+
+    vault = DataVault(backend)
+    vault.remove_annotation("training", "annotation_2", missing_ok=True)
+    assert vault.list_dataset_annotations("training", asset="friendly-alias") == [record]
+    vault.remove_annotation("training", record)
+    backend.delete_annotation_record.assert_called_once_with("annotation_1")
+
+
+def test_sync_data_vault_duplicate_create_and_missing_remove_errors():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    backend = Mock()
+    backend.list_collections = Mock(side_effect=[[collection], [collection], [collection]])
+    backend.get_asset = Mock(return_value=asset)
+    backend.list_collection_items = Mock(return_value=[])
+    backend.list_annotation_sets = Mock(return_value=[])
+    vault = DataVault(backend)
+
+    with pytest.raises(ValueError, match="already exists"):
+        vault.create_dataset("training")
+    with pytest.raises(DocumentNotFoundError, match="not part of dataset"):
+        vault.remove_asset("training", "asset_1")
+    with pytest.raises(DocumentNotFoundError, match="not part of dataset"):
+        vault.remove_annotation("training", "annotation_1")
+
+
+def test_sync_data_vault_internal_asset_and_dataset_shortcuts():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    backend = Mock()
+    backend.list_collections = Mock(return_value=[collection])
+    vault = DataVault(backend)
+    dataset = VaultDataset(
+        dataset_id="collection_1",
+        name="training",
+        description=None,
+        status="active",
+        metadata={},
+        asset_count=0,
+        created_at=collection.created_at,
+        created_by=None,
+        updated_at=collection.updated_at,
+    )
+
+    assert vault._resolve_asset_id(asset) == "asset_1"
+    assert vault._get_dataset_collection(dataset) == collection
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_dataset_edge_cases_and_internal_paths():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    existing = CollectionItem(
+        collection_id="collection_1",
+        asset_id="asset_1",
+        collection_item_id="ci_1",
+        split="val",
+    )
+    backend = Mock()
+    backend.get_asset = AsyncMock(side_effect=DocumentNotFoundError("no direct asset"))
+    backend.get_asset_by_alias = AsyncMock(return_value=asset)
+    backend.list_collections = AsyncMock(side_effect=[[collection], [], [collection, collection]])
+    backend.list_collection_items = AsyncMock(return_value=[existing])
+    backend.update_collection_item = AsyncMock(return_value=existing.model_copy(update={"split": "train"}))
+
+    vault = AsyncDataVault(backend)
+    assert await vault._resolve_asset_id("friendly") == "asset_1"
+    assert await vault.get_dataset("training") == VaultDataset(
+        dataset_id="collection_1",
+        name="training",
+        description=None,
+        status="active",
+        metadata={},
+        asset_count=1,
+        created_at=collection.created_at,
+        created_by=None,
+        updated_at=collection.updated_at,
+    )
+    with pytest.raises(DocumentNotFoundError, match="Dataset 'missing' not found"):
+        await vault._get_dataset_collection("missing")
+    with pytest.raises(ValueError, match="Multiple active datasets matched"):
+        await vault._get_dataset_collection("duplicate")
+    item = await vault._ensure_collection_item(collection, "asset_1", split="train")
+    assert item.split == "train"
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_internal_shortcuts_and_reuse_paths():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    active_item = CollectionItem(
+        collection_id="collection_1",
+        asset_id="asset_1",
+        collection_item_id="ci_1",
+        status="active",
+        metadata={"old": True},
+    )
+    inactive_item = CollectionItem(
+        collection_id="collection_1",
+        asset_id="asset_2",
+        collection_item_id="ci_2",
+        status="removed",
+        metadata={"old": True},
+    )
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+        status="active",
+    )
+    backend = Mock()
+    backend.list_collections = AsyncMock(return_value=[collection])
+    backend.list_collection_items = AsyncMock(side_effect=[[active_item], [inactive_item]])
+    backend.update_collection_item = AsyncMock(
+        side_effect=[
+            active_item.model_copy(update={"metadata": {"old": True, "new": True}}),
+            inactive_item.model_copy(update={"status": "active"}),
+        ]
+    )
+    backend.list_annotation_sets = AsyncMock(return_value=[annotation_set])
+    vault = AsyncDataVault(backend)
+    dataset = VaultDataset(
+        dataset_id="collection_1",
+        name="training",
+        description=None,
+        status="active",
+        metadata={},
+        asset_count=0,
+        created_at=collection.created_at,
+        created_by=None,
+        updated_at=collection.updated_at,
+    )
+
+    assert await vault._resolve_asset_id(asset) == "asset_1"
+    assert await vault._get_dataset_collection(dataset) == collection
+    updated_active = await vault._ensure_collection_item(collection, "asset_1", metadata={"new": True})
+    assert updated_active.metadata == {"old": True, "new": True}
+    reactivated = await vault._ensure_collection_item(collection, "asset_2")
+    assert reactivated.status == "active"
+    reused = await vault._get_or_create_dataset_annotation_set(collection, "asset_1")
+    assert reused == annotation_set
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_list_assets_dedupes_and_remove_annotation_missing_ok():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    backend = Mock()
+    backend.list_collections = AsyncMock(side_effect=[[collection], [collection]])
+    backend.list_collection_items = AsyncMock(side_effect=[[item, item], []])
+    backend.get_asset = AsyncMock(return_value=asset)
+    backend.list_annotation_sets = AsyncMock(return_value=[])
+    backend.delete_annotation_record = AsyncMock(return_value=None)
+
+    vault = AsyncDataVault(backend)
+    assert await vault.list_dataset_assets("training") == [asset]
+    await vault.remove_annotation("training", "annotation_1", missing_ok=True)
+    backend.delete_annotation_record.assert_not_awaited()
+
+
 def test_sync_data_vault_create_and_list_datasets():
     collection = Collection(name="training", collection_id="collection_1")
     backend = Mock()
@@ -672,3 +1053,108 @@ async def test_async_data_vault_add_annotation_brings_asset_into_dataset():
     backend.create_collection_item.assert_awaited_once()
     backend.create_annotation_set.assert_awaited_once()
     backend.add_annotation_records.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_public_dataset_workflows():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1"],
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    dataset_page = CursorPage(
+        items=[collection], page=PageInfo(limit=1, next_cursor=None, has_more=False, total_count=1)
+    )
+    backend = Mock()
+    backend.list_collections = AsyncMock(
+        side_effect=[
+            [collection],
+            [collection],
+            [],
+            [collection],
+            [collection],
+            [collection],
+            [collection],
+            [collection],
+        ]
+    )
+    backend.list_collections_page = AsyncMock(return_value=dataset_page)
+
+    async def iter_collections(**kwargs):
+        assert kwargs == {"filters": {"status": "active"}, "sort": "updated_desc", "batch_size": 5}
+        yield collection
+
+    backend.iter_collections = iter_collections
+    backend.create_collection = AsyncMock(return_value=collection)
+    backend.get_asset = AsyncMock(side_effect=[asset, asset, asset, asset, asset])
+    backend.list_collection_items = AsyncMock(side_effect=[[item], [item], [item], [item], [item], [item], [item]])
+    backend.update_collection_item = AsyncMock(return_value=item)
+    backend.delete_collection_item = AsyncMock(return_value=None)
+    backend.list_annotation_sets = AsyncMock(side_effect=[[annotation_set], [annotation_set], []])
+    backend.get_annotation_record = AsyncMock(return_value=record)
+    backend.delete_annotation_record = AsyncMock(return_value=None)
+
+    vault = AsyncDataVault(backend)
+    summary = await vault.get_dataset("training")
+    assert summary.asset_count == 1
+    assert await vault.list_datasets() == [summary]
+    page = await vault.list_datasets_page(limit=1, include_total=True)
+    assert page.items == [summary]
+    assert [dataset async for dataset in vault.iter_datasets(batch_size=5)] == [summary]
+    created = await vault.create_dataset("new-dataset")
+    assert created.name == "training"
+    assert await vault.add_asset("training", "asset_1", split="train") == asset
+    assert await vault.list_dataset_assets("training") == [asset]
+    assert await vault.list_dataset_annotations("training", asset="asset_1") == [record]
+    await vault.remove_annotation("training", "annotation_1")
+    backend.delete_annotation_record.assert_awaited_once_with("annotation_1")
+    await vault.remove_asset("training", "asset_1")
+    backend.delete_collection_item.assert_awaited_once_with("ci_1")
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_public_dataset_error_paths():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    backend = Mock()
+    backend.list_collections = AsyncMock(side_effect=[[collection], [collection], [collection], [collection]])
+    backend.get_asset = AsyncMock(return_value=asset)
+    backend.list_collection_items = AsyncMock(return_value=[])
+    backend.list_annotation_sets = AsyncMock(return_value=[])
+
+    vault = AsyncDataVault(backend)
+    with pytest.raises(ValueError, match="already exists"):
+        await vault.create_dataset("training")
+    with pytest.raises(DocumentNotFoundError, match="not part of dataset"):
+        await vault.remove_asset("training", "asset_1")
+    with pytest.raises(DocumentNotFoundError, match="not part of dataset"):
+        await vault.remove_annotation("training", "annotation_1")
+    with pytest.raises(ValueError, match="must reference an asset subject"):
+        await vault.add_annotation(
+            "training",
+            {"kind": "bbox", "label": "cat", "source": {"type": "human", "name": "review"}, "geometry": {}},
+        )

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -1,6 +1,7 @@
 """Unit tests for :mod:`mindtrace.datalake.data_vault`."""
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -26,6 +27,8 @@ from mindtrace.datalake.types import (
     Asset,
     Collection,
     CollectionItem,
+    DatasetVersion,
+    ResolvedDatasetVersion,
     StorageRef,
     SubjectRef,
 )
@@ -1158,3 +1161,143 @@ async def test_async_data_vault_public_dataset_error_paths():
             "training",
             {"kind": "bbox", "label": "cat", "source": {"type": "human", "name": "review"}, "geometry": {}},
         )
+
+
+def test_sync_data_vault_freeze_dataset_persists_snapshot():
+    collection = Collection(name="training", collection_id="collection_1")
+    item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1", split="train")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    source_set = AnnotationSet(
+        annotation_set_id="source_set_1",
+        name="training:asset_1",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1"],
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={"x": 1, "y": 2, "width": 3, "height": 4},
+    )
+    resolved = ResolvedDatasetVersion(
+        dataset_version=DatasetVersion(dataset_name="training", version="1.2.3"), datums=[]
+    )
+    datalake = Mock()
+    datalake.list_collections = Mock(return_value=[collection])
+    datalake.list_collection_items = Mock(return_value=[item])
+    datalake.get_asset = Mock(return_value=asset)
+    datalake.list_annotation_sets = Mock(return_value=[source_set])
+    datalake.get_annotation_record = Mock(return_value=record)
+    datalake.create_datum = Mock(return_value=SimpleNamespace(datum_id="datum_1"))
+    datalake.create_annotation_set = Mock(
+        return_value=AnnotationSet(
+            annotation_set_id="snapshot_set_1",
+            name="training:asset_1",
+            purpose="ground_truth",
+            source_type="human",
+            status="active",
+        )
+    )
+    datalake.add_annotation_records = Mock(return_value=[])
+    datalake.create_dataset_version = Mock(return_value=DatasetVersion(dataset_name="training", version="1.2.3"))
+    datalake.resolve_dataset_version = Mock(return_value=resolved)
+
+    snapshot = DataVault(datalake)._freeze_dataset("training", persist_snapshot=True, snapshot_version="1.2.3")
+
+    assert snapshot == resolved
+    datalake.create_datum.assert_called_once()
+    datalake.create_annotation_set.assert_called_once()
+    datalake.add_annotation_records.assert_called_once()
+    datalake.create_dataset_version.assert_called_once()
+    assert datalake.create_dataset_version.call_args.kwargs["dataset_name"] == "training"
+    assert datalake.create_dataset_version.call_args.kwargs["version"] == "1.2.3"
+    assert datalake.create_dataset_version.call_args.kwargs["manifest"] == ["datum_1"]
+    assert (
+        datalake.create_dataset_version.call_args.kwargs["metadata"]["mindtrace"]["data_vault"]["source_dataset_id"]
+        == "collection_1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_freeze_dataset_persists_snapshot():
+    collection = Collection(name="training", collection_id="collection_1")
+    item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1", split="train")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    source_set = AnnotationSet(
+        annotation_set_id="source_set_1",
+        name="training:asset_1",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1"],
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={"x": 1, "y": 2, "width": 3, "height": 4},
+    )
+    resolved = ResolvedDatasetVersion(
+        dataset_version=DatasetVersion(dataset_name="training", version="1.2.3"), datums=[]
+    )
+    datalake = Mock()
+    datalake.list_collections = AsyncMock(return_value=[collection])
+    datalake.list_collection_items = AsyncMock(return_value=[item])
+    datalake.get_asset = AsyncMock(return_value=asset)
+    datalake.list_annotation_sets = AsyncMock(return_value=[source_set])
+    datalake.get_annotation_record = AsyncMock(return_value=record)
+    datalake.create_datum = AsyncMock(return_value=SimpleNamespace(datum_id="datum_1"))
+    datalake.create_annotation_set = AsyncMock(
+        return_value=AnnotationSet(
+            annotation_set_id="snapshot_set_1",
+            name="training:asset_1",
+            purpose="ground_truth",
+            source_type="human",
+            status="active",
+        )
+    )
+    datalake.add_annotation_records = AsyncMock(return_value=[])
+    datalake.create_dataset_version = AsyncMock(return_value=DatasetVersion(dataset_name="training", version="1.2.3"))
+    datalake.resolve_dataset_version = AsyncMock(return_value=resolved)
+
+    snapshot = await AsyncDataVault(datalake)._freeze_dataset(
+        "training", persist_snapshot=True, snapshot_version="1.2.3"
+    )
+
+    assert snapshot == resolved
+    datalake.create_datum.assert_awaited_once()
+    datalake.create_annotation_set.assert_awaited_once()
+    datalake.add_annotation_records.assert_awaited_once()
+    datalake.create_dataset_version.assert_awaited_once()
+
+
+def test_data_vault_export_dataset_requires_local_backend():
+    vault = object.__new__(DataVault)
+    vault._backend = Mock()
+
+    with pytest.raises(NotImplementedError, match="local Datalake backend"):
+        vault._require_local_datalake()
+
+
+def test_async_data_vault_export_dataset_requires_local_backend():
+    vault = object.__new__(AsyncDataVault)
+    vault._backend = Mock()
+
+    with pytest.raises(NotImplementedError, match="local AsyncDatalake backend"):
+        vault._require_local_datalake()

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -11,6 +11,8 @@ from PIL import Image
 from mindtrace.database.core.exceptions import DocumentNotFoundError
 from mindtrace.datalake.async_datalake import SlowOperationDisabledError, SlowOperationWarning, SlowOpsPolicy
 from mindtrace.datalake.data_vault import (
+    _DATASET_ANNOTATIONS_CURSOR_KIND,
+    _DATASET_ASSETS_CURSOR_KIND,
     AsyncDataVault,
     DataVault,
     VaultDataset,
@@ -20,8 +22,12 @@ from mindtrace.datalake.data_vault import (
     _annotations_bound_to_asset,
     _coerce_annotation_payload,
     _dataset_annotation_set_filters,
+    _decode_dataset_cursor,
+    _encode_dataset_cursor,
     _extract_annotation_asset_id,
+    _guard_slow_list_operation,
     _pil_image_to_png_bytes,
+    _resolve_slow_ops_policy,
     _resolved_primary_asset,
 )
 from mindtrace.datalake.data_vault_backends import (
@@ -82,6 +88,110 @@ def test_annotations_bound_to_asset_copies_dict_and_annotation_record():
     )
     merged_rec = _annotations_bound_to_asset([rec], "asset_z")
     assert merged_rec[0].subject == SubjectRef(kind="asset", id="asset_z")
+
+
+def test_data_vault_private_paging_helpers_and_policy_resolution():
+    backend = SimpleNamespace(slow_ops_policy="allow")
+    wrapped = SimpleNamespace(_datalake=SimpleNamespace(slow_ops_policy="forbid"))
+
+    assert _resolve_slow_ops_policy(backend, None) == SlowOpsPolicy.ALLOW
+    assert _resolve_slow_ops_policy(wrapped, None) == SlowOpsPolicy.FORBID
+    assert _resolve_slow_ops_policy(SimpleNamespace(slow_ops_policy=Mock()), None) == SlowOpsPolicy.WARN
+    assert _resolve_slow_ops_policy(object(), SlowOpsPolicy.ALLOW) == SlowOpsPolicy.ALLOW
+
+    payload = {"kind": _DATASET_ASSETS_CURSOR_KIND, "collection_id": "collection_1", "sort": "created_desc"}
+    cursor = _encode_dataset_cursor(payload)
+    assert _decode_dataset_cursor(cursor, expected_kind=_DATASET_ASSETS_CURSOR_KIND) == payload
+
+    with pytest.raises(ValueError, match="Invalid dataset page cursor"):
+        _decode_dataset_cursor("not-base64", expected_kind=_DATASET_ASSETS_CURSOR_KIND)
+    with pytest.raises(ValueError, match="Invalid dataset page cursor"):
+        _decode_dataset_cursor(
+            _encode_dataset_cursor({"kind": _DATASET_ANNOTATIONS_CURSOR_KIND}),
+            expected_kind=_DATASET_ASSETS_CURSOR_KIND,
+        )
+
+    _guard_slow_list_operation(SlowOpsPolicy.ALLOW, "list_dataset_assets", alternatives="iter_dataset_assets()")
+    with pytest.warns(SlowOperationWarning, match="list_dataset_assets"):
+        _guard_slow_list_operation(SlowOpsPolicy.WARN, "list_dataset_assets", alternatives="iter_dataset_assets()")
+    with pytest.raises(SlowOperationDisabledError, match="list_dataset_assets"):
+        _guard_slow_list_operation(SlowOpsPolicy.FORBID, "list_dataset_assets", alternatives="iter_dataset_assets()")
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_count_helpers_continue_across_pages():
+    item_1 = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    item_2 = CollectionItem(collection_id="collection_1", asset_id="asset_2", collection_item_id="ci_2")
+    asset_page_1 = CursorPage(items=[item_1], page=PageInfo(limit=1, next_cursor="cursor-1", has_more=True))
+    asset_page_2 = CursorPage(items=[item_2], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    annotation_page_1 = AnnotationSetPageOutput(
+        items=[
+            AnnotationSet(
+                annotation_set_id="annotation_set_1",
+                name="training:asset_1",
+                purpose="other",
+                source_type="human",
+                annotation_record_ids=["annotation_1", "annotation_2"],
+            )
+        ],
+        page=PageInfo(limit=1, next_cursor="cursor-1", has_more=True),
+    )
+    annotation_page_2 = AnnotationSetPageOutput(
+        items=[
+            AnnotationSet(
+                annotation_set_id="annotation_set_2",
+                name="training:asset_2",
+                purpose="other",
+                source_type="human",
+                annotation_record_ids=["annotation_3"],
+            )
+        ],
+        page=PageInfo(limit=1, next_cursor=None, has_more=False),
+    )
+    backend = Mock()
+    backend.list_collection_items_page = AsyncMock(
+        side_effect=lambda **kwargs: asset_page_1 if kwargs.get("cursor") is None else asset_page_2
+    )
+    backend.list_annotation_sets_page = AsyncMock(
+        side_effect=lambda **kwargs: annotation_page_1 if kwargs.get("cursor") is None else annotation_page_2
+    )
+
+    vault = AsyncDataVault(backend)
+    assert await vault._count_dataset_assets("collection_1") == 2
+    assert await vault._count_dataset_annotations("collection_1", None) == 3
+
+
+def test_sync_data_vault_count_annotations_continue_across_pages():
+    annotation_page_1 = AnnotationSetPageOutput(
+        items=[
+            AnnotationSet(
+                annotation_set_id="annotation_set_1",
+                name="training:asset_1",
+                purpose="other",
+                source_type="human",
+                annotation_record_ids=["annotation_1", "annotation_2"],
+            )
+        ],
+        page=PageInfo(limit=1, next_cursor="cursor-1", has_more=True),
+    )
+    annotation_page_2 = AnnotationSetPageOutput(
+        items=[
+            AnnotationSet(
+                annotation_set_id="annotation_set_2",
+                name="training:asset_2",
+                purpose="other",
+                source_type="human",
+                annotation_record_ids=["annotation_3"],
+            )
+        ],
+        page=PageInfo(limit=1, next_cursor=None, has_more=False),
+    )
+    backend = Mock()
+    backend.list_annotation_sets_page = Mock(
+        side_effect=lambda **kwargs: annotation_page_1 if kwargs.get("cursor") is None else annotation_page_2
+    )
+
+    assert DataVault(backend)._count_dataset_annotations("collection_1", None) == 3
 
 
 @pytest.mark.asyncio
@@ -1229,6 +1339,157 @@ def test_sync_data_vault_dataset_assets_page_iter_and_total():
 
 
 @pytest.mark.asyncio
+async def test_async_data_vault_dataset_assets_page_resume_validation_and_total():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset_1 = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n1", version="1"),
+        asset_id="asset_1",
+    )
+    asset_2 = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n2", version="1"),
+        asset_id="asset_2",
+    )
+    item_1 = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    item_2 = CollectionItem(collection_id="collection_1", asset_id="asset_2", collection_item_id="ci_2")
+    page = CursorPage(items=[item_1, item_2], page=PageInfo(limit=5, next_cursor=None, has_more=False))
+
+    backend = Mock()
+    backend.list_collections = AsyncMock(return_value=[collection])
+    backend.list_collection_items_page = AsyncMock(side_effect=lambda **kwargs: page)
+    backend.get_asset = AsyncMock(side_effect=lambda asset_id: {"asset_1": asset_1, "asset_2": asset_2}[asset_id])
+    vault = AsyncDataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+
+    asset_page = await vault.list_dataset_assets_page("training", limit=5, include_total=True)
+    assert [asset.asset_id for asset in asset_page.items] == ["asset_1", "asset_2"]
+    assert asset_page.page.total_count == 2
+    assert [asset.asset_id async for asset in vault.iter_dataset_assets("training", batch_size=5)] == [
+        "asset_1",
+        "asset_2",
+    ]
+
+    resume_cursor = _encode_dataset_cursor(
+        {
+            "kind": _DATASET_ASSETS_CURSOR_KIND,
+            "collection_id": "collection_1",
+            "sort": "created_desc",
+            "limit": 2,
+            "items_cursor": None,
+            "seen_asset_ids": [],
+            "pending_asset_ids": ["asset_1"],
+        }
+    )
+    resumed = await vault.list_dataset_assets_page("training", cursor=resume_cursor)
+    assert [asset.asset_id for asset in resumed.items] == ["asset_1"]
+    assert resumed.page.has_more is False
+
+    limited_cursor = _encode_dataset_cursor(
+        {
+            "kind": _DATASET_ASSETS_CURSOR_KIND,
+            "collection_id": "collection_1",
+            "sort": "created_desc",
+            "limit": 1,
+            "items_cursor": None,
+            "seen_asset_ids": [],
+            "pending_asset_ids": ["asset_1", "asset_2"],
+        }
+    )
+    limited = await vault.list_dataset_assets_page("training", cursor=limited_cursor)
+    assert [asset.asset_id for asset in limited.items] == ["asset_1"]
+    assert limited.page.has_more is True
+    assert limited.page.next_cursor is not None
+
+    with pytest.raises(ValueError, match="requested dataset"):
+        await vault.list_dataset_assets_page(
+            "training",
+            cursor=_encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ASSETS_CURSOR_KIND,
+                    "collection_id": "other_collection",
+                    "sort": "created_desc",
+                }
+            ),
+        )
+    with pytest.raises(ValueError, match="sort order"):
+        await vault.list_dataset_assets_page(
+            "training",
+            sort="updated_desc",
+            cursor=_encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ASSETS_CURSOR_KIND,
+                    "collection_id": "collection_1",
+                    "sort": "created_desc",
+                }
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_dataset_assets_page_empty_duplicate_and_iter_edges():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset_1 = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n1", version="1"),
+        asset_id="asset_1",
+    )
+    asset_2 = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n2", version="1"),
+        asset_id="asset_2",
+    )
+    item_1 = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    item_2 = CollectionItem(collection_id="collection_1", asset_id="asset_2", collection_item_id="ci_2")
+    duplicate_page = CursorPage(items=[item_1, item_1], page=PageInfo(limit=5, next_cursor=None, has_more=False))
+    empty_page = CursorPage(items=[], page=PageInfo(limit=2, next_cursor=None, has_more=False))
+    iter_page_1 = CursorPage(items=[item_1], page=PageInfo(limit=1, next_cursor="cursor-1", has_more=True))
+    iter_page_2 = CursorPage(items=[item_2], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+
+    duplicate_backend = Mock()
+    duplicate_backend.list_collections = AsyncMock(return_value=[collection])
+    duplicate_backend.get_asset = AsyncMock(return_value=asset_1)
+    duplicate_backend.list_collection_items_page = AsyncMock(return_value=duplicate_page)
+    duplicate_vault = AsyncDataVault(duplicate_backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+
+    duplicate_cursor = _encode_dataset_cursor(
+        {
+            "kind": _DATASET_ASSETS_CURSOR_KIND,
+            "collection_id": "collection_1",
+            "sort": "created_desc",
+            "limit": 5,
+            "items_cursor": None,
+            "seen_asset_ids": [],
+            "pending_asset_ids": ["asset_1", "asset_1"],
+        }
+    )
+    duplicate_resumed = await duplicate_vault.list_dataset_assets_page("training", cursor=duplicate_cursor)
+    assert [asset.asset_id for asset in duplicate_resumed.items] == ["asset_1"]
+    duplicate_page = await duplicate_vault.list_dataset_assets_page("training")
+    assert [asset.asset_id for asset in duplicate_page.items] == ["asset_1"]
+
+    empty_backend = Mock()
+    empty_backend.list_collections = AsyncMock(return_value=[collection])
+    empty_backend.list_collection_items_page = AsyncMock(return_value=empty_page)
+    empty_backend.get_asset = AsyncMock()
+    empty_vault = AsyncDataVault(empty_backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+    assert (await empty_vault.list_dataset_assets_page("training")).items == []
+
+    iter_backend = Mock()
+    iter_backend.list_collections = AsyncMock(return_value=[collection])
+    iter_backend.list_collection_items_page = AsyncMock(side_effect=[iter_page_1, iter_page_2])
+    iter_backend.get_asset = AsyncMock(side_effect=lambda asset_id: {"asset_1": asset_1, "asset_2": asset_2}[asset_id])
+    iter_vault = AsyncDataVault(iter_backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+    assert [asset.asset_id async for asset in iter_vault.iter_dataset_assets("training", batch_size=1)] == [
+        "asset_1",
+        "asset_2",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_async_data_vault_dataset_annotations_page_iter_and_asset_filter():
     collection = Collection(name="training", collection_id="collection_1")
     asset = Asset(
@@ -1315,6 +1576,428 @@ async def test_async_data_vault_dataset_annotations_page_iter_and_asset_filter()
     assert [
         record.annotation_id async for record in vault.iter_dataset_annotations("training", asset=asset, batch_size=2)
     ] == ["annotation_1", "annotation_2", "annotation_3"]
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_dataset_annotations_page_resume_validation_and_total():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    record_1 = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    record_2 = AnnotationRecord(
+        annotation_id="annotation_2",
+        kind="bbox",
+        label="dog",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1", "annotation_2"],
+        metadata={"mindtrace": {"data_vault": {"dataset_collection_id": "collection_1", "asset_id": "asset_1"}}},
+    )
+    page = AnnotationSetPageOutput(items=[annotation_set], page=PageInfo(limit=5, next_cursor=None, has_more=False))
+
+    backend = Mock()
+    backend.list_collections = AsyncMock(return_value=[collection])
+    backend.list_annotation_sets_page = AsyncMock(side_effect=lambda **kwargs: page)
+    backend.get_annotation_record = AsyncMock(
+        side_effect=lambda annotation_id: {"annotation_1": record_1, "annotation_2": record_2}[annotation_id]
+    )
+    vault = AsyncDataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+
+    annotation_page = await vault.list_dataset_annotations_page("training", asset=asset, limit=5, include_total=True)
+    assert [record.annotation_id for record in annotation_page.items] == ["annotation_1", "annotation_2"]
+    assert annotation_page.page.total_count == 2
+
+    resume_cursor = _encode_dataset_cursor(
+        {
+            "kind": _DATASET_ANNOTATIONS_CURSOR_KIND,
+            "collection_id": "collection_1",
+            "asset_id": "asset_1",
+            "sort": "created_desc",
+            "limit": 3,
+            "annotation_sets_cursor": None,
+            "pending_annotation_ids": ["annotation_1"],
+        }
+    )
+    resumed = await vault.list_dataset_annotations_page("training", asset=asset, cursor=resume_cursor)
+    assert [record.annotation_id for record in resumed.items] == ["annotation_1"]
+    assert resumed.page.has_more is False
+
+    limited_cursor = _encode_dataset_cursor(
+        {
+            "kind": _DATASET_ANNOTATIONS_CURSOR_KIND,
+            "collection_id": "collection_1",
+            "asset_id": "asset_1",
+            "sort": "created_desc",
+            "limit": 1,
+            "annotation_sets_cursor": None,
+            "pending_annotation_ids": ["annotation_1", "annotation_2"],
+        }
+    )
+    limited = await vault.list_dataset_annotations_page("training", asset=asset, cursor=limited_cursor)
+    assert [record.annotation_id for record in limited.items] == ["annotation_1"]
+    assert limited.page.has_more is True
+    assert limited.page.next_cursor is not None
+
+    with pytest.raises(ValueError, match="requested dataset"):
+        await vault.list_dataset_annotations_page(
+            "training",
+            asset=asset,
+            cursor=_encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ANNOTATIONS_CURSOR_KIND,
+                    "collection_id": "other_collection",
+                    "asset_id": "asset_1",
+                    "sort": "created_desc",
+                }
+            ),
+        )
+    with pytest.raises(ValueError, match="sort order"):
+        await vault.list_dataset_annotations_page(
+            "training",
+            asset=asset,
+            sort="updated_desc",
+            cursor=_encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ANNOTATIONS_CURSOR_KIND,
+                    "collection_id": "collection_1",
+                    "asset_id": "asset_1",
+                    "sort": "created_desc",
+                }
+            ),
+        )
+    with pytest.raises(ValueError, match="asset filter"):
+        await vault.list_dataset_annotations_page(
+            "training",
+            asset=asset,
+            cursor=_encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ANNOTATIONS_CURSOR_KIND,
+                    "collection_id": "collection_1",
+                    "asset_id": "asset_2",
+                    "sort": "created_desc",
+                }
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_dataset_annotations_page_empty_page_edge():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    empty_page = AnnotationSetPageOutput(items=[], page=PageInfo(limit=2, next_cursor=None, has_more=False))
+    backend = Mock()
+    backend.list_collections = AsyncMock(return_value=[collection])
+    backend.list_annotation_sets_page = AsyncMock(return_value=empty_page)
+    vault = AsyncDataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+
+    page = await vault.list_dataset_annotations_page("training", asset=asset)
+    assert page.items == []
+    assert page.page.has_more is False
+
+
+def test_sync_data_vault_dataset_assets_page_resume_and_validation():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset_1 = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n1", version="1"),
+        asset_id="asset_1",
+    )
+    asset_2 = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n2", version="1"),
+        asset_id="asset_2",
+    )
+    item_1 = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    item_2 = CollectionItem(collection_id="collection_1", asset_id="asset_2", collection_item_id="ci_2")
+    page = CursorPage(items=[item_1, item_2], page=PageInfo(limit=5, next_cursor=None, has_more=False))
+
+    backend = Mock()
+    backend.list_collections = Mock(return_value=[collection])
+    backend.list_collection_items_page = Mock(side_effect=lambda **kwargs: page)
+    backend.get_asset = Mock(side_effect=lambda asset_id: {"asset_1": asset_1, "asset_2": asset_2}[asset_id])
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+
+    resume_cursor = _encode_dataset_cursor(
+        {
+            "kind": _DATASET_ASSETS_CURSOR_KIND,
+            "collection_id": "collection_1",
+            "sort": "created_desc",
+            "limit": 2,
+            "items_cursor": None,
+            "seen_asset_ids": [],
+            "pending_asset_ids": ["asset_1"],
+        }
+    )
+    resumed = vault.list_dataset_assets_page("training", cursor=resume_cursor)
+    assert [asset.asset_id for asset in resumed.items] == ["asset_1"]
+    assert resumed.page.has_more is False
+
+    asset_page = vault.list_dataset_assets_page("training", limit=5, include_total=True)
+    assert [asset.asset_id for asset in asset_page.items] == ["asset_1", "asset_2"]
+    assert asset_page.page.total_count == 2
+
+    with pytest.raises(ValueError, match="requested dataset"):
+        vault.list_dataset_assets_page(
+            "training",
+            cursor=_encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ASSETS_CURSOR_KIND,
+                    "collection_id": "other_collection",
+                    "sort": "created_desc",
+                }
+            ),
+        )
+    with pytest.raises(ValueError, match="sort order"):
+        vault.list_dataset_assets_page(
+            "training",
+            sort="updated_desc",
+            cursor=_encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ASSETS_CURSOR_KIND,
+                    "collection_id": "collection_1",
+                    "sort": "created_desc",
+                }
+            ),
+        )
+
+
+def test_sync_data_vault_dataset_assets_page_empty_and_duplicate_edges():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset_1 = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n1", version="1"),
+        asset_id="asset_1",
+    )
+    item_1 = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    duplicate_page = CursorPage(items=[item_1, item_1], page=PageInfo(limit=5, next_cursor=None, has_more=False))
+    empty_page = CursorPage(items=[], page=PageInfo(limit=2, next_cursor=None, has_more=False))
+
+    duplicate_backend = Mock()
+    duplicate_backend.list_collections = Mock(return_value=[collection])
+    duplicate_backend.list_collection_items_page = Mock(return_value=duplicate_page)
+    duplicate_backend.get_asset = Mock(return_value=asset_1)
+    duplicate_vault = DataVault(duplicate_backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+    assert [asset.asset_id for asset in duplicate_vault.list_dataset_assets_page("training").items] == ["asset_1"]
+
+    empty_backend = Mock()
+    empty_backend.list_collections = Mock(return_value=[collection])
+    empty_backend.list_collection_items_page = Mock(return_value=empty_page)
+    empty_backend.get_asset = Mock()
+    empty_vault = DataVault(empty_backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+    assert empty_vault.list_dataset_assets_page("training").items == []
+
+
+def test_sync_data_vault_dataset_annotations_page_iter_total_and_validation():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    record_1 = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    record_2 = AnnotationRecord(
+        annotation_id="annotation_2",
+        kind="bbox",
+        label="dog",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1", "annotation_2"],
+        metadata={"mindtrace": {"data_vault": {"dataset_collection_id": "collection_1", "asset_id": "asset_1"}}},
+    )
+    page = AnnotationSetPageOutput(items=[annotation_set], page=PageInfo(limit=5, next_cursor=None, has_more=False))
+
+    backend = Mock()
+    backend.list_collections = Mock(return_value=[collection])
+    backend.list_annotation_sets_page = Mock(side_effect=lambda **kwargs: page)
+    backend.get_annotation_record = Mock(
+        side_effect=lambda annotation_id: {"annotation_1": record_1, "annotation_2": record_2}[annotation_id]
+    )
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+
+    annotation_page = vault.list_dataset_annotations_page("training", asset=asset, limit=5, include_total=True)
+    assert [record.annotation_id for record in annotation_page.items] == ["annotation_1", "annotation_2"]
+    assert annotation_page.page.total_count == 2
+    assert [
+        record.annotation_id for record in vault.iter_dataset_annotations("training", asset=asset, batch_size=5)
+    ] == [
+        "annotation_1",
+        "annotation_2",
+    ]
+
+    resume_cursor = _encode_dataset_cursor(
+        {
+            "kind": _DATASET_ANNOTATIONS_CURSOR_KIND,
+            "collection_id": "collection_1",
+            "asset_id": "asset_1",
+            "sort": "created_desc",
+            "limit": 3,
+            "annotation_sets_cursor": None,
+            "pending_annotation_ids": ["annotation_1"],
+        }
+    )
+    resumed = vault.list_dataset_annotations_page("training", asset=asset, cursor=resume_cursor)
+    assert [record.annotation_id for record in resumed.items] == ["annotation_1"]
+    assert resumed.page.has_more is False
+
+    with pytest.raises(ValueError, match="requested dataset"):
+        vault.list_dataset_annotations_page(
+            "training",
+            asset=asset,
+            cursor=_encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ANNOTATIONS_CURSOR_KIND,
+                    "collection_id": "other_collection",
+                    "asset_id": "asset_1",
+                    "sort": "created_desc",
+                }
+            ),
+        )
+    with pytest.raises(ValueError, match="sort order"):
+        vault.list_dataset_annotations_page(
+            "training",
+            asset=asset,
+            sort="updated_desc",
+            cursor=_encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ANNOTATIONS_CURSOR_KIND,
+                    "collection_id": "collection_1",
+                    "asset_id": "asset_1",
+                    "sort": "created_desc",
+                }
+            ),
+        )
+    with pytest.raises(ValueError, match="asset filter"):
+        vault.list_dataset_annotations_page(
+            "training",
+            asset=asset,
+            cursor=_encode_dataset_cursor(
+                {
+                    "kind": _DATASET_ANNOTATIONS_CURSOR_KIND,
+                    "collection_id": "collection_1",
+                    "asset_id": "asset_2",
+                    "sort": "created_desc",
+                }
+            ),
+        )
+
+
+def test_sync_data_vault_dataset_annotations_page_limit_empty_and_iter_edges():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    record_1 = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    record_2 = AnnotationRecord(
+        annotation_id="annotation_2",
+        kind="bbox",
+        label="dog",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1"],
+        metadata={"mindtrace": {"data_vault": {"dataset_collection_id": "collection_1", "asset_id": "asset_1"}}},
+    )
+    empty_page = AnnotationSetPageOutput(items=[], page=PageInfo(limit=2, next_cursor=None, has_more=False))
+    iter_page_1 = AnnotationSetPageOutput(
+        items=[annotation_set], page=PageInfo(limit=1, next_cursor="cursor-1", has_more=True)
+    )
+    iter_page_2 = AnnotationSetPageOutput(items=[], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+
+    limit_backend = Mock()
+    limit_backend.list_collections = Mock(return_value=[collection])
+    limit_backend.get_annotation_record = Mock(
+        side_effect=lambda annotation_id: {"annotation_1": record_1, "annotation_2": record_2}[annotation_id]
+    )
+    limit_vault = DataVault(limit_backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+    limited_cursor = _encode_dataset_cursor(
+        {
+            "kind": _DATASET_ANNOTATIONS_CURSOR_KIND,
+            "collection_id": "collection_1",
+            "asset_id": "asset_1",
+            "sort": "created_desc",
+            "limit": 1,
+            "annotation_sets_cursor": None,
+            "pending_annotation_ids": ["annotation_1", "annotation_2"],
+        }
+    )
+    limited = limit_vault.list_dataset_annotations_page("training", asset=asset, cursor=limited_cursor)
+    assert [record.annotation_id for record in limited.items] == ["annotation_1"]
+    assert limited.page.has_more is True
+
+    empty_backend = Mock()
+    empty_backend.list_collections = Mock(return_value=[collection])
+    empty_backend.list_annotation_sets_page = Mock(return_value=empty_page)
+    empty_vault = DataVault(empty_backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+    assert empty_vault.list_dataset_annotations_page("training", asset=asset).items == []
+
+    iter_backend = Mock()
+    iter_backend.list_collections = Mock(return_value=[collection])
+    iter_backend.list_annotation_sets_page = Mock(side_effect=[iter_page_1, iter_page_2])
+    iter_backend.get_annotation_record = Mock(return_value=record_1)
+    iter_vault = DataVault(iter_backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
+    assert [
+        record.annotation_id for record in iter_vault.iter_dataset_annotations("training", asset=asset, batch_size=1)
+    ] == ["annotation_1"]
 
 
 def test_sync_data_vault_eager_dataset_methods_obey_slow_ops_policy_forbid():

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -9,6 +9,7 @@ import pytest
 from PIL import Image
 
 from mindtrace.database.core.exceptions import DocumentNotFoundError
+from mindtrace.datalake.async_datalake import SlowOperationDisabledError, SlowOperationWarning, SlowOpsPolicy
 from mindtrace.datalake.data_vault import (
     AsyncDataVault,
     DataVault,
@@ -31,6 +32,7 @@ from mindtrace.datalake.pagination_types import CursorPage, PageInfo
 from mindtrace.datalake.service_types import (
     AddedAnnotationRecordsOutput,
     AnnotationSetOutput,
+    AnnotationSetPageOutput,
     AssetOutput,
     CollectionItemListOutput,
     CollectionListOutput,
@@ -391,7 +393,7 @@ def test_sync_data_vault_delegates_list_and_get_asset():
     backend = Mock()
     backend.list_assets = Mock(return_value=[asset])
     backend.get_asset = Mock(return_value=asset)
-    vault = DataVault(backend)
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     assert vault.list_assets({"kind": "image"}) == [asset]
     backend.list_assets.assert_called_once_with({"kind": "image"})
     assert vault.list_image_assets() == [asset]
@@ -422,7 +424,7 @@ def test_sync_data_vault_paged_and_streaming_asset_discovery():
     backend.list_assets_page = Mock(return_value=asset_page)
     backend.iter_assets = Mock(return_value=iter([image_asset]))
 
-    vault = DataVault(backend)
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     assert vault.list_assets_page(filters={"kind": "image"}, limit=1, include_total=True) == asset_page
     backend.list_assets_page.assert_called_once_with(
         filters={"kind": "image"},
@@ -457,7 +459,7 @@ def test_sync_data_vault_load_image_by_asset_id():
     backend = Mock()
     backend.get_asset = Mock(return_value=asset)
     backend.get_object = Mock(return_value=png)
-    vault = DataVault(backend)
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     out = vault.load_image_by_asset_id("img-1")
     assert out.tobytes() == im.tobytes()
     backend.get_asset.assert_called_once_with("img-1")
@@ -550,7 +552,7 @@ def test_data_vault_dataset_helpers_cover_annotation_shapes():
 def test_sync_data_vault_get_dataset_errors():
     backend = Mock()
     backend.list_collections = Mock(side_effect=[[], [Collection(name="x"), Collection(name="x")]])
-    vault = DataVault(backend)
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
 
     with pytest.raises(DocumentNotFoundError, match="Dataset 'missing' not found"):
         vault.get_dataset("missing")
@@ -581,7 +583,7 @@ def test_sync_data_vault_add_asset_uses_alias_and_updates_existing_item():
     backend.list_collection_items = Mock(return_value=[existing])
     backend.update_collection_item = Mock(return_value=updated)
 
-    vault = DataVault(backend)
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     out = vault.add_asset("training", "friendly-alias", split="train", metadata={"new": True})
 
     assert out == asset
@@ -610,7 +612,7 @@ def test_sync_data_vault_add_asset_reactivates_existing_item():
     backend.list_collection_items = Mock(return_value=[inactive])
     backend.update_collection_item = Mock(return_value=inactive.model_copy(update={"status": "active"}))
 
-    vault = DataVault(backend)
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     vault.add_asset("training", "asset_1", metadata={"new": True})
 
     backend.update_collection_item.assert_called_once_with(
@@ -698,7 +700,7 @@ def test_sync_data_vault_remove_annotation_missing_ok_and_filtered_annotation_li
     backend.get_annotation_record = Mock(return_value=record)
     backend.delete_annotation_record = Mock()
 
-    vault = DataVault(backend)
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     vault.remove_annotation("training", "annotation_2", missing_ok=True)
     assert vault.list_dataset_annotations("training", asset="friendly-alias") == [record]
     vault.remove_annotation("training", record)
@@ -777,7 +779,7 @@ async def test_async_data_vault_dataset_edge_cases_and_internal_paths():
     backend.list_collection_items = AsyncMock(return_value=[existing])
     backend.update_collection_item = AsyncMock(return_value=existing.model_copy(update={"split": "train"}))
 
-    vault = AsyncDataVault(backend)
+    vault = AsyncDataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     assert await vault._resolve_asset_id("friendly") == "asset_1"
     assert await vault.get_dataset("training") == VaultDataset(
         dataset_id="collection_1",
@@ -838,7 +840,7 @@ async def test_async_data_vault_internal_shortcuts_and_reuse_paths():
         ]
     )
     backend.list_annotation_sets = AsyncMock(return_value=[annotation_set])
-    vault = AsyncDataVault(backend)
+    vault = AsyncDataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     dataset = VaultDataset(
         dataset_id="collection_1",
         name="training",
@@ -878,7 +880,7 @@ async def test_async_data_vault_list_assets_dedupes_and_remove_annotation_missin
     backend.list_annotation_sets = AsyncMock(return_value=[])
     backend.delete_annotation_record = AsyncMock(return_value=None)
 
-    vault = AsyncDataVault(backend)
+    vault = AsyncDataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     assert await vault.list_dataset_assets("training") == [asset]
     await vault.remove_annotation("training", "annotation_1", missing_ok=True)
     backend.delete_annotation_record.assert_not_awaited()
@@ -894,7 +896,7 @@ def test_sync_data_vault_create_and_list_datasets():
     page = CursorPage(items=[collection], page=PageInfo(limit=1, next_cursor=None, has_more=False, total_count=1))
     backend.list_collections_page = Mock(return_value=page)
 
-    vault = DataVault(backend)
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     created = vault.create_dataset("training", description="demo")
     assert created == VaultDataset(
         dataset_id="collection_1",
@@ -962,7 +964,7 @@ def test_sync_data_vault_add_annotation_brings_asset_into_dataset():
     backend.create_annotation_set = Mock(return_value=annotation_set)
     backend.add_annotation_records = Mock(return_value=[record])
 
-    vault = DataVault(backend)
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     out = vault.add_annotation(
         "training",
         {"kind": "bbox", "label": "cat", "source": {"type": "human", "name": "review"}, "geometry": {}},
@@ -1020,7 +1022,7 @@ def test_sync_data_vault_list_assets_and_annotations_and_remove_membership():
     backend.delete_annotation_record = Mock()
     backend.delete_collection_item = Mock()
 
-    vault = DataVault(backend)
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     assert vault.list_dataset_assets("training") == [asset]
     assert vault.list_dataset_annotations("training") == [record, record]
 
@@ -1066,7 +1068,7 @@ async def test_async_data_vault_add_annotation_brings_asset_into_dataset():
     backend.create_annotation_set = AsyncMock(return_value=annotation_set)
     backend.add_annotation_records = AsyncMock(return_value=[record])
 
-    vault = AsyncDataVault(backend)
+    vault = AsyncDataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     out = await vault.add_annotation(
         "training",
         {"kind": "bbox", "label": "cat", "source": {"type": "human", "name": "review"}, "geometry": {}},
@@ -1137,7 +1139,7 @@ async def test_async_data_vault_public_dataset_workflows():
     backend.get_annotation_record = AsyncMock(return_value=record)
     backend.delete_annotation_record = AsyncMock(return_value=None)
 
-    vault = AsyncDataVault(backend)
+    vault = AsyncDataVault(backend, slow_ops_policy=SlowOpsPolicy.ALLOW)
     summary = await vault.get_dataset("training")
     assert summary.asset_count == 1
     assert await vault.list_datasets() == [summary]
@@ -1182,6 +1184,165 @@ async def test_async_data_vault_public_dataset_error_paths():
             "training",
             {"kind": "bbox", "label": "cat", "source": {"type": "human", "name": "review"}, "geometry": {}},
         )
+
+
+def test_sync_data_vault_dataset_assets_page_iter_and_total():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset_1 = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n1", version="1"),
+        asset_id="asset_1",
+    )
+    asset_2 = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n2", version="1"),
+        asset_id="asset_2",
+    )
+    page_1 = CursorPage(
+        items=[CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")],
+        page=PageInfo(limit=1, next_cursor="raw-2", has_more=True),
+    )
+    page_2 = CursorPage(
+        items=[CollectionItem(collection_id="collection_1", asset_id="asset_2", collection_item_id="ci_2")],
+        page=PageInfo(limit=1, next_cursor=None, has_more=False),
+    )
+    backend = Mock()
+    backend.list_collections = Mock(return_value=[collection])
+    backend.list_collection_items_page = Mock(side_effect=[page_1, page_1, page_2, page_1, page_2])
+    backend.get_asset = Mock(side_effect=lambda asset_id: {"asset_1": asset_1, "asset_2": asset_2}[asset_id])
+    vault = DataVault(backend)
+
+    first_page = vault.list_dataset_assets_page("training", limit=1, include_total=True)
+    second_page = vault.list_dataset_assets_page("training", limit=1, cursor=first_page.page.next_cursor)
+
+    assert [asset.asset_id for asset in first_page.items] == ["asset_1"]
+    assert first_page.page.total_count == 2
+    assert first_page.page.has_more is True
+    assert [asset.asset_id for asset in second_page.items] == ["asset_2"]
+    assert second_page.page.has_more is False
+
+    backend.list_collection_items_page.reset_mock()
+    backend.list_collection_items_page.side_effect = [page_1, page_2]
+    assert [asset.asset_id for asset in vault.iter_dataset_assets("training", batch_size=1)] == ["asset_1", "asset_2"]
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_dataset_annotations_page_iter_and_asset_filter():
+    collection = Collection(name="training", collection_id="collection_1")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n1", version="1"),
+        asset_id="asset_1",
+    )
+    set_1 = AnnotationSet(
+        annotation_set_id="set_1",
+        name="set-1",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1", "annotation_2"],
+    )
+    set_2 = AnnotationSet(
+        annotation_set_id="set_2",
+        name="set-2",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_3"],
+    )
+    record_1 = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    record_2 = AnnotationRecord(
+        annotation_id="annotation_2",
+        kind="bbox",
+        label="dog",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    record_3 = AnnotationRecord(
+        annotation_id="annotation_3",
+        kind="bbox",
+        label="bird",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={},
+    )
+    page_1 = AnnotationSetPageOutput(items=[set_1], page=PageInfo(limit=1, next_cursor="set-cursor-2", has_more=True))
+    page_2 = AnnotationSetPageOutput(items=[set_2], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    backend = Mock()
+    backend.list_collections = AsyncMock(return_value=[collection])
+    backend.get_asset = AsyncMock(return_value=asset)
+    backend.get_asset_by_alias = AsyncMock(return_value=asset)
+    backend.list_annotation_sets_page = AsyncMock(side_effect=[page_1, page_2, page_1, page_2])
+    backend.get_annotation_record = AsyncMock(
+        side_effect=lambda annotation_id: {
+            "annotation_1": record_1,
+            "annotation_2": record_2,
+            "annotation_3": record_3,
+        }[annotation_id]
+    )
+    vault = AsyncDataVault(backend)
+
+    first_page = await vault.list_dataset_annotations_page("training", asset=asset, limit=2)
+    second_page = await vault.list_dataset_annotations_page(
+        "training",
+        asset=asset,
+        limit=2,
+        cursor=first_page.page.next_cursor,
+    )
+
+    assert [record.annotation_id for record in first_page.items] == ["annotation_1", "annotation_2"]
+    assert first_page.page.has_more is True
+    assert [record.annotation_id for record in second_page.items] == ["annotation_3"]
+    assert second_page.page.has_more is False
+    assert (
+        backend.list_annotation_sets_page.await_args_list[0].kwargs["filters"]["metadata.mindtrace.data_vault.asset_id"]
+        == "asset_1"
+    )
+
+    backend.list_annotation_sets_page.reset_mock()
+    backend.list_annotation_sets_page.side_effect = [page_1, page_2]
+    assert [
+        record.annotation_id async for record in vault.iter_dataset_annotations("training", asset=asset, batch_size=2)
+    ] == ["annotation_1", "annotation_2", "annotation_3"]
+
+
+def test_sync_data_vault_eager_dataset_methods_obey_slow_ops_policy_forbid():
+    backend = Mock()
+    vault = DataVault(backend, slow_ops_policy=SlowOpsPolicy.FORBID)
+
+    with pytest.raises(SlowOperationDisabledError, match="list_dataset_assets"):
+        vault.list_dataset_assets("training")
+    with pytest.raises(SlowOperationDisabledError, match="list_dataset_annotations"):
+        vault.list_dataset_annotations("training")
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_eager_dataset_methods_obey_slow_ops_policy_warn():
+    collection = Collection(name="training", collection_id="collection_1")
+    backend = Mock()
+    backend.list_collections = AsyncMock(return_value=[collection])
+    backend.list_collection_items = AsyncMock(return_value=[])
+    backend.list_annotation_sets_page = AsyncMock(
+        return_value=AnnotationSetPageOutput(items=[], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    )
+    backend.list_annotation_sets = AsyncMock(return_value=[])
+    vault = AsyncDataVault(backend, slow_ops_policy=SlowOpsPolicy.WARN)
+
+    with pytest.warns(SlowOperationWarning, match="list_dataset_assets"):
+        assert await vault.list_dataset_assets("training") == []
+    with pytest.warns(SlowOperationWarning, match="list_dataset_annotations"):
+        assert await vault.list_dataset_annotations("training") == []
 
 
 def test_sync_data_vault_freeze_dataset_persists_snapshot():

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -1,5 +1,6 @@
 """Unit tests for :mod:`mindtrace.datalake.data_vault`."""
 
+import base64
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
@@ -22,7 +23,23 @@ from mindtrace.datalake.data_vault import (
     _pil_image_to_png_bytes,
     _resolved_primary_asset,
 )
+from mindtrace.datalake.data_vault_backends import (
+    DatalakeServiceAsyncDataVaultBackend,
+    DatalakeServiceDataVaultBackend,
+)
 from mindtrace.datalake.pagination_types import CursorPage, PageInfo
+from mindtrace.datalake.service_types import (
+    AddedAnnotationRecordsOutput,
+    AnnotationSetOutput,
+    AssetOutput,
+    CollectionItemListOutput,
+    CollectionListOutput,
+    CollectionOutput,
+    DatasetVersionOutput,
+    DatumOutput,
+    ObjectDataOutput,
+    ResolvedDatasetVersionOutput,
+)
 from mindtrace.datalake.types import (
     AnnotationRecord,
     AnnotationSet,
@@ -1291,20 +1308,173 @@ async def test_async_data_vault_freeze_dataset_persists_snapshot():
     datalake.create_dataset_version.assert_awaited_once()
 
 
-def test_data_vault_export_dataset_requires_local_backend():
-    vault = object.__new__(DataVault)
-    vault._backend = Mock()
+@pytest.mark.asyncio
+async def test_async_data_vault_freeze_dataset_persists_snapshot_remote_backend():
+    collection = Collection(name="training", collection_id="collection_1")
+    item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1", split="train")
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    source_set = AnnotationSet(
+        annotation_set_id="source_set_1",
+        name="training:asset_1",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1"],
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={"x": 1, "y": 2, "width": 3, "height": 4},
+    )
+    datum = Datum(datum_id="datum_1", asset_refs={"image": "asset_1"})
+    dataset_version = DatasetVersion(dataset_name="training", version="1.2.3")
+    resolved = ResolvedDatasetVersion(dataset_version=dataset_version, datums=[])
+    cm = Mock()
+    cm.acollections_list = AsyncMock(return_value=CollectionListOutput(collections=[collection]))
+    cm.acollection_items_list = AsyncMock(return_value=CollectionItemListOutput(collection_items=[item]))
+    cm.aassets_get = AsyncMock(return_value=AssetOutput(asset=asset))
+    cm.aannotation_sets_list = AsyncMock(return_value=SimpleNamespace(annotation_sets=[source_set]))
+    cm.aannotation_records_get = AsyncMock(return_value=SimpleNamespace(annotation_record=record))
+    cm.adatums_create = AsyncMock(return_value=DatumOutput(datum=datum))
+    cm.aannotation_sets_create = AsyncMock(
+        return_value=AnnotationSetOutput(
+            annotation_set=AnnotationSet(
+                annotation_set_id="snapshot_set_1",
+                name="training:asset_1",
+                purpose="ground_truth",
+                source_type="human",
+                status="active",
+            )
+        )
+    )
+    cm.aannotation_records_add = AsyncMock(return_value=AddedAnnotationRecordsOutput(annotation_records=[]))
+    cm.adataset_versions_create = AsyncMock(return_value=DatasetVersionOutput(dataset_version=dataset_version))
+    cm.adataset_versions_resolve = AsyncMock(
+        return_value=ResolvedDatasetVersionOutput(resolved_dataset_version=resolved)
+    )
 
-    with pytest.raises(NotImplementedError, match="local Datalake backend"):
-        vault._require_local_datalake()
+    snapshot = await AsyncDataVault(DatalakeServiceAsyncDataVaultBackend(cm))._freeze_dataset(
+        "training",
+        persist_snapshot=True,
+        snapshot_version="1.2.3",
+    )
+
+    assert snapshot == resolved
+    cm.adatums_create.assert_awaited_once()
+    cm.aannotation_sets_create.assert_awaited_once()
+    cm.aannotation_records_add.assert_awaited_once()
+    cm.adataset_versions_create.assert_awaited_once()
 
 
-def test_async_data_vault_export_dataset_requires_local_backend():
-    vault = object.__new__(AsyncDataVault)
-    vault._backend = Mock()
+def test_sync_data_vault_export_dataset_uses_service_backend(tmp_path: Path):
+    asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="n", version="1"),
+        asset_id="asset_1",
+    )
+    source_set = AnnotationSet(
+        annotation_set_id="source_set_1",
+        name="training:asset_1",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1"],
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "review"},
+        geometry={"x": 1, "y": 2, "width": 3, "height": 4},
+    )
+    resolved = ResolvedDatasetVersion(
+        dataset_version=DatasetVersion(dataset_name="training", version="1.2.3"),
+        datums=[
+            ResolvedDatum(
+                datum=Datum(datum_id="datum_1", asset_refs={"image": "asset_1"}, split="train"),
+                assets={"image": asset},
+                annotation_sets=[source_set],
+                annotation_records={source_set.annotation_set_id: [record]},
+            )
+        ],
+    )
+    png_b64 = base64.b64encode(_pil_image_to_png_bytes(Image.new("RGB", (1, 1), color=(255, 0, 0)))).decode("ascii")
+    cm = Mock()
+    cm.objects_get = Mock(
+        return_value=ObjectDataOutput(
+            storage_ref=asset.storage_ref,
+            data_base64=png_b64,
+        )
+    )
+    vault = DataVault(DatalakeServiceDataVaultBackend(cm))
+    vault._freeze_dataset = Mock(return_value=resolved)
 
-    with pytest.raises(NotImplementedError, match="local AsyncDatalake backend"):
-        vault._require_local_datalake()
+    result = vault.export_dataset("training", format="coco", destination=tmp_path / "coco-export", overwrite=True)
+
+    assert result.asset_count == 1
+    assert (tmp_path / "coco-export" / "annotations" / "train.json").exists()
+    cm.objects_get.assert_called_once()
+
+
+def test_sync_data_vault_prepare_import_target_dataset_archives_existing_collection_remote_backend():
+    existing = Collection(name="training", collection_id="collection_existing")
+    created = Collection(name="training", collection_id="collection_new")
+    cm = Mock()
+    cm.collections_list = Mock(
+        side_effect=[
+            CollectionListOutput(collections=[existing]),
+            CollectionListOutput(collections=[]),
+        ]
+    )
+    cm.collections_update = Mock(return_value=CollectionOutput(collection=existing))
+    cm.collections_create = Mock(return_value=CollectionOutput(collection=created))
+
+    dataset = DataVault(DatalakeServiceDataVaultBackend(cm))._prepare_import_target_dataset(
+        dataset_name="training",
+        description="Imported",
+        metadata={"source": "snapshot"},
+        overwrite=True,
+        created_by="tester",
+    )
+
+    assert dataset.dataset_id == "collection_new"
+    cm.collections_update.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_prepare_import_target_dataset_archives_existing_collection_remote_backend():
+    existing = Collection(name="training", collection_id="collection_existing")
+    created = Collection(name="training", collection_id="collection_new")
+    cm = Mock()
+    cm.acollections_list = AsyncMock(
+        side_effect=[
+            CollectionListOutput(collections=[existing]),
+            CollectionListOutput(collections=[]),
+        ]
+    )
+    cm.acollections_update = AsyncMock(return_value=CollectionOutput(collection=existing))
+    cm.acollections_create = AsyncMock(return_value=CollectionOutput(collection=created))
+
+    dataset = await AsyncDataVault(DatalakeServiceAsyncDataVaultBackend(cm))._prepare_import_target_dataset(
+        dataset_name="training",
+        description="Imported",
+        metadata={"source": "snapshot"},
+        overwrite=True,
+        created_by="tester",
+    )
+
+    assert dataset.dataset_id == "collection_new"
+    cm.acollections_update.assert_awaited_once()
 
 
 def test_data_vault_import_helpers_handle_asset_selection_and_unbound_annotations():
@@ -1569,6 +1739,78 @@ def test_sync_data_vault_import_dataset_version_skips_empty_datums_and_non_prima
     vault._ensure_collection_item.assert_called_once()
     datalake.create_annotation_set.assert_not_called()
     datalake.add_annotation_records.assert_not_called()
+
+
+def test_sync_data_vault_import_dataset_version_materializes_mutable_dataset_remote_backend():
+    source_dataset = DatasetVersion(
+        dataset_name="source-dataset", version="1.0.0", dataset_version_id="dataset_version_1"
+    )
+    image_asset = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="image", version="1"),
+        asset_id="asset_image",
+    )
+    image_record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="cat",
+        subject=SubjectRef(kind="asset", id="asset_image"),
+        source={"type": "human", "name": "review"},
+        geometry={"x": 1, "y": 2, "width": 3, "height": 4},
+    )
+    source_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="source-set",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1"],
+    )
+    resolved = ResolvedDatasetVersion(
+        dataset_version=source_dataset,
+        datums=[
+            ResolvedDatum(
+                datum=Datum(asset_refs={"image": "asset_image"}, split="train", metadata={"row": 1}),
+                assets={"image": image_asset},
+                annotation_sets=[source_set],
+                annotation_records={source_set.annotation_set_id: [image_record]},
+            )
+        ],
+    )
+    imported_dataset = VaultDataset(
+        dataset_id="collection_1",
+        name="training-copy",
+        created_at=Collection(name="training-copy").created_at,
+        updated_at=Collection(name="training-copy").updated_at,
+    )
+    imported_set = AnnotationSet(
+        annotation_set_id="imported_set_1",
+        name="source-set",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+    )
+    cm = Mock()
+    cm.dataset_versions_resolve = Mock(return_value=ResolvedDatasetVersionOutput(resolved_dataset_version=resolved))
+    cm.annotation_sets_create = Mock(return_value=AnnotationSetOutput(annotation_set=imported_set))
+    cm.annotation_records_add = Mock(return_value=AddedAnnotationRecordsOutput(annotation_records=[image_record]))
+    vault = DataVault(DatalakeServiceDataVaultBackend(cm))
+    vault._prepare_import_target_dataset = Mock(return_value=imported_dataset)
+    vault._get_dataset_collection = Mock(return_value=Collection(name="training-copy", collection_id="collection_1"))
+    vault._ensure_collection_item = Mock(
+        return_value=CollectionItem(collection_id="collection_1", asset_id="asset_image")
+    )
+    vault.get_dataset = Mock(return_value=imported_dataset)
+
+    result = vault.import_dataset_version("source-dataset", "1.0.0", target_name="training-copy")
+
+    assert result == imported_dataset
+    vault._ensure_collection_item.assert_called_once()
+    cm.annotation_sets_create.assert_called_once()
+    added_payloads = cm.annotation_records_add.call_args.args[0].annotations
+    assert len(added_payloads) == 1
+    assert added_payloads[0]["subject"]["id"] == "asset_image"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mindtrace/datalake/test_data_vault_backends.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault_backends.py
@@ -22,19 +22,40 @@ from mindtrace.datalake.service_types import (
     AddAnnotationRecordsInput,
     AddedAnnotationRecordsOutput,
     AnnotationRecordListOutput,
+    AnnotationRecordOutput,
+    AnnotationSetListOutput,
+    AnnotationSetOutput,
     AssetAliasOutput,
     AssetListOutput,
     AssetOutput,
     AssetPageOutput,
+    CollectionItemListOutput,
+    CollectionItemOutput,
+    CollectionListOutput,
+    CollectionOutput,
+    CreateAnnotationSetInput,
     CreateAssetFromObjectInput,
+    CreateCollectionInput,
+    CreateCollectionItemInput,
+    DeleteByIdInput,
     GetAssetByAliasInput,
     GetByIdInput,
     ListAnnotationRecordsForAssetInput,
     ListInput,
     ObjectDataOutput,
     PageInput,
+    UpdateCollectionItemInput,
 )
-from mindtrace.datalake.types import AnnotationRecord, Asset, AssetAlias, StorageRef, SubjectRef
+from mindtrace.datalake.types import (
+    AnnotationRecord,
+    AnnotationSet,
+    Asset,
+    AssetAlias,
+    Collection,
+    CollectionItem,
+    StorageRef,
+    SubjectRef,
+)
 from mindtrace.services.core.connection_manager import ConnectionManager
 
 
@@ -329,7 +350,10 @@ def test_datalake_service_sync_backend_create_and_add_alias():
     cm.aliases_add = Mock(return_value=AssetAliasOutput(asset_alias=row))
 
     backend = DatalakeServiceDataVaultBackend(cm)
-    assert backend.create_asset_from_object(name="n", obj=b"b", kind="artifact", media_type="application/octet-stream") is asset
+    assert (
+        backend.create_asset_from_object(name="n", obj=b"b", kind="artifact", media_type="application/octet-stream")
+        is asset
+    )
     assert backend.add_alias("id1", "f") is row
 
 
@@ -349,12 +373,16 @@ class _BareAsyncConnectionManager(ConnectionManager):
 
 
 def test_looks_like_datalake_service_sync_client_accepts_connection_manager_without_endpoint_probe():
-    assert looks_like_datalake_service_sync_client(_BareSyncConnectionManager(url=parse_url("http://localhost:8080"))) is True
+    assert (
+        looks_like_datalake_service_sync_client(_BareSyncConnectionManager(url=parse_url("http://localhost:8080")))
+        is True
+    )
 
 
 def test_looks_like_datalake_service_async_client_accepts_connection_manager_without_endpoint_probe():
     assert (
-        looks_like_datalake_service_async_client(_BareAsyncConnectionManager(url=parse_url("http://localhost:8080"))) is True
+        looks_like_datalake_service_async_client(_BareAsyncConnectionManager(url=parse_url("http://localhost:8080")))
+        is True
     )
 
 
@@ -526,7 +554,9 @@ async def test_local_async_backend_delegates_annotation_methods():
 
     backend = LocalAsyncDataVaultBackend(dl)
     assert await backend.add_annotation_records([{"kind": "bbox"}], annotation_set_id="s1") == [rec]
-    dl.add_annotation_records.assert_awaited_once_with([{"kind": "bbox"}], annotation_set_id="s1", annotation_schema_id=None)
+    dl.add_annotation_records.assert_awaited_once_with(
+        [{"kind": "bbox"}], annotation_set_id="s1", annotation_schema_id=None
+    )
     assert await backend.list_annotation_records_for_asset("a1") == [rec]
     dl.list_annotation_records_for_asset.assert_awaited_once_with("a1")
 
@@ -635,7 +665,9 @@ def test_local_sync_backend_delegates_annotation_methods():
 
     backend = LocalDataVaultBackend(dl)
     assert backend.add_annotation_records([{"kind": "bbox"}], annotation_schema_id="sch") == [rec]
-    dl.add_annotation_records.assert_called_once_with([{"kind": "bbox"}], annotation_set_id=None, annotation_schema_id="sch")
+    dl.add_annotation_records.assert_called_once_with(
+        [{"kind": "bbox"}], annotation_set_id=None, annotation_schema_id="sch"
+    )
     assert backend.list_annotation_records_for_asset("a1") == [rec]
     dl.list_annotation_records_for_asset.assert_called_once_with("a1")
 
@@ -693,3 +725,197 @@ def test_datalake_service_sync_backend_add_and_list_annotation_records():
     linp = cm.annotation_records_list_for_asset.call_args.args[0]
     assert isinstance(linp, ListAnnotationRecordsForAssetInput)
     assert linp.asset_id == "a1"
+
+
+@pytest.mark.asyncio
+async def test_local_async_backend_delegates_dataset_methods():
+    collection = Collection(name="training", collection_id="collection_1")
+    item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="x",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "t"},
+        geometry={},
+    )
+    dl = AsyncMock()
+    dl.list_collections = AsyncMock(return_value=[collection])
+    dl.create_collection = AsyncMock(return_value=collection)
+    dl.list_collection_items = AsyncMock(return_value=[item])
+    dl.create_collection_item = AsyncMock(return_value=item)
+    dl.update_collection_item = AsyncMock(return_value=item)
+    dl.list_annotation_sets = AsyncMock(return_value=[annotation_set])
+    dl.create_annotation_set = AsyncMock(return_value=annotation_set)
+    dl.get_annotation_record = AsyncMock(return_value=record)
+    dl.list_annotation_records = AsyncMock(return_value=[record])
+    dl.delete_annotation_record = AsyncMock(return_value=None)
+
+    backend = LocalAsyncDataVaultBackend(dl)
+    assert await backend.list_collections() == [collection]
+    assert await backend.create_collection(name="training") == collection
+    assert await backend.list_collection_items() == [item]
+    assert await backend.create_collection_item(collection_id="collection_1", asset_id="asset_1") == item
+    assert await backend.update_collection_item("ci_1", status="active") == item
+    assert await backend.list_annotation_sets() == [annotation_set]
+    assert (
+        await backend.create_annotation_set(name="training:asset_1", purpose="other", source_type="human")
+        == annotation_set
+    )
+    assert await backend.get_annotation_record("annotation_1") == record
+    assert await backend.list_annotation_records() == [record]
+    await backend.delete_annotation_record("annotation_1")
+    dl.delete_annotation_record.assert_awaited_once_with("annotation_1")
+
+
+def test_local_sync_backend_delegates_dataset_methods():
+    collection = Collection(name="training", collection_id="collection_1")
+    item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="x",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "t"},
+        geometry={},
+    )
+    dl = Mock()
+    dl.list_collections = Mock(return_value=[collection])
+    dl.create_collection = Mock(return_value=collection)
+    dl.list_collection_items = Mock(return_value=[item])
+    dl.create_collection_item = Mock(return_value=item)
+    dl.update_collection_item = Mock(return_value=item)
+    dl.list_annotation_sets = Mock(return_value=[annotation_set])
+    dl.create_annotation_set = Mock(return_value=annotation_set)
+    dl.get_annotation_record = Mock(return_value=record)
+    dl.list_annotation_records = Mock(return_value=[record])
+    dl.delete_annotation_record = Mock(return_value=None)
+
+    backend = LocalDataVaultBackend(dl)
+    assert backend.list_collections() == [collection]
+    assert backend.create_collection(name="training") == collection
+    assert backend.list_collection_items() == [item]
+    assert backend.create_collection_item(collection_id="collection_1", asset_id="asset_1") == item
+    assert backend.update_collection_item("ci_1", status="active") == item
+    assert backend.list_annotation_sets() == [annotation_set]
+    assert (
+        backend.create_annotation_set(name="training:asset_1", purpose="other", source_type="human") == annotation_set
+    )
+    assert backend.get_annotation_record("annotation_1") == record
+    assert backend.list_annotation_records() == [record]
+    backend.delete_annotation_record("annotation_1")
+    dl.delete_annotation_record.assert_called_once_with("annotation_1")
+
+
+@pytest.mark.asyncio
+async def test_datalake_service_async_backend_dataset_methods():
+    collection = Collection(name="training", collection_id="collection_1")
+    item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="x",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "t"},
+        geometry={},
+    )
+    cm = Mock()
+    cm.acollections_list = AsyncMock(return_value=CollectionListOutput(collections=[collection]))
+    cm.acollections_create = AsyncMock(return_value=CollectionOutput(collection=collection))
+    cm.acollection_items_list = AsyncMock(return_value=CollectionItemListOutput(collection_items=[item]))
+    cm.acollection_items_create = AsyncMock(return_value=CollectionItemOutput(collection_item=item))
+    cm.acollection_items_update = AsyncMock(return_value=CollectionItemOutput(collection_item=item))
+    cm.aannotation_sets_list = AsyncMock(return_value=AnnotationSetListOutput(annotation_sets=[annotation_set]))
+    cm.aannotation_sets_create = AsyncMock(return_value=AnnotationSetOutput(annotation_set=annotation_set))
+    cm.aannotation_records_get = AsyncMock(return_value=AnnotationRecordOutput(annotation_record=record))
+    cm.aannotation_records_list = AsyncMock(return_value=AnnotationRecordListOutput(annotation_records=[record]))
+    cm.aannotation_records_delete = AsyncMock(return_value=None)
+
+    backend = DatalakeServiceAsyncDataVaultBackend(cm)
+    assert await backend.list_collections() == [collection]
+    assert await backend.create_collection(name="training") == collection
+    assert await backend.list_collection_items() == [item]
+    assert await backend.create_collection_item(collection_id="collection_1", asset_id="asset_1") == item
+    assert await backend.update_collection_item("ci_1", status="active") == item
+    assert await backend.list_annotation_sets() == [annotation_set]
+    assert (
+        await backend.create_annotation_set(name="training:asset_1", purpose="other", source_type="human")
+        == annotation_set
+    )
+    assert await backend.get_annotation_record("annotation_1") == record
+    assert await backend.list_annotation_records() == [record]
+    await backend.delete_annotation_record("annotation_1")
+
+    assert isinstance(cm.acollections_create.await_args.args[0], CreateCollectionInput)
+    assert isinstance(cm.acollection_items_create.await_args.args[0], CreateCollectionItemInput)
+    assert isinstance(cm.acollection_items_update.await_args.args[0], UpdateCollectionItemInput)
+    assert isinstance(cm.aannotation_sets_create.await_args.args[0], CreateAnnotationSetInput)
+    assert isinstance(cm.aannotation_records_delete.await_args.args[0], DeleteByIdInput)
+
+
+def test_datalake_service_sync_backend_dataset_methods():
+    collection = Collection(name="training", collection_id="collection_1")
+    item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_1",
+        kind="bbox",
+        label="x",
+        subject=SubjectRef(kind="asset", id="asset_1"),
+        source={"type": "human", "name": "t"},
+        geometry={},
+    )
+    cm = Mock()
+    cm.collections_list = Mock(return_value=CollectionListOutput(collections=[collection]))
+    cm.collections_create = Mock(return_value=CollectionOutput(collection=collection))
+    cm.collection_items_list = Mock(return_value=CollectionItemListOutput(collection_items=[item]))
+    cm.collection_items_create = Mock(return_value=CollectionItemOutput(collection_item=item))
+    cm.collection_items_update = Mock(return_value=CollectionItemOutput(collection_item=item))
+    cm.annotation_sets_list = Mock(return_value=AnnotationSetListOutput(annotation_sets=[annotation_set]))
+    cm.annotation_sets_create = Mock(return_value=AnnotationSetOutput(annotation_set=annotation_set))
+    cm.annotation_records_get = Mock(return_value=AnnotationRecordOutput(annotation_record=record))
+    cm.annotation_records_list = Mock(return_value=AnnotationRecordListOutput(annotation_records=[record]))
+    cm.annotation_records_delete = Mock(return_value=None)
+
+    backend = DatalakeServiceDataVaultBackend(cm)
+    assert backend.list_collections() == [collection]
+    assert backend.create_collection(name="training") == collection
+    assert backend.list_collection_items() == [item]
+    assert backend.create_collection_item(collection_id="collection_1", asset_id="asset_1") == item
+    assert backend.update_collection_item("ci_1", status="active") == item
+    assert backend.list_annotation_sets() == [annotation_set]
+    assert (
+        backend.create_annotation_set(name="training:asset_1", purpose="other", source_type="human") == annotation_set
+    )
+    assert backend.get_annotation_record("annotation_1") == record
+    assert backend.list_annotation_records() == [record]
+    backend.delete_annotation_record("annotation_1")
+
+    assert isinstance(cm.collections_create.call_args.args[0], CreateCollectionInput)
+    assert isinstance(cm.collection_items_create.call_args.args[0], CreateCollectionItemInput)
+    assert isinstance(cm.collection_items_update.call_args.args[0], UpdateCollectionItemInput)
+    assert isinstance(cm.annotation_sets_create.call_args.args[0], CreateAnnotationSetInput)
+    assert isinstance(cm.annotation_records_delete.call_args.args[0], DeleteByIdInput)

--- a/tests/unit/mindtrace/datalake/test_data_vault_backends.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault_backends.py
@@ -763,6 +763,7 @@ async def test_local_async_backend_delegates_dataset_methods():
     assert await backend.list_collection_items() == [item]
     assert await backend.create_collection_item(collection_id="collection_1", asset_id="asset_1") == item
     assert await backend.update_collection_item("ci_1", status="active") == item
+    await backend.delete_collection_item("ci_1")
     assert await backend.list_annotation_sets() == [annotation_set]
     assert (
         await backend.create_annotation_set(name="training:asset_1", purpose="other", source_type="human")
@@ -772,6 +773,20 @@ async def test_local_async_backend_delegates_dataset_methods():
     assert await backend.list_annotation_records() == [record]
     await backend.delete_annotation_record("annotation_1")
     dl.delete_annotation_record.assert_awaited_once_with("annotation_1")
+
+    page = CursorPage(items=[collection], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    item_page = CursorPage(items=[item], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    dl.list_collections_page = AsyncMock(return_value=page)
+    dl.list_collection_items_page = AsyncMock(return_value=item_page)
+
+    async def iter_collections(**kwargs):
+        assert kwargs == {"filters": {"status": "active"}, "sort": "created_desc", "batch_size": 2}
+        yield collection
+
+    dl.iter_collections = iter_collections
+    assert await backend.list_collections_page(filters={"status": "active"}, limit=1) == page
+    assert await backend.list_collection_items_page(filters={"collection_id": "collection_1"}, limit=1) == item_page
+    assert [c async for c in backend.iter_collections(filters={"status": "active"}, batch_size=2)] == [collection]
 
 
 def test_local_sync_backend_delegates_dataset_methods():
@@ -817,6 +832,16 @@ def test_local_sync_backend_delegates_dataset_methods():
     assert backend.list_annotation_records() == [record]
     backend.delete_annotation_record("annotation_1")
     dl.delete_annotation_record.assert_called_once_with("annotation_1")
+
+    page = CursorPage(items=[collection], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    item_page = CursorPage(items=[item], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    dl.list_collections_page = Mock(return_value=page)
+    dl.list_collection_items_page = Mock(return_value=item_page)
+    dl.iter_collections = Mock(return_value=iter([collection]))
+
+    assert backend.list_collections_page(filters={"status": "active"}, limit=1) == page
+    assert backend.list_collection_items_page(filters={"collection_id": "collection_1"}, limit=1) == item_page
+    assert list(backend.iter_collections(filters={"status": "active"}, batch_size=2)) == [collection]
 
 
 @pytest.mark.asyncio
@@ -871,6 +896,27 @@ async def test_datalake_service_async_backend_dataset_methods():
     assert isinstance(cm.aannotation_records_delete.await_args.args[0], DeleteByIdInput)
 
 
+@pytest.mark.asyncio
+async def test_datalake_service_async_backend_collection_paging_and_deletes():
+    collection = Collection(name="training", collection_id="collection_1")
+    item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    collection_page_1 = CursorPage(items=[collection], page=PageInfo(limit=1, next_cursor="cursor-1", has_more=True))
+    collection_page_2 = CursorPage(items=[], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    item_page = CursorPage(items=[item], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    cm = Mock()
+    cm.acollections_list_page = AsyncMock(side_effect=[collection_page_1, collection_page_1, collection_page_2])
+    cm.acollection_items_list_page = AsyncMock(return_value=item_page)
+    cm.acollection_items_delete = AsyncMock(return_value=None)
+
+    backend = DatalakeServiceAsyncDataVaultBackend(cm)
+    assert await backend.list_collections_page(limit=1) == collection_page_1
+    assert [c async for c in backend.iter_collections(batch_size=1)] == [collection]
+    assert await backend.list_collection_items_page(filters={"collection_id": "collection_1"}, limit=1) == item_page
+    await backend.delete_collection_item("ci_1")
+    assert isinstance(cm.acollections_list_page.await_args_list[0].args[0], PageInput)
+    assert isinstance(cm.acollection_items_delete.await_args.args[0], DeleteByIdInput)
+
+
 def test_datalake_service_sync_backend_dataset_methods():
     collection = Collection(name="training", collection_id="collection_1")
     item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
@@ -919,3 +965,23 @@ def test_datalake_service_sync_backend_dataset_methods():
     assert isinstance(cm.collection_items_update.call_args.args[0], UpdateCollectionItemInput)
     assert isinstance(cm.annotation_sets_create.call_args.args[0], CreateAnnotationSetInput)
     assert isinstance(cm.annotation_records_delete.call_args.args[0], DeleteByIdInput)
+
+
+def test_datalake_service_sync_backend_collection_paging_and_deletes():
+    collection = Collection(name="training", collection_id="collection_1")
+    item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
+    collection_page_1 = CursorPage(items=[collection], page=PageInfo(limit=1, next_cursor="cursor-1", has_more=True))
+    collection_page_2 = CursorPage(items=[], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    item_page = CursorPage(items=[item], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    cm = Mock()
+    cm.collections_list_page = Mock(side_effect=[collection_page_1, collection_page_1, collection_page_2])
+    cm.collection_items_list_page = Mock(return_value=item_page)
+    cm.collection_items_delete = Mock(return_value=None)
+
+    backend = DatalakeServiceDataVaultBackend(cm)
+    assert backend.list_collections_page(limit=1) == collection_page_1
+    assert list(backend.iter_collections(batch_size=1)) == [collection]
+    assert backend.list_collection_items_page(filters={"collection_id": "collection_1"}, limit=1) == item_page
+    backend.delete_collection_item("ci_1")
+    assert isinstance(cm.collections_list_page.call_args_list[0].args[0], PageInput)
+    assert isinstance(cm.collection_items_delete.call_args.args[0], DeleteByIdInput)

--- a/tests/unit/mindtrace/datalake/test_data_vault_backends.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault_backends.py
@@ -25,6 +25,7 @@ from mindtrace.datalake.service_types import (
     AnnotationRecordOutput,
     AnnotationSetListOutput,
     AnnotationSetOutput,
+    AnnotationSetPageOutput,
     AssetAliasOutput,
     AssetListOutput,
     AssetOutput,
@@ -1055,6 +1056,43 @@ def test_datalake_service_sync_backend_dataset_methods():
     assert isinstance(cm.collection_items_update.call_args.args[0], UpdateCollectionItemInput)
     assert isinstance(cm.annotation_sets_create.call_args.args[0], CreateAnnotationSetInput)
     assert isinstance(cm.annotation_records_delete.call_args.args[0], DeleteByIdInput)
+
+
+@pytest.mark.asyncio
+async def test_datalake_service_async_backend_annotation_set_paging():
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+    )
+    page = AnnotationSetPageOutput(items=[annotation_set], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    cm = Mock()
+    cm.aannotation_sets_list_page = AsyncMock(return_value=page)
+
+    backend = DatalakeServiceAsyncDataVaultBackend(cm)
+    out = await backend.list_annotation_sets_page(filters={"status": "active"}, limit=1)
+
+    assert out == page
+    assert isinstance(cm.aannotation_sets_list_page.await_args.args[0], PageInput)
+
+
+def test_datalake_service_sync_backend_annotation_set_paging():
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="training:asset_1",
+        purpose="other",
+        source_type="human",
+    )
+    page = AnnotationSetPageOutput(items=[annotation_set], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    cm = Mock()
+    cm.annotation_sets_list_page = Mock(return_value=page)
+
+    backend = DatalakeServiceDataVaultBackend(cm)
+    out = backend.list_annotation_sets_page(filters={"status": "active"}, limit=1)
+
+    assert out == page
+    assert isinstance(cm.annotation_sets_list_page.call_args.args[0], PageInput)
 
 
 def test_datalake_service_sync_backend_snapshot_methods():

--- a/tests/unit/mindtrace/datalake/test_data_vault_backends.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault_backends.py
@@ -37,13 +37,20 @@ from mindtrace.datalake.service_types import (
     CreateAssetFromObjectInput,
     CreateCollectionInput,
     CreateCollectionItemInput,
+    CreateDatasetVersionInput,
+    CreateDatumInput,
+    DatasetVersionOutput,
+    DatumOutput,
     DeleteByIdInput,
     GetAssetByAliasInput,
     GetByIdInput,
+    GetDatasetVersionInput,
     ListAnnotationRecordsForAssetInput,
     ListInput,
     ObjectDataOutput,
     PageInput,
+    ResolvedDatasetVersionOutput,
+    UpdateCollectionInput,
     UpdateCollectionItemInput,
 )
 from mindtrace.datalake.types import (
@@ -53,6 +60,9 @@ from mindtrace.datalake.types import (
     AssetAlias,
     Collection,
     CollectionItem,
+    DatasetVersion,
+    Datum,
+    ResolvedDatasetVersion,
     StorageRef,
     SubjectRef,
 )
@@ -845,6 +855,51 @@ def test_local_sync_backend_delegates_dataset_methods():
 
 
 @pytest.mark.asyncio
+async def test_local_async_backend_delegates_snapshot_methods():
+    collection = Collection(name="training", collection_id="collection_1")
+    datum = Datum(datum_id="datum_1", asset_refs={"image": "asset_1"})
+    dataset_version = DatasetVersion(dataset_name="training", version="1.0.0")
+    resolved = ResolvedDatasetVersion(dataset_version=dataset_version, datums=[])
+    dl = AsyncMock()
+    dl.update_collection = AsyncMock(return_value=collection)
+    dl.create_datum = AsyncMock(return_value=datum)
+    dl.create_dataset_version = AsyncMock(return_value=dataset_version)
+    dl.resolve_dataset_version = AsyncMock(return_value=resolved)
+
+    backend = LocalAsyncDataVaultBackend(dl)
+
+    assert await backend.update_collection("collection_1", status="archived") == collection
+    assert await backend.create_datum(asset_refs={"image": "asset_1"}) == datum
+    assert (
+        await backend.create_dataset_version(dataset_name="training", version="1.0.0", manifest=["datum_1"])
+        == dataset_version
+    )
+    assert await backend.resolve_dataset_version("training", "1.0.0") == resolved
+
+
+def test_local_sync_backend_delegates_snapshot_methods():
+    collection = Collection(name="training", collection_id="collection_1")
+    datum = Datum(datum_id="datum_1", asset_refs={"image": "asset_1"})
+    dataset_version = DatasetVersion(dataset_name="training", version="1.0.0")
+    resolved = ResolvedDatasetVersion(dataset_version=dataset_version, datums=[])
+    dl = Mock()
+    dl.update_collection = Mock(return_value=collection)
+    dl.create_datum = Mock(return_value=datum)
+    dl.create_dataset_version = Mock(return_value=dataset_version)
+    dl.resolve_dataset_version = Mock(return_value=resolved)
+
+    backend = LocalDataVaultBackend(dl)
+
+    assert backend.update_collection("collection_1", status="archived") == collection
+    assert backend.create_datum(asset_refs={"image": "asset_1"}) == datum
+    assert (
+        backend.create_dataset_version(dataset_name="training", version="1.0.0", manifest=["datum_1"])
+        == dataset_version
+    )
+    assert backend.resolve_dataset_version("training", "1.0.0") == resolved
+
+
+@pytest.mark.asyncio
 async def test_datalake_service_async_backend_dataset_methods():
     collection = Collection(name="training", collection_id="collection_1")
     item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1")
@@ -894,6 +949,41 @@ async def test_datalake_service_async_backend_dataset_methods():
     assert isinstance(cm.acollection_items_update.await_args.args[0], UpdateCollectionItemInput)
     assert isinstance(cm.aannotation_sets_create.await_args.args[0], CreateAnnotationSetInput)
     assert isinstance(cm.aannotation_records_delete.await_args.args[0], DeleteByIdInput)
+
+
+@pytest.mark.asyncio
+async def test_datalake_service_async_backend_snapshot_methods():
+    collection = Collection(name="training", collection_id="collection_1")
+    datum = Datum(datum_id="datum_1", asset_refs={"image": "asset_1"})
+    dataset_version = DatasetVersion(dataset_name="training", version="1.0.0")
+    resolved = ResolvedDatasetVersion(dataset_version=dataset_version, datums=[])
+    cm = Mock()
+    cm.acollections_update = AsyncMock(return_value=CollectionOutput(collection=collection))
+    cm.adatums_create = AsyncMock(return_value=DatumOutput(datum=datum))
+    cm.adataset_versions_create = AsyncMock(return_value=DatasetVersionOutput(dataset_version=dataset_version))
+    cm.adataset_versions_resolve = AsyncMock(
+        return_value=ResolvedDatasetVersionOutput(resolved_dataset_version=resolved)
+    )
+
+    backend = DatalakeServiceAsyncDataVaultBackend(cm)
+
+    assert await backend.update_collection("collection_1", status="archived") == collection
+    assert await backend.create_datum(asset_refs={"image": "asset_1"}, split="train") == datum
+    assert (
+        await backend.create_dataset_version(
+            dataset_name="training",
+            version="1.0.0",
+            manifest=["datum_1"],
+            description="snapshot",
+        )
+        == dataset_version
+    )
+    assert await backend.resolve_dataset_version("training", "1.0.0") == resolved
+
+    assert isinstance(cm.acollections_update.await_args.args[0], UpdateCollectionInput)
+    assert isinstance(cm.adatums_create.await_args.args[0], CreateDatumInput)
+    assert isinstance(cm.adataset_versions_create.await_args.args[0], CreateDatasetVersionInput)
+    assert isinstance(cm.adataset_versions_resolve.await_args.args[0], GetDatasetVersionInput)
 
 
 @pytest.mark.asyncio
@@ -965,6 +1055,38 @@ def test_datalake_service_sync_backend_dataset_methods():
     assert isinstance(cm.collection_items_update.call_args.args[0], UpdateCollectionItemInput)
     assert isinstance(cm.annotation_sets_create.call_args.args[0], CreateAnnotationSetInput)
     assert isinstance(cm.annotation_records_delete.call_args.args[0], DeleteByIdInput)
+
+
+def test_datalake_service_sync_backend_snapshot_methods():
+    collection = Collection(name="training", collection_id="collection_1")
+    datum = Datum(datum_id="datum_1", asset_refs={"image": "asset_1"})
+    dataset_version = DatasetVersion(dataset_name="training", version="1.0.0")
+    resolved = ResolvedDatasetVersion(dataset_version=dataset_version, datums=[])
+    cm = Mock()
+    cm.collections_update = Mock(return_value=CollectionOutput(collection=collection))
+    cm.datums_create = Mock(return_value=DatumOutput(datum=datum))
+    cm.dataset_versions_create = Mock(return_value=DatasetVersionOutput(dataset_version=dataset_version))
+    cm.dataset_versions_resolve = Mock(return_value=ResolvedDatasetVersionOutput(resolved_dataset_version=resolved))
+
+    backend = DatalakeServiceDataVaultBackend(cm)
+
+    assert backend.update_collection("collection_1", status="archived") == collection
+    assert backend.create_datum(asset_refs={"image": "asset_1"}, split="train") == datum
+    assert (
+        backend.create_dataset_version(
+            dataset_name="training",
+            version="1.0.0",
+            manifest=["datum_1"],
+            description="snapshot",
+        )
+        == dataset_version
+    )
+    assert backend.resolve_dataset_version("training", "1.0.0") == resolved
+
+    assert isinstance(cm.collections_update.call_args.args[0], UpdateCollectionInput)
+    assert isinstance(cm.datums_create.call_args.args[0], CreateDatumInput)
+    assert isinstance(cm.dataset_versions_create.call_args.args[0], CreateDatasetVersionInput)
+    assert isinstance(cm.dataset_versions_resolve.call_args.args[0], GetDatasetVersionInput)
 
 
 def test_datalake_service_sync_backend_collection_paging_and_deletes():

--- a/tests/unit/mindtrace/datalake/test_data_vault_backends.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault_backends.py
@@ -846,12 +846,15 @@ def test_local_sync_backend_delegates_dataset_methods():
 
     page = CursorPage(items=[collection], page=PageInfo(limit=1, next_cursor=None, has_more=False))
     item_page = CursorPage(items=[item], page=PageInfo(limit=1, next_cursor=None, has_more=False))
+    annotation_set_page = CursorPage(items=[annotation_set], page=PageInfo(limit=1, next_cursor=None, has_more=False))
     dl.list_collections_page = Mock(return_value=page)
     dl.list_collection_items_page = Mock(return_value=item_page)
+    dl.list_annotation_sets_page = Mock(return_value=annotation_set_page)
     dl.iter_collections = Mock(return_value=iter([collection]))
 
     assert backend.list_collections_page(filters={"status": "active"}, limit=1) == page
     assert backend.list_collection_items_page(filters={"collection_id": "collection_1"}, limit=1) == item_page
+    assert backend.list_annotation_sets_page(filters={"status": "active"}, limit=1) == annotation_set_page
     assert list(backend.iter_collections(filters={"status": "active"}, batch_size=2)) == [collection]
 
 

--- a/tests/unit/mindtrace/datalake/test_exporters.py
+++ b/tests/unit/mindtrace/datalake/test_exporters.py
@@ -1,0 +1,599 @@
+import json
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from PIL import Image
+
+from mindtrace.datalake import AsyncDataVault, Datalake, DataVault
+from mindtrace.datalake.annotations import BboxAnnotation, ClassificationAnnotation, PolygonAnnotation
+from mindtrace.datalake.async_datalake import AsyncDatalake
+from mindtrace.datalake.exporters.base import (
+    _annotation_subject_asset_id,
+    _build_exportable_item,
+    _primary_asset_entry,
+    build_exportable_dataset_from_resolved_version_async,
+    build_exportable_dataset_from_resolved_version_sync,
+    default_export_filename,
+    prepare_export_destination,
+)
+from mindtrace.datalake.exporters.coco import _polygon_area, export_dataset_as_coco
+from mindtrace.datalake.exporters.huggingface import export_dataset_as_huggingface
+from mindtrace.datalake.exporters.types import ExportableDataset, ExportableItem
+from mindtrace.datalake.types import (
+    AnnotationRecord,
+    AnnotationSet,
+    Asset,
+    Collection,
+    CollectionItem,
+    DatasetVersion,
+    Datum,
+    ResolvedDatasetVersion,
+    ResolvedDatum,
+    StorageRef,
+    SubjectRef,
+)
+
+
+def _png_bytes(size: tuple[int, int] = (16, 12)) -> bytes:
+    image = Image.new("RGB", size, color=(255, 0, 0))
+    payload = BytesIO()
+    image.save(payload, format="PNG")
+    return payload.getvalue()
+
+
+def _asset(asset_id: str = "asset_img") -> Asset:
+    return Asset(
+        asset_id=asset_id,
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="assets", name=asset_id, version="1"),
+        metadata={"source": "unit-test"},
+    )
+
+
+def _collection(name: str = "dataset-a") -> Collection:
+    return Collection(collection_id="collection_1", name=name, description="Dataset export test")
+
+
+def _annotation_set(asset_id: str, annotation_ids: list[str], *, annotation_set_id: str | None = None) -> AnnotationSet:
+    return AnnotationSet(
+        annotation_set_id=annotation_set_id or f"set_{asset_id}",
+        name=f"set-{asset_id}",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=annotation_ids,
+        metadata={
+            "mindtrace": {
+                "data_vault": {
+                    "dataset_collection_id": "collection_1",
+                    "dataset_name": "dataset-a",
+                    "asset_id": asset_id,
+                }
+            }
+        },
+    )
+
+
+def _annotation_record(
+    annotation_id: str, *, kind: str = "bbox", label: str = "car", asset_id: str = "asset_img"
+) -> AnnotationRecord:
+    geometry = (
+        {"x": 1, "y": 2, "width": 3, "height": 4} if kind == "bbox" else {"vertices": [[0, 0], [10, 0], [10, 10]]}
+    )
+    return AnnotationRecord(
+        annotation_id=annotation_id,
+        kind=kind,
+        label=label,
+        subject=SubjectRef(kind="asset", id=asset_id),
+        source={"type": "human", "name": "annotator"},
+        geometry=geometry,
+    )
+
+
+def _resolved_dataset_version(
+    *,
+    asset: Asset | None = None,
+    split: str | None = "train",
+    annotation_records: list[AnnotationRecord] | None = None,
+    extra_assets: dict[str, Asset] | None = None,
+    extra_record_sets: dict[str, list[AnnotationRecord]] | None = None,
+) -> ResolvedDatasetVersion:
+    asset = asset or _asset()
+    annotation_records = annotation_records or [_annotation_record("annotation_1", asset_id=asset.asset_id)]
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_1",
+        name="gt",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=[record.annotation_id for record in annotation_records],
+    )
+    record_lookup = {annotation_set.annotation_set_id: annotation_records}
+    annotation_sets = [annotation_set]
+    if extra_record_sets:
+        for annotation_set_id, records in extra_record_sets.items():
+            annotation_sets.append(
+                AnnotationSet(
+                    annotation_set_id=annotation_set_id,
+                    name=annotation_set_id,
+                    purpose="ground_truth",
+                    source_type="human",
+                    status="active",
+                    annotation_record_ids=[record.annotation_id for record in records],
+                )
+            )
+            record_lookup[annotation_set_id] = records
+    assets = {"image": asset}
+    if extra_assets:
+        assets.update(extra_assets)
+    datum = Datum(
+        datum_id="datum_1",
+        asset_refs={role: value.asset_id for role, value in assets.items()},
+        split=split,
+        metadata={"source_image_id": "image_1"},
+        annotation_set_ids=[annotation_set.annotation_set_id for annotation_set in annotation_sets],
+    )
+    dataset_version = DatasetVersion(
+        dataset_name="dataset-a",
+        version="1.0.0",
+        description="Dataset export test",
+        manifest=[datum.datum_id],
+        metadata={"source": "unit-test"},
+    )
+    return ResolvedDatasetVersion(
+        dataset_version=dataset_version,
+        datums=[
+            ResolvedDatum(
+                datum=datum,
+                assets=assets,
+                annotation_sets=annotation_sets,
+                annotation_records=record_lookup,
+            )
+        ],
+    )
+
+
+def test_build_exportable_dataset_from_resolved_version_sync_collects_primary_asset_annotations():
+    asset = _asset()
+    non_primary_asset = Asset(
+        asset_id="asset_mask",
+        kind="mask",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="assets", name="asset_mask", version="1"),
+    )
+    resolved_dataset_version = _resolved_dataset_version(
+        asset=asset,
+        annotation_records=[_annotation_record("annotation_1", asset_id=asset.asset_id)],
+        extra_assets={"mask": non_primary_asset},
+        extra_record_sets={
+            "annotation_set_2": [_annotation_record("annotation_2", asset_id=non_primary_asset.asset_id)]
+        },
+    )
+    datalake = Mock()
+    datalake.get_object.return_value = _png_bytes()
+
+    exportable = build_exportable_dataset_from_resolved_version_sync(datalake, resolved_dataset_version)
+
+    assert exportable.asset_count == 1
+    assert exportable.annotation_count == 1
+    assert exportable.items[0].split == "train"
+    assert exportable.items[0].source_filename == "asset_img.png"
+    assert exportable.items[0].annotations[0].annotation_id == "annotation_1"
+    assert any("multiple assets" in warning for warning in exportable.warnings)
+    assert any("has no records for asset" in warning for warning in exportable.warnings)
+
+
+def test_export_snapshot_helper_handles_non_asset_subjects_and_fallback_roles():
+    asset = Asset(
+        asset_id="asset_other",
+        kind="artifact",
+        media_type="application/octet-stream",
+        storage_ref=StorageRef(mount="assets", name="asset_other", version="1"),
+    )
+    datum = ResolvedDatum(
+        datum=Datum(datum_id="datum_other", asset_refs={"thumbnail": asset.asset_id}),
+        assets={"thumbnail": asset},
+        annotation_sets=[],
+        annotation_records={},
+    )
+    record = AnnotationRecord(
+        annotation_id="annotation_subjectless",
+        kind="bbox",
+        label="car",
+        source={"type": "human", "name": "annotator"},
+        geometry={"x": 1, "y": 2, "width": 3, "height": 4},
+    )
+
+    export_item, warnings = _build_exportable_item(datum, payload_bytes=b"payload")
+
+    assert _annotation_subject_asset_id(record) is None
+    assert _primary_asset_entry(datum) == ("thumbnail", asset)
+    assert export_item is not None
+    assert export_item.asset.asset_id == "asset_other"
+    assert warnings == []
+
+
+def test_export_snapshot_helper_rejects_datums_without_assets():
+    export_item, warnings = _build_exportable_item(
+        ResolvedDatum(
+            datum=Datum(datum_id="datum_empty", asset_refs={}),
+            assets={},
+            annotation_sets=[],
+            annotation_records={},
+        ),
+        payload_bytes=b"",
+    )
+
+    assert export_item is None
+    assert any("does not reference any assets" in warning for warning in warnings)
+
+
+def test_export_snapshot_helper_warns_for_non_primary_records_in_same_set():
+    asset = _asset()
+    mask_asset = Asset(
+        asset_id="asset_mask",
+        kind="mask",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="assets", name="asset_mask", version="1"),
+    )
+    annotation_set = AnnotationSet(
+        annotation_set_id="annotation_set_mixed",
+        name="mixed",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=["annotation_1", "annotation_2"],
+    )
+    resolved_datum = ResolvedDatum(
+        datum=Datum(
+            datum_id="datum_1",
+            asset_refs={"image": asset.asset_id, "mask": mask_asset.asset_id},
+            annotation_set_ids=[annotation_set.annotation_set_id],
+        ),
+        assets={"image": asset, "mask": mask_asset},
+        annotation_sets=[annotation_set],
+        annotation_records={
+            annotation_set.annotation_set_id: [
+                _annotation_record("annotation_1", asset_id=asset.asset_id),
+                _annotation_record("annotation_2", asset_id=mask_asset.asset_id),
+            ]
+        },
+    )
+
+    export_item, warnings = _build_exportable_item(resolved_datum, payload_bytes=_png_bytes())
+
+    assert export_item is not None
+    assert [record.annotation_id for record in export_item.annotations] == ["annotation_1"]
+    assert any("non-primary asset" in warning for warning in warnings)
+
+
+@pytest.mark.asyncio
+async def test_build_exportable_dataset_from_resolved_version_async_skips_datums_without_assets():
+    resolved_dataset_version = ResolvedDatasetVersion(
+        dataset_version=DatasetVersion(dataset_name="dataset-a", version="1.0.0"),
+        datums=[
+            ResolvedDatum(
+                datum=Datum(datum_id="datum_empty", asset_refs={}), assets={}, annotation_sets=[], annotation_records={}
+            )
+        ],
+    )
+    datalake = AsyncMock()
+
+    exportable = await build_exportable_dataset_from_resolved_version_async(datalake, resolved_dataset_version)
+
+    assert exportable.items == []
+    assert any("does not reference any assets" in warning for warning in exportable.warnings)
+
+
+def test_build_exportable_dataset_from_resolved_version_sync_skips_datums_without_assets():
+    resolved_dataset_version = ResolvedDatasetVersion(
+        dataset_version=DatasetVersion(dataset_name="dataset-a", version="1.0.0"),
+        datums=[
+            ResolvedDatum(
+                datum=Datum(datum_id="datum_empty", asset_refs={}), assets={}, annotation_sets=[], annotation_records={}
+            )
+        ],
+    )
+    datalake = Mock()
+
+    exportable = build_exportable_dataset_from_resolved_version_sync(datalake, resolved_dataset_version)
+
+    assert exportable.items == []
+    assert any("does not reference any assets" in warning for warning in exportable.warnings)
+
+
+def test_export_helpers_choose_stable_filenames_and_overwrite_file_destination(tmp_path: Path):
+    jpeg_asset = Asset(
+        asset_id="jpeg_asset",
+        kind="image",
+        media_type="image/jpeg",
+        storage_ref=StorageRef(mount="assets", name="jpeg", version="1"),
+    )
+    unknown_asset = Asset(
+        asset_id="blob_asset",
+        kind="artifact",
+        media_type="application/x-custom-export",
+        storage_ref=StorageRef(mount="assets", name="blob", version="1"),
+    )
+    destination = tmp_path / "existing-file"
+    destination.write_text("existing")
+
+    prepared = prepare_export_destination(destination, overwrite=True)
+
+    assert default_export_filename(jpeg_asset) == "jpeg_asset.jpg"
+    assert default_export_filename(unknown_asset) == "blob_asset.bin"
+    assert prepared.is_dir()
+
+
+def test_export_helpers_overwrite_existing_directory_and_short_polygon_area(tmp_path: Path):
+    destination = tmp_path / "existing-dir"
+    destination.mkdir()
+    (destination / "old.txt").write_text("stale")
+
+    prepared = prepare_export_destination(destination, overwrite=True)
+
+    assert prepared.is_dir()
+    assert not (prepared / "old.txt").exists()
+    assert _polygon_area([[0, 0], [1, 1]]) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_async_datalake_export_dataset_version_to_format_writes_coco(tmp_path: Path):
+    resolved_dataset_version = _resolved_dataset_version()
+    fake_datalake = SimpleNamespace(
+        resolve_dataset_version=AsyncMock(return_value=resolved_dataset_version),
+        get_object=AsyncMock(return_value=_png_bytes()),
+    )
+
+    result = await AsyncDatalake.export_dataset_version_to_format(
+        fake_datalake,
+        "dataset-a",
+        "1.0.0",
+        format="coco",
+        destination=tmp_path / "coco",
+    )
+
+    assert result.format == "coco"
+    assert (tmp_path / "coco" / "annotations" / "train.json").exists()
+    fake_datalake.resolve_dataset_version.assert_awaited_once_with("dataset-a", "1.0.0")
+
+
+def test_sync_datalake_export_dataset_version_to_format_delegates_to_backend(tmp_path: Path):
+    datalake = object.__new__(Datalake)
+    datalake._backend = Mock()
+    datalake._submit_coro = Mock(return_value="exported")
+
+    result = Datalake.export_dataset_version_to_format(
+        datalake,
+        "dataset-a",
+        "1.0.0",
+        format="huggingface",
+        destination=tmp_path / "hf",
+    )
+
+    assert result == "exported"
+    datalake._backend.export_dataset_version_to_format.assert_called_once()
+    datalake._submit_coro.assert_called_once()
+
+
+def test_data_vault_export_dataset_writes_split_aware_coco(tmp_path: Path):
+    asset = _asset()
+    item = CollectionItem(collection_id="collection_1", asset_id=asset.asset_id, split="val")
+    bbox = BboxAnnotation(
+        label="dog",
+        x=1,
+        y=2,
+        width=3,
+        height=4,
+        source={"type": "human", "name": "annotator"},
+    ).to_payload()
+    polygon = PolygonAnnotation(
+        label="cat",
+        vertices=[[0, 0], [10, 0], [10, 10]],
+        source={"type": "human", "name": "annotator"},
+    ).to_payload()
+    classification = ClassificationAnnotation(
+        label="scene",
+        source={"type": "human", "name": "annotator"},
+    ).to_payload()
+
+    backend = Mock()
+    backend.list_collections.return_value = [_collection()]
+    backend.list_collection_items.return_value = [item]
+    backend.list_annotation_sets.return_value = [_annotation_set(asset.asset_id, ["ann_bbox", "ann_poly", "ann_cls"])]
+    backend.get_annotation_record.side_effect = [
+        AnnotationRecord(**bbox, annotation_id="ann_bbox"),
+        AnnotationRecord(**polygon, annotation_id="ann_poly"),
+        AnnotationRecord(**classification, annotation_id="ann_cls"),
+    ]
+    backend.get_asset.return_value = asset
+    backend.get_object.return_value = _png_bytes()
+
+    result = DataVault(backend).export_dataset(
+        "dataset-a",
+        format="coco",
+        destination=tmp_path / "coco",
+        split_map={"val": "validation"},
+    )
+
+    payload = json.loads((tmp_path / "coco" / "annotations" / "validation.json").read_text())
+    assert result.format == "coco"
+    assert payload["images"][0]["file_name"] == "images/validation/asset_img.png"
+    assert {category["name"] for category in payload["categories"]} == {"cat", "dog"}
+    assert len(payload["annotations"]) == 2
+    assert (tmp_path / "coco" / "images" / "validation" / "asset_img.png").exists()
+    assert any("unsupported COCO annotation kind 'classification'" in warning for warning in result.warnings)
+
+
+def test_coco_export_writes_default_annotations_file_and_skips_invalid_polygon(tmp_path: Path):
+    asset = _asset()
+    polygon = AnnotationRecord(
+        annotation_id="ann_poly",
+        kind="polygon",
+        label="cat",
+        source={"type": "human", "name": "annotator"},
+        geometry={"vertices": [[0, 0], [1, 1]]},
+    )
+    dataset = ExportableDataset(
+        name="dataset-a",
+        items=[
+            ExportableItem(
+                asset=asset,
+                annotations=[polygon],
+                payload_bytes=_png_bytes(),
+                source_filename="asset_img.png",
+            )
+        ],
+    )
+
+    result = export_dataset_as_coco(dataset, destination=tmp_path / "coco", include_media=False)
+    payload = json.loads((tmp_path / "coco" / "annotations.json").read_text())
+
+    assert payload["annotations"] == []
+    assert any("fewer than 3 vertices" in warning for warning in result.warnings)
+
+
+def test_coco_export_requires_image_payloads(tmp_path: Path):
+    image_asset = _asset()
+    no_payload_dataset = ExportableDataset(
+        name="dataset-a",
+        items=[ExportableItem(asset=image_asset, payload_bytes=None, source_filename="asset_img.png")],
+    )
+    non_image_asset = Asset(
+        asset_id="asset_doc",
+        kind="document",
+        media_type="application/pdf",
+        storage_ref=StorageRef(mount="assets", name="doc", version="1"),
+    )
+    non_image_dataset = ExportableDataset(
+        name="dataset-a",
+        items=[ExportableItem(asset=non_image_asset, payload_bytes=b"pdf", source_filename="asset_doc.pdf")],
+    )
+
+    with pytest.raises(ValueError, match="requires payload bytes"):
+        export_dataset_as_coco(no_payload_dataset, destination=tmp_path / "coco-no-payload")
+    with pytest.raises(ValueError, match="supports image assets only"):
+        export_dataset_as_coco(non_image_dataset, destination=tmp_path / "coco-non-image")
+
+
+class _FakeDataset:
+    def __init__(self, rows):
+        self.rows = rows
+
+    @classmethod
+    def from_list(cls, rows):
+        return cls(rows)
+
+    def save_to_disk(self, path: str):
+        target = Path(path)
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "dataset.json").write_text(json.dumps(self.rows, sort_keys=True))
+
+
+class _FakeDatasetDict(dict):
+    def save_to_disk(self, path: str):
+        target = Path(path)
+        target.mkdir(parents=True, exist_ok=True)
+        serialized = {name: dataset.rows for name, dataset in self.items()}
+        (target / "dataset_dict.json").write_text(json.dumps(serialized, sort_keys=True))
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_export_dataset_writes_huggingface_directory(tmp_path: Path, monkeypatch):
+    from mindtrace.datalake.exporters import huggingface as huggingface_exporter
+
+    asset = _asset()
+    item = CollectionItem(collection_id="collection_1", asset_id=asset.asset_id, split="train")
+    annotation = BboxAnnotation(
+        label="dog",
+        x=1,
+        y=2,
+        width=3,
+        height=4,
+        source={"type": "human", "name": "annotator"},
+    ).to_payload()
+
+    fake_module = SimpleNamespace(Dataset=_FakeDataset, DatasetDict=_FakeDatasetDict)
+    monkeypatch.setattr(huggingface_exporter.importlib, "import_module", lambda name: fake_module)
+
+    backend = AsyncMock()
+    backend.list_collections.return_value = [_collection()]
+    backend.list_collection_items.return_value = [item]
+    backend.list_annotation_sets.return_value = [_annotation_set(asset.asset_id, ["ann_bbox"])]
+    backend.get_annotation_record.return_value = AnnotationRecord(**annotation, annotation_id="ann_bbox")
+    backend.get_asset.return_value = asset
+    backend.get_object.return_value = _png_bytes()
+
+    result = await AsyncDataVault(backend).export_dataset(
+        "dataset-a",
+        format="huggingface",
+        destination=tmp_path / "hf",
+        include_media=False,
+    )
+
+    payload = json.loads((tmp_path / "hf" / "dataset_dict.json").read_text())
+    assert result.format == "huggingface"
+    assert payload["train"][0]["asset_id"] == asset.asset_id
+    assert payload["train"][0]["image_path"] is None
+    assert payload["train"][0]["annotations"][0]["label"] == "dog"
+
+
+def test_huggingface_export_raises_helpful_error_when_dependency_missing(monkeypatch, tmp_path: Path):
+    from mindtrace.datalake.exporters import huggingface as huggingface_exporter
+
+    monkeypatch.setattr(
+        huggingface_exporter.importlib,
+        "import_module",
+        Mock(side_effect=ImportError("datasets missing")),
+    )
+
+    with pytest.raises(ImportError, match="mindtrace-datalake\\[export-huggingface\\]"):
+        export_dataset_as_huggingface(
+            ExportableDataset(name="dataset-a"),
+            destination=tmp_path / "hf",
+        )
+
+
+def test_huggingface_export_writes_media_for_default_split(tmp_path: Path, monkeypatch):
+    from mindtrace.datalake.exporters import huggingface as huggingface_exporter
+
+    fake_module = SimpleNamespace(Dataset=_FakeDataset, DatasetDict=_FakeDatasetDict)
+    monkeypatch.setattr(huggingface_exporter.importlib, "import_module", lambda name: fake_module)
+    dataset = ExportableDataset(
+        name="dataset-a",
+        items=[
+            ExportableItem(
+                asset=_asset(),
+                payload_bytes=_png_bytes(),
+                source_filename="asset_img.png",
+            )
+        ],
+    )
+
+    result = export_dataset_as_huggingface(dataset, destination=tmp_path / "hf-default", include_media=True)
+    payload = json.loads((tmp_path / "hf-default" / "dataset.json").read_text())
+
+    assert result.files_written[0] == "media/default/asset_img.png"
+    assert payload[0]["image_path"] == "media/default/asset_img.png"
+
+
+def test_coco_export_rejects_existing_destination_without_overwrite(tmp_path: Path):
+    destination = tmp_path / "coco"
+    destination.mkdir()
+
+    with pytest.raises(FileExistsError, match="Export destination already exists"):
+        export_dataset_as_coco(ExportableDataset(name="dataset-a"), destination=destination)
+
+
+def test_data_vault_export_dataset_rejects_unknown_format(tmp_path: Path):
+    backend = Mock()
+    backend.list_collections.return_value = [_collection()]
+    backend.list_collection_items.return_value = []
+    backend.list_annotation_sets.return_value = []
+
+    with pytest.raises(ValueError, match="Unsupported dataset export format"):
+        DataVault(backend).export_dataset("dataset-a", format="unknown", destination=tmp_path / "export")


### PR DESCRIPTION
## Summary

This PR adds a human-facing mutable dataset layer to DataVault, then extends it with snapshot-based export so datasets can be curated through collections/assets/annotations and exported through stable frozen views rather than live mutable state.

The main changes are:

- add mutable dataset workflows to `DataVault` / `AsyncDataVault`
- represent datasets as collection-backed summaries (`VaultDataset`) with asset membership and dataset-scoped annotations
- add sync/async backend support for dataset operations across local and service-backed vault clients
- introduce a dedicated exporter subsystem with canonical export models
- add COCO and Hugging Face exporters
- switch export semantics to resolved snapshots so mutable DataVault datasets are frozen before export and immutable dataset versions export directly
- scaffold dataset-version import and explicit dataset freeze APIs in DataVault
- extend dataset workflows to remote vault backends where possible
- add unit coverage across public dataset workflows, backend delegation, and exporter behavior

## What changed

### Mutable dataset workflows in DataVault

Adds a user-facing dataset API to `mindtrace/datalake/data_vault.py` for both sync and async callers.

This includes:

- `list_datasets(...)`
- `list_datasets_page(...)`
- `iter_datasets(...)`
- `get_dataset(...)`
- `create_dataset(...)`
- `add_asset(...)`
- `remove_asset(...)`
- `list_dataset_assets(...)`
- `add_annotation(...)`
- `remove_annotation(...)`
- `list_dataset_annotations(...)`

Datasets are exposed as `VaultDataset` summaries rather than leaking raw collection records directly.

### Datasets built on existing datalake primitives

Rather than introducing a second storage model, this PR builds the dataset abstraction out of existing datalake entities:

- collections represent dataset identity
- collection items represent asset membership
- annotation sets / annotation records represent dataset-scoped labels

This keeps mutable datasets aligned with the current Datalake model while still giving users a simpler dataset-oriented surface.

### Membership and dataset-scoped annotation behavior

The new dataset workflows are more than thin CRUD wrappers.

Notable behavior includes:

- asset resolution by id or alias
- reusing and reactivating collection membership when possible
- split / membership metadata updates on existing items
- implicit dataset membership creation when adding an annotation for an asset
- dataset-specific annotation-set metadata so exported/frozen views retain dataset context

### Backend support across local and service clients

Extends `mindtrace/datalake/data_vault_backends.py` so the dataset APIs work across:

- local sync backends
- local async backends
- `DatalakeService` sync connection-manager clients
- `DatalakeService` async connection-manager clients

The backend contracts now cover collections, collection items, annotation sets, annotation records, paging, iterator parity, and the remote workflow support needed by the higher-level dataset layer.

### Export subsystem with canonical export models

Adds a dedicated exporter package under `mindtrace/datalake/exporters/`.

This introduces canonical export-facing types:

- `ExportableItem`
- `ExportableDataset`
- `ExportResult`

and shared export helpers in `exporters/base.py` for building a stable in-memory export view from resolved dataset snapshots.

### COCO and Hugging Face export

Adds first-class exporters for:

- COCO
- Hugging Face

These exporters operate from the canonical export view rather than directly from mutable vault state.

### Snapshot-based export semantics

This PR changes export to be snapshot-oriented.

For mutable DataVault datasets:

- `DataVault.export_dataset(...)` / `AsyncDataVault.export_dataset(...)` first freeze the mutable dataset into a resolved dataset snapshot
- snapshot naming / versioning can be controlled, with generated defaults when omitted
- snapshots can optionally be persisted

For immutable dataset versions:

- `AsyncDatalake.export_dataset_version_to_format(...)` and sync `Datalake` wrappers export directly from the resolved dataset version

This keeps export reproducible and avoids writing external artifacts from a moving mutable target.

### Dataset import and explicit freeze APIs

Adds explicit lifecycle helpers in `DataVault` / `AsyncDataVault` for bridging mutable and immutable dataset representations.

This includes:

- `import_dataset_version(...)` to materialize an immutable dataset version into a mutable vault dataset
- `freeze_dataset(...)` to freeze a mutable dataset into a resolved dataset version, optionally persisting the snapshot

This gives curation and export workflows a shared snapshot model instead of treating export as the only freeze boundary.

### Public exports from `mindtrace.datalake`

Exports the new dataset/export pieces from `mindtrace.datalake`, including:

- `VaultDataset`
- `ExportableDataset`
- `ExportableItem`
- `ExportResult`
- exporter lookup / dispatch helpers

## Validation / coverage added

This branch adds or expands unit coverage for:

- public sync/async dataset workflows in `DataVault`
- dataset edge cases and helper behavior
- dataset import / freeze flows
- local backend delegation for dataset operations
- service backend delegation for dataset operations
- remote vault dataset workflow support
- exporter base-model construction
- COCO export output
- Hugging Face export output
- public package exports in `mindtrace.datalake.__init__`

Relevant touched test areas include:

- `tests/unit/mindtrace/datalake/test_data_vault.py`
- `tests/unit/mindtrace/datalake/test_data_vault_backends.py`
- `tests/unit/mindtrace/datalake/test_exporters.py`
- `tests/unit/mindtrace/datalake/test___init__.py`

## Tests

All tests should pass.

- `ds test: datalake --unit` should include **100% coverage**

## Example snippets

Below are compact examples for the main user-facing additions in the PR.

### Datalake API (Low Level)

#### Sync example

##### 1. Create a mutable working dataset

```python
from mindtrace.datalake import Datalake

datalake = Datalake(...)  # however you construct/connect it
collection = datalake.create_collection(
    name="pascal-voc-curation",
    description="Mutable working set for cleanup",
    metadata={"source_dataset": "pascal-voc@1.0.0"},
    created_by="jeremy",
)

# Add assets into the working set.
item1 = datalake.create_collection_item(
    collection_id=collection.collection_id,
    asset_id="asset_img_001",
    split="train",
    metadata={"review_status": "pending"},
    added_by="jeremy",
)
item2 = datalake.create_collection_item(
    collection_id=collection.collection_id,
    asset_id="asset_img_002",
    split="val",
    added_by="jeremy",
)
```

##### 2. Change membership or splits during curation

```python
# Move one item from train -> val.
datalake.update_collection_item(
    item1.collection_item_id,
    split="val",
    metadata={"review_status": "approved"},
)

# Soft-remove an item from the working set.
datalake.update_collection_item(
    item2.collection_item_id,
    status="archived",
)
```

##### 3. Add curated annotations for one asset

A practical pattern is one dataset-scoped `AnnotationSet` per asset in the collection.

```python
annotation_set = datalake.create_annotation_set(
    name="pascal-voc-curation:asset_img_001",
    purpose="ground_truth",
    source_type="human",
    status="active",
    metadata={
        "mindtrace": {
            "curation": {
                "collection_id": collection.collection_id,
                "asset_id": "asset_img_001",
            }
        }
    },
    created_by="jeremy",
)

records = datalake.add_annotation_records(
    [
        {
            "kind": "bbox",
            "label": "person",
            "subject": {"kind": "asset", "id": "asset_img_001"},
            "source": {"type": "human", "name": "reviewer"},
            "geometry": {"x": 10, "y": 20, "width": 100, "height": 200},
        },
        {
            "kind": "bbox",
            "label": "dog",
            "subject": {"kind": "asset", "id": "asset_img_001"},
            "source": {"type": "human", "name": "reviewer"},
            "geometry": {"x": 220, "y": 80, "width": 90, "height": 70},
        },
    ],
    annotation_set_id=annotation_set.annotation_set_id,
)
```

##### 4. Review the mutable dataset

```python
active_items = datalake.list_collection_items(
    {"collection_id": collection.collection_id, "status": "active"}
)
dataset_sets = datalake.list_annotation_sets(
    {
        "metadata.mindtrace.curation.collection_id": collection.collection_id,
        "status": "active",
    }
)

print("active assets:", len(active_items))
print("annotation sets:", len(dataset_sets))
```

##### 5. Freeze the curated collection into a `DatasetVersion`

This is the low-level equivalent of `DataVault.freeze_dataset(...)`.

```python
manifest = []
for item in datalake.list_collection_items(
    {"collection_id": collection.collection_id, "status": "active"}
):
    asset = datalake.get_asset(item.asset_id)
    asset_sets = datalake.list_annotation_sets(
        {
            "metadata.mindtrace.curation.collection_id": collection.collection_id,
            "metadata.mindtrace.curation.asset_id": asset.asset_id,
            "status": "active",
        }
    )
    frozen_set_ids = []
    for source_set in asset_sets:
        frozen_set = datalake.create_annotation_set(
            name=source_set.name,
            purpose=source_set.purpose,
            source_type=source_set.source_type,
            status=source_set.status,
            metadata={
                **(source_set.metadata or {}),
                "mindtrace": {
                    "frozen_from": {
                        "collection_id": collection.collection_id,
                        "asset_id": asset.asset_id,
                    }
                },
            },
            created_by="jeremy",
        )
        source_records = [
            datalake.get_annotation_record(annotation_id)
            for annotation_id in source_set.annotation_record_ids
        ]
        if source_records:
            datalake.add_annotation_records(
                [
                    record.model_dump(
                        mode="json",
                        exclude={"annotation_id", "created_at", "updated_at"},
                    )
                    for record in source_records
                ],
                annotation_set_id=frozen_set.annotation_set_id,
                annotation_schema_id=source_set.annotation_schema_id,
            )
        frozen_set_ids.append(frozen_set.annotation_set_id)
    datum = datalake.create_datum(
        asset_refs={"image": asset.asset_id},
        split=item.split,
        metadata=item.metadata or {},
        annotation_set_ids=frozen_set_ids,
    )
    manifest.append(datum.datum_id)

dataset_version = datalake.create_dataset_version(
    dataset_name="pascal-voc-curation",
    version="1.1.0",
    description="Curated snapshot after review",
    manifest=manifest,
    metadata={"source_collection_id": collection.collection_id},
    created_by="jeremy",
)

resolved = datalake.resolve_dataset_version("pascal-voc-curation", "1.1.0")
print(resolved.dataset_version.dataset_name, resolved.dataset_version.version)
```

#### Async example

Same pattern, just await each operation.

##### 1. Import an existing frozen dataset into a mutable collection

This is the direct equivalent of `AsyncDataVault.import_dataset_version(...)`.

```python
from mindtrace.datalake import AsyncDatalake

datalake = AsyncDatalake(...)
resolved = await datalake.resolve_dataset_version("pascal-voc", "1.0.0")
collection = await datalake.create_collection(
    name="pascal-voc-curation",
    description="Async mutable working set",
    metadata={"source_dataset": "pascal-voc@1.0.0"},
    created_by="jeremy",
)
for resolved_datum in resolved.datums:
    image_asset = resolved_datum.assets.get("image")
    if image_asset is None:
        continue
    await datalake.create_collection_item(
        collection_id=collection.collection_id,
        asset_id=image_asset.asset_id,
        split=resolved_datum.datum.split,
        metadata=resolved_datum.datum.metadata or {},
        added_by="jeremy",
    )
```

##### 2. Add or revise annotations during review

```python
annotation_set = await datalake.create_annotation_set(
    name="pascal-voc-curation:asset_img_001",
    purpose="ground_truth",
    source_type="human",
    status="active",
    metadata={
        "mindtrace": {
            "curation": {
                "collection_id": collection.collection_id,
                "asset_id": "asset_img_001",
            }
        }
    },
    created_by="jeremy",
)
await datalake.add_annotation_records(
    [
        {
            "kind": "bbox",
            "label": "car",
            "subject": {"kind": "asset", "id": "asset_img_001"},
            "source": {"type": "human", "name": "reviewer"},
            "geometry": {"x": 30, "y": 40, "width": 120, "height": 60},
        }
    ],
    annotation_set_id=annotation_set.annotation_set_id,
)
```

##### 3. Freeze the curated async collection

```python
manifest = []
items = await datalake.list_collection_items(
    {"collection_id": collection.collection_id, "status": "active"}
)
for item in items:
    asset = await datalake.get_asset(item.asset_id)
    asset_sets = await datalake.list_annotation_sets(
        {
            "metadata.mindtrace.curation.collection_id": collection.collection_id,
            "metadata.mindtrace.curation.asset_id": asset.asset_id,
            "status": "active",
        }
    )
    frozen_set_ids = []
    for source_set in asset_sets:
        frozen_set = await datalake.create_annotation_set(
            name=source_set.name,
            purpose=source_set.purpose,
            source_type=source_set.source_type,
            status=source_set.status,
            metadata=source_set.metadata or {},
            created_by="jeremy",
        )
        source_records = [
            await datalake.get_annotation_record(annotation_id)
            for annotation_id in source_set.annotation_record_ids
        ]
        if source_records:
            await datalake.add_annotation_records(
                [
                    record.model_dump(
                        mode="json",
                        exclude={"annotation_id", "created_at", "updated_at"},
                    )
                    for record in source_records
                ],
                annotation_set_id=frozen_set.annotation_set_id,
                annotation_schema_id=source_set.annotation_schema_id,
            )
        frozen_set_ids.append(frozen_set.annotation_set_id)
    datum = await datalake.create_datum(
        asset_refs={"image": asset.asset_id},
        split=item.split,
        metadata=item.metadata or {},
        annotation_set_ids=frozen_set_ids,
    )
    manifest.append(datum.datum_id)

dataset_version = await datalake.create_dataset_version(
    dataset_name="pascal-voc-curation",
    version="1.1.0",
    manifest=manifest,
    description="Async curated snapshot",
    created_by="jeremy",
)

resolved_snapshot = await datalake.resolve_dataset_version("pascal-voc-curation", "1.1.0")
print(resolved_snapshot.dataset_version.version)
```

### DataVault API (High Level)

For DataVault, the clean pattern is:

- use typed annotation models like `BboxAnnotation`, `PolygonAnnotation`, and `ClassificationAnnotation`
- pass `asset=` explicitly to `add_annotation(...)`

That lets the vault assign the correct asset subject internally.

#### Sync `DataVault`

```python
from pathlib import Path

from mindtrace.datalake import DataVault
from mindtrace.datalake.annotations import BboxAnnotation

# Connect to a remote DatalakeService.
vault = DataVault.from_url("http://localhost:8080")

# 1) Import a frozen DatasetVersion into a mutable VaultDataset.
working = vault.import_dataset_version(
    "pascal-voc",
    "1.0.0",
    target_name="pascal-voc-curation",
    target_description="Working copy for manual cleanup",
    overwrite=True,
    created_by="jeremy",
)
print("Imported working dataset:", working.name)

# 2) Inspect the mutable dataset.
assets = vault.list_dataset_assets(working)
if not assets:
    raise RuntimeError("Expected at least one asset in the imported working dataset")
asset = assets[0]
existing_annotations = vault.list_dataset_annotations(working, asset=asset)
print("Assets in working dataset:", len(assets))
print("Existing annotations for first asset:", len(existing_annotations))

# 3) Example curation step A: remove one existing annotation if present.
if existing_annotations:
    vault.remove_annotation(working, existing_annotations[0])

# 4) Example curation step B: add a corrected annotation using a typed model.
vault.add_annotation(
    working,
    BboxAnnotation(
        label="person",
        source={"type": "human", "name": "reviewer"},
        x=42,
        y=28,
        width=160,
        height=220,
        metadata={
            "review": {
                "status": "approved",
                "note": "Corrected box after manual QA",
            }
        },
    ),
    asset=asset,
    created_by="jeremy",
)

# 5) Example curation step C: add another typed annotation.
vault.add_annotation(
    working,
    BboxAnnotation(
        label="dog",
        source={"type": "human", "name": "reviewer"},
        x=220,
        y=80,
        width=90,
        height=70,
        attributes={"occluded": False},
    ),
    asset=asset,
    created_by="jeremy",
)

# 6) Example curation step D: optionally remove an unwanted asset from the dataset.
if len(assets) > 1:
    vault.remove_asset(working, assets[-1], missing_ok=True)
updated_assets = vault.list_dataset_assets(working)
updated_annotations = vault.list_dataset_annotations(working, asset=asset)
print("Assets after curation:", len(updated_assets))
print("Annotations for first asset after curation:", len(updated_annotations))

# 7) Freeze the mutable VaultDataset into a persistent DatasetVersion.
snapshot = vault.freeze_dataset(
    working,
    snapshot_name="pascal-voc-curation",
    snapshot_version="1.1.0",
    persist=True,
    created_by="jeremy",
)
print("Created snapshot:", snapshot.dataset_name, snapshot.version)

# 8) Export to COCO.
coco_result = vault.export_dataset(
    working,
    format="coco",
    destination=Path("./exports/pascal-voc-coco"),
    overwrite=True,
    persist_snapshot=False,
)
print("COCO export:", coco_result.asset_count, "assets,", coco_result.annotation_count, "annotations")

# 9) Export to Hugging Face.
hf_result = vault.export_dataset(
    working,
    format="huggingface",
    destination=Path("./exports/pascal-voc-hf"),
    overwrite=True,
    persist_snapshot=False,
)
print("HF export:", hf_result.asset_count, "assets,", hf_result.annotation_count, "annotations")
```

#### Async `AsyncDataVault`

```python
from pathlib import Path

from mindtrace.datalake import AsyncDataVault
from mindtrace.datalake.annotations import BboxAnnotation

vault = AsyncDataVault.from_url("http://localhost:8080")
working = await vault.import_dataset_version(
    "pascal-voc",
    "1.0.0",
    target_name="pascal-voc-curation",
    overwrite=True,
    created_by="jeremy",
)
assets = await vault.list_dataset_assets(working)
if not assets:
    raise RuntimeError("Expected at least one asset in the imported working dataset")
asset = assets[0]
existing_annotations = await vault.list_dataset_annotations(working, asset=asset)
if existing_annotations:
    await vault.remove_annotation(working, existing_annotations[0])
await vault.add_annotation(
    working,
    BboxAnnotation(
        label="person",
        source={"type": "human", "name": "reviewer"},
        x=42,
        y=28,
        width=160,
        height=220,
        metadata={
            "review": {
                "status": "approved",
                "note": "Corrected box after manual QA",
            }
        },
    ),
    asset=asset,
    created_by="jeremy",
)
await vault.add_annotation(
    working,
    BboxAnnotation(
        label="dog",
        source={"type": "human", "name": "reviewer"},
        x=220,
        y=80,
        width=90,
        height=70,
    ),
    asset=asset,
    created_by="jeremy",
)
snapshot = await vault.freeze_dataset(
    working,
    snapshot_name="pascal-voc-curation",
    snapshot_version="1.1.0",
    persist=True,
    created_by="jeremy",
)
print(snapshot.dataset_name, snapshot.version)
await vault.export_dataset(
    working,
    format="coco",
    destination=Path("./exports/pascal-voc-coco"),
    overwrite=True,
)
await vault.export_dataset(
    working,
    format="huggingface",
    destination=Path("./exports/pascal-voc-hf"),
    overwrite=True,
)
```

#### Another example with `PolygonAnnotation`

If your dataset uses polygons instead of boxes:

```python
from mindtrace.datalake.annotations import PolygonAnnotation

vault.add_annotation(
    working,
    PolygonAnnotation(
        label="car",
        source={"type": "human", "name": "reviewer"},
        vertices=[
            [10, 10],
            [120, 12],
            [118, 80],
            [15, 78],
        ],
        metadata={"review": {"tool": "polygon-editor"}},
    ),
    asset=asset,
)
```

#### Key point

With typed models like `BboxAnnotation`, `PolygonAnnotation`, and `ClassificationAnnotation`, you should generally do this:

```python
vault.add_annotation(dataset, typed_annotation_model, asset=asset)
```

## Notable commits

- `5f89865f` — `feat(datalake): add dataset workflows to DataVault`
- `a7b7ac66` — `test(datalake): cover DataVault dataset operations`
- `ec84265a` — `test(datalake): complete unit coverage for DataVault datasets`
- `52faffc3` — `feat(datalake): switch dataset export to snapshots`
- `c87eb235` — `feat(datalake): scaffold vault dataset import and freeze`
- `2173519f` — `feat(datalake): support remote vault dataset workflows`

## Notes

- This PR focuses on making datasets a first-class mutable concept in DataVault while keeping export reproducible through snapshot-based semantics.
- The implementation intentionally builds datasets out of existing datalake primitives rather than recreating the legacy mtrix dataset storage model.
- Export support in this branch is centered on common formats (currently COCO and Hugging Face), not a legacy-format compatibility layer.
- Snapshot-based export is intended to provide a stable bridge between mutable curation workflows and training-oriented external artifacts.
