### PR TITLE
Fix generated client JSON serialization for Pydantic inputs

### DIFF
--- a/mindtrace/services/mindtrace/services/core/utils.py
+++ b/mindtrace/services/mindtrace/services/core/utils.py
@@ -149,9 +149,9 @@ def generate_connection_manager(
                             raise ValueError(
                                 f"Service method {endpoint_name} must be called with either kwargs or a single argument of type {input_schema}"
                             )
-                        payload = args[0].model_dump()
+                        payload = args[0].model_dump(mode="json")
                     else:
-                        payload = input_schema(**kwargs).model_dump() if input_schema is not None else {}
+                        payload = input_schema(**kwargs).model_dump(mode="json") if input_schema is not None else {}
                 else:
                     payload = kwargs
                 res = httpx.post(str(self.url).rstrip("/") + endpoint_path, json=payload, timeout=60)
@@ -183,9 +183,9 @@ def generate_connection_manager(
                             raise ValueError(
                                 f"Service method a{endpoint_name} must be called with either kwargs or a single argument of type {input_schema}"
                             )
-                        payload = args[0].model_dump()
+                        payload = args[0].model_dump(mode="json")
                     else:
-                        payload = input_schema(**kwargs).model_dump() if input_schema is not None else {}
+                        payload = input_schema(**kwargs).model_dump(mode="json") if input_schema is not None else {}
                 else:
                     payload = kwargs
                 async with httpx.AsyncClient(timeout=60) as client:

--- a/tests/unit/mindtrace/services/core/test_utils.py
+++ b/tests/unit/mindtrace/services/core/test_utils.py
@@ -1,7 +1,8 @@
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
 from fastapi import HTTPException
+from pydantic import BaseModel
 from urllib3.util.url import parse_url
 
 from mindtrace.services.core.connection_manager import ConnectionManager
@@ -692,7 +693,6 @@ class TestGenerateConnectionManager:
     @patch("mindtrace.services.core.utils.httpx")
     def test_generated_method_single_valid_arg(self, mock_httpx, mock_service_class):
         """Test that method works with a single valid arg."""
-        from pydantic import BaseModel
 
         class TestInput(BaseModel):
             value: str
@@ -718,10 +718,63 @@ class TestGenerateConnectionManager:
         assert result == {"result": "success"}
 
     @patch("mindtrace.services.core.utils.httpx")
+    def test_generated_method_kwargs_uses_json_mode_dump(self, mock_httpx, mock_service_class):
+        """Validated kwargs should be serialized with model_dump(mode='json')."""
+        mock_service_class, mock_service, mock_endpoint1, _ = mock_service_class
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"result": "success"}
+        mock_httpx.post.return_value = mock_response
+
+        mock_input_instance = Mock()
+        mock_input_instance.model_dump.return_value = {"object_id": "json-safe-id"}
+        mock_input_schema = Mock(return_value=mock_input_instance)
+        mock_endpoint1.input_schema = mock_input_schema
+        mock_endpoint1.output_schema = None
+
+        ConnectionManagerClass = generate_connection_manager(mock_service_class)
+        manager = ConnectionManagerClass(url=parse_url("http://test.com"))
+
+        result = manager.test_endpoint(object_id="raw-id")
+
+        mock_input_schema.assert_called_once_with(object_id="raw-id")
+        mock_input_instance.model_dump.assert_called_once_with(mode="json")
+        mock_httpx.post.assert_called_once_with(
+            "http://test.com/test_endpoint", json={"object_id": "json-safe-id"}, timeout=60
+        )
+        assert result == {"result": "success"}
+
+    @patch("mindtrace.services.core.utils.httpx")
+    def test_generated_method_single_valid_arg_uses_json_mode_dump(self, mock_httpx, mock_service_class):
+        """Validated positional inputs should be serialized with model_dump(mode='json')."""
+
+        class TestInput(BaseModel):
+            value: str
+
+        mock_service_class, mock_service, mock_endpoint1, _ = mock_service_class
+        mock_endpoint1.input_schema = TestInput
+        mock_endpoint1.output_schema = None
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"result": "success"}
+        mock_httpx.post.return_value = mock_response
+
+        ConnectionManagerClass = generate_connection_manager(mock_service_class)
+        manager = ConnectionManagerClass(url=parse_url("http://test.com"))
+
+        with patch.object(TestInput, "model_dump", autospec=True, return_value={"value": "test"}) as mock_dump:
+            result = manager.test_endpoint(TestInput(value="test"))
+
+        mock_dump.assert_called_once_with(ANY, mode="json")
+        mock_httpx.post.assert_called_once_with("http://test.com/test_endpoint", json={"value": "test"}, timeout=60)
+        assert result == {"result": "success"}
+
+    @patch("mindtrace.services.core.utils.httpx")
     @pytest.mark.asyncio
     async def test_generated_async_method_single_valid_arg(self, mock_httpx, mock_service_class):
         """Test that async method works with a single valid arg."""
