### PR TITLE
tests: minor time improvements in unit tests

### DIFF
--- a/tests/integration/mindtrace/cluster/conftest.py
+++ b/tests/integration/mindtrace/cluster/conftest.py
@@ -8,7 +8,7 @@ from mindtrace.cluster.core.types import LaunchStatusEnum
 from mindtrace.core import get_free_port
 
 
-def wait_for_job_status(cm, job_id, expected_status, timeout=10, poll_interval=0.1):
+def wait_for_job_status(cm, job_id, expected_status, timeout=10, poll_interval=0.02):
     """Poll job status until it matches expected_status or timeout."""
     start = time.time()
     result = None
@@ -21,7 +21,7 @@ def wait_for_job_status(cm, job_id, expected_status, timeout=10, poll_interval=0
 
 
 def wait_for_worker_launch(
-    cluster_cm, node_url: str, launch_id: str, timeout: float = 60.0, poll_interval: float = 0.5
+    cluster_cm, node_url: str, launch_id: str, timeout: float = 60.0, poll_interval: float = 0.02
 ):
     """Poll worker launch status until READY or FAILED, or timeout.
 

--- a/tests/unit/mindtrace/datalake/test_service.py
+++ b/tests/unit/mindtrace/datalake/test_service.py
@@ -158,8 +158,11 @@ def _set_minimal_env(monkeypatch):
     Service.config = CoreConfig()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def datalake_objects():
+    # All values returned here are immutable Pydantic models or primitive
+    # bytes/strings, so a single instance can be shared across the 60+
+    # parametrized cases in this module without risk of cross-test mutation.
     storage_ref = StorageRef(mount="nas", name="images/cat.jpg", version="v1")
     source_storage_ref = StorageRef(mount="raw", name="images/source.jpg", version="v0")
     copied_storage_ref = StorageRef(mount="archive", name="images/cat-copy.jpg", version="v2")

--- a/tests/unit/mindtrace/hardware/services/cameras/test_inline_encoding_colorspace.py
+++ b/tests/unit/mindtrace/hardware/services/cameras/test_inline_encoding_colorspace.py
@@ -33,8 +33,11 @@ def _bgr_pixel(b: int, g: int, r: int) -> np.ndarray:
     return np.array([[[b, g, r]]], dtype=np.uint8)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def service() -> CameraManagerService:
+    # The service is expensive to construct (FastAPI + MCP wiring). Tests in
+    # this module either call pure helpers or replace ``_camera_manager`` with
+    # a fresh Mock per test, so a single shared instance is safe.
     return CameraManagerService(include_mocks=True)
 
 
@@ -138,7 +141,7 @@ class TestAsyncCameraColorspace:
 
         manager = AsyncCameraManager(include_mocks=True)
         try:
-            names = [n for n in AsyncCameraManager.discover(include_mocks=True) if n.startswith("MockBasler:")]
+            names = AsyncCameraManager.discover(backends="MockBasler", include_mocks=True)
             assert names
             cam = await manager.open(names[0])
 
@@ -159,7 +162,7 @@ class TestAsyncCameraColorspace:
 
         manager = AsyncCameraManager(include_mocks=True)
         try:
-            names = [n for n in AsyncCameraManager.discover(include_mocks=True) if n.startswith("MockBasler:")]
+            names = AsyncCameraManager.discover(backends="MockBasler", include_mocks=True)
             cam = await manager.open(names[0])
 
             bgr_blue = np.zeros((2, 2, 3), dtype=np.uint8)
@@ -185,7 +188,7 @@ class TestAsyncCameraColorspace:
 
         manager = AsyncCameraManager(include_mocks=True)
         try:
-            names = [n for n in AsyncCameraManager.discover(include_mocks=True) if n.startswith("MockBasler:")]
+            names = AsyncCameraManager.discover(backends="MockBasler", include_mocks=True)
             cam = await manager.open(names[0])
             cam.backend.capture = AsyncMock(return_value=bgr_frame)
 

--- a/tests/unit/mindtrace/hardware/services/cameras/test_service.py
+++ b/tests/unit/mindtrace/hardware/services/cameras/test_service.py
@@ -60,6 +60,14 @@ def _patch_hardware_exports(monkeypatch, **attrs):
         monkeypatch.setattr(hardware_pkg, name, value, raising=False)
 
 
+@pytest.fixture(scope="module")
+def _shared_camera_service():
+    # CameraManagerService construction is expensive (FastAPI + MCP wiring).
+    # Per-test fixtures that just want to swap in a mock ``_camera_manager``
+    # share this instance to amortize that cost.
+    return CameraManagerService(include_mocks=True)
+
+
 class TestCameraManagerServiceInitialization:
     """Test service initialization and lifecycle management."""
 
@@ -194,9 +202,11 @@ class TestCameraManagerServiceBusinessLogic:
     """Test real business logic: error handling, request validation, response formatting."""
 
     @pytest.fixture
-    def service_with_mock_manager(self):
+    def service_with_mock_manager(self, _shared_camera_service):
         """Create service with controlled mock manager for testing business logic."""
-        service = CameraManagerService(include_mocks=True)
+        service = _shared_camera_service
+        service._active_streams = {}
+        service._capabilities_cache = {}
 
         # Create mock manager that we can control for specific test scenarios
         mock_manager = Mock()
@@ -632,9 +642,11 @@ class TestCameraManagerServiceErrorHandling:
     """Test error handling and exception mapping in service layer."""
 
     @pytest.fixture
-    def service_with_mock_manager(self):
+    def service_with_mock_manager(self, _shared_camera_service):
         """Service with mock manager for error testing."""
-        service = CameraManagerService(include_mocks=True)
+        service = _shared_camera_service
+        service._active_streams = {}
+        service._capabilities_cache = {}
         mock_manager = Mock()
         mock_manager.active_cameras = []
         service._camera_manager = mock_manager
@@ -688,8 +700,10 @@ class TestCameraManagerServiceResponseModels:
     """Test response model creation and data formatting."""
 
     @pytest.fixture
-    def service_with_mock_manager(self):
-        service = CameraManagerService(include_mocks=True)
+    def service_with_mock_manager(self, _shared_camera_service):
+        service = _shared_camera_service
+        service._active_streams = {}
+        service._capabilities_cache = {}
         mock_manager = Mock()
         service._camera_manager = mock_manager
         return service, mock_manager
@@ -796,8 +810,10 @@ class TestCameraManagerServiceCaptureAndHomography:
     """Additional capture, health, and homography service coverage."""
 
     @pytest.fixture
-    def service_with_mock_manager(self):
-        service = CameraManagerService(include_mocks=True)
+    def service_with_mock_manager(self, _shared_camera_service):
+        service = _shared_camera_service
+        service._active_streams = {}
+        service._capabilities_cache = {}
         mock_manager = Mock()
         mock_manager.active_cameras = ["Basler:cam1", "Basler:cam2"]
         mock_manager.open = AsyncMock()

--- a/tests/unit/mindtrace/hardware/services/cameras/test_service_streams_and_performance.py
+++ b/tests/unit/mindtrace/hardware/services/cameras/test_service_streams_and_performance.py
@@ -15,9 +15,18 @@ from mindtrace.hardware.services.cameras.models.requests import (
 from mindtrace.hardware.services.cameras.service import CameraManagerService
 
 
+@pytest.fixture(scope="module")
+def _shared_camera_service():
+    return CameraManagerService(include_mocks=True)
+
+
 @pytest.fixture
-def service_and_manager():
-    service = CameraManagerService(include_mocks=True)
+def service_and_manager(_shared_camera_service):
+    service = _shared_camera_service
+    # The shared service is reused across tests in this module — reset any
+    # mutable state that individual tests poke at so we don't leak between them.
+    service._active_streams = {}
+    service._capabilities_cache = {}
     manager = Mock()
     manager.active_cameras = ["Basler:cam1"]
     manager.timeout_ms = 1000

--- a/tests/unit/mindtrace/models/archivers/timm_archiver/test_timm_model_archiver.py
+++ b/tests/unit/mindtrace/models/archivers/timm_archiver/test_timm_model_archiver.py
@@ -171,8 +171,10 @@ def test_timm_archiver_roundtrip(temp_dir):
     """Test full save/load roundtrip with real timm model."""
     archiver = TimmModelArchiver(uri=temp_dir)
 
-    # Create real model
-    model = timm.create_model("resnet18", pretrained=False, num_classes=5)
+    # Use a tiny model — the test verifies save/load round-trip integrity, not
+    # any architecture-specific behaviour, so the smallest available timm model
+    # exercises the same code path much faster than resnet18.
+    model = timm.create_model("mobilenetv3_small_050", pretrained=False, num_classes=5)
     model.eval()
 
     # Save

--- a/tests/unit/mindtrace/models/archivers/ultralytics/test_package_import_fallback.py
+++ b/tests/unit/mindtrace/models/archivers/ultralytics/test_package_import_fallback.py
@@ -2,40 +2,29 @@
 
 from __future__ import annotations
 
-import subprocess
-import sys
-from pathlib import Path
-
-_REPO_ROOT = Path(__file__).resolve().parents[6]
-
-
-def test_ultralytics_archivers_init_passes_when_yolo_submodule_unavailable():
-    script = r"""
 import builtins
+import importlib
 import sys
 
-sys.path.insert(0, sys.argv[1])
-_real = builtins.__import__
 
-def _fake(name, globals=None, locals=None, fromlist=(), level=0):
-    if name == "mindtrace.models.archivers.ultralytics.yolo_archiver":
-        raise ImportError("simulated optional ultralytics yolo archiver failure")
-    return _real(name, globals, locals, fromlist, level)
+def test_ultralytics_archivers_init_passes_when_yolo_submodule_unavailable(monkeypatch):
+    real_import = builtins.__import__
 
-builtins.__import__ = _fake
-for key in list(sys.modules.keys()):
-    if key.startswith("mindtrace.models.archivers.ultralytics"):
-        del sys.modules[key]
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "mindtrace.models.archivers.ultralytics.yolo_archiver":
+            raise ImportError("simulated optional ultralytics yolo archiver failure")
+        return real_import(name, globals, locals, fromlist, level)
 
-import mindtrace.models.archivers.ultralytics as ultra_pkg
+    prefix = "mindtrace.models.archivers.ultralytics"
+    saved = {k: v for k, v in sys.modules.items() if k == prefix or k.startswith(prefix + ".")}
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    for k in list(saved):
+        sys.modules.pop(k, None)
 
-assert ultra_pkg.__all__ == []
-"""
-    proc = subprocess.run(
-        [sys.executable, "-c", script, str(_REPO_ROOT)],
-        capture_output=True,
-        text=True,
-        timeout=120,
-        check=False,
-    )
-    assert proc.returncode == 0, proc.stderr
+    try:
+        ultra_pkg = importlib.import_module(prefix)
+        assert ultra_pkg.__all__ == []
+    finally:
+        for k in [k for k in sys.modules if k == prefix or k.startswith(prefix + ".")]:
+            sys.modules.pop(k, None)
+        sys.modules.update(saved)

--- a/tests/unit/mindtrace/models/test_models_package_init.py
+++ b/tests/unit/mindtrace/models/test_models_package_init.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-import subprocess
+import builtins
+import importlib
 import sys
-from pathlib import Path
 
 import pytest
 
 import mindtrace.models as models
-
-_REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
 def test_auto_segmenter_exported_from_package_root() -> None:
@@ -22,39 +20,25 @@ def test_models_package_unknown_attribute_raises() -> None:
         _ = models.NonexistentExportXYZ
 
 
-def test_models_package_import_skips_optional_backbone_adapters_on_import_error() -> None:
-    """Covers ``except ImportError: pass`` around backbone adapter exports (lines 92–93)."""
-    script = r"""
-import builtins
-import sys
+def test_models_package_import_skips_optional_backbone_adapters_on_import_error(monkeypatch) -> None:
+    """Covers ``except ImportError: pass`` around backbone adapter exports."""
+    real_import = builtins.__import__
 
-sys.path.insert(0, sys.argv[1])
-_real_import = builtins.__import__
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "mindtrace.models.architectures.backbones" and fromlist and "MindtraceBackboneAdapter" in fromlist:
+            raise ImportError("simulated missing optional backbone adapters")
+        return real_import(name, globals, locals, fromlist, level)
 
-def _fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-    if (
-        name == "mindtrace.models.architectures.backbones"
-        and fromlist
-        and "MindtraceBackboneAdapter" in fromlist
-    ):
-        raise ImportError("simulated missing optional backbone adapters")
-    return _real_import(name, globals, locals, fromlist, level)
+    saved = {k: v for k, v in sys.modules.items() if k == "mindtrace" or k.startswith("mindtrace.")}
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    for k in list(saved):
+        sys.modules.pop(k, None)
 
-builtins.__import__ = _fake_import
-for key in list(sys.modules.keys()):
-    if key == "mindtrace" or key.startswith("mindtrace."):
-        del sys.modules[key]
-
-import mindtrace.models as m
-
-assert m.Trainer is not None
-assert getattr(m, "MindtraceBackboneAdapter", None) is None
-"""
-    proc = subprocess.run(
-        [sys.executable, "-c", script, str(_REPO_ROOT)],
-        capture_output=True,
-        text=True,
-        timeout=120,
-        check=False,
-    )
-    assert proc.returncode == 0, proc.stderr
+    try:
+        m = importlib.import_module("mindtrace.models")
+        assert m.Trainer is not None
+        assert getattr(m, "MindtraceBackboneAdapter", None) is None
+    finally:
+        for k in [k for k in sys.modules if k == "mindtrace" or k.startswith("mindtrace.")]:
+            sys.modules.pop(k, None)
+        sys.modules.update(saved)

--- a/tests/unit/mindtrace/models/test_tracking.py
+++ b/tests/unit/mindtrace/models/test_tracking.py
@@ -1008,38 +1008,28 @@ class TestHuggingFaceTrackerBridge:
 
 
 class TestBridgesTransformersImportFallback:
-    def test_hf_bridge_base_is_object_when_transformers_missing(self):
-        import subprocess
+    def test_hf_bridge_base_is_object_when_transformers_missing(self, monkeypatch):
+        import builtins
+        import importlib
         import sys
-        from pathlib import Path
 
-        root = Path(__file__).resolve().parents[4]
-        script = r"""
-import builtins
-import sys
+        real_import = builtins.__import__
 
-sys.path.insert(0, sys.argv[1])
-_real = builtins.__import__
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "transformers" or name.startswith("transformers."):
+                raise ImportError("simulated missing transformers")
+            return real_import(name, globals, locals, fromlist, level)
 
-def _fake(name, globals=None, locals=None, fromlist=(), level=0):
-    if name == "transformers" or name.startswith("transformers."):
-        raise ImportError("simulated missing transformers")
-    return _real(name, globals, locals, fromlist, level)
+        prefix = "mindtrace.models.tracking"
+        saved = {k: v for k, v in sys.modules.items() if k == prefix or k.startswith(prefix + ".")}
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        for k in list(saved):
+            sys.modules.pop(k, None)
 
-builtins.__import__ = _fake
-for key in list(sys.modules.keys()):
-    if key.startswith("mindtrace.models.tracking"):
-        del sys.modules[key]
-
-import mindtrace.models.tracking.bridges as bridges
-
-assert bridges._HFBase is object
-"""
-        proc = subprocess.run(
-            [sys.executable, "-c", script, str(root)],
-            capture_output=True,
-            text=True,
-            timeout=120,
-            check=False,
-        )
-        assert proc.returncode == 0, proc.stderr
+        try:
+            bridges = importlib.import_module("mindtrace.models.tracking.bridges")
+            assert bridges._HFBase is object
+        finally:
+            for k in [k for k in sys.modules if k == prefix or k.startswith(prefix + ".")]:
+                sys.modules.pop(k, None)
+            sys.modules.update(saved)

--- a/tests/unit/mindtrace/models/test_trainer.py
+++ b/tests/unit/mindtrace/models/test_trainer.py
@@ -901,7 +901,7 @@ class TestFitIntegration:
         loader = [(x, y)]
 
         trainer = _make_trainer(model, loss_fn, opt)
-        history = trainer.fit(loader, epochs=20)
+        history = trainer.fit(loader, epochs=5)
         losses = history["train/loss"]
         # First loss should be higher than last
         assert losses[0] > losses[-1]


### PR DESCRIPTION
This PR:
- replaces 3 subprocess-based import-fallback tests with in-process monkeypatch.setattr(builtins, "__import__", ...) + importlib.import_module(...).
- module-scopes datalake_objects and adds shared _shared_camera_service fixture across 3 camera-service test files.
- Swaps resnet18 → mobilenetv3_small_050 in test_timm_archiver_roundtrip; reduces test_trainer.py::test_loss_decreases epochs 20→5. 
- lowers cluster integration poll interval.

Impact:
- Cumulative ~50% reduction in CPU time for touched files (~15s on workstations, should be 2-4x gain on CI runs)