### PR TITLE
tests: parallelize unit tests with pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     "twine>=6.1.0",
     "tomlkit>=0.13.3",
     "setuptools>=82.0.0",
+    "pytest-xdist>=3.8.0",
 ]
 docs = [
     "mkdocs-material>=9.6.21",

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -155,11 +155,12 @@ OVERALL_EXIT_CODE=0
 
 # Run unit tests if requested
 if [ "$RUN_UNIT" = true ]; then
+    UNIT_PYTEST_ARGS=(-n auto)
     echo "Running unit tests..."
     for module in "${MODULES[@]}"; do
         echo "Running unit tests for $module..."
         if [ -d "tests/unit/mindtrace/$module" ]; then
-            run_pytest_with_coverage -rs -W ignore::DeprecationWarning "${PYTEST_ARGS[@]}" tests/unit/mindtrace/$module
+            run_pytest_with_coverage "${UNIT_PYTEST_ARGS[@]}" -rs -W ignore::DeprecationWarning "${PYTEST_ARGS[@]}" tests/unit/mindtrace/$module
             if [ $? -ne 0 ]; then
                 echo "Unit tests for $module failed. Stopping test execution."
                 OVERALL_EXIT_CODE=1
@@ -169,7 +170,7 @@ if [ "$RUN_UNIT" = true ]; then
         fi
     done
     if [ ${#MODULES[@]} -eq 0 ]; then
-        run_pytest_with_coverage -rs -W ignore::DeprecationWarning "${PYTEST_ARGS[@]}" tests/unit/mindtrace
+        run_pytest_with_coverage "${UNIT_PYTEST_ARGS[@]}" -rs -W ignore::DeprecationWarning "${PYTEST_ARGS[@]}" tests/unit/mindtrace
         if [ $? -ne 0 ]; then
             echo "Unit tests failed. Stopping test execution."
             OVERALL_EXIT_CODE=1


### PR DESCRIPTION
#### Changes:
- Pass `-n auto` to unit-test pytest runs via `UNIT_PYTEST_ARGS` in `scripts/run_tests.sh`
- Scoped to `--unit` only; integration/utils/stress runs unchanged
- User args still win (e.g. `ds test: --unit -n 0`)

#### Testing:
`ds test --unit` / `ds test: --unit` / `ds test: [module] --unit` should run in parallel across available cores.

#### Timings (on CI with 2 workers)
Before:
```
6636 passed, 8 skipped, 1 warning in 470.41s (0:07:50)
```
After:
```
6636 passed, 8 skipped, 2 warnings in 282.78s (0:04:42)
```
Should be ~40s with 16 workers on workstations.