### PR TITLE
fix(datalake): make docker compose --wait work with datalake stack

### DIFF
--- a/docker/datalake/docker-compose.yml
+++ b/docker/datalake/docker-compose.yml
@@ -24,27 +24,42 @@ services:
     image: minio/mc
     depends_on:
       - minio
-    restart: "no"
-    entrypoint: >-
-      /bin/sh -c '
-      until mc alias set local http://minio:9000 "$${MINIO_ROOT_USER}" "$${MINIO_ROOT_PASSWORD}"; do
-        sleep 1;
-      done;
-      mc mb --ignore-existing local/"$${MINDTRACE_DATALAKE__S3_BUCKET}";
-      '
+    # One-shot jobs that exit(0) break `docker compose up --wait` (compose treats exit as failure).
+    # Run setup once, mark done, then idle so the service can become healthy and satisfy --wait.
+    restart: unless-stopped
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -euo pipefail
+        until mc alias set local http://minio:9000 "$${MINIO_ROOT_USER}" "$${MINIO_ROOT_PASSWORD}"; do
+          sleep 1
+        done
+        mc mb --ignore-existing local/"$${MINDTRACE_DATALAKE__S3_BUCKET}"
+        touch /tmp/minio-setup-done
+        exec tail -f /dev/null
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
       MINDTRACE_DATALAKE__S3_BUCKET: ${MINDTRACE_DATALAKE__S3_BUCKET:-datalake}
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /tmp/minio-setup-done"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 30s
 
   datalake-service:
     build:
       context: ../..
       dockerfile: docker/datalake/Dockerfile
     depends_on:
-      - mongodb
-      - minio
-      - minio-setup
+      mongodb:
+        condition: service_started
+      minio:
+        condition: service_started
+      minio-setup:
+        condition: service_healthy
     restart: unless-stopped
     environment:
       MINDTRACE_DATALAKE__SERVICE_HOST: ${MINDTRACE_DATALAKE__SERVICE_HOST:-0.0.0.0}


### PR DESCRIPTION
## Summary
Updates the datalake `docker-compose.yml` so `docker compose up --wait` can succeed. The `minio-setup` one-shot previously exited after creating the bucket; Compose treats that exit as a failed dependency and breaks `--wait`.

## What changed
- **minio-setup**: Run the mc bootstrap once, touch a done file, then `tail -f /dev/null` so the container stays up; add a **healthcheck** that passes once setup finished.
- **minio-setup**: Use `restart: unless-stopped` instead of `restart: "no"` so the long-running idle process behaves like a normal service.
- **datalake-service**: Use `depends_on` with `service_healthy` for `minio-setup` so the app starts only after MinIO + bucket setup is complete.

## Motivation
Local and CI flows that use `docker compose up --wait` should reliably wait for MinIO to be ready and the bucket to exist before starting `datalake-service`.

## How to test
```bash
cd docker/datalake
docker compose up --build --wait
```
Confirm `minio-setup` becomes healthy and `datalake-service` starts without compose reporting a failed dependency.

## Breaking changes
None for application code; only Compose behavior for the datalake stack.

---

## Checklist
- [x] Bug fix (datalake compose / `--wait`)
- [ ] Feature
- [ ] Unit tests pass (N/A — Compose-only change)
- [ ] Manual testing completed (see commands above)

Made with [Cursor](https://cursor.com)