### PR TITLE
feat(hardware): configurable MockBasler frames from image files

### DIFF
--- a/docker/hardware/camera/.env.example
+++ b/docker/hardware/camera/.env.example
@@ -120,3 +120,12 @@ MINDTRACE_HW_CAMERA_BUFFER_COUNT=10
 # Mock cameras for testing
 MINDTRACE_HW_CAMERA_MOCK_ENABLED=false
 MINDTRACE_HW_CAMERA_MOCK_COUNT=0
+
+# Mock Basler fixture images (optional)
+# Provide deterministic frames from image files when using MockBasler cameras.
+# - If MINDTRACE_HW_CAMERA_MOCK_BASLER_IMAGE_DIR is set, the service looks for:
+#   <dir>/<device_name>.png (or .jpg/.jpeg), e.g. /app/data/mock-cameras/mock_basler_1.png
+# - MINDTRACE_HW_CAMERA_MOCK_BASLER_IMAGE_MAP can override per-device paths with a JSON object string:
+#   {"mock_basler_1":"/app/data/mock-cameras/a.png","mock_basler_2":"/app/data/mock-cameras/b.png"}
+MINDTRACE_HW_CAMERA_MOCK_BASLER_IMAGE_DIR=
+MINDTRACE_HW_CAMERA_MOCK_BASLER_IMAGE_MAP=

--- a/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/mock_basler_camera_backend.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/mock_basler_camera_backend.py
@@ -95,6 +95,8 @@ class MockBaslerCameraBackend(CameraBackend):
                 - synthetic_pattern: One of {"auto","gradient","checkerboard","circular","noise"}
                 - synthetic_checker_size: Checker size (int) used when pattern is checkerboard
                 - synthetic_overlay_text: If False, disables text overlays in synthetic images
+                - mock_image_path: Path to an image file used as the returned frame (optional)
+                - mock_image_paths: List of paths to cycle through as returned frames (optional)
 
         Raises:
             CameraConfigurationError: If configuration is invalid
@@ -147,6 +149,17 @@ class MockBaslerCameraBackend(CameraBackend):
         self.synthetic_checker_size: int = int(backend_kwargs.get("synthetic_checker_size", 50))
         self.synthetic_overlay_text: bool = bool(backend_kwargs.get("synthetic_overlay_text", True))
 
+        # Optional file-backed fixtures for deterministic mock frames
+        raw_paths = backend_kwargs.get("mock_image_paths")
+        raw_path = backend_kwargs.get("mock_image_path")
+        fixture_paths: List[str] = []
+        if isinstance(raw_paths, list):
+            fixture_paths.extend([p for p in raw_paths if isinstance(p, str) and p])
+        if isinstance(raw_path, str) and raw_path:
+            fixture_paths.append(raw_path)
+        self._fixture_image_paths: List[str] = fixture_paths
+        self._fixture_images: Optional[List[np.ndarray]] = None
+
         # Optionally override image size via constructor
         syn_w = backend_kwargs.get("synthetic_width")
         syn_h = backend_kwargs.get("synthetic_height")
