### PR TITLE
Stabilize RunScriptWorker Docker integration test

### DIFF
--- a/tests/integration/mindtrace/cluster/test_run_script_worker_integration.py
+++ b/tests/integration/mindtrace/cluster/test_run_script_worker_integration.py
@@ -118,7 +118,9 @@ def test_run_script_worker_docker_environment(cluster_cm, node):
 
     # Launch worker on the node
     worker_url = f"http://localhost:{free_port()}"
-    cluster_cm.launch_worker(node_url=str(node.url), worker_type="runscriptworker", worker_url=worker_url)
+    launch = cluster_cm.launch_worker(node_url=str(node.url), worker_type="runscriptworker", worker_url=worker_url)
+    # Ensure the worker is ready before consuming the test timeout budget.
+    wait_for_worker_launch(cluster_cm, str(node.url), launch.launch_id, timeout=60.0)
 
     # Create job with Docker environment
     job = job_from_schema(
@@ -126,21 +128,23 @@ def test_run_script_worker_docker_environment(cluster_cm, node):
         input_data={
             "environment": {
                 "docker": {
-                    "image": "ubuntu:22.04",
+                    # Use a small image to avoid flaky timeouts on first-time pulls.
+                    "image": "alpine:3.20",
                     "environment": {},
                     "volumes": {},
                     "devices": [],
                     "working_dir": "/app",
                 }
             },
-            "command": "echo 'Hello, World!' && echo 'Goodnight, World!'",
+            # Run via shell so `&&` is interpreted reliably.
+            "command": "sh -lc \"echo 'Hello, World!' && echo 'Goodnight, World!'\"",
         },
     )
 
     # Submit job and wait for completion
     cluster_cm.submit_job(job)
 
-    status = wait_for_job_status(cluster_cm, job.id, "completed", timeout=60)
+    status = wait_for_job_status(cluster_cm, job.id, "completed", timeout=120)
     print(f"Final job status: {status}")
 
 
@@ -164,7 +168,8 @@ def test_run_script_worker_both_environments(cluster_cm, node):
 
     # Launch worker on the node
     worker_url = f"http://localhost:{free_port()}"
-    cluster_cm.launch_worker(node_url=str(node.url), worker_type="runscriptworker", worker_url=worker_url)
+    launch = cluster_cm.launch_worker(node_url=str(node.url), worker_type="runscriptworker", worker_url=worker_url)
+    wait_for_worker_launch(cluster_cm, str(node.url), launch.launch_id, timeout=60.0)
 
     # Test 1: Git environment job
     git_job = job_from_schema(
@@ -192,21 +197,21 @@ def test_run_script_worker_both_environments(cluster_cm, node):
         input_data={
             "environment": {
                 "docker": {
-                    "image": "ubuntu:22.04",
+                    "image": "alpine:3.20",
                     "environment": {},
                     "volumes": {},
                     "devices": [],
                     "working_dir": "/app",
                 }
             },
-            "command": "echo 'Hello, World!' && echo 'Goodnight, World!'",
+            "command": "sh -lc \"echo 'Hello, World!' && echo 'Goodnight, World!'\"",
         },
     )
 
     cluster_cm.submit_job(docker_job)
 
     # Wait for Docker job to complete
-    docker_status = wait_for_job_status(cluster_cm, docker_job.id, "completed", timeout=60)
+    docker_status = wait_for_job_status(cluster_cm, docker_job.id, "completed", timeout=120)
 
     print("Both jobs completed successfully:")
     print(f"Git job: {git_status}")


### PR DESCRIPTION
## Summary
Reduces flakiness in `test_run_script_worker_docker_environment` (and the Docker half of `test_run_script_worker_both_environments`).

## Why
The test could time out at 60s while the job stayed `running`, often because:
- The worker was not awaited after `launch_worker`, so startup consumed part of the timeout budget.
- `ubuntu:22.04` can take a long time to pull on a cold Docker cache.

## Changes
- Call `wait_for_worker_launch` after `launch_worker`, consistent with other tests in this file.
- Use `alpine:3.20` for a smaller, faster pull.
- Run the command with `sh -lc` so `&&` is interpreted reliably in the container.
- Increase Docker job completion wait to 120s.

## How to test
```bash
ds test: tests/integration/mindtrace/cluster/test_run_script_worker_integration.py::test_run_script_worker_docker_environment -vv
```

## Breaking changes
None.

---

- [x] Bug fix (test stability)
- [ ] Feature
- [x] Unit / integration test path exercised locally
- [x] Manual testing: `ds test:` on the single test above

Made with [Cursor](https://cursor.com)