### PR TITLE
docs: restore README improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ architecture where dependency direction matters.
 
 ### Modules (non-exhaustive)
 
-`apps`, `automation`, `cluster`, `core`, `database`, `datalake`,
+`apps`, `agents`, `automation`, `cluster`, `core`, `database`, `datalake`,
 `hardware`, `jobs`, `models`, `registry`, `services`, `storage`, `ui`
 
 ### Dependency Boundaries (Critical)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,153 +1,180 @@
-## Contributing to Mindtrace
+# Contributing to Mindtrace
 
-Thank you for your interest in contributing to Mindtrace!  
-This guide will help you get started with contributing to the project.  
+Thanks for your interest in contributing to Mindtrace!
 
-The Mindtrace project is organized into the following modules:  
-`apps`, `automation`, `cluster`, `core`, `database`, `datalake`, `hardware`, `jobs`, `models`, `registry`, `services`, `storage`, `ui`  
-When contributing, ensure your changes respect the modular architecture and dependency boundaries.  
+Mindtrace is a modular project, so contributions should respect module boundaries and dependency direction. The main modules include:
 
+`apps`, `agents`, `automation`, `cluster`, `core`, `database`, `datalake`, `hardware`, `jobs`, `models`, `registry`, `services`, `storage`, and `ui`.
 