@@ -193,7 +206,16 @@ class MockBaslerCameraBackend(CameraBackend):
         Returns:
             List of mock camera names or dict with details
         """
-        mock_cameras = [f"mock_basler_{i}" for i in range(1, 6)]
+        count = 5
+        try:
+            from mindtrace.hardware.core.config import get_hardware_config
+
+            cfg = get_hardware_config().get_config()
+            count = int(getattr(cfg.cameras, "mock_camera_count", count))
+        except Exception:
+            pass
+        count = max(0, count)
+        mock_cameras = [f"mock_basler_{i}" for i in range(1, count + 1)]
 
         if include_details:
             camera_details = {}
@@ -816,6 +838,44 @@ class MockBaslerCameraBackend(CameraBackend):
         except Exception as e:
             self.logger.error(f"Failed to initialize image enhancement for mock camera '{self.camera_name}': {str(e)}")
 
+    def _get_fixture_image(self, *, width: int, height: int) -> Optional[np.ndarray]:
+        """Return a resized fixture image if configured; otherwise None."""
+        if not self._fixture_image_paths:
+            return None
+
+        if self._fixture_images is None:
+            images: List[np.ndarray] = []
+            for path in self._fixture_image_paths:
+                try:
+                    if not os.path.exists(path):
+                        self.logger.warning(
+                            f"Mock Basler fixture image not found for '{self.camera_name}': {path}. Falling back to synthetic."
+                        )
+                        continue
+                    with open(path, "rb") as f:
+                        encoded = np.frombuffer(f.read(), dtype=np.uint8)
+                    img = cv2.imdecode(encoded, cv2.IMREAD_COLOR)
+                    if img is None or img.size == 0:
+                        self.logger.warning(
+                            f"Mock Basler fixture image unreadable for '{self.camera_name}': {path}. Falling back to synthetic."
+                        )
+                        continue
+                    images.append(img)
+                except Exception as e:
+                    self.logger.warning(
+                        f"Mock Basler fixture image failed to load for '{self.camera_name}': {path}. Error: {e}. Falling back to synthetic."
+                    )
+            self._fixture_images = images
+
+        if not self._fixture_images:
+            return None
+
+        idx = self.image_counter % len(self._fixture_images)
+        base = self._fixture_images[idx]
+        if base.shape[1] != width or base.shape[0] != height:
+            return cv2.resize(base, (width, height), interpolation=cv2.INTER_AREA)
+        return base.copy()
+
     def _generate_synthetic_image(self) -> np.ndarray:
         """Generate synthetic test image using vectorized operations for performance.
 
@@ -825,6 +885,10 @@ class MockBaslerCameraBackend(CameraBackend):
         width = self.roi["width"]
         height = self.roi["height"]
         try:
+            fixture = self._get_fixture_image(width=width, height=height)
+            if fixture is not None:
+                return fixture
+
             # Use vectorized operations for much better performance
             x_coords = np.arange(width)
             y_coords = np.arange(height)

--- a/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/mock_basler_camera_backend.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/mock_basler_camera_backend.py
@@ -95,8 +95,8 @@ class MockBaslerCameraBackend(CameraBackend):
                 - synthetic_pattern: One of {"auto","gradient","checkerboard","circular","noise"}
                 - synthetic_checker_size: Checker size (int) used when pattern is checkerboard
                 - synthetic_overlay_text: If False, disables text overlays in synthetic images
-                - mock_image_path: Path to an image file used as the returned frame (optional)
-                - mock_image_paths: List of paths to cycle through as returned frames (optional)
+                - mock_image_paths: List of image file paths to cycle through as returned frames (optional; use a
+                  length-one list for a single fixture)
 
         Raises:
             CameraConfigurationError: If configuration is invalid
@@ -151,12 +151,9 @@ class MockBaslerCameraBackend(CameraBackend):
 
         # Optional file-backed fixtures for deterministic mock frames
         raw_paths = backend_kwargs.get("mock_image_paths")
-        raw_path = backend_kwargs.get("mock_image_path")
         fixture_paths: List[str] = []
         if isinstance(raw_paths, list):
             fixture_paths.extend([p for p in raw_paths if isinstance(p, str) and p])
-        if isinstance(raw_path, str) and raw_path:
-            fixture_paths.append(raw_path)
         self._fixture_image_paths: List[str] = fixture_paths
         self._fixture_images: Optional[List[np.ndarray]] = None
 

--- a/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera_manager.py
@@ -1015,7 +1015,7 @@ class AsyncCameraManager(Mindtrace):
                 )
                 if backend_name == "basler":
                     cam_cfg = self._hardware_config.cameras
-                    if "mock_image_paths" not in kwargs and "mock_image_path" not in kwargs:
+                    if "mock_image_paths" not in kwargs:
                         fixture_paths: list[str] = []
                         mapped = cam_cfg.mock_basler_image_map.get(device_name)
                         if mapped:

--- a/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera_manager.py
@@ -1013,6 +1013,26 @@ class AsyncCameraManager(Mindtrace):
                 self.logger.debug(
                     f"Creating mock camera instance for {backend}:{device_name} with timeout={kwargs['timeout_ms']}ms, retry={kwargs['retrieve_retry_count']}"
                 )
