### PR TITLE
test(hardware): show Basler hardware integration tests as skipped when deps/cameras missing

### DIFF
--- a/tests/integration/mindtrace/hardware/cameras/backends/basler/test_basler_hardware_integration.py
+++ b/tests/integration/mindtrace/hardware/cameras/backends/basler/test_basler_hardware_integration.py
@@ -4,8 +4,10 @@ These tests validate that the BaslerCameraBackend correctly integrates with actu
 when they are connected. They test full initialization, capture, configuration, and lifecycle
 management with real hardware.
 
-Note: These tests will be skipped if no Basler cameras are detected.
-Skip with: pytest -m "not hardware" or set SKIP_HARDWARE_TESTS=1
+Tests are always collected; they are skipped with explicit reasons when ``SKIP_HARDWARE_TESTS`` is set,
+pypylon is missing, or no cameras are enumerated (same visibility pattern as Photoneo 3D scanner tests).
+
+Skip entirely via: ``pytest -m "not hardware"`` or ``SKIP_HARDWARE_TESTS=1``.
 """
 
 import os
@@ -15,43 +17,55 @@ import pytest
 
 from mindtrace.core.utils.checks import check_libs
 
-# Skip all tests if SKIP_HARDWARE_TESTS is set
-if os.environ.get("SKIP_HARDWARE_TESTS", "0") == "1":
-    pytest.skip("Hardware tests disabled via SKIP_HARDWARE_TESTS env var", allow_module_level=True)
-
-# Skip all tests in this module if pypylon is not available
-missing_libs = check_libs(["pypylon"])
-if missing_libs:
-    pytest.skip(
-        f"Required libraries are not installed: {', '.join(missing_libs)}. Skipping test.", allow_module_level=True
-    )
+_missing_pypylon = check_libs(["pypylon"])
 
 
-def get_connected_cameras():
-    """Get list of connected Basler cameras for testing."""
+def check_basler_cameras_connected() -> bool:
+    """Return True if at least one Basler camera is enumerated by the SDK."""
+    if _missing_pypylon:
+        return False
     try:
         from mindtrace.hardware.cameras.backends.basler.basler_camera_backend import BaslerCameraBackend
 
-        return BaslerCameraBackend.get_available_cameras()
-    except Exception as e:
-        if "SDKNotAvailableError" in str(type(e)) or "SDK 'pypylon' is not available" in str(e):
-            pytest.skip(f"Pypylon SDK not available: {e}", allow_module_level=True)
-        return []
+        return len(BaslerCameraBackend.get_available_cameras()) > 0
+    except Exception:
+        return False
 
 
-# Skip all tests if no cameras are connected
-connected_cameras = get_connected_cameras()
-if not connected_cameras:
-    pytest.skip("No Basler cameras detected. Skipping Basler hardware integration tests.", allow_module_level=True)
-
-# Mark all tests in this module as hardware tests
-pytestmark = pytest.mark.hardware
+# Collect all tests even when hardware or SDK is missing; skip with visible reasons (like 3D scanner tests).
+pytestmark = [
+    pytest.mark.hardware,
+    pytest.mark.skipif(
+        os.environ.get("SKIP_HARDWARE_TESTS", "0") == "1",
+        reason="Hardware tests disabled via SKIP_HARDWARE_TESTS env var",
+    ),
+    pytest.mark.skipif(
+        bool(_missing_pypylon),
+        reason=(
+            "Required libraries are not installed: "
+            + ", ".join(_missing_pypylon)
+            + ". Install pypylon to run Basler hardware integration tests."
+        ),
+    ),
+    pytest.mark.skipif(
+        not _missing_pypylon and not check_basler_cameras_connected(),
+        reason=(
+            "No Basler cameras detected (or pypylon could not enumerate devices). "
+            "Connect cameras and verify the Basler SDK."
+        ),
+    ),
+]
 
 
 @pytest.fixture
 def camera_name():
     """Fixture providing the name of the first connected camera."""
-    return connected_cameras[0]
+    from mindtrace.hardware.cameras.backends.basler.basler_camera_backend import BaslerCameraBackend
+
+    cameras = BaslerCameraBackend.get_available_cameras()
+    if not cameras:
+        pytest.skip("No Basler cameras available")
+    return cameras[0]
 
 
 def _is_camera_in_use_error(error: Exception) -> bool:


### PR DESCRIPTION
## Summary

Basler hardware integration tests in `tests/integration/mindtrace/hardware/cameras/backends/basler/test_basler_hardware_integration.py` previously used `pytest.skip(..., allow_module_level=True)` when `SKIP_HARDWARE_TESTS` was set, pypylon was missing, or no cameras were enumerated. That stopped pytest from collecting those tests, so they disappeared from the run instead of showing as skipped with a clear reason.

This change matches the Photoneo 3D scanner integration pattern: tests stay collected and are marked skipped with `pytest.mark.skipif` and explicit reasons (env flag, missing pypylon, no enumerated cameras or enumeration failure). The `camera_name` fixture resolves the first enumerated camera at runtime when tests actually run.

Tests should now show `SKIPPED [1] tests/integration/mindtrace/hardware/cameras/backends/basler/test_basler_hardware_integration.py:113: No Basler cameras detected (or pypylon could not enumerate devices). Connect cameras and verify the Basler SDK.` if no cameras are connected.

Closes #463

## Why

Contributors running integration tests without Basler hardware should still see which tests exist and what is required (SDK install, connected cameras, unsetting skip flags) instead of silently dropping an entire module from the report.

## How to test

Hardware integration tests for the `hardware` package:

```bash
ds test: hardware --integration
```

Focused run for this file:

```bash
ds test: tests/integration/mindtrace/hardware/cameras/backends/basler/test_basler_hardware_integration.py
```

Without Basler cameras or with SKIP_HARDWARE_TESTS=1, expect those tests to appear as skipped with the documented skip reasons (not omitted from collection).

Lint:

```bash
ruff check tests/integration/mindtrace/hardware/cameras/backends/basler/test_basler_hardware_integration.py
```

## Scope

Single file: tests/integration/mindtrace/hardware/cameras/backends/basler/test_basler_hardware_integration.py
No changes to camera backends or other production code.