-### Prerequisites
+## Before You Start
+
+You will need:
 
 - Python 3.12+
 - Git
 - [uv](https://docs.astral.sh/uv/)
-- Docker with Compose - For integration tests (both `docker-compose` v1 and `docker compose` v2 are supported)
+- Docker (recommended for integration tests and backend services)
 
+## Setup
 
-### Setup
+### 1. Fork and clone
 
-1. **Fork the repository:**
-   - [Fork your copy of the mindtrace repo](https://github.com/Mindtrace/mindtrace/fork)
-   - Clone your fork locally:
-   ```bash
-   git clone https://github.com/YOUR_USERNAME/mindtrace.git
-   cd mindtrace/
-   ```
+Fork the repository, then clone your fork locally:
 
-2. **Install dependencies:**
-   ```bash
-   uv sync --dev
-   uv tool install ds-run
-   uv tool install ruff
-   ```
+```bash
+git clone https://github.com/YOUR_USERNAME/mindtrace.git && cd mindtrace
+```
 
-3. **Verify your setup:**
-   ```bash
-   ds test --unit
-   ```
+### 2. Install dependencies
 
+```bash
+uv sync --dev --all-extras
+uv tool install ds-run
+uv tool install ruff
+```
 
-### Development Workflow
+### 3. Verify your environment
 
-#### 1. Create a Branch
+```bash
+ds test --unit
+```
 
-Create a new branch from `dev` with a descriptive name:
+## Development Workflow
+
+### 1. Create a branch from `dev`
 
 ```bash
 git checkout dev
 git pull origin dev
 git checkout -b feature/short-description
-# or
-git checkout -b fix/issue-description
-# or
-git checkout -b docs/update-description
 ```
 
-#### 2. Make Changes
+Use a descriptive branch name, for example:
 
-- **Focus on small, atomic changes** - Keep your PRs focused and manageable
-- **Write clear, descriptive code** with proper naming conventions
-- **Add docstrings** for new functions and classes using [Google-style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
-- **Use type hints** for better code clarity and IDE support
-- **Add unit tests** for new functionality (`tests/unit/mindtrace/[module]`)
-- **Add integration tests** where applicable (`tests/integration/mindtrace/[module]`)
-- **Add or update any relevant README files** to include descriptions of important functionality and modules. Link to sub-module READMEs for covering more detail where necessary.
-- **Add or update any relevant samples** in `samples/[module]/` providing simple, clear, self-contained example usage code that just works
+- `feature/add-service-endpoint`
+- `fix/redis-timeout-handling`
+- `docs/update-registry-readme`
 
-#### 3. Code Quality
+### 2. Make focused changes
 
-Before committing, ensure your code meets quality standards:
+Prefer small, atomic pull requests.
+
+As you work:
+
+- keep changes scoped to a clear purpose
+- use clear names and type hints
+- follow [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
+- add docstrings for new public functions and classes using Google-style Python docstrings
+- update relevant tests
+- update relevant README files when behavior or public interfaces change
+- add or update samples in `samples/[module]/` when new functionality needs example usage
+
+For documentation work specifically:
+
+- keep top-level READMEs as practical guides, not full API references
+- use module READMEs for deeper walkthroughs
+- prefer human-readable example links over raw file paths when possible
+- keep examples and prose aligned with [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) where applicable
+
+## Code Quality
+
+Run linting and formatting before you commit:
 
 ```bash
-# Check for linting issues
 ruff check
-
-# Check formatting
 ruff format --check
+```
 
-# Apply auto-fixes for linting and formatting
+To auto-fix where possible:
+
+```bash
 ruff check --fix
 ruff format
 ```
 
-#### 4. Testing
+## Testing
 
-Run the standard test suite and ensure that tests pass locally before submitting your PR.  
+Run the test suite relevant to your change.
+
+### Fast local loop
+
+```bash
+ds test --unit
+```
+
+### Full local test run
+
 ```bash
 ds test
 ```
-Ensure that code coverage does not regress.  
-For more details on running tests, including running smaller test sets for iterative development, see [TESTING.md](./TESTING.md)
 
-#### 5. Commit Changes
+### Module-specific test runs
 
-Make small, focused commits with clear messages:
+Examples:
 
 ```bash
-git add .
-git commit -m "feat: add new feature description"
-# or
-git commit -m "fix: resolve issue with specific component"
-# or
-git commit -m "docs: update API documentation"
+ds test: services
+ds test: --unit services
+
+ds test: registry
+ds test: --unit registry
 ```
 
-#### 6. Push and Create Pull Request
+For more detail, see [TESTING.md](./TESTING.md).
+
+## Commits
+
+Use small, focused commits with clear messages.
+
+Examples:
 
 ```bash
-git push origin your-branch-name
+git commit -m "feat: add Redis queue priority support"
+git commit -m "fix: handle missing registry metadata"
+git commit -m "docs: rewrite services README"
 ```
 
-Then create a pull request to the `dev` branch on the main repo: [https://github.com/Mindtrace/mindtrace](https://github.com/Mindtrace/mindtrace).
+## Pull Requests
 
+Open pull requests against the `dev` branch.
 
-### Pull Request Guidelines
+Your PR should include:
 
-#### PR Title and Description
+- a clear title
+- a short explanation of the problem or goal
+- a summary of what changed
+- testing notes explaining how you verified the change
+- links to any relevant issues, PRs, or discussions
 
-Your pull request should include:
+### PR checklist
 
-- **Clear, descriptive title** that summarizes the change
-- **Detailed description** covering:
-  - **Scope and motivation** - What problem does this solve?
-  - **Changes included** - What was modified, added, or removed?
-  - **How to test** - Specific steps to verify the changes work
-  - **Impact** - Any breaking changes, potential concerns, or side effects
+Before opening a PR, make sure:
 
+- [ ] the PR targets `dev`
+- [ ] tests pass locally for the affected scope
+- [ ] `ruff check` passes
+- [ ] formatting is clean
+- [ ] documentation is updated where needed
+- [ ] samples are updated where needed
+- [ ] commit messages are clear and useful
 
-#### Requirements Checklist
+## Review Process
 
-- [x] All tests pass (`ds test`)
-- [x] Code is properly formatted (`ruff format --check`)
-- [x] No linting issues (`ruff check`)
-- [x] PR targets the `dev` branch
-- [x] Tests added for new functionality
-- [x] No regression in test coverage
-- [x] Documentation and READMEs updated as needed
-- [x] Useful commit messages
-- [x] Links to relevant issues/PRs/discussions, if any
-- [x] Samples working as expected
+Typical review flow:
 
+1. automated checks run
+2. maintainers review the change
+3. follow-up fixes or clarifications are requested if needed
+4. once approved, the PR is merged into `dev`
 
-### Code Review Process
+## Contribution Tips
 
-1. **Automated Checks** - All PRs run automated tests, linting, and formatting checks. Please ensure they pass
-2. **Review** - Maintainers will review your code and may request clarifications and/or changes
-3. **Merge** - Once approved, your PR will be merged to `dev` and included in the next release cycle
+A few things that help a lot:
 
+- prefer clear examples over clever abstractions
+- keep public APIs typed and documented
+- when changing a module README, make sure the examples match the actual current code
+- if there are real sample files in `samples/`, link to them from the relevant README
+- if there are no real external examples, do not add a self-referential “Examples” section
 
----
-
-Thank you for contributing to Mindtrace and helping to improve it! 🎉
+Thanks for helping improve Mindtrace.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,33 @@
-[![PyPI version](https://img.shields.io/pypi/v/mindtrace)](https://pypi.org/project/mindtrace/)
-[![License](https://img.shields.io/pypi/l/mindtrace)](https://github.com/mindtrace/mindtrace/blob/main/LICENSE)
-[![Downloads](https://static.pepy.tech/badge/mindtrace)](https://pepy.tech/projects/mindtrace)
+<p align="center">
+  <img alt="Mindtrace" src="docs/assets/mindtrace-logo-horizontal.png" width="75%">
+</p>
 
-# Mindtrace
+<p align="center">
+  <a href="https://pypi.org/project/mindtrace/"><img alt="PyPI version" src="https://img.shields.io/pypi/v/mindtrace"></a>
+  <a href="https://github.com/mindtrace/mindtrace/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/pypi/l/mindtrace"></a>
+  <a href="https://pepy.tech/projects/mindtrace"><img alt="Downloads" src="https://static.pepy.tech/badge/mindtrace"></a>
+</p>
 
-A modular Python framework for building ML infrastructure: microservices, artifact registries, job orchestration, hardware integrations, and more.
+<br />
 
-📖 [Docs](https://mindtrace.github.io/mindtrace/) · 💡 [Samples](samples/) · 🤝 [Contributing](CONTRIBUTING.md)
+<h1 align="center">An Open Source Framework for AI Orchestration</h1>
 
-## 📦 Installation
+<p align="center">Mindtrace is an open source Python framework for building, deploying, and operating end-to-end AI systems in production.</p>
+
+<p align="center"><a href="https://mindtrace.github.io/mindtrace/">Docs</a> · <a href="samples/">Samples</a> · <a href="CONTRIBUTING.md">Contributing</a></p>
+
+## Features
+
+- **Composable by design** — use one package or the whole stack, depending on what you need
+- **Typed service framework** — build APIs with generated Python clients and built-in MCP support
+- **Versioned artifact registry** — store models, datasets, configs, and outputs with reproducible versioning across local and cloud backends
+- **Unified data backends** — work with MongoDB, Redis, or Registry-backed persistence through one consistent ODM
+- **Queue-backed execution** — run typed background jobs locally or on Redis/RabbitMQ without changing your application model
+- **Cluster orchestration** — add worker, node, and resource management for distributed compute workloads
+- **Agent runtime** — build tool-using LLM agents with memory, callbacks, streaming, and MCP toolsets
+- **Hardware integration** — connect cameras, scanners, PLCs, and sensors to the same service and orchestration stack
+
+## Installation
 
 ```bash
 pip install mindtrace
@@ -19,142 +38,363 @@ uv add mindtrace
 Or install only what you need:
 
 ```bash
-pip install mindtrace-services  # Microservices
-pip install mindtrace-registry  # Artifact storage
-pip install mindtrace-cluster   # Distributed workers
+pip install mindtrace-services   # Typed microservices
+pip install mindtrace-registry   # Versioned artifact storage
+pip install mindtrace-storage    # Object storage backends
+pip install mindtrace-database   # ODM layer for MongoDB / Redis / Registry
+pip install mindtrace-jobs       # Typed job queues
+pip install mindtrace-cluster    # Distributed workers and routing
+pip install mindtrace-agents     # LLM agents with tools and memory
+pip install mindtrace-hardware   # Cameras, scanners, PLCs, sensors
 ```
 
-## 🚀 Getting Started
+## Quick Tour
 
-### Config & Logging
+The Mindtrace ecosystem is designed so that you can start small and compose modules as your system grows.
+
+### Core
+
+`mindtrace-core` gives you the shared building blocks used across the rest of the framework: configuration, logging, base classes, observables, and typed task schemas.
 
 ```python
 from mindtrace.core import Mindtrace
 
+
 class MyProcessor(Mindtrace):
     def run(self):
-        # self.config and self.logger are provided automatically
-        self.logger.error(f"Cache dir: {self.config.MINDTRACE_DIR_PATHS.ROOT}")
+        self.logger.info(f"Temp dir: {self.config.MINDTRACE_DIR_PATHS.TEMP_DIR}")
 
-processor = MyProcessor()
-processor.run()
-# [2026-01-08 10:39:42] ERROR: MyProcessor: Cache dir: ~/.cache/mindtrace
+
+with MyProcessor() as processor:
+    processor.run()
 ```
 
-### Deploy a Microservice
+### Services
+
+`mindtrace-services` lets you define typed endpoints once and get a service plus a generated client.
 
 ```python
-from mindtrace.services.samples.echo_service import EchoService
-
-# Launch service and get auto-generated client
-client = EchoService.launch(port=8080)
-
-result = client.echo(message="Hello, world!")
-print(result.echoed)  # "Hello, world!"
-
-client.shutdown()
-```
-
-Define your own service (must be in an importable module):
-
-```python
-# mypackage/predictor.py
 from pydantic import BaseModel
-from mindtrace.services import Service
+
 from mindtrace.core import TaskSchema
+from mindtrace.services import Service
 
-class PredictInput(BaseModel):
-    text: str
 
-class PredictOutput(BaseModel):
-    label: str
-    confidence: float
+class EchoInput(BaseModel):
+    message: str
 
-predict_schema = TaskSchema(
-    name="predict",
-    input_schema=PredictInput,
-    output_schema=PredictOutput,
+
+class EchoOutput(BaseModel):
+    echoed: str
+
+
+echo_schema = TaskSchema(
+    name="echo",
+    input_schema=EchoInput,
+    output_schema=EchoOutput,
 )
 
-class PredictorService(Service):
+
+class EchoService(Service):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.add_endpoint("predict", self.predict, schema=predict_schema)
+        self.add_endpoint("echo", self.echo, schema=echo_schema)
 
-    def predict(self, payload: PredictInput) -> PredictOutput:
-        return PredictOutput(label="positive", confidence=0.95)
+    def echo(self, payload: EchoInput) -> EchoOutput:
+        return EchoOutput(echoed=payload.message)
+
+
+cm = EchoService.launch(host="localhost", port=8080, wait_for_launch=True)
+print(cm.echo(message="Hello, world!").echoed)
+cm.shutdown()
 ```
 
-### Save & Load Artifacts
+While the service is running, you can inspect the generated API docs at `http://localhost:8080/docs`.
+
+### Registry
+
+`mindtrace-registry` is the versioned artifact layer and supports local, S3-compatible, and GCS-backed registries.
 
 ```python
-from mindtrace.registry import Registry
 import numpy as np
 
-registry = Registry()
+from mindtrace.registry import Registry
 
-# Save anything: arrays, datasets, configs, dicts
+
 embeddings = np.random.rand(100, 768).astype(np.float32)
-registry.save("data:embeddings:v1", embeddings)
 
-# Load it back (with automatic versioning)
-loaded = registry.load("data:embeddings:v1")
-print(f"Loaded: {loaded.shape}, {loaded.dtype}")
-# Loaded: (100, 768), float32
+registry = Registry()  # Defaults to the local registry at ~/.cache/mindtrace/registry
+registry.save("data:embeddings", embeddings)
+loaded = registry.load("data:embeddings")
+print(loaded.shape)
 ```
 
-### Reactive State with Observables
+You can also link the same `Registry` to a remote S3-compatible (AWS/Minio) or GCS backend.
 
 ```python
-from mindtrace.core import ObservableContext
+from mindtrace.registry import Registry, S3RegistryBackend
 
-@ObservableContext(vars=["status", "progress"])
-class Pipeline:
-    def __init__(self):
-        self.status = "idle"
-        self.progress = 0
 
-def on_change(source, var, old, new):
-    print(f"{var}: {old} → {new}")
+s3_backend = S3RegistryBackend(
+    endpoint="localhost:9000",
+    access_key="minioadmin",
+    secret_key="minioadmin",
+    bucket="mindtrace-registry",
+    secure=False,
+)
+registry = Registry(s3_backend)
 
-pipeline = Pipeline()
-pipeline.subscribe(on_change, "context_updated")
-
-pipeline.status = "running"   # prints: status: idle → running
-pipeline.progress = 50        # prints: progress: 0 → 50
+registry["data:embeddings"] = embeddings  # Registry also supports a convenient dict-like API
+loaded = registry["data:embeddings"]
 ```
 
-## 📚 Modules
+For multi-registry workflows, use `Store` to mount several registries behind one interface.
+
+```python
+from mindtrace.registry import Registry, Store
+
+
+store = Store()
+store.add_mount("local", Registry("~/.cache/mindtrace/temp/my_local_registry"))
+store.add_mount("remote", Registry(s3_backend))
+store.set_default_mount("local")
+
+store["data:embeddings"] = embeddings  # Saves to the default mount
+store["remote/data:embeddings"] = embeddings  # Qualify with mount name to target another mount
+
+local_embeddings = store["local/data:embeddings"]
+remote_embeddings = store["remote/data:embeddings"]
+```
+
+### Database
+
+`mindtrace-database` provides a unified ODM layer over MongoDB, Redis, and Registry-backed storage.
+
+```python
+from pydantic import Field
+
+from mindtrace.database import BackendType, UnifiedMindtraceDocument, UnifiedMindtraceODM
+
+
+class User(UnifiedMindtraceDocument):
+    name: str = Field(description="User name")
+    email: str = Field(description="Email")
+
+    class Meta:
+        collection_name = "users"
+        global_key_prefix = "myapp"
+        indexed_fields = ["email"]
+        unique_fields = ["email"]
+
+
+db = UnifiedMindtraceODM(
+    unified_model_cls=User,
+    mongo_db_uri="mongodb://localhost:27017",
+    mongo_db_name="myapp",
+    redis_url="redis://localhost:6379",
+    preferred_backend=BackendType.MONGO,
+)
+
+inserted = db.insert(User(name="Alice", email="alice@example.com"))
+fetched = db.get(inserted.id)
+print(fetched)
+```
+
+### Jobs
+
+`mindtrace-jobs` gives you a unified job manager/orchestrator for typed jobs, with swappable local, Redis, and RabbitMQ backends.
+
+```python
+from pydantic import BaseModel
+
+from mindtrace.jobs import Consumer, JobSchema, LocalClient, Orchestrator
+
+
+class EchoInput(BaseModel):
+    message: str
+
+
+echo_schema = JobSchema(name="echo_job", input_schema=EchoInput)
+orchestrator = Orchestrator(LocalClient())
+orchestrator.register(echo_schema)
+
+
+class EchoConsumer(Consumer):
+    def run(self, job_dict: dict) -> dict:
+        return {"echoed": job_dict["payload"]["message"]}
+
+
+consumer = EchoConsumer()
+consumer.connect_to_orchestrator(orchestrator, "echo_job")
+
+orchestrator.publish("echo_job", EchoInput(message="Hello jobs"))
+consumer.consume(num_messages=1)
+```
+
+### Cluster
+
+`mindtrace-cluster` builds on `mindtrace-jobs` to add worker, compute-node, and resource management for queued jobs across services and machines.
+
+```python
+from mindtrace.cluster import ClusterManager, Node
+
+
+cluster = ClusterManager.launch(host="localhost", port=8002, wait_for_launch=True)
+node = Node.launch(host="localhost", port=8003, cluster_url=str(cluster.url), wait_for_launch=True)
+print(cluster.status())
+print(node.status())
+```
+
+### Hardware
+
+`mindtrace-hardware` provides interfaces and service tooling for cameras, scanners, PLCs, and sensors.
+
+```python
+from mindtrace.hardware.cameras import Camera
+
+
+camera = Camera(name="Basler:basler_camera_0")
+image = camera.capture()
+print(type(image))
+camera.close()
+```
+
+### Agents
+
+`mindtrace-agents` provides agents with tools, memory, callbacks, and MCP toolsets.
+
+```python
+from mindtrace.agents import MindtraceAgent, OpenAIChatModel, OpenAIProvider
+
+
+provider = OpenAIProvider()
+model = OpenAIChatModel("gpt-4o-mini", provider=provider)
+agent = MindtraceAgent(model=model, name="assistant")
+
+result = agent.run_sync("What is 2 + 2?")
+print(result)
+```
+
+## Modules
 
 | Module | Description |
 |--------|-------------|
-| [`core`](mindtrace/core) | Config, logging, observables, base classes |
-| [`services`](mindtrace/services) | Microservice framework with auto-generated clients |
-| [`registry`](mindtrace/registry) | Versioned artifact storage (models, datasets, configs) |
-| [`database`](mindtrace/database) | Redis & MongoDB ODM with async support |
-| [`cluster`](mindtrace/cluster) | Distributed worker orchestration |
-| [`jobs`](mindtrace/jobs) | Job schemas and execution backends |
-| [`hardware`](mindtrace/hardware) | Camera, PLC, and sensor integrations |
-| [`datalake`](mindtrace/datalake) | Query and manage datasets, models, labels, and datums |
-| [`models`](mindtrace/models) | Model definitions, inference, and leaderboards |
-| [`storage`](mindtrace/storage) | Cloud storage interfaces (GCS, S3) |
-| [`automation`](mindtrace/automation) | Pipeline orchestration and Label Studio integration |
-| [`ui`](mindtrace/ui) | UI components and visualization |
+| [`core`](mindtrace/core) | Foundational abstractions for config, logging, observables, and typed schemas |
+| [`services`](mindtrace/services) | Typed service framework with generated clients, launch helpers, and MCP support |
+| [`registry`](mindtrace/registry) | Versioned artifact registry with local and remote backends |
+| [`storage`](mindtrace/storage) | Lower-level object storage backends for GCS and S3-compatible services |
+| [`database`](mindtrace/database) | Unified ODM layer for MongoDB, Redis, and Registry-backed persistence |
+| [`jobs`](mindtrace/jobs) | Unified job manager/orchestrator for typed jobs across multiple queue backends |
+| [`cluster`](mindtrace/cluster) | Worker, node, and cluster resource management on top of queued jobs |
+| [`agents`](mindtrace/agents) | LLM agents with tools, memory, callbacks, streaming, and MCP integration |
+| [`hardware`](mindtrace/hardware) | Hardware interfaces and service tooling for cameras, scanners, PLCs, and sensors |
+| [`datalake`](mindtrace/datalake) | Dataset, model, label, and datum management |
+| [`models`](mindtrace/models) | Model definitions, inference workflows, and related evaluation utilities |
+| [`automation`](mindtrace/automation) | Pipeline orchestration and workflow integrations |
+| [`ui`](mindtrace/ui) | UI components and visualization tools |
 | [`apps`](mindtrace/apps) | End-user applications and demos |
 
-## 🏗️ Layered Architecture
+## Module Dependencies
 
-Modules are organized into levels based on dependency direction. Each layer only depends on modules in lower levels.
+<details>
+<summary>Show module dependency diagram</summary>
 
-| Level | Modules |
-|-------|---------|
-| **1. Foundation** | `core` |
-| **2. Core Consumers** | `jobs`, `registry`, `database`, `services`, `storage`, `ui` |
-| **3. Infrastructure** | `hardware`, `cluster`, `datalake`, `models` |
-| **4. Automation** | `automation` |
-| **5. Applications** | `apps` |
+```mermaid
+%%{init: {'flowchart': {'curve': 'stepAfter'}}}%%
+flowchart TB
+    subgraph L1[Foundation]
+        core[core]
+    end
 
-## 📖 Documentation
+    subgraph L2[Core infrastructure]
+        services[services]
+        registry[registry]
+        storage[storage]
+        database[database]
+        jobs[jobs]
+    end
+
+    subgraph L3[Higher-level systems]
+        cluster[cluster]
+        agents[agents]
+        hardware[hardware]
+        datalake[datalake]
+        models[models]
+    end
+
+    subgraph L4[Orchestration and apps]
+        automation[automation]
+        ui[ui]
+        apps[apps]
+    end
+
+    core --> services
+    core --> registry
+    core --> storage
+    core --> database
+    core --> jobs
+
+    storage --> registry
+    registry --> database
+
+    services --> cluster
+    jobs --> cluster
+    registry --> cluster
+    database --> cluster
+
+    core --> agents
+    services --> agents
+    database --> agents
+
+    core --> hardware
+    services --> hardware
+    database --> hardware
+    registry --> hardware
+
+    core --> datalake
+    registry --> datalake
+    database --> datalake
+    services --> datalake
+
+    core --> models
+    registry --> models
+    database --> models
+    services --> models
+
+    cluster --> automation
+    services --> automation
+    agents --> automation
+    datalake --> automation
+    models --> automation
+
+    core --> ui
+    services --> ui
+
+    automation --> apps
+    ui --> apps
+    services --> apps
+    agents --> apps
+```
+
+</details>
+
+## Choose the Right Module
+
+If you are not sure where to start:
+
+- **Need config, logging, base utilities, or typed schemas?** → [`core`](mindtrace/core)
+- **Need a deployable API or MCP-capable service?** → [`services`](mindtrace/services)
+- **Need versioned artifact storage?** → [`registry`](mindtrace/registry)
+- **Need a document/database abstraction?** → [`database`](mindtrace/database)
+- **Need queue-backed background jobs?** → [`jobs`](mindtrace/jobs)
+- **Need distributed workers across machines?** → [`cluster`](mindtrace/cluster)
+- **Need LLM agents with tools and memory?** → [`agents`](mindtrace/agents)
+- **Need industrial hardware/device integration?** → [`hardware`](mindtrace/hardware)
+- **Need data/model/label management?** → [`datalake`](mindtrace/datalake)
+
+Mindtrace is intentionally layered so higher-level modules build on lower-level ones rather than duplicating shared concerns. You do not need to adopt every module at once; most projects start with just one or two and grow from there.
+
+## Documentation
 
 - [Full Documentation](https://mindtrace.github.io/mindtrace/)
 - [Samples](samples/)

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,71 +1,209 @@
-## Testing Guide
+# Testing Guide
 
-Quick reference for running tests for the [mindtrace](https://github.com/Mindtrace/mindtrace) repo with `ds` commands.
+This guide covers the standard way to run tests in the [mindtrace](https://github.com/Mindtrace/mindtrace) repo using `ds`.
 
-### Requirements
+## Requirements
+
+You will need:
 
 - Python 3.12+
-- git
+- Git
 - [uv](https://docs.astral.sh/uv/)
-- ds-run
-- Docker with Compose (both `docker-compose` v1 and `docker compose` v2 are supported)
+- `ds-run`
+- Docker (recommended for integration tests and backend services)
 
-### Setup
+## Setup
 
 ```bash
-git clone https://github.com/Mindtrace/mindtrace.git
-cd mindtrace/
-uv sync --dev
+git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+uv sync --dev --all-extras
 uv tool install ds-run
 ```
 
-### Basic Commands
+Run test commands from the repository root.
 
-All tests are run from the project's root.
+## Common Commands
+
+### Standard test suite
+
 ```bash
-# Run the standard test suite (unit + integration)
 ds test
+```
 
-# Run only unit tests
+This runs the standard suite, which typically means unit + integration tests.
+
+### Unit tests only
+
+```bash
 ds test --unit
+```
 
-# Run only integration tests
+### Integration tests only
+
+```bash
 ds test --integration
+```
 
-# Run only stress tests
+### Stress tests only
+
+```bash
 ds test --stress
+```
 
-# Run both unit and integration tests. Same as `ds test`
+### Explicit unit + integration
+
+```bash
 ds test --unit --integration
 ```
 
-Note: Integration tests automatically spin up required containers from [tests/docker-compose.yml](./tests/docker-compose.yml) (includes MinIO, Redis, RabbitMQ, and MongoDB).
+This is equivalent to the standard `ds test` flow.
 
-### Specifying modules, directories and files
+## Module-Specific Test Runs
 
-During development and/or debugging, it is often useful to run a limited set of tests repeatedly.  
-For specifying one or more test paths or modules, use `ds test: paths` (note the colon `:` after `test`)
+For day-to-day development, it is usually faster to test only the module you are working on.
+
+Use `ds test:` (with a colon) when you want to target specific modules, directories, or files.
+
+### Module examples
 
 ```bash
-# Specific test files/directories
-ds test: tests/unit/mindtrace/core/test_logger.py
-ds test: tests/unit
-
-# Module names (unit + integration by default)
 ds test: core
-ds test: services jobs
-
-# Modules with flags
-ds test: core --unit
-ds test: services jobs --integration
+ds test: services
+ds test: registry
 ```
 
-### Available Modules
+### Module + scope examples
 
-`apps`, `automation`, `cluster`, `core`, `database`, `datalake`, `hardware`, `jobs`, `models`, `registry`, `services`, `storage`, `ui`
+```bash
+ds test: core --unit
+ds test: services --unit
+ds test: jobs --integration
+```
 
+### Multiple modules
 
-### Coverage
+```bash
+ds test: services jobs
+ds test: database registry --unit
+```
 
-Detailed code coverage (per-file and overall) is reported after the tests have finished.  
-When running multiple test groups, e.g. unit + integration via `ds test`, reports are combined to provide a cumulative coverage.
+## Running Specific Test Paths
+
+You can also point directly at files or directories.
+
+```bash
+ds test: tests/unit/mindtrace/core/test_logger.py
+ds test: tests/unit
+ds test: tests/integration/mindtrace/services
+```
+
+You can also target specific tests within a file using the pytest `::` syntax:
+
+```bash
+ds test: tests/unit/mindtrace/core/test_logger.py::MyLoggerTestSuite
+ds test: tests/unit/mindtrace/core/test_logger.py::MyLoggerTestSuite::test_basic_logging
+```
+
+Any extra arguments are passed through to pytest. For example:
+
+```bash
+ds test: tests/unit/mindtrace/core/test_logger.py --durations=20
+```
+
+This is especially useful when iterating on a single failing test or a small test group.
+
+## Available Test Scopes
+
+Mindtrace currently has these main scopes:
+
+- `unit`
+- `integration`
+- `stress`
+
+And the main modules include:
+
+`apps`, `automation`, `cluster`, `core`, `database`, `datalake`, `hardware`, `jobs`, `models`, `registry`, `services`, `storage`, and `ui`.
+
+## Integration Test Infrastructure
+
+Integration tests may start supporting services automatically using Docker Compose.
+
+Relevant files include:
+
+- [`tests/docker-compose.yml`](./tests/docker-compose.yml)
+- [`tests/docker-compose-standard-ports.yml`](./tests/docker-compose-standard-ports.yml)
+
+These integration environments include services such as:
+
+- MinIO
+- Redis
+- RabbitMQ
+- MongoDB
+
+If integration tests fail unexpectedly, make sure Docker is available and healthy.
+
+## Recommended Local Workflow
+
+A good default workflow is:
+
+```bash
+# Fast iteration while coding
+ds test: your-module --unit
+
+# Broader verification before opening a PR
+ds test: your-module
+
+# Full project verification when needed
+ds test
+```
+
+For example:
+
+```bash
+ds test: services --unit
+ds test: services
+ds test
+```
+
+## Coverage
+
+Coverage is reported after test runs.
+
+When multiple test groups are run together, coverage is combined so you can see cumulative results across the selected scopes.
+
+As a general rule:
+
+- do not let coverage regress for the area you changed
+- add tests for new behavior
+- prefer focused unit tests first, then add integration coverage where it matters
+
+## Troubleshooting
+
+### `ds` command not found
+
+Install `ds-run`:
+
+```bash
+uv tool install ds-run
+```
+
+### Dependency or environment issues
+
+Re-sync the environment:
+
+```bash
+uv sync --dev --all-extras
+```
+
+### Integration tests failing unexpectedly
+
+Check that Docker is running and that the required backend containers can start cleanly.
+
+### Need the fastest feedback loop
+
+Run a specific module or file instead of the full suite:
+
+```bash
+ds test: core --unit
+ds test: tests/unit/mindtrace/core/test_logger.py
+```

--- a/mindtrace/agents/README.md
+++ b/mindtrace/agents/README.md
@@ -1,43 +1,28 @@
-# mindtrace-agents
+[![PyPI version](https://img.shields.io/pypi/v/mindtrace-agents)](https://pypi.org/project/mindtrace-agents/)
+[![License](https://img.shields.io/pypi/l/mindtrace-agents)](https://github.com/mindtrace/mindtrace/blob/main/mindtrace/agents/LICENSE)
+[![Downloads](https://static.pepy.tech/badge/mindtrace-agents)](https://pepy.tech/projects/mindtrace-agents)
 
-Agent framework for the Mindtrace platform. Build LLM-powered agents with tool use, conversation history, lifecycle callbacks, and pluggable model providers — all integrated with Mindtrace logging and configuration.
+# Mindtrace Agents
 
-## Installation
+The `Agents` module provides Mindtrace’s framework for building LLM-powered agents with tool use, conversation history, memory, callbacks, streaming, and distributed execution.
 
-```bash
-uv add mindtrace-agents
-# or
-pip install mindtrace-agents
-```
+## Features
 
----
-
-## Core Concepts
-
-| Concept | Class | What it does |
-|---------|-------|-------------|
-| **Agent** | `MindtraceAgent` | Orchestrates model + tools, runs the conversation loop |
-| **Model** | `OpenAIChatModel` | Calls the LLM API (supports streaming) |
-| **Provider** | `OpenAIProvider` / `OllamaProvider` / `GeminiProvider` | Holds the authenticated client |
-| **Tool** | `Tool` | Wraps a Python function for LLM tool-calling |
-| **Toolset** | `FunctionToolset` / `CompoundToolset` / `MCPToolset` | Groups tools and controls which are exposed to the agent |
-| **ToolFilter** | `ToolFilter` | Predicate for selectively showing/hiding tools by name or description |
-| **Callbacks** | `AgentCallbacks` | Lifecycle hooks: before/after LLM call and tool call |
-| **History** | `AbstractHistoryStrategy` / `InMemoryHistory` | Persists conversation across runs |
-| **RunContext** | `RunContext[T]` | Injected into tools — carries deps, retry count, step |
-| **Memory** | `MemoryToolset` / `InMemoryStore` / `JsonFileStore` | Agent-controlled persistent memory exposed as tools |
-| **Task Queue** | `LocalTaskQueue` / `RabbitMQTaskQueue` | Distribute agent execution across processes or workers |
-| **DistributedAgent** | `DistributedAgent` | Transparent wrapper that routes `run()` through a task queue |
-
----
+- **Agent runtime** with `MindtraceAgent`
+- **Pluggable models and providers** for OpenAI, Ollama, and Gemini
+- **Tool calling** with Python functions, toolsets, and remote MCP tools
+- **Lifecycle control** with callbacks, streaming events, and step-by-step iteration
+- **State and persistence** with history backends and memory toolsets
+- **Multi-agent composition** with agents-as-tools and handoff markers
+- **Distributed execution** with local and RabbitMQ-backed task queues
 
 ## Quick Start
 
-### Basic agent with OpenAI
-
 ```python
 import asyncio
+
 from mindtrace.agents import MindtraceAgent, OpenAIChatModel, OpenAIProvider
+
 
 provider = OpenAIProvider()  # reads OPENAI_API_KEY from env
 model = OpenAIChatModel("gpt-4o-mini", provider=provider)
@@ -49,424 +34,380 @@ agent = MindtraceAgent(
 )
 
 result = asyncio.run(agent.run("What is 2 + 2?"))
-print(result)  # "4"
+print(result)
 ```
 
-### With Ollama (local)
+In practice, a `MindtraceAgent` coordinates four things:
+
+- a **model** that generates responses
+- a **provider** that talks to the backend API
+- optional **tools** or **toolsets** the model may call
+- optional **history**, **memory**, and **callbacks** around the run loop
+
+## MindtraceAgent
+
+`MindtraceAgent` is the central runtime in the package. It runs the conversation loop:
+
+1. build the message list
+2. call the model
+3. expose tools to the model when available
+4. execute tool calls and append results back into the conversation
+5. return the final output
+
+A minimal agent looks like this:
+
+```python
+from mindtrace.agents import MindtraceAgent, OpenAIChatModel, OpenAIProvider
+
+
+provider = OpenAIProvider()
+model = OpenAIChatModel("gpt-4o-mini", provider=provider)
+
+agent = MindtraceAgent(model=model, name="assistant")
+```
+
+## Models and Providers
+
+Models and providers are related, but they are not the same thing.
+
+- a **provider** holds the authenticated backend client or connection details
+- a **model** implements the request/response interface for a specific model family
+
+### OpenAI
+
+```python
+from mindtrace.agents import MindtraceAgent, OpenAIChatModel, OpenAIProvider
+
+
+provider = OpenAIProvider()
+model = OpenAIChatModel("gpt-4o-mini", provider=provider)
+agent = MindtraceAgent(model=model, name="openai_agent")
+```
+
+### Ollama
 
 ```python
 from mindtrace.agents import MindtraceAgent, OpenAIChatModel, OllamaProvider
+
 
 provider = OllamaProvider(base_url="http://localhost:11434/v1")
 model = OpenAIChatModel("llama3.2", provider=provider)
 agent = MindtraceAgent(model=model, name="local_agent")
 ```
 
-### With Gemini
+### Gemini
 
 ```python
 from mindtrace.agents import MindtraceAgent, OpenAIChatModel, GeminiProvider
 
-provider = GeminiProvider()  # reads GEMINI_API_KEY from env
+
+provider = GeminiProvider()
 model = OpenAIChatModel("gemini-2.0-flash", provider=provider)
 agent = MindtraceAgent(model=model, name="gemini_agent")
 ```
 
----
+## Tools and RunContext
 
-## Adding Tools
-
-Tools are Python functions (sync or async). Annotate parameters with types — these become the JSON schema shown to the model.
+Tools are Python functions that the model can call. Parameters and docstrings are used to build the schema and description exposed to the model.
 
 ```python
-from mindtrace.agents import MindtraceAgent, OpenAIChatModel, OpenAIProvider, Tool, RunContext
+import asyncio
+
+from mindtrace.agents import MindtraceAgent, OpenAIChatModel, OpenAIProvider, RunContext, Tool
+
 
 def get_weather(ctx: RunContext[None], city: str) -> str:
     """Get the current weather for a city."""
     return f"Weather in {city}: Sunny, 22°C"
 
-async def search_web(query: str, max_results: int = 5) -> list[str]:
-    """Search the web and return URLs."""
-    # ctx is optional — omit it for plain tools
-    return [f"https://example.com/result/{i}" for i in range(max_results)]
 
 provider = OpenAIProvider()
 model = OpenAIChatModel("gpt-4o-mini", provider=provider)
-
-agent = MindtraceAgent(
-    model=model,
-    tools=[Tool(get_weather), Tool(search_web)],
-    system_prompt="You have access to weather and search tools.",
-)
+agent = MindtraceAgent(model=model, tools=[Tool(get_weather)])
 
 result = asyncio.run(agent.run("What's the weather in Paris?"))
 ```
 
-### Tool with dependencies (typed deps)
+`RunContext` is injected into tools when needed. It can carry:
+
+- `deps` — your application dependencies
+- `step` — the current agent iteration
+- retry and tool-execution context
+
+### Tool dependencies
 
 ```python
 from dataclasses import dataclass
 
+from mindtrace.agents import RunContext
+
+
 @dataclass
 class AppDeps:
     db_url: str
-    api_key: str
+
 
 def lookup_user(ctx: RunContext[AppDeps], user_id: str) -> dict:
     """Look up a user by ID."""
-    # ctx.deps is your AppDeps instance
     return {"id": user_id, "db": ctx.deps.db_url}
-
-deps = AppDeps(db_url="postgresql://...", api_key="secret")
-result = asyncio.run(agent.run("Find user 123", deps=deps))
 ```
-
----
 
 ## Toolsets
 
-Toolsets are the primary way to supply tools to an agent. They group related tools together and give you control over which tools are visible to the model at runtime.
+Toolsets are the main way to organize and expose tools to an agent.
 
 ### FunctionToolset
 
-`FunctionToolset` collects Python `Tool` objects and exposes them to the agent. Use it when you want to organise tools manually or share a toolset across multiple agents.
+Use `FunctionToolset` for Python tools you want to manage directly.
 
 ```python
+from mindtrace.agents import MindtraceAgent, Tool
 from mindtrace.agents.toolsets import FunctionToolset
-from mindtrace.agents.tools import Tool
+
 
 def add(a: int, b: int) -> int:
     """Add two numbers."""
     return a + b
 
-async def fetch(url: str) -> str:
-    """Fetch a URL."""
-    ...
 
 toolset = FunctionToolset(max_retries=2)
 toolset.add_tool(Tool(add))
-toolset.add_tool(Tool(fetch))
 
 agent = MindtraceAgent(model=model, toolset=toolset)
 ```
 
-`max_retries` on the toolset is the default for every tool added to it. Override per-tool by setting `Tool(..., max_retries=N)` before calling `add_tool()`.
-
 ### CompoundToolset
 
-`CompoundToolset` merges tools from multiple toolsets into one. Later toolsets win on name collisions — use `prefix` on `MCPToolset` to avoid conflicts.
+Use `CompoundToolset` to merge multiple toolsets into one.
 
 ```python
-from mindtrace.agents.toolsets import CompoundToolset, FunctionToolset
+from mindtrace.agents import MindtraceAgent
+from mindtrace.agents.toolsets import CompoundToolset, FunctionToolset, MCPToolset
+
 
 agent = MindtraceAgent(
     model=model,
     toolset=CompoundToolset(
         MCPToolset.from_http("http://localhost:8001/mcp-server/mcp/"),
-        FunctionToolset(),   # local tools
+        FunctionToolset(),
     ),
 )
 ```
 
 ### MCPToolset
 
-`MCPToolset` exposes tools from any remote MCP server. Requires `fastmcp`:
+MCP (Model Context Protocol) is a standard way to expose application functionality as structured tools for AI clients. `MCPToolset` lets a `MindtraceAgent` use tools from any compatible remote MCP server.
+
+Requires the MCP extra:
 
 ```bash
 pip install 'mindtrace-agents[mcp]'
 ```
 
-**Constructors**
+Examples:
 
 ```python
 from mindtrace.agents.toolsets import MCPToolset
 
-# HTTP (streamable-http) — default for Mindtrace services
+
+# HTTP (default for Mindtrace services)
 ts = MCPToolset.from_http("http://localhost:8001/mcp-server/mcp/")
 
-# SSE (legacy HTTP)
+# SSE
 ts = MCPToolset.from_sse("http://localhost:9000/sse")
 
-# stdio — local subprocess servers (e.g. npx)
+# stdio
 ts = MCPToolset.from_stdio(["npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp"])
 ```
 
-**Prefix** — avoid name collisions when combining multiple MCP services:
+To avoid tool name collisions when combining multiple MCP sources, use `prefix`:
 
 ```python
 ts = MCPToolset.from_http("http://localhost:8002/mcp/", prefix="db")
-# tools are exposed as "db__query", "db__list_tables", etc.
+# tools become db__query, db__list_tables, ...
 ```
 
----
+## Filtering Tools
 
-## Filtering tools
-
-Every toolset exposes shorthand methods that return a `FilteredToolset`. Chain them to control exactly which tools the agent sees.
+Toolsets can be filtered so the model sees only the tools you want to expose.
 
 ```python
-# Allow only named tools
+# Allow only selected tools
 toolset.include("search", "summarise")
 
-# Block a specific tool
+# Exclude one tool
 toolset.exclude("drop_table")
 
 # Glob patterns
 toolset.include_pattern("read_*", "list_*")
 toolset.exclude_pattern("admin_*")
+```
 
-# Compose via FilteredToolset.with_filter() for boolean logic
+You can also compose filters explicitly:
+
+```python
 from mindtrace.agents.toolsets import ToolFilter
+
 
 f = ToolFilter.include_pattern("read_*") & ~ToolFilter.include("read_credentials")
 toolset.with_filter(f)
 ```
 
-Filtering applies at `get_tools()` time — the underlying toolset is unchanged.
-
-### ToolFilter API
-
-| Factory | Behaviour |
-|---------|-----------|
-| `ToolFilter.include(*names)` | Allow only tools whose name is in `names` |
-| `ToolFilter.exclude(*names)` | Block tools whose name is in `names` |
-| `ToolFilter.include_pattern(*globs)` | Allow tools matching any glob (e.g. `"read_*"`) |
-| `ToolFilter.exclude_pattern(*globs)` | Block tools matching any glob |
-| `ToolFilter.by_description(fn)` | Custom predicate on the tool description string |
-
-Filters compose with `&` (AND), `|` (OR), and `~` (NOT).
-
-### Combining filtering with CompoundToolset
-
-```python
-agent = MindtraceAgent(
-    model=model,
-    toolset=CompoundToolset(
-        MCPToolset.from_http("http://localhost:8001/mcp/").include("generate_image"),
-        MCPToolset.from_http("http://localhost:8002/mcp/").exclude_pattern("admin_*"),
-        FunctionToolset(),
-    ),
-)
-```
-
----
-
 ## Lifecycle Callbacks
 
-Attach async or sync callbacks to hook into the agent's execution.
+`AgentCallbacks` lets you intercept key lifecycle points around model and tool execution.
 
 ```python
-from mindtrace.agents import MindtraceAgent, AgentCallbacks
+from mindtrace.agents import AgentCallbacks, MindtraceAgent
+
 
 def log_before_llm(messages, model_settings):
     print(f"Sending {len(messages)} messages to LLM")
-    # Return (messages, model_settings) to modify, or None to keep unchanged
     return None
+
 
 async def log_after_tool(tool_name, args, result, ctx):
     print(f"Tool {tool_name!r} returned: {result}")
-    # Return modified result or None to keep unchanged
     return None
+
 
 callbacks = AgentCallbacks(
     before_llm_call=log_before_llm,
-    after_llm_call=None,         # (response) -> response | None
-    before_tool_call=None,       # (tool_name, args, ctx) -> (name, args) | None
     after_tool_call=log_after_tool,
 )
 
 agent = MindtraceAgent(model=model, tools=[...], callbacks=callbacks)
 ```
 
-### Callback signatures
+Use callbacks when you want to:
 
-| Callback | Arguments | Return |
-|----------|-----------|--------|
-| `before_llm_call` | `(messages: list, model_settings: dict\|None)` | `(messages, model_settings)` or `None` |
-| `after_llm_call` | `(response: ModelResponse)` | `ModelResponse` or `None` |
-| `before_tool_call` | `(tool_name: str, args: str, ctx: RunContext)` | `(tool_name, args)` or `None` |
-| `after_tool_call` | `(tool_name: str, args: str, result: Any, ctx: RunContext)` | modified result or `None` |
-
-All callbacks can be **sync or async** — the framework handles both transparently.
-
----
+- inspect or modify messages before the model call
+- inspect or modify tool calls and tool results
+- add tracing, metrics, or custom observability around the run loop
 
 ## Conversation History
 
-Pass `session_id` to `run()` to automatically persist and reload conversation history.
+History backends let an agent persist and reload conversation state across runs.
 
 ```python
-from mindtrace.agents import MindtraceAgent, InMemoryHistory
+import asyncio
+
+from mindtrace.agents import InMemoryHistory, MindtraceAgent
+
 
 history = InMemoryHistory()
-
 agent = MindtraceAgent(
     model=model,
     history=history,
     system_prompt="You are a helpful assistant.",
 )
 
-# First turn — history is empty, gets saved under "user-123"
 reply1 = asyncio.run(agent.run("My name is Alice.", session_id="user-123"))
-
-# Second turn — history is loaded automatically, agent remembers Alice
 reply2 = asyncio.run(agent.run("What's my name?", session_id="user-123"))
-# → "Your name is Alice."
 ```
 
-### Custom history backend
+For a custom backend, implement `AbstractHistoryStrategy`.
 
-Implement `AbstractHistoryStrategy` to persist history anywhere (Redis, MongoDB, etc.):
+## Streaming and Iteration
 
-```python
-from mindtrace.agents import AbstractHistoryStrategy, ModelMessage
+If you want more than a single final response, the agents package gives you two good options.
 
-class RedisHistory(AbstractHistoryStrategy):
-    async def load(self, session_id: str) -> list[ModelMessage]:
-        data = await redis.get(f"history:{session_id}")
-        return deserialize(data) if data else []
+### Streaming events
 
-    async def save(self, session_id: str, messages: list[ModelMessage]) -> None:
-        await redis.set(f"history:{session_id}", serialize(messages))
-
-    async def clear(self, session_id: str) -> None:
-        await redis.delete(f"history:{session_id}")
-```
-
----
-
-## Streaming
-
-Use `run_stream_events()` to receive events as the model generates tokens:
+Use `run_stream_events()` when you want token deltas, tool results, and the final result as events.
 
 ```python
-from mindtrace.agents import PartDeltaEvent, PartStartEvent, ToolResultEvent, AgentRunResultEvent
+import asyncio
+
+from mindtrace.agents import AgentRunResultEvent, PartDeltaEvent, PartStartEvent, ToolResultEvent
+
 
 async def stream_example():
     async for event in agent.run_stream_events("Tell me a joke", session_id="s1"):
         if isinstance(event, PartStartEvent) and event.part_kind == "text":
             print("\n[Text started]")
-        elif isinstance(event, PartDeltaEvent):
-            if hasattr(event.delta, "content_delta"):
-                print(event.delta.content_delta, end="", flush=True)
+        elif isinstance(event, PartDeltaEvent) and hasattr(event.delta, "content_delta"):
+            print(event.delta.content_delta, end="", flush=True)
         elif isinstance(event, ToolResultEvent):
             print(f"\n[Tool result: {event.content}]")
         elif isinstance(event, AgentRunResultEvent):
             print(f"\n[Done: {event.result.output}]")
 
+
 asyncio.run(stream_example())
 ```
 
----
+### Step-by-step iteration
 
-## Step-by-step iteration
-
-Use `iter()` for fine-grained control over the execution loop:
+Use `iter()` when you want structured control over the execution loop itself.
 
 ```python
 async def iterate_example():
     async with agent.iter("What's 15% of 240?") as steps:
         async for step in steps:
             if step["step"] == "model_response":
-                print(f"LLM said: {step['text']}")
-                print(f"Tool calls: {step['tool_calls']}")
+                print(step["text"])
             elif step["step"] == "tool_result":
-                print(f"Tool {step['tool_name']} → {step['result']}")
+                print(step["tool_name"], step["result"])
             elif step["step"] == "complete":
-                print(f"Final answer: {step['result']}")
+                print(step["result"])
 ```
-
----
 
 ## WrapperAgent
 
-Compose agents or add cross-cutting behaviour without modifying base classes:
+Use `WrapperAgent` when you want to add cross-cutting behavior around an existing agent without modifying the original class.
 
 ```python
+import asyncio
+import time
+
 from mindtrace.agents import WrapperAgent
+
 
 class TimedAgent(WrapperAgent):
     async def run(self, input_data, *, deps=None, **kwargs):
-        import time
         start = time.monotonic()
         result = await super().run(input_data, deps=deps, **kwargs)
         self.logger.info(f"Run took {time.monotonic() - start:.2f}s")
         return result
 
+
 timed = TimedAgent(agent)
 result = asyncio.run(timed.run("Hello"))
 ```
 
----
+## Multi-Agent Composition
 
-## Sync usage
-
-```python
-result = agent.run_sync("What is the capital of France?")
-# → "Paris"
-```
-
----
-
-## Logging and config
-
-All agents, models, and providers inherit from `MindtraceABC` and automatically receive:
-
-- `self.logger` — a structured logger scoped to the class name
-- `self.config` — the `CoreConfig` instance
-
-```python
-agent.logger.info("Starting run", session_id="abc")
-```
-
----
-
----
-
-## Multi-Agent Coworking
-
-Agents are first-class tools. Pass any `MindtraceAgent` directly into `tools=[]` alongside regular `Tool` objects — the framework converts it automatically.
+Agents are first-class tools. You can pass one agent into another agent’s `tools=[]`, and the framework converts it automatically.
 
 ```python
 researcher = MindtraceAgent(
     model=model,
     name="researcher",
-    description="Research a topic and return facts",  # shown to LLM as tool description
-    tools=[web_search_tool],
+    description="Research a topic and return facts",
 )
 
 writer = MindtraceAgent(
     model=model,
     name="writer",
     description="Write a structured report from given facts",
-    tools=[format_tool],
 )
 
 orchestrator = MindtraceAgent(
     model=model,
-    tools=[researcher, writer, some_regular_tool],  # mix freely
+    tools=[researcher, writer],
 )
-
-result = await orchestrator.run("Write a report on climate change")
 ```
 
-The `description` field is required when using an agent as a tool — it's what the LLM reads to decide when to call it. Parent `deps` are forwarded to sub-agents automatically via `RunContext`.
-
-### Context exchange between agents
-
-| Deployment | Mechanism |
-|---|---|
-| Same process | `deps` carries shared state directly — mutations visible across agents |
-| Distributed workers | `deps` carries a **client** (Redis, DB) — workers read/write through it, not raw data |
-
-`deps` is serialised when submitted to a task queue. Don't put live in-memory objects in deps for distributed use — put connection config and reconnect on the worker side.
+When using an agent as a tool, `description` matters because that is what the parent model sees when deciding whether to call it.
 
 ### HandoffPart
 
-Use `HandoffPart` to mark an explicit handoff boundary in an agent's message history. Useful for observability and keeping sub-agent history scoped:
+`HandoffPart` marks an explicit agent-to-agent handoff boundary in message history.
 
 ```python
 from mindtrace.agents import HandoffPart
+
 
 part = HandoffPart(
     from_agent="orchestrator",
@@ -475,150 +416,155 @@ part = HandoffPart(
 )
 ```
 
----
-
 ## Agent Memory
 
-`MemoryToolset` exposes persistent memory as LLM-callable tools. The agent decides what to save and when to recall — no code wiring needed.
+`MemoryToolset` exposes persistent memory as agent-callable tools. The agent can decide what to save, recall, search, or forget.
 
 ```python
-from mindtrace.agents import MindtraceAgent, MemoryToolset, JsonFileStore, CompoundToolset
-from mindtrace.agents.toolsets import FunctionToolset
+from mindtrace.agents import JsonFileStore, MemoryToolset, MindtraceAgent
+from mindtrace.agents.toolsets import CompoundToolset, FunctionToolset
 
-memory = JsonFileStore("./agent_memory.json")  # persists across restarts
+
+memory = JsonFileStore("./agent_memory.json")
 
 agent = MindtraceAgent(
     model=model,
     toolset=CompoundToolset(
-        FunctionToolset([my_tools]),
+        FunctionToolset(),
         MemoryToolset(memory, namespace="user_123"),
     ),
 )
 ```
 
-**Tools exposed to the agent:**
+Exposed memory tools include:
 
-| Tool | Args | Effect |
-|---|---|---|
-| `save_memory` | `key, value` | Persist a fact |
-| `recall_memory` | `key` | Retrieve by key |
-| `search_memory` | `query, top_k=5` | Substring search across all memories |
-| `forget_memory` | `key` | Delete an entry |
-| `list_memories` | — | List all keys |
-
-The `namespace` parameter scopes entries per-user or per-session — two `MemoryToolset` instances on the same store with different namespaces never see each other's data.
+- `save_memory`
+- `recall_memory`
+- `search_memory`
+- `forget_memory`
+- `list_memories`
 
 ### Memory backends
 
-| Class | Persistence | `search()` |
-|---|---|---|
-| `InMemoryStore` | None (lost on restart) | Substring |
-| `JsonFileStore` | Local `.json` file | Substring |
+- `InMemoryStore` — in-memory only
+- `JsonFileStore` — local JSON persistence
 
-Implement `AbstractMemoryStore` for custom backends (Redis, vector DB, etc.). The only method that varies meaningfully is `search()` — simple backends use substring, vector backends use embeddings.
+Implement `AbstractMemoryStore` if you want Redis, vector DBs, or other storage systems.
 
-```python
-from mindtrace.agents import AbstractMemoryStore, MemoryEntry
-
-class RedisMemoryStore(AbstractMemoryStore):
-    async def save(self, key, value, metadata=None): ...
-    async def get(self, key) -> MemoryEntry | None: ...
-    async def search(self, query, top_k=5) -> list[MemoryEntry]: ...
-    async def delete(self, key): ...
-    async def list_keys(self) -> list[str]: ...
-```
-
-Install optional extras for third-party backends:
+Optional extras:
 
 ```bash
-pip install 'mindtrace-agents[memory-redis]'   # Redis
-pip install 'mindtrace-agents[memory-vector]'  # ChromaDB
+pip install 'mindtrace-agents[memory-redis]'
+pip install 'mindtrace-agents[memory-vector]'
 ```
-
----
 
 ## Distributed Execution
 
-### Task queues
+For larger deployments, agent execution can be routed through a task queue.
 
-`AbstractTaskQueue` decouples task submission from execution. Use `LocalTaskQueue` for single-process orchestration, `RabbitMQTaskQueue` for multi-worker deployments.
+### LocalTaskQueue
+
+Use `LocalTaskQueue` for single-process orchestration.
 
 ```python
-from mindtrace.agents import LocalTaskQueue, AgentTask
+from mindtrace.agents import AgentTask, LocalTaskQueue
+
 
 queue = LocalTaskQueue()
-queue.register(researcher)   # agents must be registered by name
+queue.register(researcher)
 
-task_id = await queue.submit(AgentTask(
-    agent_name="researcher",
-    input="What caused the 2008 financial crisis?",
-    deps=my_deps,
-    session_id="s1",
-))
-result = await queue.get_result(task_id)
+# submit/get_result are async; shown here as the key flow
+# task_id = await queue.submit(AgentTask(...))
+# result = await queue.get_result(task_id)
 ```
-
-`TaskStatus` values: `PENDING → RUNNING → DONE | FAILED`
 
 ### DistributedAgent
 
-`DistributedAgent` wraps any agent and routes `run()` through a task queue. The API is identical to `MindtraceAgent` — callers don't need to change.
+`DistributedAgent` wraps an agent and routes `run()` through a queue, while keeping the same high-level API.
 
 ```python
 from mindtrace.agents import DistributedAgent
 
+
 distributed_researcher = DistributedAgent(researcher, task_queue=queue)
-result = await distributed_researcher.run("Research topic")  # executes via queue
+# result = await distributed_researcher.run("Research topic")
 ```
 
 ### RabbitMQ
 
-Requires `aio-pika`:
+Install the RabbitMQ extra when you want multi-worker execution:
 
 ```bash
 pip install 'mindtrace-agents[distributed-rabbitmq]'
 ```
 
-**Caller side** (submit tasks):
+Caller side:
 
 ```python
 from mindtrace.agents.execution.rabbitmq import RabbitMQTaskQueue
 
+
 queue = RabbitMQTaskQueue(url="amqp://guest:guest@localhost/")
 distributed = DistributedAgent(researcher, task_queue=queue)
-result = await distributed.run("Research topic")
 ```
 
-**Worker side** (consume and execute):
+Worker side:
 
 ```python
 queue = RabbitMQTaskQueue(url="amqp://guest:guest@localhost/")
-await queue.serve(researcher)  # blocks; run N replicas for parallelism
+# await queue.serve(researcher)
 ```
 
-RabbitMQ round-robins tasks across replicas automatically. `AgentTask` is serialised with `pickle` — `deps` must be pickle-serialisable. For cross-process use, put connection config in `deps` (not live connections).
+## Sync Usage
 
----
+If you do not want to manage the event loop directly, use `run_sync()`:
 
-## Package layout
-
+```python
+result = agent.run_sync("What is the capital of France?")
 ```
-mindtrace/agents/
-├── __init__.py          # public API
-├── _run_context.py      # RunContext dataclass
-├── _function_schema.py  # type introspection + Pydantic validation
-├── _tool_manager.py     # tool dispatch + retry
-├── prompts.py           # UserPromptPart, BinaryContent, ImageUrl
-├── profiles/            # ModelProfile capability flags
-├── events/              # streaming event types
-├── messages/            # ModelMessage, parts (incl. HandoffPart), builder
-├── tools/               # Tool, ToolDefinition
-├── toolsets/            # AbstractToolset, FunctionToolset, CompoundToolset, MCPToolset, ToolFilter, FilteredToolset
-├── providers/           # Provider ABC + OpenAI, Ollama, Gemini
-├── models/              # Model ABC + OpenAIChatModel
-├── callbacks/           # AgentCallbacks + _invoke helper
-├── history/             # AbstractHistoryStrategy + InMemoryHistory
-├── memory/              # AbstractMemoryStore, InMemoryStore, JsonFileStore, MemoryToolset
-├── execution/           # AbstractTaskQueue, AgentTask, LocalTaskQueue, RabbitMQTaskQueue
-└── core/                # AbstractMindtraceAgent, MindtraceAgent, WrapperAgent, DistributedAgent
+
+## Logging and Config
+
+Agents, models, and providers inherit from Mindtrace base classes and automatically receive:
+
+- `self.logger`
+- `self.config`
+
+```python
+agent.logger.info("Starting run", session_id="abc")
 ```
+
+## Examples
+
+See these examples and related docs in the repo for more end-to-end reference:
+
+- [Agents README quick-start examples](README.md)
+- [MCP toolset examples in this README](README.md#mcp-toolset)
+- [Memory toolset examples in this README](README.md#agent-memory)
+- [Distributed execution examples in this README](README.md#distributed-execution)
+
+## Testing
+
+If you are working in the full Mindtrace repo, run tests for this module specifically:
+
+```bash
+git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+uv sync --dev --all-extras
+```
+
+```bash
+# Run the agents test suite
+ds test: agents
+
+# Run only unit tests for agents
+ds test: --unit agents
+```
+
+## Practical Notes and Caveats
+
+- Providers and models are separate concepts: providers handle backend connectivity, models handle the request/response interface.
+- Tool docstrings and descriptions matter because the model sees them when deciding which tools to call.
+- When using an agent as a tool, make sure it has a clear `description`.
+- Distributed execution requires serializable task payloads; avoid passing live in-memory objects through distributed queues.
+- MCP, RabbitMQ, and some memory backends require optional extras.
+- `run()` is the simplest API, but streaming and iteration provide much better observability for debugging and UX.

--- a/mindtrace/cluster/README.md
+++ b/mindtrace/cluster/README.md
@@ -2,252 +2,552 @@
 [![License](https://img.shields.io/pypi/l/mindtrace-cluster)](https://github.com/mindtrace/mindtrace/blob/main/mindtrace/cluster/LICENSE)
 [![Downloads](https://static.pepy.tech/badge/mindtrace-cluster)](https://pepy.tech/projects/mindtrace-cluster)
 
-# Mindtrace Cluster Module
+# Mindtrace Cluster
 
-The Mindtrace Cluster module provides a distributed computing framework for managing and orchestrating jobs across multiple worker nodes. It enables scalable, fault-tolerant job execution with support for various execution environments including Git repositories and Docker containers.
+The `Cluster` module provides Mindtrace’s distributed job-execution framework, using `ClusterManager`, `Node`, and `Worker` services to route jobs, launch workers, and track execution across queue-backed clusters.
 
-## Overview
+## Features
 
-The cluster module consists of three main components:
+- **Cluster-wide job routing** through `ClusterManager`
+- **Service-based worker orchestration** with `Node` and `Worker`
+- **Direct endpoint or queued execution** depending on job schema targeting
+- **RabbitMQ-backed job queues** through `mindtrace-jobs`
+- **Redis-backed job and worker status tracking**
+- **Worker registry and remote launch support** via Registry / MinIO
+- **Built-in workers** such as `EchoWorker` and `RunScriptWorker`
+- **Dead-letter queue (DLQ) tooling** for failed jobs
 
-- **ClusterManager**: Central orchestrator that manages job distribution and worker coordination
-- **Node**: Worker node that can launch and manage workers
-- **Worker**: Executable units that process jobs
-
-## Architecture
-
-```
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│  ClusterManager │    │      Node       │    │     Worker      │
-│                 │    │                 │    │                 │
-│ • Job routing   │◄──►│ • Worker launch │◄──►│ • Job execution │
-│ • Status tracking│    │ • Registry access│    │ • Environment mgmt│
-│ • Worker mgmt   │    │ • Resource mgmt │    │ • Status reporting│
-└─────────────────┘    └─────────────────┘    └─────────────────┘
-```
-
-## Core Components
-
-### ClusterManager
-
-The central orchestrator that:
-- Routes jobs to appropriate endpoints or workers
-- Tracks job and worker status
-- Manages worker registration and auto-connection
-- Provides a unified API for job submission and monitoring
-
-**Key Features:**
-- Job schema targeting (direct endpoint routing vs orchestrator)
-- Worker type registration with Git/Docker support
-- Automatic worker-to-job schema connection
-- Real-time status monitoring
-
-### Node
-
-A worker node that:
-- Launches workers from the registry
-- Manages worker lifecycle
-- Provides resource isolation
-
-**Key Features:**
-- Worker registry integration
-- Automatic cluster registration
-- Worker process management
-
-### Worker
-
-Executable units that:
-- Process individual jobs
-- Report status back to cluster
-- Support various execution environments
-
-**Key Features:**
-- Abstract base class for custom workers
-- Built-in status tracking
-- Cluster communication
-- Environment management
-
-## Built-in Workers
-
-### EchoWorker
-
-A simple worker that echoes messages with optional delay:
+## Quick Start
 
 ```python
-from mindtrace.cluster.workers.echo_worker import EchoWorker
+from pydantic import BaseModel
 
-# Usage
-worker = EchoWorker()
-result = worker._run({"message": "Hello World", "delay": 2})
-# Returns: {"status": "completed", "output": {"echoed": "Hello World"}}
-```
-
-### RunScriptWorker
-
-A worker that executes scripts in isolated environments. For git repositories, will sync the environment using `uv sync`.
-
-```python
-from mindtrace.cluster.workers.run_script_worker import RunScriptWorker
-
-# Git environment example
-job_data = {
-    "environment": {
-        "git": {
-            "repo_url": "https://github.com/user/repo",
-            "branch": "main",
-            "working_dir": "scripts"
-        }
-    },
-    "command": "python process_data.py"
-}
-
-# Docker environment example
-job_data = {
-    "environment": {
-        "docker": {
-            "image": "python:3.9",
-            "working_dir": "/app",
-            "volumes": {"/host/path": "/container/path"},
-            "environment": {"ENV_VAR": "value"}
-        }
-    },
-    "command": "python script.py"
-}
-```
-
-## Usage Examples
-
-### Basic Cluster Setup
-
-```python
 from mindtrace.cluster import ClusterManager, Node
 from mindtrace.jobs import JobSchema, job_from_schema
 
-# Launch cluster manager
-cluster = ClusterManager.launch(host="localhost", port=8002)
 
-# Launch node
-node = Node.launch(
-    host="localhost", 
-    port=8003, 
-    cluster_url=str(cluster.url)
-)
+class EchoInput(BaseModel):
+    message: str
+    delay: int = 0
 
-# Register worker type
+
+echo_job_schema = JobSchema(name="echo_job", input_schema=EchoInput)
+
+# Launch the cluster manager service
+cluster = ClusterManager.launch(host="localhost", port=8002, wait_for_launch=True)
+
+# Launch a node service that will host workers
+node = Node.launch(host="localhost", port=8003, cluster_url=str(cluster.url), wait_for_launch=True)
+
+# Register a worker type and connect it to the job schema
 cluster.register_worker_type(
-    worker_name="myworker",
-    worker_class="myapp.workers.MyWorker",
-    worker_params={}
+    worker_name="echo_worker",
+    worker_class="mindtrace.cluster.workers.echo_worker.EchoWorker",
+    worker_params={},
+    job_type="echo_job",
 )
 
-# Launch worker
-worker_url = "http://localhost:8004"
-node.launch_worker(worker_type="myworker", worker_url=worker_url)
+# Launch the worker on the node
+launch = cluster.launch_worker(
+    node_url=str(node.url),
+    worker_type="echo_worker",
+    worker_url="http://localhost:8004",
+)
+status = cluster.launch_worker_status(node_url=str(node.url), launch_id=launch.launch_id)
+print(status)
 
-# Submit job
-job = job_from_schema(my_job_schema, input_data={"key": "value"})
-result = cluster.submit_job(job)
+# Submit a job
+job = job_from_schema(echo_job_schema, {"message": "Hello cluster", "delay": 0})
+job_status = cluster.submit_job(job)
+print(job_status)
 ```
 
-### Gateway Mode
+At a high level, the cluster module works like this:
 
-Use ClusterManager as a gateway to route requests:
+- `ClusterManager` routes jobs and is the usual **single entry point** for clients: submit work, inspect job and worker status, launch workers on nodes, plus registrations and DLQ handling
+- `Node` launches worker services on machines
+- `Worker` instances consume jobs and report results back
+- RabbitMQ carries queued work, Redis tracks status, and Registry/MinIO stores worker launcher definitions
+
+## ClusterManager
+
+`ClusterManager` is the control plane for the cluster. It is both:
+
+- a **Mindtrace service**
+- a **Gateway** for job routing
+
+It is responsible for:
+
+- registering how job schemas should be routed
+- tracking job status
+- tracking worker status
+- registering worker types
+- asking nodes to launch workers
+- handling DLQ workflows
+
+### Launching a cluster manager
 
 ```python
 from mindtrace.cluster import ClusterManager
 
-# Launch as gateway
-gateway = ClusterManager.launch(port=8097)
 
-# Register service
-gateway.register_job_to_endpoint(
-    job_type="echo_job", 
-    endpoint="echo/run"
-)
-
-# Submit job (automatically routed to endpoint)
-job = job_from_schema(echo_job_schema, input_data={"message": "Hello"})
-result = gateway.submit_job(job)
+cluster = ClusterManager.launch(host="localhost", port=8002, wait_for_launch=True)
+print(cluster.status())
 ```
 
-### Git-based Worker
+### Registering a job schema to a direct endpoint
 
-Launch workers from Git repositories:
+Use this when a job should be sent directly to an HTTP endpoint instead of being queued through workers.
+
+`ClusterManager` is a `Gateway`. The usual pattern is to **register the downstream service on the gateway first** (`register_app`), then map the job type to the **gateway-relative path** that forwards to that app (for example `echo/run` for app name `echo` and downstream route `run`). See [`samples/cluster/cluster_as_gateway.py`](../../samples/cluster/cluster_as_gateway.py).
 
 ```python
-# Register worker from Git
+cluster.register_app(
+    name="echo",
+    url="http://localhost:8098/",
+    connection_manager=echo_cm,  # optional; enables ProxyConnectionManager-style access via the gateway
+)
+cluster.register_job_to_endpoint(
+    job_type="echo_job",
+    endpoint="echo/run",
+)
+```
+
+### Registering a job schema to an existing worker
+
+Use this when a worker is already running at a known URL (for example pre-launched or started outside a node) and you want that instance to subscribe to the orchestrator queue for a job type. The cluster manager routes the job schema to `@orchestrator`, ensures the queue exists, and connects that worker to the cluster for the given `job_type`.
+
+```python
+cluster.register_job_to_worker(
+    job_type="echo_job",
+    worker_url="http://localhost:8004",
+)
+```
+
+### Registering worker types
+
+Worker types are stored in the worker registry and can later be launched by nodes.
+
+```python
 cluster.register_worker_type(
-    worker_name="gitworker",
-    worker_class="myapp.worker.MyWorker",
+    worker_name="echo_worker",
+    worker_class="mindtrace.cluster.workers.echo_worker.EchoWorker",
     worker_params={},
-    git_repo_url="https://github.com/user/worker-repo",
+    job_type="echo_job",
+)
+```
+
+You can also register workers that should be launched from a Git repository:
+
+```python
+cluster.register_worker_type(
+    worker_name="git_worker",
+    worker_class="my_package.workers.MyWorker",
+    worker_params={},
+    job_type="script_job",
+    git_repo_url="https://github.com/user/repo",
     git_branch="main",
-    git_working_dir="worker"
+    git_working_dir="worker",
+)
+```
+
+### Registering a job schema to workers
+
+Use this when a job should go through the orchestrator/queue path.
+
+```python
+cluster.register_job_schema_to_worker_type(
+    job_schema_name="echo_job",
+    worker_type="echo_worker",
+)
+```
+
+This sets the job schema to target `@orchestrator`, declares the queue, and enables auto-connect for that worker type.
+
+### Submitting jobs
+
+```python
+job = job_from_schema(echo_job_schema, {"message": "Hello cluster", "delay": 0})
+job_status = cluster.submit_job(job)
+print(job_status.status)
+```
+
+### Querying status
+
+```python
+job_status = cluster.get_job_status(job_id=job.id)
+print(job_status)
+
+worker_status = cluster.get_worker_status(worker_id="worker-id")
+print(worker_status)
+```
+
+## Node
+
+`Node` is the service that launches and manages workers on a machine.
+
+When a node is connected to a cluster manager, it:
+
+- registers itself with the cluster
+- receives MinIO and RabbitMQ connection details
+- loads worker definitions from the worker registry
+- launches worker services asynchronously
+- tracks which ports and workers it owns
+
+### Launching a node
+
+```python
+from mindtrace.cluster import Node
+
+
+node = Node.launch(
+    host="localhost",
+    port=8003,
+    cluster_url="http://localhost:8002",
+    wait_for_launch=True,
+)
+print(node.status())
+```
+
+### Launching a worker through a node
+
+Nodes launch workers asynchronously, so you get a `launch_id` back and then query launch status.
+
+```python
+launch = node.launch_worker(
+    worker_type="echo_worker",
+    worker_url="http://localhost:8004",
 )
 
-# Launch worker (automatically clones repo)
-node.launch_worker(worker_type="gitworker", worker_url="http://localhost:8005")
+status = node.launch_worker_status(launch_id=launch.launch_id)
+print(status)
 ```
 
-## Configuration
+You can do the same thing **through the cluster manager**: call `launch_worker` and `launch_worker_status` on your `ClusterManager` client and pass `node_url`. The manager connects to that node and forwards the call. If the worker type is linked to a job schema (via `register_worker_type` / `register_job_schema_to_worker_type`), it also passes **auto-connect** so the worker is registered on the correct queue once the launch finishes. (Here `cluster` is the manager for the `cluster_url` you used when launching the node.)
 
-### Environment Variables
+```python
+launch = cluster.launch_worker(
+    node_url=str(node.url),
+    worker_type="echo_worker",
+    worker_url="http://localhost:8004",
+)
+status = cluster.launch_worker_status(node_url=str(node.url), launch_id=launch.launch_id)
+print(status)
+```
+
+### Shutting down workers
+
+```python
+node.shutdown_worker(worker_name="echo_worker")
+node.shutdown_worker_by_id(worker_id="worker-id")
+node.shutdown_worker_by_port(worker_port=8004)
+node.shutdown_all_workers()
+```
+
+## Worker
+
+`Worker` is the execution unit in the cluster. It is both:
+
+- a **Mindtrace service**
+- a **jobs Consumer**
+
+A worker:
+
+- exposes service endpoints such as `/run`, `/connect_to_cluster`, and `/get_status`
+- consumes queued jobs
+- reports started/completed state to `ClusterManager`
+- delegates the actual job logic to `_run(...)`
+
+### Writing a custom worker
+
+Subclass `Worker` and implement `_run()`.
+
+```python
+from mindtrace.cluster import Worker
+
+
+class UppercaseWorker(Worker):
+    def _run(self, job_dict: dict) -> dict:
+        message = job_dict["message"]
+        return {
+            "status": "completed",
+            "output": {"uppercased": message.upper()},
+        }
+```
+
+### Launching a worker directly
+
+```python
+worker = UppercaseWorker.launch(url="http://localhost:8004", wait_for_launch=True)
+print(worker.status())
+```
+
+### Worker lifecycle hooks
+
+Use `start()` for initialization that should run once the worker is connected to the cluster.
+
+```python
+class MyWorker(Worker):
+    def start(self):
+        super().start()
+        self.logger.info("Worker initialized")
+```
+
+## Routing Modes
+
+One of the most important ideas in the cluster package is that jobs can be routed in two different ways.
+
+### Direct endpoint routing
+
+In this mode, a job schema is mapped to a path on the cluster manager, which acts as a **Gateway**. Typically you **`register_app`** for the backing service, then **`register_job_to_endpoint`** with the forwarded path (for example `echo/run`).
+
+```python
+cluster.register_app(name="echo", url="http://localhost:8098/", connection_manager=echo_cm)
+cluster.register_job_to_endpoint(
+    job_type="echo_job",
+    endpoint="echo/run",
+)
+```
+
+When the job is submitted, `ClusterManager` POSTs to its own base URL plus `endpoint` (not a separate absolute URL). Use a path segment that matches the gateway route (`/{app_name}/...`).
+
+This is useful when:
+
+- you already have a service endpoint that should run the work
+- you do not need queue-based worker execution
+- you want gateway-style request routing
+
+### Orchestrator / worker routing
+
+In this mode, the job schema is mapped to `@orchestrator`, queued in RabbitMQ, and consumed by workers.
+
+```python
+cluster.register_job_schema_to_worker_type(
+    job_schema_name="echo_job",
+    worker_type="echo_worker",
+)
+```
+
+This is useful when:
+
+- work should be handled asynchronously
+- workers may run on separate nodes
+- you want queue-based scaling and worker isolation
+
+## Built-in Workers
+
+These workers are **services**: run them with `WorkerClass.launch(...)`, **register** them on the cluster manager (`register_job_to_worker` for an already-running worker, or `register_worker_type` + node launch for registry-driven setups), then **submit** a `Job` built from a `JobSchema`. The snippets below follow the pre-launched worker pattern; see [`samples/cluster/cluster_with_prelaunched_workers.py`](../../samples/cluster/cluster_with_prelaunched_workers.py) and [`samples/cluster/run_script/run_script_worker.py`](../../samples/cluster/run_script/run_script_worker.py) for full scripts.
+
+### EchoWorker
+
+`EchoWorker` is the simplest built-in worker and is useful for smoke tests and demos.
+
+```python
+import time
+
+from mindtrace.cluster import ClusterManager
+from mindtrace.cluster.workers.echo_worker import EchoWorker
+from mindtrace.jobs import JobSchema, job_from_schema
+from mindtrace.services.samples.echo_service import EchoInput, EchoOutput
+
+cluster = ClusterManager.launch(host="localhost", port=8002, wait_for_launch=True)
+worker_cm = EchoWorker.launch(host="localhost", port=8004, wait_for_launch=True)
+try:
+    schema = JobSchema(name="echo_demo", input_schema=EchoInput, output_schema=EchoOutput)
+    cluster.register_job_to_worker(job_type="echo_demo", worker_url=str(worker_cm.url))
+    job = job_from_schema(schema, {"message": "Hello World", "delay": 0})
+    cluster.submit_job(job)
+    status = cluster.get_job_status(job_id=job.id)
+    while str(status.status) not in ("completed", "failed", "error"):
+        time.sleep(0.2)
+        status = cluster.get_job_status(job_id=job.id)
+    print(status)
+finally:
+    worker_cm.shutdown()
+    cluster.clear_databases()
+    cluster.shutdown()
+```
+
+### RunScriptWorker
+
+`RunScriptWorker` executes commands in an isolated environment for each job. It supports:
+
+- Git-based environments
+- Docker-based environments
+
+Same worker and registration for both: a **Docker** job and a **Git** checkout job (`environment.git` + `command` run in that tree). Adjust `repo_url` / `branch` / `command` to match your repository.
+
+```python
+import time
+
+from mindtrace.cluster import ClusterManager
+from mindtrace.cluster.workers.run_script_worker import RunScriptWorker, RunScriptWorkerInput, RunScriptWorkerOutput
+from mindtrace.jobs import JobSchema, job_from_schema
+
+
+def wait_done(cluster, job_id):
+    status = cluster.get_job_status(job_id=job_id)
+    while str(status.status) not in ("completed", "failed", "error"):
+        time.sleep(0.5)
+        status = cluster.get_job_status(job_id=job_id)
+    return status
+
+
+cluster = ClusterManager.launch(host="localhost", port=8002, wait_for_launch=True)
+worker_cm = RunScriptWorker.launch(host="localhost", port=8004, wait_for_launch=True)
+try:
+    schema = JobSchema(
+        name="run_script_demo",
+        input_schema=RunScriptWorkerInput,
+        output_schema=RunScriptWorkerOutput,
+    )
+    cluster.register_job_to_worker(job_type="run_script_demo", worker_url=str(worker_cm.url))
+
+    job_docker = job_from_schema(
+        schema,
+        {
+            "environment": {
+                "docker": {
+                    "image": "ubuntu:22.04",
+                    "working_dir": "/tmp",
+                    "environment": {},
+                    "volumes": {},
+                    "devices": [],
+                }
+            },
+            "command": "echo hello",
+        },
+    )
+    cluster.submit_job(job_docker)
+    print(wait_done(cluster, job_docker.id))
+
+    job_git = job_from_schema(
+        schema,
+        {
+            "environment": {
+                "git": {
+                    "repo_url": "https://github.com/Mindtrace/mindtrace.git",
+                    "branch": "main",
+                    "working_dir": "",
+                }
+            },
+            "command": "python samples/cluster/run_script/test_script.py",
+        },
+    )
+    cluster.submit_job(job_git)
+    print(wait_done(cluster, job_git.id))
+finally:
+    worker_cm.shutdown()
+    cluster.clear_databases()
+    cluster.shutdown()
+```
+
+## Dead-Letter Queue (DLQ)
+
+Failed jobs are stored in a DLQ database so they can be inspected and retried later.
+
+### Viewing DLQ jobs
+
+```python
+jobs = cluster.get_dlq_jobs().jobs
+print(jobs)
+```
+
+### Requeueing a failed job
+
+```python
+requeued = cluster.requeue_from_dlq(job_id="job-id")
+print(requeued)
+```
+
+### Discarding a failed job
+
+```python
+cluster.discard_from_dlq(job_id="job-id")
+```
+
+### Interactive DLQ helper
+
+The module also includes a simple helper for interactive DLQ processing:
+
+```python
+from mindtrace.cluster import ClusterManager
+from mindtrace.cluster.core.dlq import process_dlq
+
+
+cluster = ClusterManager.connect("http://localhost:8002")
+requeued_jobs = process_dlq(cluster)
+```
+
+## Configuration and Infrastructure
+
+The cluster module depends on several external services.
+
+### RabbitMQ
+
+RabbitMQ is used for queued job execution.
 
 ```bash
-# Redis configuration
-MINDTRACE_CLUSTER__DEFAULT_REDIS_URL=redis://localhost:6379
-MINDTRACE_WORKER__DEFAULT_REDIS_URL=redis://localhost:6379
-
-# MinIO configuration (for worker registry)
-MINDTRACE_CLUSTER__MINIO_ENDPOINT=localhost:9000
-MINDTRACE_CLUSTER__MINIO_ACCESS_KEY=minioadmin
-MINDTRACE_CLUSTER__MINIO_SECRET_KEY=minioadmin
-MINDTRACE_CLUSTER__MINIO_BUCKET=workers
+$ docker run -d --name rabbitmq \
+    -p 5672:5672 \
+    -p 15672:15672 \
+    -e RABBITMQ_DEFAULT_USER=user \
+    -e RABBITMQ_DEFAULT_PASS=password \
+    rabbitmq:3-management
 ```
 
-### Database Models
+### Redis
 
-The cluster uses several database models for tracking:
+Redis is used for job status, worker status, schema targeting, and DLQ state.
 
-- **JobStatus**: Tracks job execution status and results
-- **JobSchemaTargeting**: Maps job types to endpoints
-- **WorkerStatus**: Tracks worker availability and current job
-- **WorkerAutoConnect**: Maps worker types to job schemas
-- **WorkerStatusLocal**: Local worker status tracking
+```bash
+$ docker run -d --name redis -p 6379:6379 redis:latest
+```
 
-## API Reference
+### MinIO / worker registry
 
-Since these are Services, the normal way to use them is via a ConnectionManager, but they can also be accessed dirctly.
+MinIO-backed Registry storage is used for worker launcher definitions.
 
-### ClusterManager Endpoints
+Relevant environment variables include:
 
-- `POST /submit_job` - Submit a job for execution
-- `POST /register_job_to_endpoint` - Route job type to specific endpoint
-- `POST /register_job_to_worker` - Connect job type to worker
-- `POST /get_job_status` - Get job execution status
-- `POST /register_worker_type` - Register new worker type
-- `POST /launch_worker` - Launch worker on node, automatically connecting it to the Orchestrator if it's registered to a job type
-- `POST /get_worker_status` - Get worker status
-- `POST /query_worker_status` - Query live worker status
-
-### Node Endpoints
-
-- `POST /launch_worker` - Launch worker from registry
-
-### Worker Endpoints
-
-- `POST /run` - Execute a job
-- `POST /connect_to_cluster` - Connect to cluster orchestrator
-- `POST /get_status` - Get worker status
-- `POST /start` - Initialize worker
+```bash
+$ export MINDTRACE_CLUSTER__DEFAULT_REDIS_URL=redis://localhost:6379
+$ export MINDTRACE_WORKER__DEFAULT_REDIS_URL=redis://localhost:6379
+$ export MINDTRACE_CLUSTER__MINIO_ENDPOINT=localhost:9000
+$ export MINDTRACE_CLUSTER__MINIO_ACCESS_KEY=minioadmin
+$ export MINDTRACE_CLUSTER__MINIO_SECRET_KEY=minioadmin
+$ export MINDTRACE_CLUSTER__MINIO_BUCKET=workers
+```
 
 ## Examples
 
-See the `samples/cluster/` directory for examples:
+Related examples in the repo:
 
-- `cluster_as_gateway.py` - Using ClusterManager as a gateway
-- `cluster_with_node.py` - Basic cluster with node setup
-- `cluster_with_node_autoregister.py` - Automatic worker registration
-- `run_script/` - RunScriptWorker examples
-- `multiprocess/` - Multi-process cluster examples
-- `separate_node/` - Distributed node examples
+- [Cluster as gateway](../../samples/cluster/cluster_as_gateway.py)
+- [Cluster with node](../../samples/cluster/cluster_with_node.py)
+- [Cluster with node auto-register](../../samples/cluster/cluster_with_node_autoregister.py)
+- [Cluster with prelaunched workers](../../samples/cluster/cluster_with_prelaunched_workers.py)
+- [Start worker from Git](../../samples/cluster/start_worker_from_git.py)
+- [RunScript worker example](../../samples/cluster/run_script/run_script_worker.py)
+- [Multiprocess cluster manager example](../../samples/cluster/multiprocess/cluster_manager.py)
+- [Separate node examples](../../samples/cluster/separate_node/cluster_and_node.py)
+
+## Testing
+
+If you are working in the full Mindtrace repo, run tests for this module specifically:
+
+```bash
+$ git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+$ uv sync --dev --all-extras
+$ ds test: cluster
+$ ds test: --unit cluster
+```
+
+## Practical Notes and Caveats
+
+- `ClusterManager`, `Node`, and `Worker` are services, not just helper classes.
+- Direct endpoint routing and orchestrator/worker routing are different operational modes and should be chosen intentionally.
+- Worker launch on nodes is asynchronous, so `launch_worker_status` is part of the normal workflow.
+- The cluster relies on RabbitMQ, Redis, and MinIO/Registry being configured correctly.
+- `RunScriptWorker` can execute commands in Git or Docker environments, so environment setup and security expectations matter.
+- Failed jobs can enter the DLQ; production workflows should include a plan for inspection, requeue, or discard.

--- a/mindtrace/core/README.md
+++ b/mindtrace/core/README.md
@@ -4,284 +4,391 @@
 
 # Mindtrace Core
 
-The foundational module of the Mindtrace ML framework, providing essential utilities, base classes, and core abstractions used across all other Mindtrace modules.
+The `Core` module provides the foundational abstractions, configuration, logging, observability, typing, and utility helpers used across the Mindtrace ecosystem.
 
-## Purpose
+## Features
 
-`mindtrace-core` serves as the foundation layer (Level 1) in the Mindtrace architecture, offering:
+- **Base abstractions** with `Mindtrace`, `MindtraceABC`, and shared metaclass behavior
+- **Configuration management** with `Config` and `CoreConfig`
+- **Task typing** with `TaskSchema`
+- **Logging and operation tracking** with standard and structured logging support
+- **Observability primitives** with `EventBus`, `ObservableContext`, and `ContextListener`
+- **Shared utility helpers** for dynamic loading, networking, timing, hashing, and metrics
 
-- **Base Classes**: Abstract base classes and metaclasses for consistent architecture
-- **Configuration Management**: Centralized configuration handling
-- **Event System**: Observable patterns and event bus for inter-component communication
-- **Utilities**: Common utility functions for dynamic imports, type checking, and more
-- **Logging**: Structured logging capabilities
-
-## Installation
-
-```bash
-# Install as standalone package
-uv add mindtrace-core
-
-# Or install as part of full Mindtrace
-uv add mindtrace
-```
-
-## Architecture
-
-The core module is organized into several submodules:
-
-### Base Classes (`base/`)
-- `MindtraceABC`: Abstract base class for all Mindtrace components
-- `MindtraceMeta`: Metaclass providing common functionality
-- `Mindtrace`: Main base class with core functionality
-
-### Configuration (`config/`)
-- `Config`: Centralized configuration management system
-
-### Observables (`observables/`)
-- `EventBus`: Publish-subscribe event system
-- `ObservableContext`: Context management with observation capabilities
-- `ContextListener`: Event listening and handling
-
-### Utilities (`utils/`)
-- `checks`: Type checking and validation utilities
-- `dynamic`: Dynamic class instantiation and import helpers
-
-### Logging (`logging/`)
-- Structured logging configuration and utilities
-
-
-
-### Core Classes
-
-#### `Mindtrace`
-Base class for all Mindtrace components.
+## Quick Start
 
 ```python
-class MyProcessor(Mindtrace):
-    def __init__(self):
-        super().__init__()
-```
+from pydantic import BaseModel
 
-#### `Config`
-The Config class in Mindtrace provides a configuration layer designed to unify various sources of configuration— Pydantic models, Settings, Dict objects in a single, easy-to-use object with attribute access, and dynamic overrides.
+from mindtrace.core import Mindtrace, TaskSchema, ifnone
 
-```python
-from mindtrace.core.config import Config
 
-# Pass a dictionary
-config = Config({"MINDTRACE_DIR_PATHS":{"TEMP":"~/tmp"}})
+class EchoInput(BaseModel):
+    message: str
 
-# Access config values
-print(config["MINDTRACE_DIR_PATHS"]["TEMP"])      
-# Attribute-style access
-print(config.MINDTRACE_DIR_PATHS.TEMP)
-```
 
-For detailed usage of the Config class—including how it's used within the Mindtrace class—refer to the [Usage documentation](https://github.com/Mindtrace/mindtrace/tree/dev/samples/core/config)
+class EchoOutput(BaseModel):
+    echoed: str
 
-#### `Logging`
-The `get_logger` function provides a unified way to configure logging across your application. It can return either a standard Python logger or a structlog
- logger, based on user-defined arguments or below [CoreConfig](../core/mindtrace/core/config/config.ini) settings (lower priority).
-```
-[MINDTRACE_DIR_PATHS]
-STRUCT_LOGGER_DIR = ${MINDTRACE_DIR_PATHS:ROOT}/structlogs
-LOGGER_DIR = ${MINDTRACE_DIR_PATHS:ROOT}/logs
-[MINDTRACE_LOGGER]
-USE_STRUCTLOG = False
-```
 
-##### Basic Logger
-
-Setup basic logger to produce logs in `~/.cache/mindtrace/logs`. 
-Here, by default propogation is set to true, and you should be able to see logs in `tail -f ~/.cache/mindtrace/logs/mindtrace.log` and `tail -f ~/.cache/mindtrace/logs/modules/mindtrace.core.module.log` files
-
-```python
-from mindtrace.core.logging.logger import get_logger
-
-# Create a standard logger
-logger = get_logger("core.module")
-logger.info("Logger configured with custom settings.")
-```
-
-##### Structured Logger
-Setup structlog to log structured events: dictionaries of key-value pairs that can later be searched, filtered, or transformed (e.g., into JSON).
-Here, by default propogation is set to true, and you should be able to see structured logs in `tail -f ~/.cache/mindtrace/structlogs/mindtrace.log` and `tail -f ~/.cache/mindtrace/structlogs/modules/mindtrace.core.module.log` files
-```python
-from mindtrace.core.logging.logger import get_logger
-
-# Create a structlog logger with custom bindings
-slogger = get_logger(
-    "core.module",
-    use_structlog=True,
-    structlog_bind={"service": "my-service"},
+echo_task = TaskSchema(
+    name="echo",
+    input_schema=EchoInput,
+    output_schema=EchoOutput,
 )
 
-slogger.info("Structured log", user_id="123")
-```
-In above example, we illustrate structlog’s ability to 
-- bind context to a logger, which ensures that certain fields are automatically included in every log message. This is especially useful for adding consistent metadata like service name, environment, or version without repeating it in every log call.
-- Extra fields like user_id="123" can be passed per log call, allowing dynamic, event-specific data to be added.
 
-##### Mindtrace autolog
-`Mindtrace.autolog` automatically logs function execution (start, end, duration, exceptions, and optional system metrics).
-It supports sync, async, and static functions with both standard and structured logging formats. See a full usage example [here](/samples/core/logging/using_autologger.py)
+class EchoComponent(Mindtrace):
+    def echo(self, payload: EchoInput) -> EchoOutput:
+        return EchoOutput(echoed=ifnone(payload.message, ""))
+
+
+component = EchoComponent()
+print(component.echo(EchoInput(message="Hello")))
+print(component.config.MINDTRACE_DIR_PATHS.TEMP_DIR)
+component.logger.info("Core component ready")
+```
+
+This example shows the typical role of `mindtrace-core`: it gives you a common base class, typed task contracts, configuration access, logging, and small utility helpers that other Mindtrace modules build on.
+
+## Mindtrace
+
+`Mindtrace` is the main base class for shared Mindtrace components. It provides:
+
+- a consistent logger on both instances and classes
+- access to `CoreConfig`
+- context-manager support
+- the `autolog()` decorator for automatic execution logging
+
+Example:
 
 ```python
 from mindtrace.core import Mindtrace
 
+
 class DataProcessor(Mindtrace):
-    @Mindtrace.autolog()
-    def process_data(self, data_list, batch_size=100):
-        # Function automatically logged
-        return [item * 2 for item in data_list]
+    def process(self, values: list[int]) -> list[int]:
+        self.logger.info("Processing values")
+        return [value * 2 for value in values]
+
+
+with DataProcessor() as processor:
+    print(processor.process([1, 2, 3]))
 ```
 
-### Observables
+If you need an abstract base class with the same Mindtrace behavior, use `MindtraceABC`.
 
-The Observables module enables lightweight observability and reactivity for class objects, automatically turning selected properties into observable variables. This framework allows external components (listeners) to be notified whenever specific values change, without hard-coding the coupling between the source and observers.
+## Config
 
-There are three main classes included in the `observables` module:
+`Config` is the general-purpose configuration container in `mindtrace-core`. Use it when you want a flexible config object built from your own dictionaries, Pydantic models, or Pydantic settings objects.
 
----
+It supports:
 
-### 1. `EventBus`
+- dict-style access
+- attribute-style access
+- environment-variable overrides
+- masking of secret fields by default
+- cloning and JSON save/load helpers
 
-The `EventBus` is a lightweight internal publish-subscribe system for event dispatching. 
+`CoreConfig` uses the same underlying configuration system, but starts from Mindtrace’s standard core settings first and then layers your overrides on top.
 
-**API:**
+In practice:
 
-Event buses expose three main methods, which may be used to `subscribe`/`unsubscribe` individual listeners and `emit` event messages.
+- use `Config` for generic application or component configuration
+- use `CoreConfig` when you want the normal Mindtrace core sections already present, such as `MINDTRACE_DIR_PATHS`, `MINDTRACE_DEFAULT_HOST_URLS`, and `MINDTRACE_MCP`
+
+Example with `Config`:
 
 ```python
-subscribe(handler: Callable, event_name: str) -> str
-unsubscribe(handler_or_id: Union[str, Callable], event_name: str)
-emit(event_name: str, **kwargs)
+from mindtrace.core import Config
+
+
+config = Config(
+    {
+        "MY_APP": {
+            "DEBUG": "true",
+            "CACHE_DIR": "~/my-app-cache",
+        }
+    }
+)
+
+print(config.MY_APP.DEBUG)
+print(config.MY_APP.CACHE_DIR)
 ```
 
-**Example Usage:**
-To use an event bus, subscribe a handler to the bus with an associated event name. The handler will be called any time the event name is emitted. 
+Example with `CoreConfig`:
+
+```python
+from mindtrace.core import CoreConfig
+
+
+config = CoreConfig(
+    {
+        "MY_APP": {
+            "DEBUG": "true",
+        }
+    }
+)
+
+# Your own settings are still present
+print(config.MY_APP.DEBUG)
+
+# But CoreConfig also includes the standard Mindtrace core sections
+print(config.MINDTRACE_DIR_PATHS.TEMP_DIR)
+print(config.MINDTRACE_DEFAULT_HOST_URLS.SERVICE)
+```
+
+## TaskSchema
+
+`TaskSchema` is the small but important typed contract used across the Mindtrace ecosystem. It describes:
+
+- the task name
+- the input model
+- the output model
+
+This is especially useful in higher-level packages such as `mindtrace-services`, where the same schema is used for endpoint validation and client generation.
+
+Example:
+
+```python
+from pydantic import BaseModel
+
+from mindtrace.core import TaskSchema
+
+
+class SummarizeInput(BaseModel):
+    text: str
+
+
+class SummarizeOutput(BaseModel):
+    summary: str
+
+
+summarize_task = TaskSchema(
+    name="summarize",
+    input_schema=SummarizeInput,
+    output_schema=SummarizeOutput,
+)
+```
+
+## Logging
+
+`mindtrace-core` provides both standard logging and structured logging support.
+
+### Standard logger
+
+Use `get_logger()` when you want a ready-to-use logger with Mindtrace defaults.
+
+```python
+from mindtrace.core.logging.logger import get_logger
+
+
+logger = get_logger("core.example")
+logger.info("Logger configured")
+```
+
+### Structured logger
+
+If enabled, the same logging helpers can produce structured logs using `structlog`.
+
+```python
+from mindtrace.core.logging.logger import get_logger
+
+
+logger = get_logger(
+    "core.example",
+    use_structlog=True,
+    structlog_bind={"service": "demo"},
+)
+logger.info("Structured log event", user_id="123")
+```
+
+### `Mindtrace.autolog`
+
+Use `Mindtrace.autolog()` when you want to automatically log function execution, completion, and failures.
+
+```python
+from mindtrace.core import Mindtrace
+
+
+class DataProcessor(Mindtrace):
+    @Mindtrace.autolog()
+    def double(self, values: list[int]) -> list[int]:
+        return [value * 2 for value in values]
+```
+
+### `track_operation`
+
+Use `track_operation()` when you want explicit operation-level logging around a specific unit of work. It is useful for things like:
+
+- measuring how long an operation took
+- attaching structured context such as a batch ID or file name
+- recording optional system metrics alongside the operation
+- producing start / completed / failed log events in a consistent format
+
+```python
+from mindtrace.core.logging.logger import track_operation
+
+
+@track_operation("load_data", include_system_metrics=True, dataset="train")
+def load_data() -> list[int]:
+    return [1, 2, 3]
+```
+
+With this pattern, the logs can include fields such as:
+
+- the operation name
+- whether it started, completed, or failed
+- duration / duration_ms
+- any extra context you bound, such as `dataset="train"`
+- optional system metrics, such as CPU or memory usage
+
+That makes `track_operation()` a good fit when you care about observability of a specific workflow step, not just generic function logging.
+
+## Observables
+
+The observables utilities support lightweight eventing and reactive state updates.
+
+## `EventBus`
+
+`EventBus` is a simple publish-subscribe mechanism for dispatching events by name.
 
 ```python
 from mindtrace.core import EventBus
 
-bus = EventBus()    
+
+bus = EventBus()
+
 
 def handler(**kwargs):
     print(kwargs)
 
-bus.subscribe(handler, "event")
-bus.emit("event", x="1", y="2")  # {'x': '1', 'y': '2'}
 
-bus.unsubscribe(handler, "event")
-bus.emit("event", x="1", y="2")  # No output
+bus.subscribe(handler, "data_loaded")
+bus.emit("data_loaded", records=3)
+bus.unsubscribe(handler, "data_loaded")
 ```
 
----
+## `ObservableContext`
 
-### 2. `ObservableContext`
-
-The `ObservableContext` class decorator automatically turns specified properties into observable fields and wires up listener support.
-
-The `ObservableContext` class supports two specific event types, with associated event names:
-
-1. `context_updated(source: str, var: str, old: any, new: any)`: May be used when _any_ observed variable changes. The name of the variable will be given as the `var` argument, with associated old and new values.
-2. `{var}_updated(source: str, old: any, new: any)`: May be used to listen to specific variables. 
-
-**API:**
-
-The `ObservableContext` decorator adds `subscribe` and `unsubscribe` methods onto a wrapped class, which may be used directly analogously to with the `EventBus`.
-
-```python
-subscribe(handler, event_name)
-unsubscribe(handler_or_id, event_name)
-```
-
-**Example Usage:**
-
-When subscribing a class-derived listener, define a `context_updated` method which will be notified anytime any observable variable is updated, or specific `{var}_updated` methods, which will be notified when the associated variable is updated.
-
-```python
-class MyListener:
-    def context_updated(self, source, var, old, new):  # May be omitted, `{var}_updated` methods will be called automatically
-        if var == "x":
-            return self.x_updated(source, old, new)
-        elif var == "y":
-            return self.y_updated(source, old, new)
-    def x_updated(...): ...
-    def y_updated(...): ...
-```
-
-Listeners may subscribe to any class that has been decorated with the `ObservableContext` decorator, listening to any of the listed `vars` in the decorator.
+`ObservableContext` is a class decorator that turns selected attributes into observable fields.
 
 ```python
 from mindtrace.core import ObservableContext
 
-@ObservableContext(vars=["x", "y"])
-class MyContext:
+
+@ObservableContext(vars=["status"])
+class JobContext:
     def __init__(self):
-        self.x = 0
-        self.y = 0
+        self.status = "created"
 
-class MyListener:
-    def x_changed(self, source, old, new):
-        print(f"[{source}] x changed from {old} to {new}")
 
-my_context = MyContext()
-my_context.subscribe(MyListener())
-
-my_context.x = 1  # [MyContext] x changed from 0 to 1
+ctx = JobContext()
+ctx.status = "running"
 ```
 
----
+## `ContextListener`
 
-### 3. `ContextListener(Mindtrace)`
+`ContextListener` is a Mindtrace-aware helper for listening to observable context changes.
 
-The `ContextListener` class is a helper class for defining observers that respond to context changes. This class is meant to provide two benefits: (1) deriving from the `Mindtrace` base class, it provides for uniform logging of events and (2) the default ContextListener class can be used to automatically log changes to variables, optionally with a custom logger.
-
-**Example usage:**
 ```python
 from mindtrace.core import ContextListener, ObservableContext
 
-@ObservableContext(vars={"x": int, "y": int})
-class MyContext:
+
+@ObservableContext(vars={"progress": int})
+class JobContext:
     def __init__(self):
-        self.x = 0
-        self.y = 0
+        self.progress = 0
 
-my_context = MyContext()
-my_context.subscribe(ContextListener(autolog=["x", "y"], logger=...))  # May provide custom logger if desired
 
-my_context.x = 1
-my_context.y = 2
-
-# Logs:
-# [MyContext] x changed: 0 → 1
-# [MyContext] y changed: 0 → 2  
+ctx = JobContext()
+ctx.subscribe(ContextListener(autolog=["progress"]))
+ctx.progress = 50
 ```
 
-### Utility Functions
+## Utility Helpers
 
-#### `check_libs(*libs)`
-Verify required libraries are installed.
+`mindtrace-core` also provides a collection of lower-level helpers used across the ecosystem.
 
-```python
-from mindtrace.core import check_libs
-check_libs("numpy", "pandas")  # Raises ImportError if missing
-```
-
-#### `ifnone(value, default)`
-Return default if value is None.
-
-```python
-from mindtrace.core import ifnone
-result = ifnone(potentially_none_value, "default")
-```
-
-#### `instantiate_target(target, **kwargs)`
-Dynamically instantiate a class from string reference.
+### Dynamic loading
 
 ```python
 from mindtrace.core import instantiate_target
-instance = instantiate_target("my.module.MyClass", param="value")
+
+
+instance = instantiate_target(
+    "my_package.my_module.MyClass",
+    **{"config_path": "settings.json", "debug": True},
+)
 ```
+
+### Network helpers
+
+```python
+from mindtrace.core import get_free_port, wait_for_service
+
+
+port = get_free_port(start_port=8000, end_port=8100)
+print(port)
+
+# Wait for something to start listening on that port
+wait_for_service("localhost", port, timeout=5.0)
+```
+
+### Timers and timeout helpers
+
+```python
+from mindtrace.core import Timeout
+
+
+def eventually_ready():
+    return "ready"
+
+
+timeout = Timeout(timeout=5)
+print(timeout.run(eventually_ready))
+```
+
+### Hashing and metrics
+
+```python
+from mindtrace.core import SystemMetricsCollector, compute_dir_hash
+
+
+collector = SystemMetricsCollector()
+print(collector())
+print(compute_dir_hash("./some-directory"))
+```
+
+## Examples
+
+See these examples and related docs in the repo for more end-to-end reference:
+
+- [Core echo task sample](mindtrace/core/mindtrace/core/samples/echo_task.py)
+- [Core configuration examples](samples/core/config)
+- [Core logging / autolog examples](samples/core/logging)
+
+## Testing
+
+If you are working in the full Mindtrace repo, run tests for this module specifically:
+
+```bash
+git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+uv sync --dev --all-extras
+```
+
+```bash
+# Run the core test suite
+ds test: core
+
+# Run only unit tests for core
+ds test: --unit core
+```
+
+## Practical Notes and Caveats
+
+- `CoreConfig` includes Mindtrace’s default core settings; plain `Config` is the more generic configuration container.
+- Secret configuration values are masked by default; use explicit secret access helpers when you need the real value.
+- `TaskSchema` is a typed contract, not an execution engine by itself.
+- `Mindtrace.autolog()` and `track_operation()` overlap conceptually, but they are useful at different levels of abstraction.
+- Many helpers in `core` are intentionally low-level building blocks; the README should help you discover them, while the code docs remain the detailed reference.

--- a/mindtrace/database/README.md
+++ b/mindtrace/database/README.md
@@ -2,706 +2,105 @@
 [![License](https://img.shields.io/pypi/l/mindtrace-database)](https://github.com/mindtrace/mindtrace/blob/main/mindtrace/database/LICENSE)
 [![Downloads](https://static.pepy.tech/badge/mindtrace-database)](https://pepy.tech/projects/mindtrace-database)
 
-# Mindtrace Database Module
+# Mindtrace Database
 
-A powerful, flexible Object-Document Mapping (ODM) system that provides a **unified interface** for working with multiple database backends in the Mindtrace project. Write once, run on MongoDB, Redis, or both.
+The `Database` module provides Mindtrace’s object-document mapping layer for MongoDB, Redis, Registry-backed storage, and unified multi-backend workflows.
 
-## Key Features
+## Features
 
-- **Unified Interface** - One API for multiple databases
-- **Multi-Model Support** - Manage multiple document types in a single ODM instance
-- **Dynamic Switching** - Switch between MongoDB and Redis at runtime
-- **Simplified Document Models** - Define once, use everywhere
-- **Full Async/Sync Support** - Both MongoDB and Redis support sync and async interfaces
-- **Seamless Interface Compatibility** - Use sync code with async databases and vice versa
-- **Advanced Querying** - Rich query capabilities across all databases
-- **Comprehensive Error Handling** - Clear, actionable error messages
-- **Full Test Coverage** - Thoroughly tested with unit and integration tests
+- **Unified ODM interface** through `UnifiedMindtraceODM`
+- **Backend-specific ODMs** for MongoDB, Redis, and Registry-backed storage
+- **Single-model and multi-model operation** in the same API style
+- **Sync and async access patterns** across all supported backends
+- **Unified document models** that can target both MongoDB and Redis
+- **Consistent exceptions** such as `DocumentNotFoundError` and `DuplicateInsertError`
 
 ## Quick Start
 
-### The Simple Way: Unified Documents
-
-Define your document model once and use it with any database:
-
 ```python
-from mindtrace.database import UnifiedMindtraceDocument, UnifiedMindtraceODM, BackendType
+import asyncio
 
 from pydantic import Field
 
-# 1. Define your document model (works with both MongoDB and Redis)
+from mindtrace.database import BackendType, UnifiedMindtraceDocument, UnifiedMindtraceODM
+
+
 class User(UnifiedMindtraceDocument):
-    name: str = Field(description="User's full name")
-    age: int = Field(ge=0, description="User's age")
-    email: str = Field(description="User's email address")
-    skills: list[str] = Field(default_factory=list)
-    
+    name: str = Field(description="User name")
+    email: str = Field(description="Email address")
+    age: int = Field(ge=0)
+
     class Meta:
         collection_name = "users"
         global_key_prefix = "myapp"
         indexed_fields = ["email", "name"]
         unique_fields = ["email"]
 
-# 2. Create ODM instance (supports both MongoDB and Redis)
-db = UnifiedMindtraceODM(
-    unified_model_cls=User,
-    mongo_db_uri="mongodb://localhost:27017",
-    mongo_db_name="myapp",
-    redis_url="redis://localhost:6379",
-    preferred_backend=BackendType.MONGO  # Start with MongoDB
-    # init_mode=InitMode.ASYNC,  # Both use ASYNC (or SYNC)
-    # If None, MongoDB defaults to ASYNC and Redis defaults to SYNC
-)
 
-# 3. Use it (Same API regardless of database - both sync and async work)
-user = User(name="Alice", age=30, email="alice@example.com", skills=["Python"])
+async def main():
+    db = UnifiedMindtraceODM(
+        unified_model_cls=User,
+        mongo_db_uri="mongodb://localhost:27017",
+        mongo_db_name="myapp",
+        redis_url="redis://localhost:6379",
+        preferred_backend=BackendType.MONGO,
+    )
 
-# Async operations (work with both MongoDB and Redis)
-inserted_user = await db.insert_async(user)
-retrieved_user = await db.get_async(inserted_user.id)
-retrieved_user.age = 31
-updated_user = await db.update_async(retrieved_user)
-python_users = await db.find_async({"skills": "Python"})
-all_users = await db.all_async()
+    user = User(name="Alice", email="alice@example.com", age=30)
+    inserted = await db.insert_async(user)
+    fetched = await db.get_async(inserted.id)
+    print(fetched)
 
-# Sync operations (also work with both MongoDB and Redis)
-inserted_user = db.insert(user)
-retrieved_user = db.get(inserted_user.id)
-retrieved_user.age = 31
-updated_user = db.update(retrieved_user)
-python_users = db.find({"skills": "Python"})
-all_users = db.all()
 
-# Switch databases on the fly
-db.switch_backend(BackendType.REDIS)
-redis_user = db.insert(user)  # Now using Redis (sync)
-# or
-redis_user = await db.insert_async(user)  # Redis with async interface
-
-# Multi-model mode (works with all ODMs)
-db = UnifiedMindtraceODM(
-    unified_models={'user': User, 'address': Address},
-    mongo_db_uri="mongodb://localhost:27017",
-    mongo_db_name="myapp",
-    redis_url="redis://localhost:6379"
-)
-
-# Access models via attributes
-address = await db.address.insert_async(Address(street="123 Main St", city="NYC"))
-user = await db.user.insert_async(User(name="Alice", email="alice@example.com"))
-
-# All operations work per model
-users = await db.user.all_async()
-addresses = await db.address.all_async()
+asyncio.run(main())
 ```
 
-### Traditional Way: Database-Specific Models
+In practice, the database module gives you a common way to define document models and CRUD workflows while choosing the backend that best fits your application.
 
-If you prefer more control, you can define database-specific models:
+## Core Concepts
+
+The package revolves around four main ODM styles:
+
+- **`UnifiedMindtraceODM`** — one API over MongoDB and/or Redis
+- **`MongoMindtraceODM`** — MongoDB-specific ODM built on Beanie
+- **`RedisMindtraceODM`** — Redis-specific ODM built on redis-om
+- **`RegistryMindtraceODM`** — Registry-backed ODM for simpler local or storage-backed document persistence
+
+The package also provides matching document model bases:
+
+- `UnifiedMindtraceDocument`
+- `MindtraceDocument`
+- `MindtraceRedisDocument`
+
+## UnifiedMindtraceODM
+
+`UnifiedMindtraceODM` is the recommended starting point when you want one API that can work across MongoDB and Redis.
+
+### Unified document model
 
 ```python
-from mindtrace.database import (
-    MongoMindtraceODM, 
-    RedisMindtraceODM,
-    MindtraceDocument,
-    MindtraceRedisDocument
-)
-from beanie import Indexed
-from redis_om import Field as RedisField
-from typing import Annotated
+from pydantic import Field
 
-# MongoDB model
-class MongoUser(MindtraceDocument):
-    name: str
-    email: Annotated[str, Indexed(unique=True)]
-    age: int
-    
-    class Settings:
-        name = "users"
+from mindtrace.database import UnifiedMindtraceDocument
 
-# Redis model
-class RedisUser(MindtraceRedisDocument):
-    name: str = RedisField(index=True)
-    email: str = RedisField(index=True)
-    age: int = RedisField(index=True)
-    
+
+class User(UnifiedMindtraceDocument):
+    name: str = Field(description="User name")
+    email: str = Field(description="Email")
+    age: int = Field(ge=0)
+
     class Meta:
+        collection_name = "users"
         global_key_prefix = "myapp"
-
-# Use them separately
-mongo_db = MongoMindtraceODM(
-    model_cls=MongoUser,
-    db_uri="mongodb://localhost:27017",
-    db_name="myapp"
-)
-
-redis_db = RedisMindtraceODM(
-    model_cls=RedisUser,
-    redis_url="redis://localhost:6379"
-)
+        indexed_fields = ["email", "name"]
+        unique_fields = ["email"]
 ```
 
-## Multi-Model Support
-
-All ODMs now support managing multiple document types in a single instance. This allows you to work with related models (e.g., `User` and `Address`) through a single ODM instance with attribute-based access.
-
-### Usage Pattern
+### Unified ODM setup
 
 ```python
-# Instead of creating separate ODMs for each model:
-user_db = MongoMindtraceODM(model_cls=User, ...)
-address_db = MongoMindtraceODM(model_cls=Address, ...)
+from mindtrace.database import BackendType, UnifiedMindtraceODM
 
-# Use multi-model mode:
-db = MongoMindtraceODM(
-    models={'user': User, 'address': Address},
-    db_uri="mongodb://localhost:27017",
-    db_name="myapp"
-)
-
-# Access models via attributes
-await db.user.insert(user)
-await db.address.insert(address)
-users = await db.user.all()
-addresses = await db.address.all()
-```
-
-**Benefits:**
-- **Shared Connection** - All models share the same database connection
-- **Unified Initialization** - All models initialize together
-- **Cleaner Code** - Single ODM instance instead of multiple
-- **Consistent API** - Same operations work across all models
-
-**Note:** In multi-model mode, you must use attribute-based access (`db.user.insert()`). Direct methods (`db.insert()`) will raise a `ValueError` to prevent ambiguity.
-
-## Available ODMs
-
-### 1. UnifiedMindtraceODM (Recommended)
-
-The flagship ODM that provides a unified interface for multiple databases:
-
-**Key Features:**
-- **Single Interface**: One API for all databases
-- **Runtime Switching**: Change databases without code changes
-- **Automatic Model Generation**: Converts unified models to database-specific formats
-- **Flexible Configuration**: Use one or multiple databases
-
-**Configuration Options:**
-```python
-# Option 1: Single unified model
-db = UnifiedMindtraceODM(
-    unified_model_cls=MyUnifiedDoc,
-    mongo_db_uri="mongodb://localhost:27017",
-    mongo_db_name="mydb",
-    redis_url="redis://localhost:6379",
-    preferred_backend=BackendType.MONGO
-)
-
-# Option 2: Multiple unified models (multi-model mode)
-db = UnifiedMindtraceODM(
-    unified_models={'user': User, 'address': Address},
-    mongo_db_uri="mongodb://localhost:27017",
-    mongo_db_name="mydb",
-    redis_url="redis://localhost:6379",
-    preferred_backend=BackendType.MONGO
-)
-# Access via: db.user, db.address
-
-# Option 3: Separate models
-db = UnifiedMindtraceODM(
-    mongo_model_cls=MyMongoDoc,
-    redis_model_cls=MyRedisDoc,
-    mongo_db_uri="mongodb://localhost:27017",
-    mongo_db_name="mydb",
-    redis_url="redis://localhost:6379",
-    preferred_backend=BackendType.REDIS
-)
-
-# Option 4: Single database
-db = UnifiedMindtraceODM(
-    unified_model_cls=MyUnifiedDoc,
-    mongo_db_uri="mongodb://localhost:27017",
-    mongo_db_name="mydb",
-    preferred_backend=BackendType.MONGO
-)
-```
-
-### 2. MongoMindtraceODM
-
-Specialized MongoDB ODM using Beanie. **Natively async, but supports sync interface too**
-
-#### Single Model Mode
-
-```python
-from mindtrace.database import MongoMindtraceODM, MindtraceDocument
-
-class User(MindtraceDocument):
-    name: str
-    email: str
-    
-    class Settings:
-        name = "users"
-        use_cache = False
-
-db = MongoMindtraceODM(
-    model_cls=User,
-    db_uri="mongodb://localhost:27017",
-    db_name="myapp"
-)
-
-# Async operations (native)
-user = await db.insert(User(name="Alice", email="alice@example.com"))
-user.age = 31
-updated_user = await db.update(user)
-all_users = await db.all()
-
-# Sync operations (wrapper methods - use from sync code)
-user = db.insert_sync(User(name="Bob", email="bob@example.com"))
-user.age = 32
-updated_user = db.update_sync(user)
-all_users = db.all_sync()
-
-# Supports MongoDB-specific features
-pipeline = [{"$match": {"age": {"$gte": 18}}}]
-results = await db.aggregate(pipeline)
-```
-
-#### Multi-Model Mode
-
-```python
-from mindtrace.database import MongoMindtraceODM, MindtraceDocument
-
-class Address(MindtraceDocument):
-    street: str
-    city: str
-    
-    class Settings:
-        name = "addresses"
-        use_cache = False
-
-class User(MindtraceDocument):
-    name: str
-    email: str
-    
-    class Settings:
-        name = "users"
-        use_cache = False
-
-# Create ODM with multiple models
-db = MongoMindtraceODM(
-    models={'user': User, 'address': Address},
-    db_uri="mongodb://localhost:27017",
-    db_name="myapp"
-)
-
-# Access models via attribute-based access
-address = await db.address.insert(Address(street="123 Main St", city="NYC"))
-user = await db.user.insert(User(name="Alice", email="alice@example.com"))
-
-# All operations work per model
-users = await db.user.all()
-addresses = await db.address.all()
-```
-
-#### Working with Linked Documents (fetch_links)
-
-MongoDB supports linking documents using Beanie's `Link` type. Use `fetch_links=True` to automatically fetch linked documents:
-
-```python
-from mindtrace.database import Link, MongoMindtraceODM, MindtraceDocument
-from typing import Optional
-
-class Address(MindtraceDocument):
-    street: str
-    city: str
-    
-    class Settings:
-        name = "addresses"
-        use_cache = False
-
-class User(MindtraceDocument):
-    name: str
-    email: str
-    address: Optional[Link[Address]] = None
-    
-    class Settings:
-        name = "users"
-        use_cache = False
-
-db = MongoMindtraceODM(
-    models={'user': User, 'address': Address},
-    db_uri="mongodb://localhost:27017",
-    db_name="myapp"
-)
-
-# Create linked documents
-address = await db.address.insert(Address(street="123 Main St", city="NYC"))
-user = await db.user.insert(User(name="Alice", email="alice@example.com", address=address))
-
-# Fetch with linked documents using fetch_links=True
-user_with_address = await db.user.get(user.id, fetch_links=True)
-print(f"User: {user_with_address.name}, Address: {user_with_address.address.street}")
-
-# Find with linked documents
-users = await db.user.find(User.name == "Alice", fetch_links=True)
-for u in users:
-    if u.address:
-        print(f"{u.name} lives at {u.address.street}")
-
-# Without fetch_links, address will be a Link object (not fetched)
-user_without_links = await db.user.get(user.id)
-# user_without_links.address is a Link object, not the actual Address document
-```
-
-### 3. RedisMindtraceODM
-
-High-performance Redis ODM with JSON support. **Natively sync, but supports async interface too**
-
-#### Single Model Mode
-
-```python
-from mindtrace.database import RedisMindtraceODM, MindtraceRedisDocument
-from redis_om import Field
-
-class User(MindtraceRedisDocument):
-    name: str = Field(index=True)
-    email: str = Field(index=True)
-    age: int = Field(index=True)
-    
-    class Meta:
-        global_key_prefix = "myapp"
-
-db = RedisMindtraceODM(
-    model_cls=User,
-    redis_url="redis://localhost:6379"
-)
-
-# Sync operations (native)
-user = db.insert(User(name="Alice", email="alice@example.com"))
-user.age = 31
-updated_user = db.update(user)
-all_users = db.all()
-
-# Async operations (wrapper methods - use from async code)
-user = await db.insert_async(User(name="Bob", email="bob@example.com"))
-user.age = 32
-updated_user = await db.update_async(user)
-all_users = await db.all_async()
-
-# Supports Redis-specific queries
-users = db.find(User.age >= 18)
-```
-
-#### Multi-Model Mode
-
-```python
-from mindtrace.database import RedisMindtraceODM, MindtraceRedisDocument
-from redis_om import Field
-
-class Address(MindtraceRedisDocument):
-    street: str = Field(index=True)
-    city: str = Field(index=True)
-    
-    class Meta:
-        global_key_prefix = "myapp"
-
-class User(MindtraceRedisDocument):
-    name: str = Field(index=True)
-    email: str = Field(index=True)
-    address_id: Optional[str] = None
-    
-    class Meta:
-        global_key_prefix = "myapp"
-
-# Create ODM with multiple models
-db = RedisMindtraceODM(
-    models={'user': User, 'address': Address},
-    redis_url="redis://localhost:6379"
-)
-
-# Access models via attribute-based access
-address = db.address.insert(Address(street="123 Main St", city="NYC"))
-user = db.user.insert(User(name="Alice", email="alice@example.com", address_id=address.id))
-
-# All operations work per model
-users = db.user.all()
-addresses = await db.address.all_async()
-```
-
-### 4. RegistryMindtraceODM
-
-Flexible ODM using the Mindtrace Registry system, supporting local storage, GCP, and other storage options:
-
-#### Single Model Mode
-
-```python
-from mindtrace.database import RegistryMindtraceODM, DocumentNotFoundError
-from mindtrace.registry import Registry, Archiver
-from typing import Any, Type
-from pydantic import BaseModel
-from pathlib import Path
-
-class User(BaseModel):
-    name: str
-    email: str
-
-class UserArchiver(Archiver):
-    def save(self, user: User):
-        with open(Path(self.uri) / "user.json", "w") as f:
-            f.write(user.model_dump_json())
-
-    def load(self, data_type: Type[Any]) -> User:
-        with open(Path(self.uri) / "user.json", "r") as f:
-            return User.model_validate_json(f.read())
-
-Registry.register_default_materializer(User, UserArchiver)
-
-db = RegistryMindtraceODM(model_cls=User)
-
-user = User(name="John Doe", email="john.doe@example.com")
-inserted_user = db.insert(user)
-
-# Update the user
-inserted_user.name = "John Smith"
-updated_user = db.update(inserted_user)
-
-# Retrieve by ID (raises DocumentNotFoundError if not found)
-try:
-    user = db.get(inserted_user.id)
-except DocumentNotFoundError:
-    print("User not found")
-```
-
-#### Multi-Model Mode
-
-```python
-from mindtrace.database import RegistryMindtraceODM
-from mindtrace.registry import Registry, Archiver
-from typing import Any, Type
-from pydantic import BaseModel
-
-class User(BaseModel):
-    name: str
-    email: str
-
-class Address(BaseModel):
-    street: str
-    city: str
-
-# Register materializers for both models
-Registry.register_default_materializer(User, UserArchiver)
-Registry.register_default_materializer(Address, AddressArchiver)
-
-# Create ODM with multiple models
-db = RegistryMindtraceODM(
-    models={'user': User, 'address': Address}
-)
-
-# Access models via attribute-based access
-address = db.address.insert(Address(street="123 Main St", city="NYC"))
-user = db.user.insert(User(name="John Doe", email="john@example.com"))
-
-# All operations work per model
-users = db.user.all()
-addresses = db.address.all()
-```
-
-**With GCP Storage:**
-
-```python
-from mindtrace.database import RegistryMindtraceODM
-from mindtrace.registry import Registry, GCPRegistryBackend, Archiver
-from typing import Any, Type
-from pydantic import BaseModel
-from pathlib import Path
-
-class User(BaseModel):
-    name: str
-    email: str
-
-class UserArchiver(Archiver):
-    def save(self, user: User):
-        with open(Path(self.uri) / "user.json", "w") as f:
-            f.write(user.model_dump_json())
-
-    def load(self, data_type: Type[Any]) -> User:
-        with open(Path(self.uri) / "user.json", "r") as f:
-            return User.model_validate_json(f.read())
-
-Registry.register_default_materializer(User, UserArchiver)
-
-gcp_registry_backend = GCPRegistryBackend(
-    uri="gs://my-bucket",
-    project_id="my-project",
-    bucket_name="my-bucket",
-)
-
-db = RegistryMindtraceODM(model_cls=User, backend=gcp_registry_backend)
-
-user = User(name="John Doe", email="john.doe@example.com")
-inserted_user = db.insert(user)
-
-# Update the user
-inserted_user.name = "John Smith"
-updated_user = db.update(inserted_user)
-
-# Retrieve by ID
-user = db.get(inserted_user.id)
-```
-
-## API Reference
-
-### Core Operations
-
-All ODMs support both **sync and async** interfaces for all operations. Choose the style that fits your codebase.
-
-#### Async Operations (Recommended for async code)
-
-```python
-# Insert a document
-inserted_doc = await db.insert_async(doc)
-
-# Get document by ID
-doc = await db.get_async("doc_id")
-
-# Get document with linked documents (MongoDB only)
-doc_with_links = await db.get_async("doc_id", fetch_links=True)
-
-# Update document
-doc.name = "Updated Name"
-updated_doc = await db.update_async(doc)
-
-# Delete document
-await db.delete_async("doc_id")
-
-# Get all documents
-all_docs = await db.all_async()
-
-# Find documents with filters
-results = await db.find_async({"name": "Alice"})
-
-# Find documents with linked documents (MongoDB only)
-results_with_links = await db.find_async({"name": "Alice"}, fetch_links=True)
-```
-
-#### Sync Operations (Works with both MongoDB and Redis)
-
-```python
-# Insert a document
-inserted_doc = db.insert(doc)
-
-# Get document by ID
-doc = db.get("doc_id")
-
-# Update document
-doc.name = "Updated Name"
-updated_doc = db.update(doc)
-
-# Delete document
-db.delete("doc_id")
-
-# Get all documents
-all_docs = db.all()
-
-# Find documents with filters
-results = db.find({"name": "Alice"})
-```
-
-**Note**: 
-- **MongoDB**: Sync methods use wrapper functions that run async code in an event loop
-- **Redis**: Async methods run sync operations in a thread pool to avoid blocking the event loop
-- **Unified ODM**: Automatically routes to the appropriate method based on the active database
-- **Document IDs**: All backends provide a consistent `id` attribute on returned documents (MongoDB uses `id`, Redis uses `pk` internally but exposes it as `id`)
-
-### Sync/Async Compatibility
-
-Both MongoDB and Redis ODMs support both interfaces:
-
-| Database | Native Interface | Wrapper Interface |
-|----------|-----------------|-------------------|
-| MongoDB | Async (`insert`, `get`, etc.) | Sync (`insert_sync`, `get_sync`, etc.) |
-| Redis | Sync (`insert`, `get`, etc.) | Async (`insert_async`, `get_async`, etc.) |
-
-This means you can:
-- Use sync code with MongoDB (via sync wrappers)
-- Use async code with Redis (via async wrappers)
-- Mix and match based on your needs
-
-### UnifiedMindtraceODM Specific
-
-Additional methods for the unified ODM:
-
-```python
-# Database management
-db.switch_backend(BackendType.REDIS)
-current_type = db.get_current_backend_type()
-is_async = db.is_async()
-
-# Database availability
-has_mongo = db.has_mongo_backend()
-has_redis = db.has_redis_backend()
-
-# Direct access to underlying ODMs
-mongo_odm = db.get_mongo_backend()
-redis_odm = db.get_redis_backend()
-
-# Model access
-raw_model = db.get_raw_model()
-unified_model = db.get_unified_model()
-```
-
-### Advanced Querying
-
-#### MongoDB (through UnifiedMindtraceODM)
-```python
-from mindtrace.database import Link
-
-# MongoDB-style queries
-users = await db.find_async({"age": {"$gte": 18}})
-users = await db.find_async({"skills": {"$in": ["Python", "JavaScript"]}})
-
-# Fetch linked documents using fetch_links=True
-user = await db.get_async(user_id, fetch_links=True)
-if user.address:
-    print(f"User lives at {user.address.street}")
-
-# Find with linked documents
-users = await db.find_async({"name": "Alice"}, fetch_links=True)
-for u in users:
-    if u.address:
-        print(f"{u.name} - {u.address.city}")
-
-# Using Beanie expressions with links (get raw model first)
-UserMongo = db.get_raw_model()
-users = await db.find_async(UserMongo.name == "Alice", fetch_links=True)
-
-# Aggregation pipelines (when using MongoDB)
-if db.get_current_backend_type() == BackendType.MONGO:
-    pipeline = [
-        {"$match": {"age": {"$gte": 18}}},
-        {"$group": {"_id": "$department", "count": {"$sum": 1}}}
-    ]
-    results = await db.get_mongo_backend().aggregate(pipeline)
-```
-
-#### Redis (through UnifiedMindtraceODM)
-```python
-# Switch to Redis for these queries
-db.switch_backend(BackendType.REDIS)
-
-# Redis OM expressions
-Model = db.get_raw_model()
-users = db.find(Model.age >= 18)
-users = db.find(Model.name == "Alice")
-users = db.find(Model.skills << "Python")  # Contains
-```
-
-## Initialization Options
-
-By default, ODMs auto-initialize on first operation. For more control, use constructor parameters:
-
-```python
-from mindtrace.database import InitMode
 
 db = UnifiedMindtraceODM(
     unified_model_cls=User,
@@ -709,354 +108,357 @@ db = UnifiedMindtraceODM(
     mongo_db_name="myapp",
     redis_url="redis://localhost:6379",
     preferred_backend=BackendType.MONGO,
-    auto_init=True,              # Initialize at creation time
-    init_mode=InitMode.SYNC,     # Use sync initialization
 )
 ```
 
-**InitMode options:**
-- `InitMode.SYNC` - Synchronous initialization (blocks until complete)
-- `InitMode.ASYNC` - Deferred initialization (completes on first async operation)
+### Common operations
 
-**Default behavior:**
-- MongoDB defaults to `InitMode.ASYNC`
-- Redis defaults to `InitMode.SYNC`
+```python
+# Async operations
+inserted_user = await db.insert_async(User(name="Alice", email="alice@example.com", age=30))
+retrieved_user = await db.get_async(inserted_user.id)
+retrieved_user.age = 31
+updated_user = await db.update_async(retrieved_user)
+all_users = await db.all_async()
+python_users = await db.find_async({"name": "Alice"})
+```
+
+```python
+# Sync operations
+inserted_user = db.insert(User(name="Bob", email="bob@example.com", age=25))
+retrieved_user = db.get(inserted_user.id)
+retrieved_user.age = 26
+updated_user = db.update(retrieved_user)
+all_users = db.all()
+```
+
+### Switching backends
+
+```python
+db.switch_backend(BackendType.REDIS)
+redis_user = db.insert(User(name="Carol", email="carol@example.com", age=28))
+
+current_backend = db.get_current_backend_type()
+print(current_backend)
+```
+
+### Multi-model mode
+
+All ODMs in this package support multi-model mode.
+
+```python
+class Address(UnifiedMindtraceDocument):
+    street: str
+    city: str
+
+    class Meta:
+        collection_name = "addresses"
+        global_key_prefix = "myapp"
+
+
+db = UnifiedMindtraceODM(
+    unified_models={"user": User, "address": Address},
+    mongo_db_uri="mongodb://localhost:27017",
+    mongo_db_name="myapp",
+    redis_url="redis://localhost:6379",
+)
+
+address = await db.address.insert_async(Address(street="123 Main St", city="NYC"))
+user = await db.user.insert_async(User(name="Alice", email="alice@example.com", age=30))
+users = await db.user.all_async()
+```
+
+In multi-model mode, use attribute-based access like `db.user.insert_async(...)` rather than `db.insert_async(...)`.
+
+## MongoMindtraceODM
+
+Use `MongoMindtraceODM` when you want MongoDB-specific document models and Beanie features.
+
+### Mongo document model
+
+```python
+from typing import Annotated
+
+from beanie import Indexed
+
+from mindtrace.database import MindtraceDocument
+
+
+class MongoUser(MindtraceDocument):
+    name: str
+    email: Annotated[str, Indexed(unique=True)]
+    age: int
+
+    class Settings:
+        name = "users"
+        use_cache = False
+```
+
+### Mongo ODM setup
+
+```python
+from mindtrace.database import MongoMindtraceODM
+
+
+db = MongoMindtraceODM(
+    model_cls=MongoUser,
+    db_uri="mongodb://localhost:27017",
+    db_name="myapp",
+)
+```
+
+### Async-first behavior
+
+MongoDB is natively async in this package.
+
+```python
+inserted = await db.insert(MongoUser(name="Alice", email="alice@example.com", age=30))
+fetched = await db.get(inserted.id)
+results = await db.find(MongoUser.name == "Alice")
+```
+
+### Sync wrappers
+
+```python
+inserted = db.insert_sync(MongoUser(name="Bob", email="bob@example.com", age=25))
+fetched = db.get_sync(inserted.id)
+all_users = db.all_sync()
+```
+
+### Linked documents
+
+MongoDB supports Beanie `Link` fields.
+
+```python
+from typing import Optional
+
+from mindtrace.database import Link, MindtraceDocument, MongoMindtraceODM
+
+
+class Address(MindtraceDocument):
+    street: str
+    city: str
+
+    class Settings:
+        name = "addresses"
+        use_cache = False
+
+
+class UserWithAddress(MindtraceDocument):
+    name: str
+    address: Optional[Link[Address]] = None
+
+    class Settings:
+        name = "users"
+        use_cache = False
+
+
+db = MongoMindtraceODM(
+    models={"user": UserWithAddress, "address": Address},
+    db_uri="mongodb://localhost:27017",
+    db_name="myapp",
+)
+
+address = await db.address.insert(Address(street="123 Main St", city="NYC"))
+user = await db.user.insert(UserWithAddress(name="Alice", address=address))
+user_with_links = await db.user.get(user.id, fetch_links=True)
+```
+
+### Aggregation
+
+```python
+pipeline = [
+    {"$match": {"age": {"$gte": 18}}},
+    {"$group": {"_id": "$age", "count": {"$sum": 1}}},
+]
+results = await db.aggregate(pipeline)
+```
+
+## RedisMindtraceODM
+
+Use `RedisMindtraceODM` when you want Redis-backed JSON documents and indexed Redis OM queries.
+
+### Redis document model
+
+```python
+from redis_om import Field
+
+from mindtrace.database import MindtraceRedisDocument
+
+
+class RedisUser(MindtraceRedisDocument):
+    name: str = Field(index=True)
+    email: str = Field(index=True)
+    age: int = Field(index=True)
+
+    class Meta:
+        global_key_prefix = "myapp"
+```
+
+### Redis ODM setup
+
+```python
+from mindtrace.database import RedisMindtraceODM
+
+
+db = RedisMindtraceODM(
+    model_cls=RedisUser,
+    redis_url="redis://localhost:6379",
+)
+```
+
+### Sync-first behavior
+
+Redis is natively sync in this package.
+
+```python
+inserted = db.insert(RedisUser(name="Alice", email="alice@example.com", age=30))
+fetched = db.get(inserted.id)
+results = db.find(RedisUser.age >= 18)
+all_users = db.all()
+```
+
+### Async wrappers
+
+```python
+inserted = await db.insert_async(RedisUser(name="Bob", email="bob@example.com", age=25))
+fetched = await db.get_async(inserted.id)
+all_users = await db.all_async()
+```
+
+### Notes on Redis IDs
+
+Redis OM uses `pk` internally, but `MindtraceRedisDocument` exposes a consistent `id` property so code can treat MongoDB and Redis documents more similarly.
+
+## RegistryMindtraceODM
+
+Use `RegistryMindtraceODM` when you want a simpler registry-backed ODM using Mindtrace’s Registry layer instead of a database server.
+
+```python
+from pydantic import BaseModel
+
+from mindtrace.database import RegistryMindtraceODM
+
+
+class User(BaseModel):
+    name: str
+    email: str
+
+
+db = RegistryMindtraceODM(model_cls=User)
+inserted = db.insert(User(name="John Doe", email="john@example.com"))
+retrieved = db.get(inserted.id)
+retrieved.name = "John Smith"
+updated = db.update(retrieved)
+all_users = db.all()
+```
+
+This backend is useful when you want the ODM interface but prefer Registry-backed storage semantics.
+
+## Sync and Async Interfaces
+
+All ODMs expose the same broad CRUD shape, but their native execution mode differs.
+
+- **MongoMindtraceODM** — native async, with sync wrappers
+- **RedisMindtraceODM** — native sync, with async wrappers
+- **UnifiedMindtraceODM** — routes to the active backend and adapts accordingly
+- **RegistryMindtraceODM** — sync-oriented
+
+That means you can often keep the same mental model while fitting your application’s execution style.
+
+## Initialization
+
+ODMs support automatic or explicit initialization.
+
+```python
+from mindtrace.database import BackendType, InitMode, UnifiedMindtraceDocument, UnifiedMindtraceODM
+
+
+db = UnifiedMindtraceODM(
+    unified_model_cls=User,
+    mongo_db_uri="mongodb://localhost:27017",
+    mongo_db_name="myapp",
+    redis_url="redis://localhost:6379",
+    preferred_backend=BackendType.MONGO,
+    auto_init=True,
+    init_mode=InitMode.SYNC,
+)
+```
+
+### Init modes
+
+- `InitMode.SYNC`
+- `InitMode.ASYNC`
+
+Defaults differ by backend:
+
+- MongoDB defaults to `ASYNC`
+- Redis defaults to `SYNC`
+- Registry is sync-oriented
 
 ## Error Handling
 
-The module provides comprehensive error handling with consistent exceptions across all backends:
+The package provides a consistent exception surface across backends.
 
 ```python
 from mindtrace.database import DocumentNotFoundError, DuplicateInsertError
 
+
 try:
-    user = await db.get_async("non_existent_id")
+    user = await db.get_async("missing-id")
 except DocumentNotFoundError as e:
-    print(f"User not found: {e}")
+    print(f"Not found: {e}")
 
 try:
-    await db.insert_async(duplicate_user)
+    await db.insert_async(User(name="Alice", email="alice@example.com", age=30))
 except DuplicateInsertError as e:
-    print(f"User already exists: {e}")
-
-# All backends raise DocumentNotFoundError (not KeyError) for consistency
-try:
-    user = db.get("missing_id")
-except DocumentNotFoundError:
-    print("Document not found")
-
-# Multi-model mode errors
-try:
-    db.insert(user)  # In multi-model mode, this raises ValueError
-except ValueError as e:
-    print(f"Use db.model_name.insert() instead: {e}")
+    print(f"Duplicate insert: {e}")
 ```
 
+In multi-model mode, calling direct methods like `db.insert(...)` instead of `db.user.insert(...)` raises a `ValueError` to prevent ambiguity.
 
-```python
-from mindtrace.database import DocumentNotFoundError, DuplicateInsertError
+## Installation
 
-try:
-    user = await db.get_async("non_existent_id")
-except DocumentNotFoundError as e:
-    print(f"User not found: {e}")
+If you are working from the full Mindtrace repo:
 
-try:
-    await db.insert_async(duplicate_user)
-except DuplicateInsertError as e:
-    print(f"User already exists: {e}")
-```
-
-## Testing
-
-The database module includes comprehensive test coverage with both unit and integration tests.
-
-### Test Structure
-
-```
-tests/
-├── unit/mindtrace/database/          # Unit tests (no DB required)
-│   ├── test_mongo_unit.py
-│   ├── test_redis_unit.py
-│   ├── test_registry_odm_backend.py
-│   └── test_unified_unit.py
-└── integration/mindtrace/database/   # Integration tests (DB required)
-    ├── test_mongo.py
-    ├── test_redis_odm.py
-    ├── test_registry_odm.py
-    └── test_unified.py
-```
-
-### Running Tests
-
-#### Quick Start - All Tests
 ```bash
-ds test: database
+$ git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+$ uv sync --dev --all-extras
 ```
 
-#### Unit Tests Only
-```bash
-ds test: database --unit
-```
-
-#### Integration Tests (Containers managed by test script)
-```bash
-ds test: database --integration
-```
-
-#### Targeted Testing
-```bash
-# Test only unified backend
-ds test: tests/integration/mindtrace/database/test_unified.py
-
-# Test only MongoDB
-ds test: tests/integration/mindtrace/database/test_mongo.py
-
-# Test only Redis
-ds test: tests/integration/mindtrace/database/test_redis_odm.py
-```
-
-### Test Coverage
-
-The test suite covers:
-
-- **CRUD Operations** - Create, Read, Update, Delete
-- **Query Operations** - Find, filter, search
-- **Error Handling** - All exception scenarios
-- **Database Switching** - Dynamic database changes
-- **Async/Sync Compatibility** - Both programming styles
-- **Model Conversion** - Unified to database-specific models
-- **Edge Cases** - Duplicate keys, missing documents, invalid queries
+The database package depends on backend libraries such as Beanie, Motor, PyMongo, and Redis OM.
 
 ## Examples
 
-### Complete Example: User Management System
+Related examples in the repo:
 
-```python
-import asyncio
-from mindtrace.database import (
-    UnifiedMindtraceODM,
-    UnifiedMindtraceDocument,
-    BackendType,
-    DocumentNotFoundError
-)
-from pydantic import Field
-from typing import List
+- [Unified ODM example](../../samples/database/unified_example.py)
+- [MongoDB example](../../samples/database/mongo_example.py)
+- [Redis example](../../samples/database/redis_example.py)
+- [Registry example](../../samples/database/registry_example.py)
+- [Database samples README](../../samples/database/README.md)
 
-class User(UnifiedMindtraceDocument):
-    name: str = Field(description="Full name")
-    email: str = Field(description="Email address")  
-    age: int = Field(ge=0, le=150, description="Age")
-    department: str = Field(description="Department")
-    skills: List[str] = Field(default_factory=list)
-    
-    class Meta:
-        collection_name = "employees"
-        global_key_prefix = "company"
-        indexed_fields = ["email", "department", "skills"]
-        unique_fields = ["email"]
+## Testing
 
-async def main():
-    # Setup with both MongoDB and Redis
-    db = UnifiedMindtraceODM(
-        unified_model_cls=User,
-        mongo_db_uri="mongodb://localhost:27017",
-        mongo_db_name="company",
-        redis_url="redis://localhost:6379",
-        preferred_backend=BackendType.MONGO
-    )
-    
-    # Create some users
-    users = [
-        User(
-            name="Alice Johnson",
-            email="alice@company.com",
-            age=30,
-            department="Engineering",
-            skills=["Python", "MongoDB", "Docker"]
-        ),
-        User(
-            name="Bob Smith", 
-            email="bob@company.com",
-            age=25,
-            department="Engineering",
-            skills=["JavaScript", "Redis", "React"]
-        ),
-        User(
-            name="Carol Davis",
-            email="carol@company.com", 
-            age=35,
-            department="Marketing",
-            skills=["Analytics", "SQL"]
-        )
-    ]
-    
-    # Insert users
-    print("Creating users...")
-    for user in users:
-        try:
-            inserted = await db.insert_async(user)
-            print(f"Created: {inserted.name} (ID: {inserted.id})")
-        except Exception as e:
-            print(f"Failed to create {user.name}: {e}")
-    
-    # Find engineers
-    print("\nFinding engineers...")
-    engineers = await db.find_async({"department": "Engineering"})
-    for eng in engineers:
-        print(f"{eng.name} - Skills: {', '.join(eng.skills)}")
-    
-    # Switch to Redis for fast lookups
-    print("\nSwitching to Redis for fast operations...")
-    db.switch_backend(BackendType.REDIS)
-    
-    # Insert more users in Redis (both sync and async work)
-    redis_user = User(
-        name="Dave Wilson",
-        email="dave@company.com",
-        age=28,
-        department="DevOps",
-        skills=["Kubernetes", "Redis", "Monitoring"]
-    )
-    
-    # Use sync interface (native for Redis)
-    redis_inserted = db.insert(redis_user)
-    print(f"Redis user created (sync): {redis_inserted.name}")
-    
-    # Or use async interface (wrapper for Redis)
-    redis_user2 = User(
-        name="Eve Brown",
-        email="eve@company.com",
-        age=32,
-        department="DevOps",
-        skills=["Docker", "CI/CD"]
-    )
-    redis_inserted2 = await db.insert_async(redis_user2)
-    print(f"Redis user created (async): {redis_inserted2.name}")
-    
-    # Demonstrate data isolation
-    print(f"\nMongoDB users: {len(await db.get_mongo_backend().all())}")
-    print(f"Redis users: {len(db.get_redis_backend().all())}")
-    
-    # Switch back to MongoDB
-    db.switch_backend(BackendType.MONGO)
-    print(f"Back to MongoDB - Users: {len(await db.all_async())}")
+If you are working in the full Mindtrace repo, run tests for this module specifically:
 
-if __name__ == "__main__":
-    asyncio.run(main())
+```bash
+$ git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+$ uv sync --dev --all-extras
+$ ds test: database
+$ ds test: --unit database
 ```
 
-### More Examples
+If you want backend-specific integration coverage as well:
 
-Check out the `samples/database/` directory for additional examples:
-
-- **`using_unified_backend.py`** - Comprehensive unified ODM usage
-- **Advanced querying patterns**
-- **Database switching strategies**
-- **Error handling best practices**
-
-## Best Practices
-
-### 1. Model Design
-```python
-# Good: Clear, descriptive models
-class Product(UnifiedMindtraceDocument):
-    name: str = Field(description="Product name", min_length=1)
-    price: float = Field(ge=0, description="Price in USD")
-    category: str = Field(description="Product category")
-    
-    class Meta:
-        collection_name = "products"
-        indexed_fields = ["category", "name"]
-        unique_fields = ["name"]
-
-# Avoid: Unclear models without validation
-class Product(UnifiedMindtraceDocument):
-    n: str
-    p: float
-    c: str
+```bash
+$ ds test: database --integration
 ```
 
-### 2. Error Handling
-```python
-# Always handle database exceptions
-try:
-    user = await db.get_async(user_id)
-    print(f"Found user: {user.name}")
-except DocumentNotFoundError:
-    print("User not found - creating new user")
-    user = await db.insert_async(User(name="New User", email="new@example.com"))
-except Exception as e:
-    logger.error(f"Database error: {e}")
-    # Handle appropriately
-```
+## Practical Notes and Caveats
 
-### 3. Database Selection
-```python
-# Choose database based on use case
-if high_frequency_reads:
-    db.switch_backend(BackendType.REDIS)  # Fast reads
-else:
-    db.switch_backend(BackendType.MONGO)  # Complex queries
-```
-
-## Contributing
-
-When adding new features:
-
-1. **Add tests** - Both unit and integration tests
-2. **Update documentation** - Keep README and docstrings current
-3. **Follow patterns** - Use existing code style and patterns
-4. **Test thoroughly** - Run the full test suite
-
-## Requirements
-
-- **MongoDB 4.4+** (for MongoMindtraceODM)
-- **Redis 6.0+** (for RedisMindtraceODM)
-- **Core dependencies**: `pydantic`, `beanie`, `redis-om-python`
-
-## Need Help?
-
-- Check the `samples/database/` directory for working examples
-- Look at the test files for usage patterns
-- Review the docstrings in the source code for detailed API documentation
-
-The Mindtrace Database Module makes it easy to work with multiple databases through a single, powerful interface.
-
----
-
-## Breaking Changes
-
-### Class Name Changes (v0.6.0)
-
-All ODM class names have been simplified by removing the "Backend" suffix:
-
-| Old Name | New Name |
-|----------|----------|
-| `MindtraceODMBackend` | `MindtraceODM` |
-| `MongoMindtraceODMBackend` | `MongoMindtraceODM` |
-| `RedisMindtraceODMBackend` | `RedisMindtraceODM` |
-| `RegistryMindtraceODMBackend` | `RegistryMindtraceODM` |
-| `UnifiedMindtraceODMBackend` | `UnifiedMindtraceODM` |
-
-**File names also updated:**
-
-| Old File | New File |
-|----------|----------|
-| `mindtrace_odm_backend.py` | `mindtrace_odm.py` |
-| `mongo_odm_backend.py` | `mongo_odm.py` |
-| `redis_odm_backend.py` | `redis_odm.py` |
-| `registry_odm_backend.py` | `registry_odm.py` |
-| `unified_odm_backend.py` | `unified_odm.py` |
-
-**Migration:**
-
-```python
-# Old
-from mindtrace.database import MongoMindtraceODMBackend, UnifiedMindtraceODMBackend
-db = MongoMindtraceODMBackend(model_cls=User, db_uri="...", db_name="...")
-
-# New
-from mindtrace.database import MongoMindtraceODM, UnifiedMindtraceODM
-db = MongoMindtraceODM(model_cls=User, db_uri="...", db_name="...")
-```
+- `UnifiedMindtraceODM` only exposes the overlap of capabilities that make sense across MongoDB and Redis; backend-specific features still live on the backend-specific ODMs.
+- Multi-model mode changes the calling style: use attribute-based access like `db.user.get(...)`.
+- MongoDB supports linked documents and aggregation; Redis does not provide the same feature set.
+- Redis and MongoDB differ in native execution style, so some methods are wrappers around the backend’s natural sync/async mode.
+- `RegistryMindtraceODM` is useful for simpler or storage-backed workflows, but its query capabilities are intentionally simpler than MongoDB or Redis.

--- a/mindtrace/hardware/mindtrace/hardware/cli/README.md
+++ b/mindtrace/hardware/mindtrace/hardware/cli/README.md
@@ -1,562 +1,207 @@
 # Mindtrace Hardware CLI
 
-A command-line interface for managing Mindtrace hardware services with process lifecycle management, status monitoring, and automated service coordination.
+The `Hardware CLI` provides command-line management for Mindtrace hardware services, including service startup, shutdown, status checks, logs, and common operational workflows.
 
 ## Features
 
-### Core Commands
+- **Service lifecycle management** for camera, stereo, scanner, and PLC services
+- **Health and status inspection** across all managed services
+- **Process tracking** with graceful shutdown behavior
+- **Convenient docs access** through `--open-docs` for supported services
+- **Configuration overrides** via CLI flags and environment variables
+- **A single operational entry point** through `mindtrace-hw`
 
-**Camera Services:**
-- **`mindtrace-hw camera start`** - Start camera API service
-- **`mindtrace-hw camera stop`** - Stop camera API service gracefully
-- **`mindtrace-hw camera status`** - Show detailed camera API status with URLs
-- **`mindtrace-hw camera logs`** - View camera API service logs and guidance
+## Quick Start
 
-**Stereo Camera Services:**
-- **`mindtrace-hw stereo start`** - Start stereo camera API service
-- **`mindtrace-hw stereo stop`** - Stop stereo camera service gracefully
-- **`mindtrace-hw stereo status`** - Show stereo camera service status with URLs
-- **`mindtrace-hw stereo logs`** - View stereo camera service logs
-
-**3D Scanner Services:**
-- **`mindtrace-hw scanner start`** - Start 3D scanner API service
-- **`mindtrace-hw scanner stop`** - Stop 3D scanner service gracefully
-- **`mindtrace-hw scanner status`** - Show 3D scanner service status with URLs
-- **`mindtrace-hw scanner logs`** - View 3D scanner service logs
-
-**PLC Services:**
-- **`mindtrace-hw plc start`** - Start PLC API service
-- **`mindtrace-hw plc stop`** - Stop PLC service gracefully
-- **`mindtrace-hw plc status`** - Show PLC service status with URLs
-- **`mindtrace-hw plc logs`** - View PLC service logs
-
-**Global Commands:**
-- **`mindtrace-hw status`** - Show all hardware services status
-- **`mindtrace-hw stop`** - Stop all services cleanly
-- **`mindtrace-hw logs <service>`** - View logs for camera, plc, scanner, stereo, or all services
-
-### Key Capabilities
-
-- **Intelligent Process Management** - Tracks service PIDs with graceful SIGTERM → SIGKILL fallback
-- **Port Availability Checking** - Validates ports before starting services
-- **Service Health Monitoring** - Real-time uptime, memory usage, and availability checks
-- **Mock Camera Support** - Include virtual cameras for testing and development
-- **Flexible Configuration** - Environment variable support with CLI overrides
-
-## Usage Examples
-
-### Basic Usage
-
-**Camera Services:**
 ```bash
-# Start camera API service
-mindtrace-hw camera start
-
-# Start with API docs opened in browser
-mindtrace-hw camera start --open-docs
-
-# Check detailed status with access URLs
-mindtrace-hw camera status
-
-# Stop camera API service gracefully
-mindtrace-hw camera stop
+$ mindtrace-hw camera start --open-docs
+$ mindtrace-hw camera status
+$ mindtrace-hw stop
 ```
 
-**Stereo Camera Services:**
+The CLI is primarily for operating hardware services in practice: starting them, checking whether they are healthy, opening their docs, and stopping them cleanly.
+
+## Service Commands
+
+The CLI exposes service-oriented subcommands for the hardware domains it currently manages.
+
+### Camera service
+
 ```bash
-# Start stereo camera API service
-mindtrace-hw stereo start
-
-# Open documentation in browser automatically
-mindtrace-hw stereo start --open-docs
-
-# Check stereo camera service status
-mindtrace-hw stereo status
-
-# Stop stereo camera service
-mindtrace-hw stereo stop
+$ mindtrace-hw camera start
+$ mindtrace-hw camera start --open-docs
+$ mindtrace-hw camera status
+$ mindtrace-hw camera logs
+$ mindtrace-hw camera stop
 ```
 
-**3D Scanner Services:**
+### Stereo camera service
+
 ```bash
-# Start 3D scanner API service
-mindtrace-hw scanner start
-
-# Open documentation in browser automatically
-mindtrace-hw scanner start --open-docs
-
-# Check 3D scanner service status
-mindtrace-hw scanner status
-
-# Stop 3D scanner service
-mindtrace-hw scanner stop
+$ mindtrace-hw stereo start
+$ mindtrace-hw stereo start --open-docs
+$ mindtrace-hw stereo status
+$ mindtrace-hw stereo logs
+$ mindtrace-hw stereo stop
 ```
 
-**PLC Services:**
+### 3D scanner service
+
 ```bash
-# Start PLC API service
-mindtrace-hw plc start
-
-# Check PLC service status
-mindtrace-hw plc status
-
-# Stop PLC service
-mindtrace-hw plc stop
+$ mindtrace-hw scanner start
+$ mindtrace-hw scanner start --open-docs
+$ mindtrace-hw scanner status
+$ mindtrace-hw scanner logs
+$ mindtrace-hw scanner stop
 ```
 
-### Advanced Configuration
+### PLC service
+
 ```bash
-# Custom host and port configuration
-mindtrace-hw camera start --api-host 192.168.1.100 --api-port 8080
-
-# Include mock cameras for development and testing
-mindtrace-hw camera start --include-mocks
-
-# Bind to all interfaces for network access
-mindtrace-hw camera start --api-host 0.0.0.0
+$ mindtrace-hw plc start
+$ mindtrace-hw plc status
+$ mindtrace-hw plc logs
+$ mindtrace-hw plc stop
 ```
 
-### Service Management
+## Global Commands
+
+Use the top-level commands when you want to inspect or stop the full set of managed services.
+
 ```bash
-# Check if services are running before starting
-mindtrace-hw camera status
-
-# Force restart existing services
-mindtrace-hw camera start  # Will prompt to restart if running
-
-# View service log information
-mindtrace-hw camera logs
+$ mindtrace-hw status
+$ mindtrace-hw stop
+$ mindtrace-hw logs all
 ```
 
-## Architecture
+You can also inspect logs for a specific service group:
 
-### Directory Structure
-```
-cli/
-├── __init__.py
-├── __main__.py           # CLI entry point with Typer integration
-├── commands/
-│   ├── __init__.py
-│   ├── camera.py         # Camera service management commands
-│   ├── scanner.py        # 3D scanner service management commands
-│   ├── stereo.py         # Stereo camera service management commands
-│   ├── plc.py            # PLC service management commands
-│   └── status.py         # Global status command
-├── core/
-│   ├── __init__.py
-│   ├── process_manager.py # Service lifecycle management with PID tracking
-│   └── logger.py          # Structured CLI logging with colors
-└── utils/
-    ├── __init__.py
-    ├── display.py         # Terminal formatting and status display
-    └── network.py         # Port checking and service health utilities
-```
-
-### Service Integration Architecture
-- **Camera API**: Managed via `mindtrace.hardware.services.cameras.launcher`
-- **Stereo Camera API**: Managed via `mindtrace.hardware.services.stereo_cameras.launcher`
-- **3D Scanner API**: Managed via `mindtrace.hardware.services.scanners_3d.launcher`
-- **PLC API**: Managed via `mindtrace.hardware.services.plcs.launcher`
-- **Process Coordination**: PID tracking in `~/.mindtrace/hw_services.json`
-- **Health Monitoring**: TCP port checks and process validation
-
-### Dependencies
-
-- **typer** - Modern CLI framework with type hints and automatic Rich integration (official Mindtrace CLI standard)
-- **psutil** - Cross-platform process and system monitoring
-- **rich** - Beautiful terminal output and progress display
-
-## Service Management
-
-### Process Lifecycle
-```python
-# Service startup sequence
-1. Check existing service status
-2. Validate port availability
-3. Start API service with specified configuration
-4. Wait for API health check (10s timeout)
-5. Monitor service health continuously
-```
-
-### Persistent State Management
-- **PID Storage**: `~/.mindtrace/hw_services.json`
-- **Graceful Shutdown**: SIGTERM with 5s timeout, then SIGKILL
-- **Automatic Cleanup**: Dead process detection and cleanup
-
-### Health Monitoring
 ```bash
-# Detailed status output includes:
-Service Name    | Status  | PID   | Host:Port        | Uptime | Memory
-camera_api      | Running | 12345 | localhost:8002   | 2h 15m | 45.2MB
+$ mindtrace-hw logs camera
+$ mindtrace-hw logs scanner
+$ mindtrace-hw logs stereo
+$ mindtrace-hw logs plc
 ```
+
+## Common Workflows
+
+### Start a service and open its docs
+
+```bash
+$ mindtrace-hw scanner start --open-docs
+$ mindtrace-hw scanner status
+```
+
+### Start on a custom host and port
+
+```bash
+$ mindtrace-hw camera start --api-host 0.0.0.0 --api-port 8080
+$ mindtrace-hw camera status
+```
+
+### Start camera service with mock devices
+
+```bash
+$ mindtrace-hw camera start --include-mocks
+$ mindtrace-hw camera status
+```
+
+### Inspect everything, then stop everything
+
+```bash
+$ mindtrace-hw status
+$ mindtrace-hw stop
+```
+
+## What the CLI manages
+
+Operationally, the CLI is responsible for things like:
+
+- checking whether a service is already running
+- validating port availability before startup
+- tracking service processes
+- reporting status, uptime, and basic health information
+- stopping services gracefully before escalating if needed
+
+That makes it the practical control surface for service-based hardware deployments.
+
+## Configuration
+
+CLI options can override service host and port at launch time.
+
+Examples:
+
+```bash
+$ mindtrace-hw camera start --api-host 192.168.1.100 --api-port 8080
+$ mindtrace-hw stereo start --api-host 0.0.0.0 --api-port 8004
+$ mindtrace-hw scanner start --api-host 0.0.0.0 --api-port 8005
+$ mindtrace-hw plc start --api-host 0.0.0.0 --api-port 8003
+```
+
+The CLI also supports environment-driven configuration. In practice, command-line flags take precedence over environment defaults.
 
 ## Installation
 
-### Using uv (Recommended)
+If you are working from the full Mindtrace repo:
+
 ```bash
-cd mindtrace/hardware
-uv sync
-mindtrace-hw --help
+$ git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+$ uv sync --dev --all-extras
 ```
 
-### System Installation
-Install as `mindtrace-hw` command:
+If you want the CLI entry point available locally from the hardware package:
+
 ```bash
-uv pip install -e mindtrace/hardware/
-mindtrace-hw --help
-```
-
-### Development Setup
-```bash
-cd mindtrace/hardware
-uv sync --dev
-mindtrace-hw camera start --include-mocks
-```
-
-## Environment Variables
-
-Configure services using standardized environment variables:
-
-### Camera API Service Configuration
-- `CAMERA_API_HOST` - API service host (default: `localhost`)
-- `CAMERA_API_PORT` - API service port (default: `8002`)
-- `CAMERA_API_URL` - Full API URL (default: `http://localhost:8002`)
-
-### Stereo Camera API Service Configuration
-- `STEREO_CAMERA_API_HOST` - API service host (default: `localhost`)
-- `STEREO_CAMERA_API_PORT` - API service port (default: `8004`)
-- `STEREO_CAMERA_API_URL` - Full API URL (default: `http://localhost:8004`)
-
-### 3D Scanner API Service Configuration
-- `SCANNER_3D_API_HOST` - API service host (default: `localhost`)
-- `SCANNER_3D_API_PORT` - API service port (default: `8005`)
-- `SCANNER_3D_API_URL` - Full API URL (default: `http://localhost:8005`)
-
-### PLC API Service Configuration
-- `PLC_API_HOST` - API service host (default: `localhost`)
-- `PLC_API_PORT` - API service port (default: `8003`)
-- `PLC_API_URL` - Full API URL (default: `http://localhost:8003`)
-
-### Example Production Configuration
-```bash
-# Network accessible configuration
-export CAMERA_API_HOST="0.0.0.0"
-export CAMERA_API_PORT="8080"
-
-# Start services with environment configuration
-mindtrace-hw camera start
-```
-
-### Environment Override
-CLI options always override environment variables:
-```bash
-# This overrides CAMERA_API_PORT even if set in environment
-mindtrace-hw camera start --api-port 9000
-```
-
-## Command Reference
-
-### Camera Commands
-
-#### camera start
-```bash
-mindtrace-hw camera start [OPTIONS]
-
-Options:
-  --api-host TEXT     API service host [default: localhost]
-  --api-port INTEGER  API service port [default: 8002]
-  --include-mocks     Include mock cameras for testing
-  --open-docs         Open API documentation in browser
-
-Examples:
-  # Start with default settings
-  mindtrace-hw camera start
-
-  # Start on custom host/port
-  mindtrace-hw camera start --api-host 0.0.0.0 --api-port 8080
-
-  # Start with mock cameras and open docs
-  mindtrace-hw camera start --include-mocks --open-docs
-
-Access URLs:
-  - API: http://localhost:8002
-  - Swagger UI: http://localhost:8002/docs
-  - ReDoc: http://localhost:8002/redoc
-```
-
-#### camera stop
-```bash
-mindtrace-hw camera stop
-
-# Gracefully stops camera API service
-```
-
-#### camera status
-```bash
-mindtrace-hw camera status
-
-# Shows detailed status:
-# - Service running status
-# - Process ID and resource usage
-# - Host:Port and access URLs
-# - Service uptime
-```
-
-#### camera logs
-```bash
-mindtrace-hw camera logs
-
-# Provides guidance on log locations:
-# - Console output for API service
-```
-
-### Stereo Camera Commands
-
-#### stereo start
-```bash
-mindtrace-hw stereo start [OPTIONS]
-
-Options:
-  --api-host TEXT     Stereo Camera API service host [default: localhost]
-  --api-port INTEGER  Stereo Camera API service port [default: 8004]
-  --open-docs        Open API documentation in browser
-
-Examples:
-  # Start with default settings
-  mindtrace-hw stereo start
-
-  # Start on custom host/port
-  mindtrace-hw stereo start --api-host 0.0.0.0 --api-port 8005
-
-  # Start and open Swagger UI in browser
-  mindtrace-hw stereo start --open-docs
-
-Access URLs:
-  - API: http://localhost:8004
-  - Swagger UI: http://localhost:8004/docs
-  - ReDoc: http://localhost:8004/redoc
-```
-
-#### stereo stop
-```bash
-mindtrace-hw stereo stop
-
-# Gracefully stops stereo camera API service
-```
-
-#### stereo status
-```bash
-mindtrace-hw stereo status
-
-# Shows detailed status:
-# - Service running status
-# - Process ID and resource usage
-# - Host:Port and access URLs
-# - Service uptime
-```
-
-#### stereo logs
-```bash
-mindtrace-hw stereo logs
-
-# Provides guidance on log locations:
-# - Console output for API service
-```
-
-### 3D Scanner Commands
-
-#### scanner start
-```bash
-mindtrace-hw scanner start [OPTIONS]
-
-Options:
-  --api-host TEXT     3D Scanner API service host [default: localhost]
-  --api-port INTEGER  3D Scanner API service port [default: 8005]
-  --open-docs        Open API documentation in browser
-
-Examples:
-  # Start with default settings
-  mindtrace-hw scanner start
-
-  # Start on custom host/port
-  mindtrace-hw scanner start --api-host 0.0.0.0 --api-port 8006
-
-  # Start and open Swagger UI in browser
-  mindtrace-hw scanner start --open-docs
-
-Access URLs:
-  - API: http://localhost:8005
-  - Swagger UI: http://localhost:8005/docs
-  - ReDoc: http://localhost:8005/redoc
-```
-
-#### scanner stop
-```bash
-mindtrace-hw scanner stop
-
-# Gracefully stops 3D scanner API service
-```
-
-#### scanner status
-```bash
-mindtrace-hw scanner status
-
-# Shows detailed status:
-# - Service running status
-# - Process ID and resource usage
-# - Host:Port and access URLs
-# - Service uptime
-```
-
-#### scanner logs
-```bash
-mindtrace-hw scanner logs
-
-# Provides guidance on log locations:
-# - Console output for API service
-```
-
-### PLC Commands
-
-#### plc start
-```bash
-mindtrace-hw plc start [OPTIONS]
-
-Options:
-  --api-host TEXT     PLC API service host [default: localhost]
-  --api-port INTEGER  PLC API service port [default: 8003]
-
-Examples:
-  # Start with default settings
-  mindtrace-hw plc start
-
-  # Start on custom host/port
-  mindtrace-hw plc start --api-host 0.0.0.0 --api-port 8005
-
-Access URLs:
-  - API: http://localhost:8003
-  - Swagger UI: http://localhost:8003/docs
-  - ReDoc: http://localhost:8003/redoc
-```
-
-#### plc stop
-```bash
-mindtrace-hw plc stop
-
-# Gracefully stops PLC API service
-```
-
-#### plc status
-```bash
-mindtrace-hw plc status
-
-# Shows detailed status:
-# - Service running status
-# - Process ID and resource usage
-# - Host:Port and access URLs
-# - Service uptime
-```
-
-#### plc logs
-```bash
-mindtrace-hw plc logs
-
-# Provides guidance on log locations:
-# - Console output for API service
+$ uv pip install -e mindtrace/hardware/
+$ mindtrace-hw --help
 ```
 
 ## Troubleshooting
 
-### Common Issues
+### Port already in use
 
-#### Port Already in Use
 ```bash
-# Error: Port 8002 is already in use on localhost
-# Solution: Check what's using the port
-netstat -tulpn | grep 8002
-# Or use a different port
-mindtrace-hw camera start --api-port 8003
+$ mindtrace-hw camera status
+$ mindtrace-hw camera start --api-port 8003
 ```
 
-#### Service Won't Start
+### Service won’t start cleanly
+
 ```bash
-# Check service status first
-mindtrace-hw camera status
-
-# Stop and restart cleanly
-mindtrace-hw camera stop
-mindtrace-hw camera start
+$ mindtrace-hw camera status
+$ mindtrace-hw camera stop
+$ mindtrace-hw camera start
 ```
 
-#### Service Health Check Timeouts
+### Need log guidance
+
 ```bash
-# API timeout (10s): Usually indicates camera backend issues
-# Check logs for more details
-mindtrace-hw camera logs
+$ mindtrace-hw logs camera
+$ mindtrace-hw logs all
 ```
 
-### Process Management Issues
-- **Orphaned Processes**: `pkill -f "camera.*service"` to clean up
-- **Permission Issues**: Ensure write access to `~/.mindtrace/`
-- **PID File Corruption**: Delete `~/.mindtrace/hw_services.json` and restart
+## Examples
 
-## Development
+Related docs in this package:
 
-### Adding New Hardware Services
-```python
-# In commands/new_service.py
-import typer
-from typing_extensions import Annotated
+- [Top-level hardware module README](../../../../README.md)
+- [3D scanner subsystem documentation](../scanners_3d/README.md)
 
-app = typer.Typer(help="Manage new hardware service")
+## Testing
 
-@app.command()
-def start(
-    api_host: Annotated[str, typer.Option("--api-host", help="API host")] = "localhost",
-    api_port: Annotated[int, typer.Option("--api-port", help="API port")] = 8005,
-):
-    """Start new service."""
-    pm = ProcessManager()
-    # Implement service startup logic
+If you are working in the full Mindtrace repo, run tests for the hardware module:
+
+```bash
+$ git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+$ uv sync --dev --all-extras
+$ ds test: hardware
+$ ds test: --unit hardware
 ```
 
-### Process Manager Integration
-```python
-# In core/process_manager.py
-def start_new_service(self, host: str, port: int) -> subprocess.Popen:
-    """Start a new hardware service."""
-    # Add service startup logic
-    # Return process object for tracking
-```
+## Practical Notes and Caveats
 
-### Extending Service Monitoring
-```python
-# In utils/display.py
-def format_new_service_status(status_data: dict) -> str:
-    """Format status display for new service."""
-    # Add custom formatting logic
-```
-
-## Future Extensions
-
-The CLI architecture supports easy addition of new hardware services:
-
-### Implemented Services
-- **Camera Management**: `mindtrace-hw camera start/stop/status/logs`
-- **Stereo Camera Management**: `mindtrace-hw stereo start/stop/status/logs`
-- **3D Scanner Management**: `mindtrace-hw scanner start/stop/status/logs`
-- **PLC Management**: `mindtrace-hw plc start/stop/status`
-
-### Planned Services
-- **Sensor Services**: `mindtrace-hw sensor start/stop/status`
-- **Unified Control**: `mindtrace-hw start --all` for all services simultaneously
-
-### Integration Points
-- **Service Registry**: Automatic service discovery and registration
-- **Configuration Management**: Centralized config for all hardware services
-- **Monitoring Dashboard**: Web-based status monitoring for all services
-- **Log Aggregation**: Centralized logging for troubleshooting
-
-## License
-
-This project is part of the Mindtrace hardware management system.
+- The CLI currently manages camera, stereo, scanner, and PLC services directly.
+- Some capabilities depend on the underlying hardware services and installed backend extras.
+- `--open-docs` is useful when you want to verify service startup quickly through `/docs`.
+- Camera workflows may support mock devices for development; not every hardware domain has the same mock story.
+- The CLI is best treated as an operational tool for service-based workflows rather than a replacement for the underlying Python APIs.

--- a/mindtrace/hardware/mindtrace/hardware/scanners_3d/README.md
+++ b/mindtrace/hardware/mindtrace/hardware/scanners_3d/README.md
@@ -1,220 +1,169 @@
-# MindTrace 3D Scanner System
+# Mindtrace 3D Scanner System
 
-A unified async 3D scanner interface for structured-light scanners (Photoneo PhoXi, MotionCam-3D) via GigE Vision. Supports multi-component capture (range, intensity, confidence, normals, color), point cloud generation, and full scanner configuration through a consistent API.
+The `3D Scanner` module provides Mindtrace’s interface for structured-light scanning workflows, including async and sync scanner access, point-cloud generation, configuration management, and service-based deployment.
 
-## Table of Contents
+## Features
 
-- [Quick Start](#quick-start)
-- [System Architecture](#system-architecture)
-- [Usage](#usage)
-- [Backends](#backends)
-- [Configuration](#configuration)
-- [Service Layer](#service-layer)
-- [SDK Setup](#sdk-setup)
-- [Testing](#testing)
-- [API Reference](#api-reference)
-- [Extending](#extending)
+- **Async and sync scanner interfaces** with `AsyncScanner3D` and `Scanner3D`
+- **Structured multi-component capture** including range, intensity, confidence, normals, and color
+- **Point-cloud generation** through `PointCloudData`
+- **Photoneo backend support** through `PhotoneoBackend`
+- **Service-oriented deployment** with scanner services and connection managers
+- **Backend setup tooling** through the Photoneo setup CLI entry point
 
 ## Quick Start
 
 ```python
+import asyncio
+
 from mindtrace.hardware.scanners_3d import AsyncScanner3D
 
-# Open first available Photoneo scanner
-scanner = await AsyncScanner3D.open()
 
-# Capture 3D scan
-result = await scanner.capture()
-print(f"Range: {result.range_shape}, Intensity: {result.intensity_shape}")
+async def main():
+    async with await AsyncScanner3D.open() as scanner:
+        result = await scanner.capture()
+        print(result.range_shape)
 
-# Generate point cloud
-point_cloud = await scanner.capture_point_cloud()
-print(f"Points: {point_cloud.num_points}")
-point_cloud.save_ply("output.ply")
+        point_cloud = await scanner.capture_point_cloud()
+        print(point_cloud.num_points)
+        point_cloud.save_ply("output.ply")
 
-await scanner.close()
+
+asyncio.run(main())
 ```
 
-## System Architecture
+This module is built around a simple progression:
 
-```mermaid
-graph TD
-    CLI["CLI: mindtrace-hw scanner start/stop"] --> SVC
-    SVC["ScannerService :8005"] --> MGR["Scanner3DManager"]
-    MGR --> ASYNC["AsyncScanner3D"]
-    SYNC["Scanner3D (sync)"] --> ASYNC
-    ASYNC --> BE["Scanner3DBackend"]
-    BE --> PH["PhotoneoBackend"]
-    BE --> MOCK["MockPhotoneoBackend"]
-    BE --> FUTURE["Future backends..."]
-    PH --> HAR["Harvesters + GenTL"]
-    HAR --> GIGE["GigE Vision / Network"]
-    GIGE --> HW["Photoneo PhoXi / MotionCam-3D"]
-```
+- open a scanner
+- capture structured scan data
+- optionally generate a point cloud
+- configure the scanner as needed
+- expose the scanner through a service when you want remote access
 
-### Layer Summary
+## Core Interfaces
 
-| Layer | Module | Purpose |
-|-------|--------|---------|
-| **Backend** | `backends/` | Direct SDK communication (Harvesters/GenTL) |
-| **Core** | `core/` | High-level async/sync wrappers, data models |
-| **Service** | `services/scanners_3d/` | REST API + MCP endpoints |
-| **CLI** | `cli/commands/scanner.py` | Service lifecycle management |
-| **Setup** | `setup/` | SDK installation and verification |
+The main exports are:
 
-### Data Flow
+- `AsyncScanner3D`
+- `Scanner3D`
+- `ScanResult`
+- `ScanComponent`
+- `CoordinateMap`
+- `PointCloudData`
+- `PhotoneoBackend`
 
-```mermaid
-sequenceDiagram
-    participant App
-    participant AsyncScanner3D
-    participant PhotoneoBackend
-    participant Harvesters
-    participant Scanner as PhoXi Scanner
+### Async interface
 
-    App->>AsyncScanner3D: capture()
-    AsyncScanner3D->>PhotoneoBackend: capture(enable_range, ...)
-    PhotoneoBackend->>Harvesters: fetch() via GenTL
-    Harvesters->>Scanner: GigE Vision GVCP/GVSP
-    Scanner-->>Harvesters: Multi-component buffer
-    Harvesters-->>PhotoneoBackend: Raw buffer data
-    PhotoneoBackend-->>AsyncScanner3D: ScanResult(range, intensity, ...)
-    AsyncScanner3D-->>App: ScanResult
-```
-
-## Usage
-
-### Async Interface (Recommended)
+Use `AsyncScanner3D` for long-running applications, orchestration, and service-style workflows.
 
 ```python
+import asyncio
+
 from mindtrace.hardware.scanners_3d import AsyncScanner3D
 
-# Open by backend and serial number
-scanner = await AsyncScanner3D.open("Photoneo:ABC123")
 
-# Multi-component capture
-result = await scanner.capture(
-    enable_range=True,
-    enable_intensity=True,
-    enable_confidence=True,
-    enable_normal=True,
-    enable_color=True,
-    timeout_ms=10000,
-)
+async def capture_scan():
+    async with await AsyncScanner3D.open("Photoneo:ABC123") as scanner:
+        result = await scanner.capture(
+            enable_range=True,
+            enable_intensity=True,
+            enable_confidence=True,
+            enable_normal=True,
+            enable_color=True,
+            timeout_ms=10000,
+        )
 
-# Access components
-print(f"Range: {result.range_shape}")        # (H, W) float32
-print(f"Intensity: {result.intensity_shape}") # (H, W) float32
-print(f"Normals: {result.normal_map.shape}")  # (H, W, 3) float32
+        print(result.range_shape)
+        print(result.intensity_shape)
 
-# Point cloud with downsampling
-point_cloud = await scanner.capture_point_cloud(
-    include_colors=True,
-    include_confidence=True,
-    downsample_factor=2,
-)
-point_cloud.save_ply("scan.ply")
 
-await scanner.close()
+asyncio.run(capture_scan())
 ```
 
-### Sync Interface
+### Sync interface
+
+Use `Scanner3D` when you want a more script-like synchronous workflow.
 
 ```python
 from mindtrace.hardware.scanners_3d import Scanner3D
 
-# Sync wrapper runs a background event loop
+
 with Scanner3D() as scanner:
     result = scanner.capture()
     point_cloud = scanner.capture_point_cloud()
     point_cloud.save_ply("scan.ply")
 ```
 
-### Mock Backend (No Hardware)
+## Capture Workflows
+
+### Multi-component capture
+
+A scan can include multiple components depending on backend support and configuration.
 
 ```python
-from mindtrace.hardware.scanners_3d import AsyncScanner3D
-
-# Use mock for development and testing
-scanner = await AsyncScanner3D.open("MockPhotoneo")
-result = await scanner.capture()
-print(f"Mock scan: {result.range_shape}")  # (1200, 1920)
-await scanner.close()
-
-# Or specific mock device
-scanner = await AsyncScanner3D.open("MockPhotoneo:MOCK002")  # PhoXi 3D Scanner L
+result = await scanner.capture(
+    enable_range=True,
+    enable_intensity=True,
+    enable_confidence=True,
+    enable_normal=True,
+    enable_color=True,
+)
 ```
 
-### Scanner Discovery
+Typical components include:
+
+- range / depth
+- intensity
+- confidence
+- surface normals
+- color
+
+### Point clouds
+
+```python
+point_cloud = await scanner.capture_point_cloud(
+    include_colors=True,
+    include_confidence=True,
+    downsample_factor=2,
+)
+
+print(point_cloud.num_points)
+point_cloud.save_ply("scan.ply")
+```
+
+## Discovery and Backends
+
+The scanner package currently centers around `PhotoneoBackend`.
+
+Example discovery flow:
 
 ```python
 from mindtrace.hardware.scanners_3d.backends.photoneo import PhotoneoBackend
 
-# Find all Photoneo scanners on the network
-serials = PhotoneoBackend.discover()
-print(f"Found: {serials}")  # ['ABC123', 'DEF456']
 
-# Detailed discovery
-devices = PhotoneoBackend.discover_detailed()
-for dev in devices:
-    print(f"{dev['model']} (SN: {dev['serial_number']})")
+serials = PhotoneoBackend.discover()
+print(serials)
 ```
 
-## Backends
+Open by explicit name when needed:
 
-### Photoneo (`PhotoneoBackend`)
-
-Production backend for Photoneo PhoXi and MotionCam-3D scanners using the Harvesters library with Matrix Vision mvGenTL Producer over GigE Vision.
-
-**Supported hardware:**
-- Photoneo PhoXi 3D Scanner (S, M, L, XL)
-- Photoneo MotionCam-3D
-
-**Requirements:**
-- `harvesters` library (`pip install harvesters`)
-- Matrix Vision mvGenTL Producer v2.49.0 (install via `mindtrace-scanner-photoneo install`)
-- GigE Vision network (host networking for device discovery)
-- Photoneo firmware >= 1.13.0
-
-**Scan components:**
-
-| Component | Array Shape | Type | Description |
-|-----------|-------------|------|-------------|
-| Range | (H, W) | float32 | Depth/distance map |
-| Intensity | (H, W) | float32 | Reflected light intensity |
-| Confidence | (H, W) | float32 | Per-pixel confidence [0, 1] |
-| Normal | (H, W, 3) | float32 | Surface normal vectors |
-| Color | (H, W, 3) | uint8 | RGB texture (if color camera) |
-
-### Mock Photoneo (`MockPhotoneoBackend`)
-
-Full-fidelity mock that mirrors every PhotoneoBackend method. Generates synthetic scan data (gradient patterns, random noise) without any hardware or SDK dependencies.
-
-**Mock devices:**
-
-| Serial | Model | Resolution |
-|--------|-------|------------|
-| MOCK001 | PhoXi 3D Scanner M | 1920 x 1200 |
-| MOCK002 | PhoXi 3D Scanner L | 2064 x 1544 |
-
-Use for unit tests, CI pipelines, and offline development.
+```python
+scanner = await AsyncScanner3D.open("Photoneo:ABC123")
+```
 
 ## Configuration
 
-### Bulk Configuration
+Use the scanner configuration APIs when you need to inspect or adjust runtime parameters.
+
+### Bulk configuration
 
 ```python
-from mindtrace.hardware.scanners_3d.core.models import (
-    ScannerConfiguration,
-    CodingQuality,
-    OperationMode,
-)
+from mindtrace.hardware.scanners_3d.core.models import CodingQuality, OperationMode, ScannerConfiguration
 
-# Get current settings
+
 config = await scanner.get_configuration()
-print(f"Exposure: {config.exposure_time}ms, Quality: {config.coding_quality}")
+print(config.exposure_time)
 
-# Apply new settings (only non-None values are applied)
 new_config = ScannerConfiguration(
     operation_mode=OperationMode.SCANNER,
     coding_quality=CodingQuality.HIGH,
@@ -224,278 +173,130 @@ new_config = ScannerConfiguration(
 await scanner.set_configuration(new_config)
 ```
 
-### Individual Settings
+### Individual settings
 
 ```python
-# Exposure
 await scanner.set_exposure_time(10.24)
 exposure = await scanner.get_exposure_time()
+print(exposure)
 
-# Trigger mode
-await scanner.set_trigger_mode("Software")  # or "Continuous", "Hardware"
+await scanner.set_trigger_mode("Software")
 mode = await scanner.get_trigger_mode()
+print(mode)
 ```
 
 ### Capabilities
 
 ```python
 caps = await scanner.get_capabilities()
-print(f"Model: {caps.model}")
-print(f"Qualities: {caps.coding_qualities}")     # ['Ultra', 'High', 'Fast']
-print(f"Exposure range: {caps.exposure_range}")   # (0.01, 100.0) ms
-print(f"LED power range: {caps.led_power_range}") # (0, 4095)
+print(caps.model)
+print(caps.coding_qualities)
+print(caps.exposure_range)
 ```
 
-### All Configuration Parameters
+## Services and Remote Access
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `operation_mode` | OperationMode | Camera, Scanner, or Mode_2D |
-| `coding_strategy` | CodingStrategy | Normal, Interreflections |
-| `coding_quality` | CodingQuality | Ultra, High, Fast |
-| `exposure_time` | float | Exposure in milliseconds |
-| `single_pattern_exposure` | float | Per-pattern exposure (ms) |
-| `shutter_multiplier` | int | Shutter multiplier |
-| `scan_multiplier` | int | Scan multiplier |
-| `color_exposure` | float | Color camera exposure (ms) |
-| `led_power` | int | LED power (0-4095) |
-| `laser_power` | int | Laser power (1-4095) |
-| `texture_source` | TextureSource | LED, Computed, Laser, Focus, Color |
-| `output_topology` | OutputTopology | Raw, RegularGrid, FullGrid |
-| `camera_space` | CameraSpace | PrimaryCamera, ColorCamera |
-| `normals_estimation_radius` | int | Radius for normal estimation |
-| `max_inaccuracy` | float | Max allowed inaccuracy (mm) |
-| `hole_filling` | bool | Enable hole filling |
-| `calibration_volume_only` | bool | Limit to calibrated volume |
-| `trigger_mode` | TriggerMode | Software, Hardware, Continuous |
-| `hardware_trigger` | bool | Enable hardware trigger |
-| `hardware_trigger_signal` | HardwareTriggerSignal | Falling, Rising, Both |
-| `maximum_fps` | float | FPS limit (0 = unlimited) |
+The scanner subsystem can be exposed through the Mindtrace hardware services layer.
 
-## Service Layer
+Top-level service exports in the hardware package include:
 
-### Starting the Service
+- `Scanner3DService`
+- `Scanner3DConnectionManager`
 
-```bash
-# Via CLI
-mindtrace-hw scanner start --api-port 8005
-
-# Or programmatically
-from mindtrace.hardware.services.scanners_3d import ScannerService
-service = ScannerService.launch(port=8005)
-```
-
-Swagger UI: `http://localhost:8005/docs`
-
-### REST Endpoints
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/health` | GET | Health check |
-| `/scanners/backends` | GET | List available backends |
-| `/scanners/backends/info` | GET | Backend details |
-| `/scanners/discover` | POST | Discover scanners |
-| `/scanners/open` | POST | Open scanner |
-| `/scanners/open/batch` | POST | Open multiple scanners |
-| `/scanners/close` | POST | Close scanner |
-| `/scanners/close/batch` | POST | Close multiple scanners |
-| `/scanners/close/all` | POST | Close all scanners |
-| `/scanners/active` | GET | List active scanners |
-| `/scanners/status` | POST | Scanner status |
-| `/scanners/info` | POST | Scanner information |
-| `/scanners/capabilities` | POST | Scanner capabilities |
-| `/scanners/configure` | POST | Set configuration |
-| `/scanners/configure/batch` | POST | Batch configure |
-| `/scanners/config/get` | POST | Get configuration |
-| `/scanners/capture` | POST | Capture scan |
-| `/scanners/capture/batch` | POST | Batch capture |
-| `/scanners/capture/pointcloud` | POST | Capture point cloud |
-| `/scanners/capture/pointcloud/batch` | POST | Batch point cloud |
-| `/system/diagnostics` | GET | System diagnostics |
-
-### Connection Manager (Typed Client)
+### Launch a scanner service
 
 ```python
-from mindtrace.hardware.services.scanners_3d import ScannerConnectionManager
+from mindtrace.hardware.services import Scanner3DService
 
-client = ScannerConnectionManager("scanner_service")
 
-# Discover and open
-devices = await client.discover_scanners()
-await client.open_scanner("Photoneo:ABC123")
-
-# Capture via service
-result = await client.capture("Photoneo:ABC123")
+cm = Scanner3DService.launch(port=8005, wait_for_launch=True)
+print(cm.status())
 ```
+
+### Connect to an existing scanner service
+
+```python
+from mindtrace.hardware.services import Scanner3DConnectionManager
+
+
+client = Scanner3DConnectionManager("http://localhost:8005")
+```
+
+### CLI workflow
+
+```bash
+$ mindtrace-hw scanner start --open-docs
+$ mindtrace-hw scanner status
+$ curl http://localhost:8005/status
+```
+
+When the service is running, its generated docs are typically available at:
+
+- `http://localhost:8005/docs`
 
 ## SDK Setup
 
-The Photoneo backend requires the Matrix Vision mvGenTL Producer. The setup script handles installation across platforms.
+The Photoneo workflow may require additional backend setup beyond the Python package itself.
 
-### Install
-
-```bash
-# Via entry point
-mindtrace-scanner-photoneo install -v
-
-# Or directly
-python mindtrace/hardware/mindtrace/hardware/scanners_3d/setup/setup_photoneo.py install -v
-```
-
-### Verify
+The package exposes a setup entry point for that workflow:
 
 ```bash
-mindtrace-scanner-photoneo verify -v
-# Checks: Harvesters library, GenTL Producer (CTI file), GENICAM_GENTL64_PATH
+$ mindtrace-scanner-photoneo --help
 ```
 
-### Discover
+Examples:
 
 ```bash
-# Photoneo scanners only
-mindtrace-scanner-photoneo discover
-
-# All GigE Vision devices
-mindtrace-scanner-photoneo discover --all
+$ mindtrace-scanner-photoneo install -v
+$ mindtrace-scanner-photoneo verify -v
+$ mindtrace-scanner-photoneo discover
 ```
 
-### Platform Support
+## Installation
 
-| Platform | Install | Uninstall | Notes |
-|----------|---------|-----------|-------|
-| Linux (x86_64) | Bash installer + tgz | `sudo rm -rf /opt/mvIMPACT_Acquire` | Requires sudo |
-| Windows (x64) | GUI installer (exe) | Uninstaller or Control Panel | Requires admin |
-| macOS (ARM64) | DMG mount + pkg | Remove app + framework dirs | Requires sudo |
-
-### Environment
-
-After installation, set `GENICAM_GENTL64_PATH` for Harvesters to locate the GenTL Producer:
+Base package install:
 
 ```bash
-# Automatic (new login sessions)
-source /etc/profile.d/genicam.sh
-
-# Manual
-export GENICAM_GENTL64_PATH=/opt/mvIMPACT_Acquire/lib/x86_64
+$ uv add mindtrace-hardware
 ```
+
+Or with pip and scanner support:
+
+```bash
+$ pip install 'mindtrace-hardware[scanners-photoneo]'
+```
+
+If you are working from the full Mindtrace repo:
+
+```bash
+$ git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+$ uv sync --dev --all-extras
+```
+
+## Examples
+
+Related docs in this package:
+
+- [Top-level hardware module README](../../../../README.md)
+- [Hardware CLI documentation](../cli/README.md)
 
 ## Testing
 
+If you are working in the full Mindtrace repo, run tests for the hardware module:
+
 ```bash
-# Unit tests (no hardware needed)
-pytest tests/unit/mindtrace/hardware/scanners_3d/ -v
-
-# Integration tests (requires scanner on network)
-pytest tests/integration/mindtrace/hardware/scanners_3d/ -v
-
-# CI pipeline
-bash scripts/run_tests.sh --unit --integration hardware
+$ git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+$ uv sync --dev --all-extras
+$ ds test: hardware
+$ ds test: --unit hardware
 ```
 
-## API Reference
+When possible, prefer development and CI workflows that do not require live hardware unless you are specifically validating device integration.
 
-### Core Classes
+## Practical Notes and Caveats
 
-| Class | Description |
-|-------|-------------|
-| `AsyncScanner3D` | Async high-level scanner interface |
-| `Scanner3D` | Synchronous wrapper (background event loop) |
-| `Scanner3DBackend` | Abstract base for backend implementations |
-| `PhotoneoBackend` | Photoneo PhoXi/MotionCam backend |
-| `MockPhotoneoBackend` | Mock backend for testing |
-
-### Data Models
-
-| Model | Description |
-|-------|-------------|
-| `ScanResult` | Multi-component scan data (range, intensity, confidence, normals, color) |
-| `PointCloudData` | 3D point cloud with optional colors, normals, confidence |
-| `CoordinateMap` | Pre-computed coordinate maps for point cloud generation |
-| `ScannerConfiguration` | Scanner settings (exposure, quality, trigger, etc.) |
-| `ScannerCapabilities` | Available features and parameter ranges |
-
-### AsyncScanner3D Methods
-
-| Method | Description |
-|--------|-------------|
-| `open(name)` | Factory: open scanner by name (`"Photoneo:serial"`, `"MockPhotoneo"`) |
-| `close()` | Close scanner and release resources |
-| `capture(...)` | Capture multi-component scan data |
-| `capture_point_cloud(...)` | Capture and generate 3D point cloud |
-| `get_capabilities()` | Get available features and ranges |
-| `get_configuration()` | Get current settings |
-| `set_configuration(config)` | Apply settings (non-None values only) |
-| `set_exposure_time(ms)` | Set exposure in milliseconds |
-| `get_exposure_time()` | Get current exposure |
-| `set_trigger_mode(mode)` | Set trigger mode |
-| `get_trigger_mode()` | Get current trigger mode |
-
-### PointCloudData Methods
-
-| Method | Description |
-|--------|-------------|
-| `save_ply(path)` | Save to PLY file |
-| `downsample(factor)` | Downsample by factor |
-| `filter_by_confidence(threshold)` | Filter points by confidence |
-| `num_points` | Number of points (property) |
-
-## File Structure
-
-```
-scanners_3d/
-├── __init__.py                          # Module exports
-├── README.md
-├── backends/
-│   ├── __init__.py
-│   ├── scanner_3d_backend.py            # Abstract base class
-│   └── photoneo/
-│       ├── __init__.py
-│       ├── photoneo_backend.py          # Harvesters/GigE implementation
-│       └── mock_photoneo_backend.py     # Mock for testing
-├── core/
-│   ├── __init__.py
-│   ├── models.py                        # ScanResult, PointCloudData, enums
-│   ├── async_scanner_3d.py              # Async high-level interface
-│   └── scanner_3d.py                    # Sync wrapper
-└── setup/
-    ├── __init__.py
-    └── setup_photoneo.py                # SDK install/verify/discover
-```
-
-## Extending
-
-### Add a New Scanner Backend
-
-```python
-from mindtrace.hardware.scanners_3d.backends.scanner_3d_backend import Scanner3DBackend
-from mindtrace.hardware.scanners_3d.core.models import ScanResult, PointCloudData
-
-class MyScanner3DBackend(Scanner3DBackend):
-    """Backend for a new 3D scanner brand."""
-
-    @staticmethod
-    def discover() -> list[str]:
-        # Return list of serial numbers
-        return ["SERIAL001"]
-
-    async def initialize(self) -> bool:
-        # Connect to scanner
-        return True
-
-    async def capture(self, timeout_ms=10000, **kwargs) -> ScanResult:
-        # Capture scan data
-        return ScanResult(range_map=my_depth_array)
-
-    async def close(self) -> None:
-        # Release resources
-        pass
-
-    # Override individual config methods as supported by hardware
-    async def set_exposure_time(self, milliseconds: float) -> None:
-        self._sdk.set_exposure(milliseconds)
-
-    async def get_exposure_time(self) -> float:
-        return self._sdk.get_exposure()
-```
-
-Then register it in `AsyncScanner3D.open()` to support `"MyScanner:serial"` syntax.
+- Scanner functionality depends heavily on backend support and the installed SDK/toolchain.
+- `AsyncScanner3D` is usually the best choice for integrations and services; `Scanner3D` is convenient for simpler scripts.
+- Point-cloud workflows can produce large outputs, so file writing and memory usage matter in real deployments.
+- Service deployment is useful when scanners should be accessed remotely or through agent/tool workflows.
+- This README focuses on the practical scanner workflow; deeper backend-specific details belong in the implementation and code docs.

--- a/mindtrace/jobs/README.md
+++ b/mindtrace/jobs/README.md
@@ -4,264 +4,347 @@
 
 # Mindtrace Jobs
 
-A job queue system that works with different backends (local, Redis, RabbitMQ).
+The `Jobs` module provides Mindtrace’s backend-agnostic job queue system for publishing typed jobs, consuming them with Python workers, and switching between local, Redis, and RabbitMQ backends with minimal application changes.
 
-## Backends
-- Local
-- Redis
-- RabbitMQ
+## Features
 
-**Setup Redis:**
-```bash
-# Local installation
-redis-server
+- **Typed job definitions** with `JobSchema` and Pydantic models
+- **Backend-agnostic orchestration** through `Orchestrator`
+- **Consumer workers** built by subclassing `Consumer`
+- **Multiple backends** for local, Redis, and RabbitMQ execution
+- **Queue variants** including FIFO, stack, and priority queues
+- **Convenient job creation** with `job_from_schema()`
 
-# Using Docker
-docker run -d --name redis -p 6379:6379 redis:latest
-
-# Test connection
-redis-cli ping 
-```
-
-### RabbitMQ Backend
-
-**Setup RabbitMQ:**
-```bash
-# Using Docker (recommended)
-docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 -e RABBITMQ_DEFAULT_USER=user -e RABBITMQ_DEFAULT_PASS=password rabbitmq:3-management
-```
-
-**Core Components:**
-- `Consumer` - Base class for processing jobs
-- `Orchestrator` - Manages job queues and routing
-- `Job`, `JobSchema` - Job data structures
-- `LocalClient`, `RedisClient`, `RabbitMQClient` - Backend implementations
-
-
-## Architecture 
-
-```mermaid
-graph TD
-    Consumer["Your Consumer<br/>MathsConsumer('maths_operations')"] 
-    Orchestrator["Orchestrator"]
-    Schema["Job Schema<br/>(maths_operations)"]
-    Job["Job Instance"]
-    Queue["Queue<br/>(maths_operations)"]
-    
-    LocalClient["LocalClient"]
-    RedisClient["RedisClient<br/>(requires Redis server)"] 
-    RabbitMQClient["RabbitMQClient<br/>(requires RabbitMQ server)"]
-    
-    Consumer --> Orchestrator
-    Schema --> Orchestrator
-    Job --> Orchestrator
-    Orchestrator --> Queue
-    
-    Orchestrator -.-> LocalClient
-    Orchestrator -.-> RedisClient
-    Orchestrator -.-> RabbitMQClient
-    
-    Queue --> Consumer
-```
-
-## Basic Example
+## Quick Start
 
 ```python
-from mindtrace.jobs import Orchestrator, LocalClient, Consumer, JobSchema, job_from_schema
 from pydantic import BaseModel
 
-# Set up the orchestrator with local backend
-orchestrator = Orchestrator(LocalClient())
+from mindtrace.jobs import Consumer, JobSchema, LocalClient, Orchestrator, job_from_schema
 
-# Define your job input/output models (inherit from BaseModel directly)
+
 class MathsInput(BaseModel):
     operation: str = "add"
     a: float = 2.0
     b: float = 1.0
 
+
 class MathsOutput(BaseModel):
     result: float = 0.0
     operation_performed: str = ""
 
-schema = JobSchema(name="maths_operations", input_schema=MathsInput, output_schema=MathsOutput)
+
+schema = JobSchema(
+    name="maths_operations",
+    input_schema=MathsInput,
+    output_schema=MathsOutput,
+)
+
+orchestrator = Orchestrator(LocalClient())
 orchestrator.register(schema)
 
-# Create a consumer
+
 class MathsConsumer(Consumer):
     def run(self, job_dict: dict) -> dict:
-        # Access input data from the dict
-        input_data = job_dict.get('input_data', {})
-        operation = input_data.get('operation', 'add')
-        a = input_data.get('a')
-        b = input_data.get('b')
-        
-        # Your processing logic here
+        payload = job_dict.get("payload", {})
+        operation = payload.get("operation", "add")
+        a = payload.get("a")
+        b = payload.get("b")
+
         if operation == "add":
             result = a + b
         elif operation == "multiply":
             result = a * b
-        elif operation == "power":
-            result = a ** b
         else:
             raise ValueError(f"Unknown operation: {operation}")
-        
+
         return {
             "result": result,
-            "operation_performed": f"{operation}({a}, {b}) = {result}"
+            "operation_performed": f"{operation}({a}, {b}) = {result}",
         }
 
-# Connect and consume jobs
-consumer = MathsConsumer("maths_operations")
-consumer.connect(orchestrator)
 
-# Add a job to the queue
-job = job_from_schema(schema, MathsInput(
-    operation="multiply",
-    a=7.0,
-    b=3.0
-))
+consumer = MathsConsumer()
+consumer.connect_to_orchestrator(orchestrator, "maths_operations")
+
+job = job_from_schema(schema, MathsInput(operation="multiply", a=7.0, b=3.0))
 orchestrator.publish("maths_operations", job)
-
-# Process jobs
 consumer.consume(num_messages=1)
 ```
 
-## Using Different Backends
+In practice, the jobs package is built around four concepts:
 
-### Redis Backend
+- a **schema** describing the job payload
+- an **orchestrator** that owns queues and publishing
+- a **backend** that stores/transports messages
+- a **consumer** that processes jobs from one or more queues
+
+## JobSchema and Job
+
+`JobSchema` is currently an alias of `TaskSchema` from `mindtrace-core`. It gives a queue/job type a name plus typed input/output models.
+
 ```python
-from mindtrace.jobs import RedisClient
+from pydantic import BaseModel
 
-redis_backend = RedisClient(host="localhost", port=6379, db=0)
-orchestrator = Orchestrator(redis_backend)
+from mindtrace.jobs import JobSchema
 
-consumer = MathsConsumer("maths_operations")
-consumer.connect(orchestrator)
-consumer.consume()
-```
 
-### RabbitMQ Backend
-```python
-from mindtrace.jobs import RabbitMQClient
+class ReportInput(BaseModel):
+    report_id: str
+    include_charts: bool = True
 
-rabbitmq_backend = RabbitMQClient(
-    host="localhost", 
-    port=5672, 
-    username="user", 
-    password="password"
+
+class ReportOutput(BaseModel):
+    path: str
+
+
+schema = JobSchema(
+    name="build_report",
+    input_schema=ReportInput,
+    output_schema=ReportOutput,
 )
-orchestrator = Orchestrator(rabbitmq_backend)
-
-consumer = MathsConsumer("maths_operations")
-consumer.connect(orchestrator)
-consumer.consume()
 ```
 
-## Backend Switching
-
-The job system supports seamless switching between backends without changing your consumer code:
+A `Job` is the executable instance that gets queued. In most cases you do not construct it by hand; you use `job_from_schema()`.
 
 ```python
-# Development: Use local backend
+from mindtrace.jobs import job_from_schema
+
+
+job = job_from_schema(schema, {"report_id": "rpt-123", "include_charts": True})
+print(job.id)
+print(job.schema_name)
+```
+
+## Orchestrator
+
+`Orchestrator` is the publishing and queue-management layer. It owns a backend and handles things like:
+
+- registering schemas
+- declaring queues
+- publishing jobs
+- counting queue messages
+- cleaning or deleting queues
+
+```python
+from mindtrace.jobs import LocalClient, Orchestrator
+
+
+orchestrator = Orchestrator(LocalClient())
+queue_name = orchestrator.register(schema)
+print(queue_name)
+```
+
+### Publishing typed input directly
+
+If a schema has been registered for a queue, you can publish either:
+
+- a full `Job`
+- or a matching Pydantic input model
+
+```python
+orchestrator.publish("build_report", ReportInput(report_id="rpt-001"))
+```
+
+That convenience is often nicer than manually creating the `Job` every time.
+
+## Consumer
+
+Subclass `Consumer` and implement `run(job_dict: dict) -> dict`.
+
+```python
+from mindtrace.jobs import Consumer
+
+
+class ReportConsumer(Consumer):
+    def run(self, job_dict: dict) -> dict:
+        payload = job_dict.get("payload", {})
+        report_id = payload.get("report_id")
+        return {"path": f"/tmp/{report_id}.pdf"}
+```
+
+Then connect the consumer to an orchestrator and start consuming:
+
+```python
+consumer = ReportConsumer()
+consumer.connect_to_orchestrator(orchestrator, "build_report")
+consumer.consume(num_messages=1)
+```
+
+### Consuming until empty
+
+```python
+consumer.consume_until_empty()
+```
+
+That is useful for local scripts, test runs, or backlog-draining workflows.
+
+## Backends
+
+The package supports three backend families.
+
+### Local backend
+
+`LocalClient` is the simplest backend and a good default for local development or single-process workflows.
+
+```python
+from mindtrace.jobs import LocalClient, Orchestrator
+
+
+backend = LocalClient()
+orchestrator = Orchestrator(backend)
+```
+
+Internally, the local backend stores queues through the registry-backed local implementation and also supports local queue variants such as:
+
+- `LocalQueue`
+- `LocalStack`
+- `LocalPriorityQueue`
+
+### Redis backend
+
+Use `RedisClient` when you want Redis-backed queues.
+
+```python
+from mindtrace.jobs import Orchestrator, RedisClient
+
+
+backend = RedisClient(host="localhost", port=6379, db=0)
+orchestrator = Orchestrator(backend)
+```
+
+Redis is a good fit when you want a lightweight shared broker across multiple processes or machines.
+
+### RabbitMQ backend
+
+Use `RabbitMQClient` when you want RabbitMQ-backed routing and queueing.
+
+```python
+from mindtrace.jobs import Orchestrator, RabbitMQClient
+
+
+backend = RabbitMQClient(
+    host="localhost",
+    port=5672,
+    username="user",
+    password="password",
+)
+orchestrator = Orchestrator(backend)
+```
+
+RabbitMQ is a better fit when you want broker-oriented messaging behavior, exchanges, and mature queue features such as max-priority support.
+
+## Switching Backends
+
+One of the main design goals of the jobs package is that your job schema and consumer logic should not need major changes when switching backends.
+
+```python
+# Development
 backend = LocalClient()
 
-# Testing: Switch to Redis
+# Shared test environment
 backend = RedisClient(host="localhost", port=6379, db=0)
 
-# Production: Switch to RabbitMQ  
+# Production / broker-oriented setup
 backend = RabbitMQClient(host="localhost", port=5672, username="user", password="password")
 
-# Same orchestrator and consumer code works with any backend
 orchestrator = Orchestrator(backend)
-consumer = MathsConsumer("maths_operations")
-consumer.connect(orchestrator)
-consumer.consume()
+consumer = ReportConsumer()
+consumer.connect_to_orchestrator(orchestrator, "build_report")
 ```
 
-## Automatic Backend Detection
+The core publishing and consuming flow stays largely the same.
 
-When you connect a consumer, the orchestrator automatically detects the backend type and creates the appropriate consumer backend:
+## Queue Types and Priority
+
+The local and Redis backends expose queue-type selection when declaring a queue.
+
+### FIFO queue
 
 ```python
-consumer = MathsConsumer("maths_operations")
-consumer.connect(orchestrator)  # Automatically detects backend type
+orchestrator.register(schema, queue_type="fifo")
 ```
 
-**Implementation:**
-
-1. The `Orchestrator` detects its backend type using `type(self.backend).__name__`
-2. Creates the corresponding consumer backend:
-   - `LocalClient` → `LocalConsumerBackend`
-   - `RedisClient` → `RedisConsumerBackend`  
-   - `RabbitMQClient` → `RabbitMQConsumerBackend`
+### Stack / LIFO queue
 
 ```python
-def create_consumer_backend_for_schema(self, schema: JobSchema) -> ConsumerBackendBase:
-    backend_type = type(self.backend).__name__
-    if backend_type == "LocalClient":
-        return LocalConsumerBackend(queue_name, self)
-    elif backend_type == "RedisClient":
-        return RedisConsumerBackend(queue_name, self, poll_timeout=5)
-    elif backend_type == "RabbitMQClient":
-        return RabbitMQConsumerBackend(queue_name, self, prefetch_count=1)
+backend.declare_queue("stack_tasks", queue_type="stack")
 ```
 
-## Priority Queues
+### Priority queue
 
-### Local Priority Queue
 ```python
-# Declare priority queue
-backend = LocalClient()
-orchestrator = Orchestrator(backend)
 backend.declare_queue("priority_tasks", queue_type="priority")
-
-# Publish with different priorities (higher numbers = higher priority)
-orchestrator.publish("priority_tasks", urgent_job, priority=10)
-orchestrator.publish("priority_tasks", normal_job, priority=5)
-orchestrator.publish("priority_tasks", background_job, priority=1)
+orchestrator.publish("priority_tasks", priority_job, priority=100)
+orchestrator.publish("priority_tasks", background_job, priority=10)
 ```
 
-### Redis Priority Queue
+### RabbitMQ priority queues
+
+RabbitMQ does not use the same `queue_type` argument. Instead, you declare a queue with `max_priority`.
+
 ```python
-# REQUIRES: Redis server running
-redis_backend = RedisClient(host="localhost", port=6379, db=0)
-orchestrator = Orchestrator(redis_backend)
-redis_backend.declare_queue("redis_priority", queue_type="priority")
-
-# Higher priority jobs processed first
-orchestrator.publish("redis_priority", critical_job, priority=100)
-orchestrator.publish("redis_priority", normal_job, priority=50)
+backend = RabbitMQClient(host="localhost", port=5672, username="user", password="password")
+backend.declare_queue("rabbitmq_priority", max_priority=255)
 ```
 
-### RabbitMQ Priority Queue
+Then publish with a priority value:
+
 ```python
-# REQUIRES: RabbitMQ server running
-rabbitmq_backend = RabbitMQClient(host="localhost", port=5672, username="user", password="password")
-orchestrator = Orchestrator(rabbitmq_backend)
-# RabbitMQ supports max priority 0-255
-rabbitmq_backend.declare_queue("rabbitmq_priority", max_priority=255)
-
-orchestrator.publish("rabbitmq_priority", critical_job, priority=255)
-orchestrator.publish("rabbitmq_priority", normal_job, priority=128)
+orchestrator = Orchestrator(backend)
+orchestrator.publish("rabbitmq_priority", job, priority=255)
 ```
 
-## API Reference
+## Redis Setup
 
-### Consumer
-```python
-class Consumer:
-    def __init__(self, job_type_name: str)
-    def connect(self, orchestrator: Orchestrator)
-    def consume(self, num_messages: Optional[int] = None)
-    def run(self, job_dict: dict) -> dict  # Implement this method
+For Redis-backed jobs, start a Redis server first.
+
+```bash
+$ redis-server
 ```
 
-### Orchestrator
-```python
-class Orchestrator:
-    def __init__(self, backend)
-    def register(self, schema: JobSchema) -> str
-    def publish(self, queue_name: str, job: Job, **kwargs) -> str
-    def receive_message(self, queue_name: str) -> Optional[dict]
-    def count_queue_messages(self, queue_name: str) -> int
+Or with Docker:
+
+```bash
+$ docker run -d --name redis -p 6379:6379 redis:latest
+$ redis-cli ping
 ```
+
+## RabbitMQ Setup
+
+For RabbitMQ-backed jobs, start a RabbitMQ server first.
+
+```bash
+$ docker run -d --name rabbitmq \
+    -p 5672:5672 \
+    -p 15672:15672 \
+    -e RABBITMQ_DEFAULT_USER=user \
+    -e RABBITMQ_DEFAULT_PASS=password \
+    rabbitmq:3-management
+```
+
+## Examples
+
+Related examples in the repo:
+
+- [Simple orchestrator example](../../samples/jobs/orchestrator_simple.py)
+- [Jobs demo sample](../../samples/jobs/sample_jobs_demo.py)
+
+## Testing
+
+If you are working in the full Mindtrace repo, run tests for this module specifically:
+
+```bash
+$ git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+$ uv sync --dev --all-extras
+$ ds test: jobs
+$ ds test: --unit jobs
+```
+
+## Practical Notes and Caveats
+
+- `JobSchema` is currently an alias of `TaskSchema`, so older naming in the jobs package may reflect that transition.
+- Consumers operate on `job_dict` payloads, so your `run()` implementation should be defensive about the shape it expects.
+- Local, Redis, and RabbitMQ backends expose similar high-level workflows, but their queue semantics and operational requirements differ.
+- Redis and RabbitMQ require external services; the local backend is the simplest place to start.
+- Priority queue support exists across backends, but the declaration model differs for RabbitMQ vs. local/Redis backends.

--- a/mindtrace/registry/README.md
+++ b/mindtrace/registry/README.md
@@ -1,3 +1,7 @@
+[![PyPI version](https://img.shields.io/pypi/v/mindtrace-registry)](https://pypi.org/project/mindtrace-registry/)
+[![License](https://img.shields.io/pypi/l/mindtrace-registry)](https://github.com/mindtrace/mindtrace/blob/main/mindtrace/registry/LICENSE)
+[![Downloads](https://static.pepy.tech/badge/mindtrace-registry)](https://pepy.tech/projects/mindtrace-registry)
+
 # Registry Module
 
 The Registry module provides a distributed, versioned object storage system with support for multiple backends. It enables storing, versioning, and retrieving objects with automatic serialization and lock-free concurrency for objects. 
@@ -225,6 +229,28 @@ result = registry.save(
 result = registry.load(["model:a", "model:b"], version=["1.0.0", "1.0.0"])
 ```
 
+## Dict-Like API
+
+The `Registry` also supports simple dict-like access for common operations:
+
+```python
+from mindtrace.registry import Registry
+
+registry = Registry()
+
+# Save
+registry["my:config"] = {"threshold": 0.8}
+
+# Load
+config = registry["my:config"]
+print(config)
+
+# Delete
+del registry["my:config"]
+```
+
+This is convenient for unversioned or latest-version style access when you want a compact interface.
+
 ## Backend Comparison
 
 | Feature | Local | S3 / MinIO | GCP |
@@ -306,3 +332,38 @@ In addition to the standard Registry exceptions, Store introduces:
 - `StoreKeyFormatError` — invalid key format
 - `StoreAmbiguousObjectError` — unqualified load matched multiple mounts
 - `PermissionError` — write to a read-only mount
+
+## Examples
+
+See these examples and related docs in the repo for more end-to-end reference:
+
+- [Registry quick-start and backend examples](README.md)
+- [Store multi-registry facade section](README.md#store-multi-registry-facade)
+
+## Testing
+
+If you are working in the full Mindtrace repo, run tests for this module specifically:
+
+```bash
+# Run the registry test suite
+ds test: registry
+
+# Run only unit tests for registry
+ds test: --unit registry
+```
+
+If you need a fresh checkout first:
+
+```bash
+git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+uv sync --dev --all-extras
+```
+
+## Practical Notes and Caveats
+
+- Remote backends typically benefit from cache usage, but cache verification level affects correctness/performance trade-offs.
+- Versioned and unversioned registries behave differently; choose the mode that matches your object lifecycle.
+- Overwrite behavior depends on registry mutability and conflict policy.
+- Batch operations are convenient, but partial failures should be handled explicitly through the returned batch result.
+- The dict-like API is compact, but explicit `save()` / `load()` calls are often clearer when versioning behavior matters.
+- `Store` reads with unqualified keys can become ambiguous if the same object exists in multiple mounts.

--- a/mindtrace/services/README.md
+++ b/mindtrace/services/README.md
@@ -4,105 +4,44 @@
 
 # Mindtrace Services
 
-[Purpose](#purpose)<br>
-[Installation](#installation)<br>
-[Architecture](#architecture)<br>
-[Auto-generation for Connection Managers](#auto-generation-for-connection-managers)<br>
-[Usage Example](#usage-example)<br>
-[Testing & Coverage](#testing-and-coverage)<br>
-[API Reference](#api-reference)<br>
-[MCP Integration: Exposing Service Endpoints as Tools](#mcp-integration-exposing-service-endpoints-as-tools)<br>
-[Remote MCP Server Usage with Cursor](#remote-mcp-server-usage-with-cursor)
+The `Services` module provides Mindtrace’s typed microservice framework. It enables you to define a `Service` once with `TaskSchema` endpoint contracts, launch it as a process, connect to it through an auto-generated client, and optionally expose those endpoints as MCP tools.
 
-The `mindtrace-services` module provides the core microservice framework for the Mindtrace ecosystem. It enables rapid development, deployment, and management of distributed services with robust and auto generated connection management, and comprehensive testing support.
+## Features
 
-## Purpose
+- **Typed service definition** with `Service` + `TaskSchema`
+- **FastAPI-backed HTTP services** with standard lifecycle endpoints
+- **Auto-generated clients** via `ConnectionManager` generation
+- **Built-in launch/connect workflow** for local service processes
+- **First-class MCP support** through FastMCP
+- **Service composition utilities** such as `Gateway` and proxy connection managers
+- **Concrete integrations** such as Discord service wrappers and sample services
 
-- **Service Class**: Unified base for all Mindtrace microservices, inspired by the ServerBase component from the mtrix package (now renamed to `Service`).
-- **Auto-Generated Connection Managers**: Connect to services with auto-generated client interfaces.
-- **Endpoint Management**: Strongly-typed, schema-driven endpoint registration and validation.
-- **Stress Testing**: Built-in support for stress, integration, and unit testing.
-
-## Installation
-
-```bash
-uv add mindtrace-services
-```
-
-## Architecture
-
-- **Service (`Service`)**: Base class for all services, providing endpoint registration, FastAPI integration, and lifecycle management.
-- **ConnectionManager**: Client-side helper for communicating with any Mindtrace service. Auto-generated if not explicitly registered.
-- **Endpoint Schemas**: All endpoints require a `TaskSchema` for input/output validation.
-- **Launcher**: Gunicorn-based launcher for production deployment.
-
-## Auto-generation for Connection Managers
-
-When calling a service's `connect` method, the following logic is used:
+## Quick Start
 
 ```python
-if cls._client_interface is None:
-    return generate_connection_manager(cls)(url=url)
-else:
-    return cls._client_interface(url=url)
-```
+import time
 
-- If a `ConnectionManager` is not explicitly registered, one is auto-generated for the service, exposing all endpoints as methods.
-- If a `ConnectionManager` is registered, it is used as before.
-
-### Updated `add_endpoint` Method
-
-- `Service.add_endpoint()` now requires a `schema: TaskSchema`, which is stored in the service's `endpoints` dictionary.
-- The auto-generator uses these schemas to add type validation and define the returned ConnectionManager's methods with the correct arguments.
-- All endpoints (except `shutdown`) are exposed as methods on the connection manager.
-
-### Both `GET` and `POST` Requests Default to Connection Manager Methods
-
-All generated endpoints are now methods in the returned connection manager. Naked properties are not currently supported:
-
-```python
-from mindtrace.services import Service
-cm = Service.launch()
-cm.status  # no longer supported
-cm.status()  # now generated as a method
-```
-
-## Usage Example
-
-See [`mindtrace/services/sample/echo_service.py`](https://github.com/Mindtrace/mindtrace/blob/dev/mindtrace/services/sample/echo_service.py) for a full example. Basic usage:
-
-```python
-from mindtrace.services import Service
-
-cm = Service.launch()
-
-cm.status()      # StatusOutput(status=<ServerStatus.Available: 'Available'>)
-cm.heartbeat()   # HeartbeatOutput(...)
-cm.endpoints()   # EndpointsOutput(endpoints=[...])
-cm.server_id()   # ServerIDOutput(...)
-cm.pid_file()    # PIDFileOutput(...)
-cm.shutdown(block=True)  # ShutdownOutput(shutdown=True)
-```
-
-### Defining a Custom Service
-
-```python
 from pydantic import BaseModel
+
 from mindtrace.core import TaskSchema
 from mindtrace.services import Service
+
 
 class EchoInput(BaseModel):
     message: str
     delay: float = 0.0
 
+
 class EchoOutput(BaseModel):
     echoed: str
+
 
 echo_task = TaskSchema(
     name="echo",
     input_schema=EchoInput,
     output_schema=EchoOutput,
 )
+
 
 class EchoService(Service):
     def __init__(self, *args, **kwargs):
@@ -113,138 +52,375 @@ class EchoService(Service):
         if payload.delay > 0:
             time.sleep(payload.delay)
         return EchoOutput(echoed=payload.message)
+
+
+cm = EchoService.launch(host="localhost", port=8080, wait_for_launch=True)
+print(cm.status())
+print(cm.echo(message="Hello"))
+cm.shutdown()
 ```
 
-## Testing and Coverage
+You can inspect the generated FastAPI docs at <http://localhost:8080/docs> while the service is running.
 
-The test runner supports unit, integration, and stress tests:
+![EchoService FastAPI docs](docs/images/echo-service-docs.png)
+
+You can also call the service directly over HTTP:
 
 ```bash
-# Run all test suites
-ds test
-
-# Run specific suites
-ds test --unit --stress
+curl -X POST http://localhost:8080/echo \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Hello from curl", "delay": 0.0}'
 ```
 
-- Test suites are run individually, but coverage is appended for later suites.
-- The stress test suite provides verbose output (e.g., tqdm progress bars).
-- Example suite times:
+If you are working in Python, you usually do not need to make raw `curl` requests at all. You can connect to the same running service and get a convenient `cm` instead:
 
-```
-unit:        522 passed, 5 skipped in 4.56s
-unit+torch:  527 passed in 9.69s
-integration: 58 passed in 41.78s
-stress:      7 passed in 208.89s (0:03:28)
-```
-
-- All test suites should pass, with `ds test --unit` yielding ~97% coverage, and `ds test --unit --integration` yielding 100%.
-
-## API Reference
-
-### Service
-- Base class for all Mindtrace services. Provides endpoint registration, FastAPI app, and lifecycle management.
-
-### ConnectionManager
-- Client-side helper for communicating with Mindtrace services. Auto-generated if not registered.
-
-### generate_connection_manager
-- Dynamically creates a ConnectionManager for a given Service, exposing all endpoints as methods.
-
-### add_endpoint
-- Register a new endpoint with a schema for input/output validation. Set `as_tool = true` for MCP tool registration.
-
-### add_tool
-- Register a new tool to the MCP HTTP app mounted on FastAPI app.
-
-### TaskSchema
-- Used to define input/output types for endpoints.
-
-## MCP Integration: Exposing Service Endpoints as Tools
-
-### What is MCP?
-The Model Context Protocol (MCP) is a protocol for exposing service functionality as callable tools, enabling both programmatic and interactive access to service endpoints. MCP allows you to interact with your microservices not only via HTTP endpoints but also as tools that can be listed and invoked through a unified client interface.
-
-### How MCP is Integrated
-- **FastMCP SDK is used to create a MCP compliant server:**
-  [FastMCP](https://gofastmcp.com/getting-started/welcome) automatically handles a standard Python function to be used as a tool:
-    - Tool Name: It uses the function name (add) as the tool’s name.
-    - Description: It uses the function’s docstring as the tool’s description for the LLM.
-    - Schema: It inspects the type hints (a: int, b: int) to generate a JSON schema for the inputs.
-- **Mounting MCP on FastAPI:**
-  Each `Service` instance mounts an MCP server on the FastAPI app. This allows the same service to be accessed both via REST endpoints and as MCP tools.
-- **Exposing Endpoints as Tools:**
-  When adding an endpoint using `add_endpoint`, you can set `as_tool=True` to expose that endpoint as an MCP tool:
-  ```python
-  self.add_endpoint("echo", self.echo, schema=echo_task, as_tool=True)
-  ```
-  This makes the `echo` function available both as a REST endpoint and as an MCP tool.
-
-### Example: EchoService with MCP
-See [`mindtrace/services/sample/echo_mcp.py`](https://github.com/Mindtrace/mindtrace/blob/dev/mindtrace/services/sample/echo_mcp.py):
 ```python
-from mindtrace.services.samples.echo_mcp import EchoService
-
-# Launch the service
-connection_manager = EchoService.launch(port=8080, host="localhost", wait_for_launch=True, timeout=30)
-
-# Synchronous call via connection manager
-result = connection_manager.echo(message="Hello, World!")
-print(result.echoed)
+cm = EchoService.connect("http://localhost:8080")
+print(cm.echo(message="Hello again"))
 ```
 
-### Adding Tools Directly with `add_tool`
-In addition to exposing same class methods as endpoints and tools, you can register standalone functions as MCP tools using `self.add_tool`. These tools will be available via the MCP interface but not as HTTP endpoints.
+## Service
 
-Example:
+`Service` is the server-side abstraction. A service instance:
+
+- builds a FastAPI app
+- tracks registered endpoints and their schemas
+- mounts an MCP server
+- provides standard lifecycle endpoints
+- can be launched in a separate process with `Service.launch()`
+
+A minimal service subclass looks like this:
+
 ```python
-# Define a tool function
-def reverse_message(payload: EchoInput) -> EchoOutput:
-    """A demo tool that reverses the input message."""
-    reversed_msg = payload.message[::-1]
-    return EchoOutput(echoed=reversed_msg)
+from mindtrace.services import Service
+
 
 class EchoService(Service):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.add_endpoint("echo", self.echo, schema=echo_task, as_tool=True)
-        # Register the reverse_message tool directly
-        self.add_tool("reverse_message", reverse_message)
+        self.add_endpoint("echo", self.echo, schema=echo_task)
 ```
 
-Now, both `echo` and `reverse_message` are available as MCP tools.
+## TaskSchema
 
-### MCP Client Manager (Service.mcp)
+`TaskSchema` is the typed contract for an endpoint. It defines:
 
-Each `Service` subclass automatically receives a class-level `mcp` helper (MCPClientManager) for creating FastMCP clients:
+- the endpoint name
+- the input schema
+- the output schema
 
-- Connect to an existing service instance
-- Launch a new service instance and return a connected client
-- Access a cached client from a running connection manager instance
+That same schema is reused across the package for:
 
-Connect to a running service:
+- FastAPI request validation
+- generated connection manager methods
+- output parsing on the client side
+- MCP tool exposure
+
+Example:
 
 ```python
-from mindtrace.services.samples.echo_mcp import EchoService
-import asyncio
+from pydantic import BaseModel
 
-async def main():
-    # Explicit URL (trailing slash optional)
-    client = EchoService.mcp.connect("http://localhost:8080/")
-    async with client:
-        tools = await client.list_tools()
-        print([t.name for t in tools])
-        result = await client.call_tool("echo", {"payload": {"message": "Hello"}})
-        print(result)
+from mindtrace.core import TaskSchema
 
-asyncio.run(main())
+
+class EchoInput(BaseModel):
+    message: str
+
+
+class EchoOutput(BaseModel):
+    echoed: str
+
+
+echo_task = TaskSchema(
+    name="echo",
+    input_schema=EchoInput,
+    output_schema=EchoOutput,
+)
 ```
 
-Launch a new service and get a connected client:
+## Defining Endpoints
+
+Register endpoints with `add_endpoint()`:
 
 ```python
-from mindtrace.services.samples.echo_mcp import EchoService
+self.add_endpoint(
+    path="echo",
+    func=self.echo,
+    schema=echo_task,
+    as_tool=True,
+)
+```
+
+Important behavior:
+
+- routes are registered as **POST** endpoints by default
+- the endpoint schema is stored in the service for later client generation
+- the function is wrapped with service logging/instrumentation
+- setting `as_tool=True` exposes the same function as an MCP tool
+
+## Built-in Endpoints
+
+Every `Service` automatically registers a standard set of lifecycle and introspection endpoints:
+
+- `endpoints` — list registered endpoint names
+- `status` — current service status
+- `heartbeat` — structured health/liveness payload
+- `server_id` — unique server ID
+- `pid_file` — PID file path for the launched process
+- `shutdown` — stop the running service
+
+These endpoints are available over HTTP, and some are also exposed as MCP tools.
+
+## ConnectionManager
+
+`ConnectionManager` is the client-side abstraction for talking to a running service over HTTP. It provides common lifecycle methods such as:
+
+- `status()` / `astatus()`
+- `shutdown()` / `ashutdown()`
+- `mcp_client` for talking to the same service via MCP
+
+Example:
+
+```python
+from mindtrace.services import Service
+
+
+cm = Service.connect("http://localhost:8080")
+print(cm.status())
+cm.shutdown(block=False)
+```
+
+## Auto-Generated Connection Managers
+
+If a service does not register a custom client class, Mindtrace generates one automatically from the service’s registered endpoint schemas. Each endpoint becomes:
+
+- a synchronous client method
+- an asynchronous client method prefixed with `a`
+
+For example, an `echo` endpoint becomes:
+
+- `cm.echo(...)`
+- `await cm.aecho(...)`
+
+For a generated client, this means you can write:
+
+```python
+cm = EchoService.launch(wait_for_launch=True)
+result = cm.echo(message="Hello")
+print(result.echoed)
+```
+
+If no custom connection manager is registered, `generate_connection_manager()` creates one dynamically from the service definition.
+
+For each registered endpoint:
+
+- a sync method is generated
+- an async method is generated
+- input kwargs are validated against the endpoint input schema
+- HTTP responses are parsed into the endpoint output schema
+
+### Method naming
+
+- endpoint `echo` → `echo()` and `aecho()`
+- dotted endpoint names are converted to valid Python method names by replacing `.` with `_`
+
+### Validation controls
+
+Generated methods support:
+
+- `validate_input=True`
+- `validate_output=True`
+
+These can be disabled when raw payload handling is needed.
+
+Examples:
+
+```python
+# Default behavior: validate kwargs against the input schema
+# and parse the response into the output schema
+result = cm.echo(message="Hello")
+print(result.echoed)
+```
+
+```python
+# Skip input validation and send the payload as-is
+result = cm.echo(validate_input=False, message="Hello", delay=0.0)
+
+# Skip output validation to receive the raw response dict
+raw_result = cm.echo(message="Hello", validate_output=False)
+print(raw_result)
+```
+
+### When to write a custom connection manager
+
+A custom connection manager is worth using when you want:
+
+- richer convenience methods than one-method-per-endpoint
+- custom retry or caching behavior
+- special authentication flows
+- a more domain-specific client surface
+
+Otherwise, the generated client is usually enough.
+
+Example:
+
+```python
+import requests
+
+from mindtrace.services import ConnectionManager, Service
+
+
+class EchoConnectionManager(ConnectionManager):
+    def echo(self, message: str, delay: float = 0.0):
+        response = requests.post(
+            f"{str(self.url).rstrip('/')}/echo",
+            json={"message": message, "delay": delay},
+            timeout=60,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def echo_twice(self, message: str):
+        first = self.echo(message)
+        second = self.echo(message)
+        return [first["echoed"], second["echoed"]]
+
+
+class EchoService(Service):
+    pass
+
+
+EchoService.register_connection_manager(EchoConnectionManager)
+cm = EchoService.connect("http://localhost:8080")
+print(cm.echo_twice("Hello"))
+```
+
+After registering the custom connection manager, `EchoService.connect(...)` or `EchoService.launch(...)` returns an `EchoConnectionManager` instead of an auto-generated one.
+
+## Launching and Connecting
+
+### `launch()`
+
+`Service.launch()`:
+
+- resolves the target URL
+- checks that no service is already running there
+- spawns a subprocess launcher
+- optionally waits for the service to become reachable
+- returns a connection manager when `wait_for_launch=True`
+
+Common arguments:
+
+- `url` — explicit full service URL
+- `host` / `port` — host and port override
+- `wait_for_launch` — wait until the service is available
+- `timeout` — startup timeout in seconds
+- `block` — keep the calling process blocked while the service runs
+- `num_workers` — worker count for the launched service
+
+Example:
+
+```python
+cm = EchoService.launch(
+    host="localhost",
+    port=8080,
+    wait_for_launch=True,
+    timeout=30,
+)
+print(cm.status())
+```
+
+### `connect()`
+
+`Service.connect()` attaches to an already-running service and returns the appropriate connection manager.
+
+Example:
+
+```python
+cm = EchoService.connect("http://localhost:8080")
+print(cm.status())
+print(cm.echo(message="Connected"))
+```
+
+## URL and Configuration Behavior
+
+In most cases, you can either provide an explicit URL or let the service use its configured defaults.
+
+Examples:
+
+```python
+# Explicit full URL
+cm = EchoService.connect("http://localhost:8080")
+```
+
+```python
+# Host/port convenience when launching
+cm = EchoService.launch(host="localhost", port=8080, wait_for_launch=True)
+```
+
+If you do not pass either, the service falls back to its configured default URL.
+
+MCP paths are also configuration-driven, so the mounted MCP endpoint is built from the service URL plus the configured MCP mount and app paths.
+
+## MCP Integration
+
+MCP (Model Context Protocol) is a standard way to expose application functionality as structured tools for AI clients. If you are familiar with FastAPI, you can think of MCP as a tool-oriented interface sitting alongside your normal HTTP routes: instead of calling REST endpoints directly, an MCP client can discover available tools and invoke them with structured inputs.
+
+In `mindtrace-services`, every service creates and mounts a FastMCP app alongside its normal FastAPI routes.
+
+### Expose an endpoint as a tool
+
+```python
+self.add_endpoint("echo", self.echo, schema=echo_task, as_tool=True)
+```
+
+This makes the same function available:
+
+- as an HTTP endpoint
+- as an MCP tool
+
+### Register an MCP-only tool
+
+```python
+def reverse_message(payload: EchoInput) -> EchoOutput:
+    """Reverse the input message."""
+    return EchoOutput(echoed=payload.message[::-1])
+
+
+self.add_tool("reverse_message", reverse_message)
+```
+
+### MCP client access
+
+You can connect to a service over MCP in three common ways.
+
+#### Class-level connect
+
+```python
+client = EchoService.mcp.connect("http://localhost:8080")
+```
+
+#### Class-level launch
+
+```python
+client = EchoService.mcp.launch(host="localhost", port=8080, wait_for_launch=True)
+```
+
+#### From an existing connection manager
+
+```python
+cm = EchoService.launch(host="localhost", port=8080, wait_for_launch=True)
+client = cm.mcp_client
+```
+
+### Minimal MCP example
+
+```python
 import asyncio
+
+from mindtrace.services.samples.echo_mcp import EchoService
+
 
 async def main():
     client = EchoService.mcp.launch(
@@ -255,82 +431,106 @@ async def main():
     )
     async with client:
         tools = await client.list_tools()
-        print([t.name for t in tools])
-        result = await client.call_tool("echo", {"payload": {"message": "Launched"}})
+        print([tool.name for tool in tools])
+        result = await client.call_tool("echo", {"payload": {"message": "Hello"}})
         print(result)
+
 
 asyncio.run(main())
 ```
 
-Get the MCP client from a connection manager instance:
+### Remote MCP usage
+
+Any Mindtrace service exposing MCP tools can also be used from MCP-capable clients such as Cursor by pointing the client at the service’s mounted MCP endpoint.
+
+Example configuration:
+
+```json
+{
+  "mcpServers": {
+    "mindtrace_echo": {
+      "url": "http://localhost:8080/mcp-server/mcp/"
+    }
+  }
+}
+```
+
+Once configured, the client can list and invoke tools exposed by the service.
+
+## Gateway and Proxy Routing
+
+The package includes service-composition helpers for routing traffic through a central gateway.
+
+### `Gateway`
+
+`Gateway` is a service that can register downstream FastAPI apps and forward requests to them.
+
+It supports:
+
+- dynamic app registration
+- HTTP request forwarding
+- enhanced connection behavior for registered apps
+
+### `ProxyConnectionManager`
+
+`ProxyConnectionManager` routes endpoint calls through a gateway instead of calling a service directly. It uses service endpoint metadata to create proxy methods matching the downstream service surface.
+
+This is useful when a service needs to be accessed indirectly through a central gateway.
+
+Example:
 
 ```python
-from mindtrace.services.samples.echo_mcp import EchoService
-import asyncio
+from mindtrace.services import EchoService, Gateway
 
-async def main():
-    cm = EchoService.launch(host="localhost", port=8081, wait_for_launch=True, timeout=30)
-    client = cm.mcp_client  # lazily created and cached per manager instance
-    async with client:
-        tools = await client.list_tools()
-        print([t.name for t in tools])
-        result = await client.call_tool("echo", {"payload": {"message": "From manager"}})
-        print(result)
 
-asyncio.run(main())
+# Launch a normal service
+backend_cm = EchoService.launch(host="localhost", port=8081, wait_for_launch=True)
+
+# Launch the gateway
+gateway_cm = Gateway.launch(host="localhost", port=8080, wait_for_launch=True)
+
+# Register the service with the gateway and attach a proxy client
+gateway_cm.register_app(
+    name="echo",
+    url="http://localhost:8081",
+    connection_manager=backend_cm,
+)
+
+# Calls are now forwarded through the gateway
+print(gateway_cm.echo.echo(message="Hello through gateway"))
 ```
 
-### Key Points
-- Endpoints added with `as_tool=True` are available as both HTTP endpoints and MCP tools.
-- The sample EchoService demonstrates both REST and MCP tool usage.
-- The MCP client allows you to list and call tools programmatically.
+## Examples in this package
 
-For trial purposes, see the sample files:
-- [`mindtrace/services/sample/echo_mcp.py`](https://github.com/Mindtrace/mindtrace/blob/dev/mindtrace/services/sample/echo_mcp.py)
-- [`samples/services/echo_mcp_service.py`](https://github.com/Mindtrace/mindtrace/blob/dev/samples/services/echo_mcp_service.py)
-- [`samples/services/mcp/mcp_client.py`](https://github.com/Mindtrace/mindtrace/blob/dev/samples/services/mcp/mcp_client.py)
+See the sample implementations in this package for end-to-end reference:
 
+- [Basic Echo service sample](mindtrace/services/samples/echo_service.py)
+- [Echo service with MCP tools](mindtrace/services/samples/echo_mcp.py)
+- [Discord service documentation](mindtrace/services/discord/README.md)
 
-## Remote MCP Server Usage with Cursor
+## Testing
 
-You can use Cursor's UI to interact directly with any Mindtrace service that exposes its endpoints as MCP tools. This allows you to call your service's functions from within Cursor chat, making development and testing seamless.
+If you are working in the full Mindtrace repo, run tests for this module specifically:
 
-### How to Connect Cursor to a Remote MCP Server
+```bash
+# Run the services test suite
+ds test: services
 
-Follow these steps to set up and use a remote MCP server with Cursor:
+# Run only unit tests for services
+ds test: --unit services
+```
 
-1. **Launch the MCP Server**
-   
-   Start your Mindtrace service with MCP enabled. For example, to launch the EchoService:
+If you need a fresh checkout first:
 
-   ```python
-   from mindtrace.services.samples.echo_mcp import EchoService
-   connection_manager = EchoService.launch(port=8080, host="localhost")
-   ```
+```bash
+git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+uv sync --dev --all-extras
+```
 
-2. **Configure Cursor to Use the MCP Server**
-   
-   - Open Cursor settings: Press `Ctrl+Shift+J` (or open the Command Palette and search for "Settings").
-   - Navigate to **Tools & Integrations**.
-   - Find and select **Add Custom MCP**.
-   - In the configuration, add your MCP server details. For example, in your `mcp.json`:
+## Practical Notes and Caveats
 
-     ```json
-     {
-       "mcpServers": {
-         "mindtrace_echo": {
-           "url": "http://localhost:8080/mcp-server/mcp/"
-         }
-       }
-     }
-     ```
-
-   - Save the configuration. Cursor will now recognize your MCP server and list its available tools.
-
-3. **Interact with Your Service via Cursor Chat**
-   
-   - Start a new chat session in Cursor.
-   - You can now use natural language prompts to call your service's MCP tools. For example:
-     - `Could you reverse the message 'POP' using mindtrace_echo tool?`
-     - `Can you check the status of echo service using mindtrace_echo tool?`
-   - Cursor will route these requests to your MCP server and display the results in the chat.
+- Generated endpoint methods use **POST** requests.
+- Protected client methods such as `status` and `shutdown` are not overwritten by generated endpoint methods.
+- A lightweight service instance may be created during client generation in order to inspect registered endpoints.
+- Endpoint names should be chosen with both route readability and Python client naming in mind.
+- `launch()` manages subprocesses and PID files, so it should be treated as a service runtime tool, not just object instantiation.

--- a/mindtrace/storage/README.md
+++ b/mindtrace/storage/README.md
@@ -2,55 +2,336 @@
 [![License](https://img.shields.io/pypi/l/mindtrace-storage)](https://github.com/mindtrace/mindtrace/blob/main/mindtrace/storage/LICENSE)
 [![Downloads](https://static.pepy.tech/badge/mindtrace-storage)](https://pepy.tech/projects/mindtrace-storage)
 
-# Storage Module
+# Mindtrace Storage
 
-This directory contains the storage-related components for the Mindtrace project. It provides abstractions and implementations for interacting with various storage backends, such as Google Cloud Storage (GCS).
+The `Storage` module provides Mindtrace’s abstraction layer for object storage backends such as Google Cloud Storage and S3-compatible services.
 
-## Structure
+## Features
 
-- `mindtrace/storage` — Contains the core storage handler implementations and interfaces.
-- `pyproject.toml` — Build and dependency configuration for the storage package.
+- **Unified object-storage interface** through `StorageHandler`
+- **Backend support** for Google Cloud Storage and S3-compatible storage
+- **Structured operation results** with `Status`, `FileResult`, `StringResult`, and `BatchResult`
+- **File and string operations** for both local-file workflows and in-memory content
+- **Batch and folder helpers** for multi-object workflows
+- **Presigned URL and metadata helpers** for remote object access
 
-## Main Components
-
-- **base.py**: Defines the abstract `StorageHandler` interface for storage operations.
-- **gcs.py**: Implements `GCSStorageHandler`, a wrapper around Google Cloud Storage APIs for uploading, downloading, listing, and managing objects in GCS buckets.
-
-## Google Cloud Storage (GCS) Usage
-
-### Usage Example
-
-To use the GCS storage handler:
+## Quick Start
 
 ```python
-from mindtrace.storage.gcs import GCSStorageHandler
+from mindtrace.storage import GCSStorageHandler
 
-handler = GCSStorageHandler(
+
+storage = GCSStorageHandler(
     bucket_name="your-bucket-name",
     project_id="your-gcp-project-id",
-    credentials_path="/path/to/service-account.json",  # Optional if using ADC
-    create_if_missing=True,
 )
 
-# Upload a file
-gcs_uri = handler.upload("local_file.txt", "remote/path/in/bucket.txt")
+result = storage.upload("local_file.txt", "docs/local_file.txt")
+print(result.status)
 
-# List objects
-print(handler.list_objects(prefix="remote/path/"))
+objects = storage.list_objects(prefix="docs/")
+print(objects)
 ```
 
-### Available GCS APIs
-The following methods are available via the `GCSStorageHandler` for explicit use:
+In practice, the storage package gives you one common interface for object stores, while preserving backend-specific authentication and deployment details.
 
-- `upload(local_path, remote_path, metadata=None)`: Upload a local file to a GCS bucket.
-- `download(remote_path, local_path)`: Download a file from GCS to a local path.
-- `delete(remote_path)`: Delete an object from the GCS bucket.
-- `list_objects(prefix="", max_results=None)`: List objects in the bucket, optionally filtered by prefix.
-- `exists(remote_path)`: Check if an object exists in the bucket.
-- `get_presigned_url(remote_path, expiration_minutes=60, method="GET")`: Generate a presigned URL for accessing an object.
-- `get_object_metadata(remote_path)`: Retrieve metadata for a specific object.
+## StorageHandler
 
-### Notes
-- Ensure you have the required Google Cloud credentials and permissions to access the target bucket.
-- For local development, you can use `gcloud auth application-default login` to set up default credentials.
+`StorageHandler` is the common abstraction that storage backends implement.
 
+Core operations include:
+
+- `upload()`
+- `download()`
+- `delete()`
+- `upload_string()`
+- `download_string()`
+- `list_objects()`
+- `exists()`
+- `get_presigned_url()`
+- `get_object_metadata()`
+
+The base class also provides convenience helpers for:
+
+- `upload_batch()`
+- `download_batch()`
+- `download_string_batch()`
+- `delete_batch()`
+- `upload_folder()`
+- `download_folder()`
+
+That means you can write code against the common interface while choosing the backend that fits your deployment.
+
+## Result Types
+
+Storage operations return structured result objects rather than only raw values.
+
+### `Status`
+
+Possible statuses include:
+
+- `ok`
+- `skipped`
+- `already_exists`
+- `overwritten`
+- `not_found`
+- `error`
+
+### `FileResult`
+
+Returned by file-based operations such as `upload()`, `download()`, and `delete()`.
+
+```python
+from mindtrace.storage import GCSStorageHandler, Status
+
+
+storage = GCSStorageHandler(bucket_name="your-bucket")
+result = storage.upload("local.txt", "docs/local.txt", fail_if_exists=True)
+
+if result.status == Status.ALREADY_EXISTS:
+    print("Object already exists")
+elif result.ok:
+    print("Upload succeeded")
+else:
+    print(result.error_type, result.error_message)
+```
+
+### `StringResult`
+
+Returned by in-memory content operations such as `upload_string()` and `download_string()`.
+
+```python
+content_result = storage.download_string("docs/config.json")
+if content_result.ok:
+    print(content_result.content)
+```
+
+### `BatchResult`
+
+Returned by batch file operations. It gives you filtered result views such as:
+
+- `ok_results`
+- `skipped_results`
+- `conflict_results`
+- `failed_results`
+- `all_ok`
+
+```python
+batch = storage.upload_batch(
+    [("a.txt", "docs/a.txt"), ("b.txt", "docs/b.txt")],
+    fail_if_exists=True,
+)
+
+print(len(batch.ok_results))
+print(len(batch.failed_results))
+```
+
+## Google Cloud Storage
+
+Use `GCSStorageHandler` when you want Google Cloud Storage support.
+
+```python
+from mindtrace.storage import GCSStorageHandler
+
+
+storage = GCSStorageHandler(
+    bucket_name="your-bucket-name",
+    project_id="your-gcp-project-id",
+    credentials_path="~/service-account.json",  # optional
+    create_if_missing=True,
+)
+```
+
+### Common GCS workflow
+
+```python
+# Upload a file
+upload_result = storage.upload("local_file.txt", "remote/path/file.txt")
+print(upload_result.status)
+
+# Download a file
+download_result = storage.download("remote/path/file.txt", "downloaded.txt")
+print(download_result.status)
+
+# List objects
+print(storage.list_objects(prefix="remote/path/"))
+
+# Metadata
+print(storage.get_object_metadata("remote/path/file.txt"))
+```
+
+### Authentication notes
+
+`GCSStorageHandler` supports:
+
+- Application Default Credentials (ADC)
+- explicit `credentials_path`
+
+For local development, ADC is often enough:
+
+```bash
+$ gcloud auth application-default login
+```
+
+## S3-Compatible Storage
+
+Use `S3StorageHandler` when you want AWS S3, MinIO, DigitalOcean Spaces, or another S3-compatible service.
+
+```python
+from mindtrace.storage import S3StorageHandler
+
+
+storage = S3StorageHandler(
+    bucket_name="my-bucket",
+    endpoint="localhost:9000",
+    access_key="minioadmin",
+    secret_key="minioadmin",
+    secure=False,
+    create_if_missing=True,
+)
+```
+
+### Common S3 workflow
+
+```python
+# Upload
+result = storage.upload("local.txt", "docs/local.txt")
+print(result.status)
+
+# Check existence
+print(storage.exists("docs/local.txt"))
+
+# Generate a presigned URL
+url = storage.get_presigned_url("docs/local.txt", expiration_minutes=30)
+print(url)
+```
+
+### Compatibility note
+
+The S3 backend is not limited to AWS. It is designed for S3-compatible APIs more generally.
+
+A backwards-compatible alias also exists in code:
+
+- `MinioStorageHandler = S3StorageHandler`
+
+## String Operations
+
+Use string operations when you want to avoid temporary local files.
+
+```python
+from mindtrace.storage import GCSStorageHandler
+
+
+storage = GCSStorageHandler(bucket_name="your-bucket")
+
+upload_result = storage.upload_string(
+    '{"hello": "world"}',
+    "docs/config.json",
+    content_type="application/json",
+    fail_if_exists=True,
+)
+print(upload_result.status)
+
+content_result = storage.download_string("docs/config.json")
+if content_result.ok:
+    print(content_result.content.decode("utf-8"))
+```
+
+These methods are especially useful for JSON, manifests, metadata blobs, or other generated content.
+
+## Batch and Folder Operations
+
+The base class includes helpers for multi-object workflows.
+
+### Batch uploads/downloads
+
+```python
+batch = storage.upload_batch(
+    [
+        ("a.txt", "docs/a.txt"),
+        ("b.txt", "docs/b.txt"),
+    ],
+    max_workers=4,
+)
+
+for result in batch:
+    print(result.remote_path, result.status)
+```
+
+### Folder uploads
+
+```python
+result = storage.upload_folder(
+    local_folder="./reports",
+    remote_prefix="archive/reports",
+    include_patterns=["*.json", "*.txt"],
+    exclude_patterns=["*.tmp"],
+)
+
+print(len(result.ok_results))
+```
+
+### Folder downloads
+
+```python
+result = storage.download_folder(
+    remote_prefix="archive/reports",
+    local_folder="./downloaded-reports",
+)
+
+print(len(result.results))
+```
+
+## Presigned URLs and Metadata
+
+Both storage backends expose helpers for common remote-object workflows.
+
+```python
+url = storage.get_presigned_url("docs/local.txt", expiration_minutes=60, method="GET")
+print(url)
+
+metadata = storage.get_object_metadata("docs/local.txt")
+print(metadata)
+```
+
+These are useful when you want to hand off temporary access to another system without proxying the object through your app.
+
+## Installation
+
+Base install:
+
+```bash
+$ uv add mindtrace-storage
+```
+
+Or with pip:
+
+```bash
+$ pip install mindtrace-storage
+```
+
+If you are working from the full Mindtrace repo:
+
+```bash
+$ git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+$ uv sync --dev --all-extras
+```
+
+## Testing
+
+If you are working in the full Mindtrace repo, run tests for this module specifically:
+
+```bash
+$ git clone https://github.com/Mindtrace/mindtrace.git && cd mindtrace
+$ uv sync --dev --all-extras
+$ ds test: storage
+$ ds test: --unit storage
+```
+
+## Practical Notes and Caveats
+
+- GCS and S3-compatible backends use different authentication and bucket-management conventions.
+- The S3 backend is intended for S3-compatible services generally, not only AWS S3.
+- Structured result objects make it easier to handle partial failures and non-exception outcomes such as `already_exists` or `skipped`.
+- Batch and folder helpers are convenience methods built on top of the core single-object operations.
+- Presigned URL behavior depends on backend credentials, configuration, and object-store capabilities.


### PR DESCRIPTION
Commit ee16bc72 ("registry: add declarative mounts and store facade") inadvertently reverted the README rewrites from the feature/services-documentation work. Restore the 14 affected READMEs (root, AGENTS, CONTRIBUTING, TESTING, plus per-module READMEs for agents/cluster/core/database/jobs/registry/services/storage and the hardware cli/scanners_3d submodules) to their state at 7b283b3a.

Two files reverted by ee16bc72 are intentionally left at HEAD because post-regression commits documented genuinely new APIs:

- mindtrace/datalake/README.md — HEAD documents DatalakeService / DataVault / AsyncDatalake; 7b283b's version describes the older monolithic Datalake class.
- mindtrace/hardware/README.md — HEAD documents capture groups, auto-reconnection, liquid-lens autofocus, and the current HomographyMeasurer (7b283b still references PlanarHomographyMeasurer).