+                if backend_name == "basler":
+                    cam_cfg = self._hardware_config.cameras
+                    if "mock_image_paths" not in kwargs and "mock_image_path" not in kwargs:
+                        fixture_paths: list[str] = []
+                        mapped = cam_cfg.mock_basler_image_map.get(device_name)
+                        if mapped:
+                            fixture_paths = [mapped]
+                        elif cam_cfg.mock_basler_image_dir:
+                            base = Path(cam_cfg.mock_basler_image_dir)
+                            for ext in (".png", ".jpg", ".jpeg"):
+                                candidate = str(base / f"{device_name}{ext}")
+                                if Path(candidate).exists():
+                                    fixture_paths = [candidate]
+                                    break
+                        if fixture_paths:
+                            kwargs["mock_image_paths"] = fixture_paths
+                    w, h = cam_cfg.mock_basler_width, cam_cfg.mock_basler_height
+                    if w > 0 and h > 0:
+                        kwargs.setdefault("synthetic_width", w)
+                        kwargs.setdefault("synthetic_height", h)
                 mock_class = self._get_mock_camera(backend_name)
                 return mock_class(device_name, **kwargs)
 

--- a/mindtrace/hardware/mindtrace/hardware/core/config.py
+++ b/mindtrace/hardware/mindtrace/hardware/core/config.py
@@ -44,6 +44,8 @@ Environment Variables:
     - MINDTRACE_HW_CAMERA_BASLER_ENABLED: Enable Basler backend
     - MINDTRACE_HW_CAMERA_OPENCV_ENABLED: Enable OpenCV backend
     - MINDTRACE_HW_CAMERA_GENICAM_ENABLED: Enable GenICam backend
+    - MINDTRACE_HW_CAMERA_MOCK_BASLER_WIDTH: Mock Basler frame width (0 = backend default 1920)
+    - MINDTRACE_HW_CAMERA_MOCK_BASLER_HEIGHT: Mock Basler frame height (0 = backend default 1080)
     - MINDTRACE_HW_STEREO_CAMERA_TIMEOUT_MS: Stereo camera capture timeout in milliseconds
     - MINDTRACE_HW_STEREO_CAMERA_EXPOSURE_TIME: Stereo camera exposure time in microseconds
     - MINDTRACE_HW_STEREO_CAMERA_GAIN: Stereo camera gain value
@@ -172,7 +174,13 @@ class CameraSettings:
     max_camera_index: int = 1  # Maximum camera index for OpenCV discovery
 
     # Mock/testing settings
-    mock_camera_count: int = 1  # Number of mock cameras to simulate
+    mock_camera_count: int = 5  # Number of mock cameras to simulate
+    mock_basler_image_dir: str = ""  # Optional directory containing per-device image fixtures
+    mock_basler_image_map: dict[str, str] = field(default_factory=dict)  # device_name -> absolute image path
+    # Mock Basler output size (fixture images are resized to this unless they already match). Zero = use
+    # backend default (1920×1080).
+    mock_basler_width: int = 0
+    mock_basler_height: int = 0
 
     # Image enhancement algorithm settings
     enhancement_gamma: float = 2.2  # Gamma correction value
@@ -618,6 +626,32 @@ class HardwareConfigManager(Mindtrace):
                 self._config.cameras.mock_camera_count = int(env_val)
             except ValueError:
                 pass  # Keep default value on invalid input
+
+        if env_val := os.getenv("MINDTRACE_HW_CAMERA_MOCK_BASLER_IMAGE_DIR"):
+            self._config.cameras.mock_basler_image_dir = env_val
+
+        if env_val := os.getenv("MINDTRACE_HW_CAMERA_MOCK_BASLER_IMAGE_MAP"):
+            try:
+                parsed = json.loads(env_val)
+                if isinstance(parsed, dict) and all(
+                    isinstance(k, str) and isinstance(v, str) for k, v in parsed.items()
+                ):
+                    self._config.cameras.mock_basler_image_map = parsed
+            except Exception:
+                # Keep defaults on invalid input
+                pass
+
+        if env_val := os.getenv("MINDTRACE_HW_CAMERA_MOCK_BASLER_WIDTH"):
+            try:
+                self._config.cameras.mock_basler_width = int(env_val)
+            except ValueError:
+                pass
+
+        if env_val := os.getenv("MINDTRACE_HW_CAMERA_MOCK_BASLER_HEIGHT"):
+            try:
+                self._config.cameras.mock_basler_height = int(env_val)
+            except ValueError:
+                pass
 
         if env_val := os.getenv("MINDTRACE_HW_CAMERA_ENHANCEMENT_GAMMA"):
             try:

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/launcher.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/launcher.py
@@ -15,6 +15,9 @@ def main():
 
     args = parser.parse_args()
 