-        from pydantic import BaseModel
 
         class TestInput(BaseModel):
             value: str
@@ -745,6 +798,66 @@ class TestGenerateConnectionManager:
         result = await manager.atest_endpoint(TestInput(value="test"))
 
         # Should call async client with dumped payload
+        mock_client.post.assert_called_once_with("http://test.com/test_endpoint", json={"value": "test"}, timeout=60)
+        assert result == {"result": "async_success"}
+
+    @patch("mindtrace.services.core.utils.httpx")
+    @pytest.mark.asyncio
+    async def test_generated_async_method_kwargs_uses_json_mode_dump(self, mock_httpx, mock_service_class):
+        """Async validated kwargs should be serialized with model_dump(mode='json')."""
+        mock_service_class, mock_service, mock_endpoint1, _ = mock_service_class
+
+        mock_client = AsyncMock()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"result": "async_success"}
+        mock_client.post.return_value = mock_response
+        mock_httpx.AsyncClient.return_value.__aenter__.return_value = mock_client
+
+        mock_input_instance = Mock()
+        mock_input_instance.model_dump.return_value = {"object_id": "json-safe-id"}
+        mock_input_schema = Mock(return_value=mock_input_instance)
+        mock_endpoint1.input_schema = mock_input_schema
+        mock_endpoint1.output_schema = None
+
+        ConnectionManagerClass = generate_connection_manager(mock_service_class)
+        manager = ConnectionManagerClass(url=parse_url("http://test.com"))
+
+        result = await manager.atest_endpoint(object_id="raw-id")
+
+        mock_input_schema.assert_called_once_with(object_id="raw-id")
+        mock_input_instance.model_dump.assert_called_once_with(mode="json")
+        mock_client.post.assert_called_once_with(
+            "http://test.com/test_endpoint", json={"object_id": "json-safe-id"}, timeout=60
+        )
+        assert result == {"result": "async_success"}
+
+    @patch("mindtrace.services.core.utils.httpx")
+    @pytest.mark.asyncio
+    async def test_generated_async_method_single_valid_arg_uses_json_mode_dump(self, mock_httpx, mock_service_class):
+        """Async validated positional inputs should be serialized with model_dump(mode='json')."""
+
+        class TestInput(BaseModel):
+            value: str
+
+        mock_service_class, mock_service, mock_endpoint1, _ = mock_service_class
+        mock_endpoint1.input_schema = TestInput
+        mock_endpoint1.output_schema = None
+
+        mock_client = AsyncMock()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"result": "async_success"}
+        mock_client.post.return_value = mock_response
+        mock_httpx.AsyncClient.return_value.__aenter__.return_value = mock_client
+
+        ConnectionManagerClass = generate_connection_manager(mock_service_class)
+        manager = ConnectionManagerClass(url=parse_url("http://test.com"))
+
+        with patch.object(TestInput, "model_dump", autospec=True, return_value={"value": "test"}) as mock_dump:
+            result = await manager.atest_endpoint(TestInput(value="test"))
+
+        mock_dump.assert_called_once_with(ANY, mode="json")
         mock_client.post.assert_called_once_with("http://test.com/test_endpoint", json={"value": "test"}, timeout=60)
         assert result == {"result": "async_success"}
 


### PR DESCRIPTION
## Summary
- serialize validated generated-client request payloads with `model_dump(mode="json")`
- add regression tests covering sync/async and kwargs/positional validated input paths
- fixes object-id style payload serialization before `httpx.post(..., json=payload)`

## Testing
- Not run here (per instruction: do not sync repo or run code in this environment)

Closes #450