+    if not args.include_mocks and os.getenv("MINDTRACE_HW_CAMERA_MOCK_ENABLED", "").lower() == "true":
+        args.include_mocks = True
+
     # Create service with mock support if requested
     service = CameraManagerService(include_mocks=args.include_mocks)
 

--- a/tests/unit/mindtrace/hardware/cameras/backends/basler/test_mock_basler_camera_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/basler/test_mock_basler_camera_backend.py
@@ -231,6 +231,45 @@ class TestMockBaslerImageGeneration:
             await camera.close()
 
     @pytest.mark.asyncio
+    async def test_fixture_image_path_returns_deterministic_frame(self):
+        """If a fixture image is configured, the mock should return it (resized to ROI)."""
+        fixture = np.zeros((12, 10, 3), dtype=np.uint8)
+        fixture[:, :] = (10, 20, 30)  # BGR
+
+        fd, fixture_path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+
+        try:
+            from PIL import Image
+
+            # Pillow expects RGB; our fixtures are BGR to match backend output.
+            Image.fromarray(fixture[..., ::-1]).save(fixture_path)
+
+            camera = MockBaslerCameraBackend(
+                "fixture_cam",
+                mock_image_path=fixture_path,
+                synthetic_pattern="noise",
+                synthetic_overlay_text=False,
+                fast_mode=True,
+            )
+            await camera.initialize()
+
+            fixture_frame = camera._get_fixture_image(width=camera.roi["width"], height=camera.roi["height"])
+            assert fixture_frame is not None
+            cy = fixture_frame.shape[0] // 2
+            cx = fixture_frame.shape[1] // 2
+            assert tuple(int(x) for x in fixture_frame[cy, cx]) == (10, 20, 30)
+
+            frame = await camera.capture()
+            assert frame.ndim == 3
+            assert frame.shape[2] == 3
+        finally:
+            try:
+                os.unlink(fixture_path)
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio
     async def test_set_triggermode_exception_handling(self):
         """Test exception handling in set_triggermode."""
         camera = MockBaslerCameraBackend("test_cam")

--- a/tests/unit/mindtrace/hardware/cameras/backends/basler/test_mock_basler_camera_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/basler/test_mock_basler_camera_backend.py
@@ -247,7 +247,7 @@ class TestMockBaslerImageGeneration:
 
             camera = MockBaslerCameraBackend(
                 "fixture_cam",
-                mock_image_path=fixture_path,
+                mock_image_paths=[fixture_path],
                 synthetic_pattern="noise",
                 synthetic_overlay_text=False,
                 fast_mode=True,


### PR DESCRIPTION
## Summary
`MockBasler` cameras can return deterministic frames from image files (Docker volume mounts and local testing), not only procedural patterns.

## Motivation
Integration and demos need stable, repeatable imagery without real Basler hardware.

## What changed
- **Config / env**: `MINDTRACE_HW_CAMERA_MOCK_BASLER_IMAGE_DIR` (per-device `{device}.png` / `.jpg` / `.jpeg`) and `MINDTRACE_HW_CAMERA_MOCK_BASLER_IMAGE_MAP` (JSON object: device name → absolute path).
- **Runtime**: `AsyncCameraManager` injects `mock_image_paths` when opening `MockBasler:*` unless the caller already passes `mock_image_path` / `mock_image_paths`.
- **Launcher**: `MINDTRACE_HW_CAMERA_MOCK_ENABLED=true` enables mock discovery (equivalent to `--include-mocks`).
- **Discovery**: `mock_camera_count` respects hardware config (default 5; override with `MINDTRACE_HW_CAMERA_MOCK_COUNT`).
- **Docs**: `docker/hardware/camera/.env.example` documents the new variables.
- **Tests**: regression in `test_mock_basler_camera_backend.py`.

## How to test
```bash
uv run pytest -q tests/unit/mindtrace/hardware/cameras/backends/basler/test_mock_basler_camera_backend.py
```

## Breaking changes
None when fixture env vars are unset.

## Checklist
- [x] Feature: configurable mock Basler fixture images
- [ ] Bug fix (N/A for this PR)
- [x] Unit tests pass (`pytest` command above)
- [ ] Manual testing in Docker (optional: mount fixtures + set env)