### PR TITLE
Add LRU pruning for registry cache

### DIFF
--- a/mindtrace/datalake/mindtrace/datalake/vault_serialization.py
+++ b/mindtrace/datalake/mindtrace/datalake/vault_serialization.py
@@ -3,7 +3,7 @@
 These hints let a :class:`~mindtrace.datalake.DataVault` client that only receives **bytes** from a
 remote ``objects.get``-style API reconstruct a Python value using the same ZenML materializers as
 :class:`~mindtrace.registry.Registry`, provided the payload matches a **single-file** staged layout
-(see :meth:`~mindtrace.registry.core._registry_core._RegistryCore.materialize_from_bytes`).
+(see :meth:`~mindtrace.registry.Registry.materialize_from_bytes`).
 """
 
 from __future__ import annotations
@@ -51,7 +51,7 @@ def serialization_block_for_save(
             "Storing a non-bytes object through DataVault requires ``registry=...`` on the vault (or pass "
             "``asset_metadata`` with a pre-filled ``mindtrace.serialization`` block)."
         )
-    hints = registry._core.serialization_hints_for_object(obj, materializer=materializer)
+    hints = registry.serialization_hints_for_object(obj, materializer=materializer)
     return {**hints, "init_params": {}}
 
 
@@ -90,9 +90,7 @@ def materialize_payload_with_hints(
     serialization: dict[str, Any],
     **materializer_kwargs: Any,
 ) -> Any:
-    """Decode *raw* using *serialization* hints and the registry core's materializer path.
-
-    See :meth:`~mindtrace.registry.core._registry_core._RegistryCore.materialize_from_bytes`.
+    """Decode *raw* using *serialization* hints and :meth:`~mindtrace.registry.Registry.materialize_from_bytes`.
 
     Only **single-file** ZenML layouts are supported here; multi-file artifacts require an in-process
     :meth:`~mindtrace.registry.Registry.load` against the backing registry.
@@ -112,7 +110,7 @@ def materialize_payload_with_hints(
     if not isinstance(init_params, dict):
         init_params = {}
 
-    return registry._core.materialize_from_bytes(
+    return registry.materialize_from_bytes(
         raw,
         object_class=serialization["class"],
         materializer=serialization["materializer"],

--- a/mindtrace/datalake/mindtrace/datalake/vault_serialization.py
+++ b/mindtrace/datalake/mindtrace/datalake/vault_serialization.py
@@ -3,7 +3,7 @@
 These hints let a :class:`~mindtrace.datalake.DataVault` client that only receives **bytes** from a
 remote ``objects.get``-style API reconstruct a Python value using the same ZenML materializers as
 :class:`~mindtrace.registry.Registry`, provided the payload matches a **single-file** staged layout
-(see :meth:`~mindtrace.registry.Registry.materialize_from_bytes`).
+(see :meth:`~mindtrace.registry.core._registry_core._RegistryCore.materialize_from_bytes`).
 """
 
 from __future__ import annotations
@@ -51,7 +51,7 @@ def serialization_block_for_save(
             "Storing a non-bytes object through DataVault requires ``registry=...`` on the vault (or pass "
             "``asset_metadata`` with a pre-filled ``mindtrace.serialization`` block)."
         )
-    hints = registry.serialization_hints_for_object(obj, materializer=materializer)
+    hints = registry._core.serialization_hints_for_object(obj, materializer=materializer)
     return {**hints, "init_params": {}}
 
 
@@ -90,7 +90,9 @@ def materialize_payload_with_hints(
     serialization: dict[str, Any],
     **materializer_kwargs: Any,
 ) -> Any:
-    """Decode *raw* using *serialization* hints and :meth:`~mindtrace.registry.Registry.materialize_from_bytes`.
+    """Decode *raw* using *serialization* hints and the registry core's materializer path.
+
+    See :meth:`~mindtrace.registry.core._registry_core._RegistryCore.materialize_from_bytes`.
 
     Only **single-file** ZenML layouts are supported here; multi-file artifacts require an in-process
     :meth:`~mindtrace.registry.Registry.load` against the backing registry.
@@ -110,7 +112,7 @@ def materialize_payload_with_hints(
     if not isinstance(init_params, dict):
         init_params = {}
 
-    return registry.materialize_from_bytes(
+    return registry._core.materialize_from_bytes(
         raw,
         object_class=serialization["class"],
         materializer=serialization["materializer"],

--- a/mindtrace/registry/README.md
+++ b/mindtrace/registry/README.md
@@ -119,7 +119,12 @@ registry = Registry(backend=gcp_backend, use_cache=True)
 
 # Keep at most 1024 concrete object versions in the local cache by default.
 # Set cache_max_entries=None to disable automatic LRU pruning.
-registry = Registry(backend=gcp_backend, use_cache=True, cache_max_entries=1024)
+registry = Registry(
+    backend=gcp_backend,
+    use_cache=True,
+    cache_max_entries=1024,
+    cache_scope="shared",  # or "process" for a process-local cache directory
+)
 
 # Control verification level on load
 obj = registry.load("my:model", verify="none")       # Trust cache, fastest
@@ -136,9 +141,14 @@ registry.clear_cache()
 - `"full"`: Integrity check + compare cache hash against remote. Detects stale cache entries.
 
 **LRU pruning**: remote registry caches retain at most `cache_max_entries`
-concrete object versions, defaulting to `1024`. Cache hits update recency, and
-when the cache exceeds the configured entry count, least-recently-used entries
-are removed first. Set `cache_max_entries=None` to keep the cache unbounded.
+concrete object versions, defaulting to `1024`. Cache hits update recency in
+memory, and cache maintenance is amortized: when cache writes push the cache
+above `cache_max_entries`, least-recently-used entries are removed down to
+`cache_max_entries - cache_prune_buffer`. The default prune buffer is
+`min(max(cache_max_entries // 4, 1), 1024)`. Set `cache_max_entries=None` to
+keep the cache unbounded. `cache_scope="shared"` reuses one cache directory per
+remote backend URI across processes; `cache_scope="process"` uses a
+process-specific cache directory to avoid cross-process cache contention.
 
 ## Version Management
 

--- a/mindtrace/registry/README.md
+++ b/mindtrace/registry/README.md
@@ -117,6 +117,10 @@ When using a remote backend, the `Registry` maintains a local cache (enabled by 
 # Caching is on by default for remote backends
 registry = Registry(backend=gcp_backend, use_cache=True)
 
+# Keep at most 1024 concrete object versions in the local cache by default.
+# Set cache_max_entries=None to disable automatic LRU pruning.
+registry = Registry(backend=gcp_backend, use_cache=True, cache_max_entries=1024)
+
 # Control verification level on load
 obj = registry.load("my:model", verify="none")       # Trust cache, fastest
 obj = registry.load("my:model", verify="integrity")   # Verify hash (default)
@@ -130,6 +134,11 @@ registry.clear_cache()
 - `"none"`: Trust cache completely. Fastest.
 - `"integrity"`: Verify loaded artifacts match the hash in metadata. Default.
 - `"full"`: Integrity check + compare cache hash against remote. Detects stale cache entries.
+
+**LRU pruning**: remote registry caches retain at most `cache_max_entries`
+concrete object versions, defaulting to `1024`. Cache hits update recency, and
+when the cache exceeds the configured entry count, least-recently-used entries
+are removed first. Set `cache_max_entries=None` to keep the cache unbounded.
 
 ## Version Management
 

--- a/mindtrace/registry/README.md
+++ b/mindtrace/registry/README.md
@@ -123,7 +123,6 @@ registry = Registry(
     backend=gcp_backend,
     use_cache=True,
     cache_max_entries=1024,
-    cache_scope="shared",  # or "process" for a process-local cache directory
 )
 
 # Control verification level on load
@@ -141,14 +140,13 @@ registry.clear_cache()
 - `"full"`: Integrity check + compare cache hash against remote. Detects stale cache entries.
 
 **LRU pruning**: remote registry caches retain at most `cache_max_entries`
-concrete object versions, defaulting to `1024`. Cache hits update recency in
-memory, and cache maintenance is amortized: when cache writes push the cache
-above `cache_max_entries`, least-recently-used entries are removed down to
-`cache_max_entries - cache_prune_buffer`. The default prune buffer is
-`min(max(cache_max_entries // 4, 1), 1024)`. Set `cache_max_entries=None` to
-keep the cache unbounded. `cache_scope="shared"` reuses one cache directory per
-remote backend URI across processes; `cache_scope="process"` uses a
-process-specific cache directory to avoid cross-process cache contention.
+concrete object versions, defaulting to `1024`. Cache hits update the cached
+object metadata file timestamp with `os.utime(...)`, so recency is visible across
+processes sharing the same cache directory. Cache maintenance is amortized: when
+cache writes push the cache above `cache_max_entries`, least-recently-used
+entries are removed down to `cache_max_entries - cache_prune_buffer`. The default
+prune buffer is `min(max(cache_max_entries // 4, 1), 1024)`. Set
+`cache_max_entries=None` to keep the cache unbounded.
 
 ## Version Management
 

--- a/mindtrace/registry/mindtrace/registry/core/registry.py
+++ b/mindtrace/registry/mindtrace/registry/core/registry.py
@@ -390,11 +390,12 @@ class Registry(Mindtrace):
     def clear_cache(self) -> None:
         """Clear the local cache. No-op if caching is not enabled."""
         if self._cached:
-            self._cache.clear()
-            self._clear_cache_lru_index()
             with self._cache_lru_lock:
-                self._cache_lru_dirty.clear()
-                self._cache_lru_estimated_entries = 0
+                with self._cache_lru_file_lock():
+                    self._cache.clear()
+                    self._clear_cache_lru_index()
+                    self._cache_lru_dirty.clear()
+                    self._cache_lru_estimated_entries = 0
             self.logger.debug("Cleared local cache.")
 
     def _cache_lru_index_path(self) -> Path:
@@ -1060,11 +1061,12 @@ class Registry(Mindtrace):
         """
         if self._cached:
             self._remote.clear(clear_registry_metadata)
-            self._cache.clear()
-            self._clear_cache_lru_index()
             with self._cache_lru_lock:
-                self._cache_lru_dirty.clear()
-                self._cache_lru_estimated_entries = 0
+                with self._cache_lru_file_lock():
+                    self._cache.clear()
+                    self._clear_cache_lru_index()
+                    self._cache_lru_dirty.clear()
+                    self._cache_lru_estimated_entries = 0
         else:
             self._core.clear(clear_registry_metadata)
 

--- a/mindtrace/registry/mindtrace/registry/core/registry.py
+++ b/mindtrace/registry/mindtrace/registry/core/registry.py
@@ -6,6 +6,8 @@ and transparently adds local caching when a remote backend is used.
 """
 
 import hashlib
+import json
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Type, overload
 
@@ -94,6 +96,7 @@ class Registry(Mindtrace):
         version_digits: int | None = None,
         versions_cache_ttl: float = 60.0,
         use_cache: bool = True,
+        cache_max_entries: int | None = 1024,
         **kwargs,
     ):
         """Initialize the registry.
@@ -110,6 +113,9 @@ class Registry(Mindtrace):
             versions_cache_ttl: TTL in seconds for the in-memory versions cache.
             use_cache: Whether to maintain a local cache for remote backends.
                 Default ``True``.
+            cache_max_entries: Maximum number of concrete object versions to keep
+                in the local cache for remote backends. Defaults to ``1024``.
+                Set to ``None`` to disable automatic LRU pruning.
             **kwargs: Additional arguments forwarded to the backend.
         """
         # Registry is a library-facing API; avoid leaking debug records into
@@ -117,6 +123,10 @@ class Registry(Mindtrace):
         kwargs.setdefault("propagate", False)
 
         super().__init__(**kwargs)
+
+        if cache_max_entries is not None and cache_max_entries < 0:
+            raise ValueError("cache_max_entries must be >= 0 or None")
+        self._cache_max_entries = cache_max_entries
 
         is_remote = backend is not None and not isinstance(backend, (str, Path, LocalRegistryBackend))
 
@@ -339,7 +349,146 @@ class Registry(Mindtrace):
         """Clear the local cache. No-op if caching is not enabled."""
         if self._cached:
             self._cache.clear()
+            self._clear_cache_lru_index()
             self.logger.debug("Cleared local cache.")
+
+    def _cache_lru_index_path(self) -> Path:
+        """Return the sidecar path used to persist cache LRU recency."""
+        return Path(self._cache.backend.uri) / ".registry_cache_lru.json"
+
+    @staticmethod
+    def _cache_lru_key(name: str, version: str) -> str:
+        """Return a stable JSON key for a concrete cached object version."""
+        return json.dumps([name, version], separators=(",", ":"))
+
+    def _load_cache_lru_index(self) -> dict[str, Any]:
+        """Load the cache LRU index, tolerating missing or corrupt sidecars."""
+        if not self._cached:
+            return {"version": 1, "entries": {}}
+
+        index_path = self._cache_lru_index_path()
+        if not index_path.exists():
+            return {"version": 1, "entries": {}}
+
+        try:
+            with open(index_path, "r") as f:
+                index = json.load(f)
+            if not isinstance(index, dict) or not isinstance(index.get("entries"), dict):
+                raise ValueError("cache LRU index has invalid shape")
+            return {"version": 1, "entries": index.get("entries", {})}
+        except Exception as e:
+            self.logger.debug(f"Could not load cache LRU index {index_path}: {e}")
+            return {"version": 1, "entries": {}}
+
+    def _save_cache_lru_index(self, index: dict[str, Any]) -> None:
+        """Atomically save the cache LRU index."""
+        if not self._cached:
+            return
+
+        index_path = self._cache_lru_index_path()
+        try:
+            index_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = index_path.with_suffix(f"{index_path.suffix}.tmp")
+            with open(tmp_path, "w") as f:
+                json.dump({"version": 1, "entries": index.get("entries", {})}, f, sort_keys=True)
+            tmp_path.replace(index_path)
+        except Exception as e:
+            self.logger.debug(f"Could not save cache LRU index {index_path}: {e}")
+
+    def _clear_cache_lru_index(self) -> None:
+        """Remove the cache LRU sidecar if it exists."""
+        if not self._cached:
+            return
+        try:
+            self._cache_lru_index_path().unlink(missing_ok=True)
+        except Exception as e:
+            self.logger.debug(f"Could not clear cache LRU index: {e}")
+
+    def _rebuild_cache_lru_index(self) -> dict[str, Any]:
+        """Build an approximate LRU index from the current local cache contents."""
+        index: dict[str, Any] = {"version": 1, "entries": {}}
+        if not self._cached:
+            return index
+
+        try:
+            for name in self._cache.list_objects():
+                for version in self._cache.list_versions(name):
+                    last_accessed = time.time()
+                    try:
+                        metadata_path = self._cache.backend._object_metadata_path(name, version)
+                        last_accessed = metadata_path.stat().st_mtime
+                    except Exception:
+                        pass
+                    index["entries"][self._cache_lru_key(name, version)] = {
+                        "name": name,
+                        "version": version,
+                        "last_accessed": last_accessed,
+                    }
+        except Exception as e:
+            self.logger.debug(f"Could not rebuild cache LRU index: {e}")
+        return index
+
+    def _touch_cache_entry(self, name: str, version: str) -> None:
+        """Mark a concrete cached object version as recently used."""
+        if not self._cached or self._cache_max_entries is None:
+            return
+
+        index = self._load_cache_lru_index()
+        index["entries"][self._cache_lru_key(name, version)] = {
+            "name": name,
+            "version": version,
+            "last_accessed": time.time(),
+        }
+        self._save_cache_lru_index(index)
+
+    def _remove_cache_lru_entries(self, entries: List[tuple[str, str]]) -> None:
+        """Remove concrete object versions from the cache LRU index."""
+        if not self._cached or self._cache_max_entries is None or not entries:
+            return
+
+        index = self._load_cache_lru_index()
+        for name, version in entries:
+            index["entries"].pop(self._cache_lru_key(name, version), None)
+        self._save_cache_lru_index(index)
+
+    def _prune_cache_lru(self) -> None:
+        """Evict least-recently-used cache entries until max entry count is satisfied."""
+        if not self._cached or self._cache_max_entries is None:
+            return
+
+        index = self._load_cache_lru_index()
+        if not index["entries"]:
+            index = self._rebuild_cache_lru_index()
+
+        live_entries: dict[str, dict[str, Any]] = {}
+        for key, entry in index["entries"].items():
+            name = entry.get("name")
+            version = entry.get("version")
+            if not isinstance(name, str) or not isinstance(version, str):
+                continue
+            try:
+                if self._cache.has_object(name, version):
+                    live_entries[key] = entry
+            except Exception:
+                continue
+
+        pruned = 0
+        sorted_entries = sorted(live_entries.items(), key=lambda item: item[1].get("last_accessed", 0.0))
+        while len(sorted_entries) > self._cache_max_entries:
+            key, entry = sorted_entries.pop(0)
+            name = entry["name"]
+            version = entry["version"]
+            try:
+                self._cache.delete(name, version)
+                live_entries.pop(key, None)
+                pruned += 1
+            except Exception as e:
+                self.logger.warning(f"Error pruning cached object {name}@{version}: {e}")
+                live_entries.pop(key, None)
+
+        self._save_cache_lru_index({"version": 1, "entries": live_entries})
+        if pruned:
+            self.logger.debug(f"Pruned {pruned} registry cache entr{'y' if pruned == 1 else 'ies'}.")
 
     # ─────────────────────────────────────────────────────────────────────────
     # Core operations (cache-aware when _cached is True)
@@ -397,6 +546,7 @@ class Registry(Mindtrace):
         )
 
         # Update cache (best effort)
+        touched_cache_entries: List[tuple[str, str]] = []
         try:
             if isinstance(name, list):
                 if isinstance(result, BatchResult):
@@ -413,11 +563,18 @@ class Registry(Mindtrace):
                             version=[t[1] for t in to_cache],
                             on_conflict=OnConflict.OVERWRITE,
                         )
+                        touched_cache_entries.extend((t[0], t[1]) for t in to_cache)
             else:
                 if result is not None:
                     self._cache.save(name, obj, version=result, on_conflict=OnConflict.OVERWRITE)
+                    touched_cache_entries.append((name, result))
         except Exception as e:
             self.logger.warning(f"Error updating cache: {e}")
+
+        for cache_name, cache_version in touched_cache_entries:
+            self._touch_cache_entry(cache_name, cache_version)
+        if touched_cache_entries:
+            self._prune_cache_lru()
 
         return result
 
@@ -595,11 +752,14 @@ class Registry(Mindtrace):
             if resolved_v and self._cache.has_object(name, resolved_v):
                 if not check_staleness or not self._is_cache_stale(name, resolved_v):
                     try:
-                        return self._cache.load(name, resolved_v, output_dir=output_dir, verify=verify, **kwargs)
+                        obj = self._cache.load(name, resolved_v, output_dir=output_dir, verify=verify, **kwargs)
+                        self._touch_cache_entry(name, resolved_v)
+                        return obj
                     except ValueError:
                         self.logger.debug(f"Cache corrupted for {name}@{resolved_v}, re-downloading")
                         try:
                             self._cache.delete(name, resolved_v)
+                            self._remove_cache_lru_entries([(name, resolved_v)])
                         except Exception:
                             pass
         except Exception:
@@ -613,6 +773,8 @@ class Registry(Mindtrace):
         if cache_v:
             try:
                 self._cache.save(name, obj, version=cache_v, on_conflict=OnConflict.OVERWRITE)
+                self._touch_cache_entry(name, cache_v)
+                self._prune_cache_lru()
             except Exception as e:
                 self.logger.warning(f"Error caching {name}: {e}")
 
@@ -668,6 +830,10 @@ class Registry(Mindtrace):
             for i in self._find_stale_indices(resolved, cached):
                 objects[i] = None  # add to misses list
 
+        for i in [i for i in pending if objects[i] is not None]:
+            cache_name, cache_version = resolved[i]
+            self._touch_cache_entry(cache_name, cache_version)
+
         # Step 3: Remote load for misses
         misses = [i for i in pending if objects[i] is None]
         if misses:
@@ -696,6 +862,9 @@ class Registry(Mindtrace):
                         version=[t[1] for t in to_cache],
                         on_conflict=OnConflict.OVERWRITE,
                     )
+                    for cache_name, cache_version, _ in to_cache:
+                        self._touch_cache_entry(cache_name, cache_version)
+                    self._prune_cache_lru()
                 except Exception as e:
                     self.logger.warning(f"Error updating cache: {e}")
 
@@ -748,6 +917,7 @@ class Registry(Mindtrace):
         try:
             names_list = name if isinstance(name, list) else [name]
             versions_list = version if isinstance(version, list) else [version] * len(names_list)
+            removed_cache_entries: List[tuple[str, str]] = []
 
             for n, v in zip(names_list, versions_list):
                 try:
@@ -755,14 +925,17 @@ class Registry(Mindtrace):
                         for ver in self._cache.list_versions(n):
                             try:
                                 self._cache.delete(n, ver)
+                                removed_cache_entries.append((n, ver))
                             except Exception:
                                 pass
                     else:
                         resolved_v = v if v != "latest" else self._cache._latest(n)
                         if resolved_v and self._cache.has_object(n, resolved_v):
                             self._cache.delete(n, resolved_v)
+                            removed_cache_entries.append((n, resolved_v))
                 except Exception:
                     pass
+            self._remove_cache_lru_entries(removed_cache_entries)
         except Exception as e:
             self.logger.warning(f"Error deleting from cache: {e}")
 
@@ -777,6 +950,7 @@ class Registry(Mindtrace):
         if self._cached:
             self._remote.clear(clear_registry_metadata)
             self._cache.clear()
+            self._clear_cache_lru_index()
         else:
             self._core.clear(clear_registry_metadata)
 

--- a/mindtrace/registry/mindtrace/registry/core/registry.py
+++ b/mindtrace/registry/mindtrace/registry/core/registry.py
@@ -541,8 +541,26 @@ class Registry(Mindtrace):
                 "last_accessed": time.time(),
             }
 
+    def _count_new_cache_entries(self, entries: List[tuple[str, str]]) -> int:
+        """Return how many cache entries are not already present before a cache write."""
+        if not self._cached or self._cache_max_entries is None or not entries:
+            return 0
+
+        unique_entries = list(dict.fromkeys(entries))
+        try:
+            exists = self._cache.backend.has_object(
+                [name for name, _ in unique_entries],
+                [version for _, version in unique_entries],
+            )
+            return sum(1 for entry in unique_entries if not exists.get(entry, False))
+        except Exception as e:
+            self.logger.debug(f"Could not preflight cache entries for LRU accounting: {e}")
+            # Fall back to the previous conservative estimate. The following
+            # prune pass rebuilds from live cache contents before deleting.
+            return len(unique_entries)
+
     def _note_cache_entries_added(self, count: int) -> None:
-        """Update the approximate cache entry count after successful cache writes."""
+        """Update the approximate cache entry count after successful new cache writes."""
         if not self._cached or self._cache_max_entries is None or count <= 0:
             return
         with self._cache_lru_lock:
@@ -683,6 +701,7 @@ class Registry(Mindtrace):
 
         # Update cache (best effort)
         touched_cache_entries: List[tuple[str, str]] = []
+        new_cache_entries = 0
         try:
             if isinstance(name, list):
                 if isinstance(result, BatchResult):
@@ -693,24 +712,28 @@ class Registry(Mindtrace):
                         if result.results[i] is not None
                     ]
                     if to_cache:
+                        cache_entries = [(t[0], t[1]) for t in to_cache]
+                        new_cache_entries = self._count_new_cache_entries(cache_entries)
                         self._cache.save(
                             [t[0] for t in to_cache],
                             [t[2] for t in to_cache],
                             version=[t[1] for t in to_cache],
                             on_conflict=OnConflict.OVERWRITE,
                         )
-                        touched_cache_entries.extend((t[0], t[1]) for t in to_cache)
+                        touched_cache_entries.extend(cache_entries)
             else:
                 if result is not None:
+                    cache_entries = [(name, result)]
+                    new_cache_entries = self._count_new_cache_entries(cache_entries)
                     self._cache.save(name, obj, version=result, on_conflict=OnConflict.OVERWRITE)
-                    touched_cache_entries.append((name, result))
+                    touched_cache_entries.extend(cache_entries)
         except Exception as e:
             self.logger.warning(f"Error updating cache: {e}")
 
         for cache_name, cache_version in touched_cache_entries:
             self._touch_cache_entry(cache_name, cache_version)
         if touched_cache_entries:
-            self._note_cache_entries_added(len(touched_cache_entries))
+            self._note_cache_entries_added(new_cache_entries)
             self._maybe_prune_cache_lru()
 
         return result
@@ -909,9 +932,11 @@ class Registry(Mindtrace):
         cache_v = resolved_v or (version if version and version != "latest" else self._remote._latest(name))
         if cache_v:
             try:
+                cache_entries = [(name, cache_v)]
+                new_cache_entries = self._count_new_cache_entries(cache_entries)
                 self._cache.save(name, obj, version=cache_v, on_conflict=OnConflict.OVERWRITE)
                 self._touch_cache_entry(name, cache_v)
-                self._note_cache_entries_added(1)
+                self._note_cache_entries_added(new_cache_entries)
                 self._maybe_prune_cache_lru()
             except Exception as e:
                 self.logger.warning(f"Error caching {name}: {e}")
@@ -994,6 +1019,8 @@ class Registry(Mindtrace):
 
             if to_cache:
                 try:
+                    cache_entries = [(t[0], t[1]) for t in to_cache]
+                    new_cache_entries = self._count_new_cache_entries(cache_entries)
                     self._cache.save(
                         [t[0] for t in to_cache],
                         [t[2] for t in to_cache],
@@ -1002,7 +1029,7 @@ class Registry(Mindtrace):
                     )
                     for cache_name, cache_version, _ in to_cache:
                         self._touch_cache_entry(cache_name, cache_version)
-                    self._note_cache_entries_added(len(to_cache))
+                    self._note_cache_entries_added(new_cache_entries)
                     self._maybe_prune_cache_lru()
                 except Exception as e:
                     self.logger.warning(f"Error updating cache: {e}")

--- a/mindtrace/registry/mindtrace/registry/core/registry.py
+++ b/mindtrace/registry/mindtrace/registry/core/registry.py
@@ -7,9 +7,15 @@ and transparently adds local caching when a remote backend is used.
 
 import hashlib
 import json
+import os
+import threading
 import time
+import uuid
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, List, Type, overload
+from typing import Any, Dict, List, Literal, Type, overload
+
+import fcntl
 
 from zenml.materializers.base_materializer import BaseMaterializer
 
@@ -97,6 +103,8 @@ class Registry(Mindtrace):
         versions_cache_ttl: float = 60.0,
         use_cache: bool = True,
         cache_max_entries: int | None = 1024,
+        cache_prune_buffer: int | None = None,
+        cache_scope: Literal["shared", "process"] = "shared",
         **kwargs,
     ):
         """Initialize the registry.
@@ -116,6 +124,12 @@ class Registry(Mindtrace):
             cache_max_entries: Maximum number of concrete object versions to keep
                 in the local cache for remote backends. Defaults to ``1024``.
                 Set to ``None`` to disable automatic LRU pruning.
+            cache_prune_buffer: Number of entries below ``cache_max_entries`` to
+                prune back to when the cache exceeds its maximum. Defaults to
+                ``min(max(cache_max_entries // 4, 1), 1024)``.
+            cache_scope: ``"shared"`` reuses one cache directory per remote backend
+                URI across processes. ``"process"`` uses a process-specific cache
+                directory to avoid cross-process cache/index contention.
             **kwargs: Additional arguments forwarded to the backend.
         """
         # Registry is a library-facing API; avoid leaking debug records into
@@ -124,9 +138,26 @@ class Registry(Mindtrace):
 
         super().__init__(**kwargs)
 
-        if cache_max_entries is not None and cache_max_entries < 0:
-            raise ValueError("cache_max_entries must be >= 0 or None")
+        if cache_max_entries is not None and cache_max_entries <= 0:
+            raise ValueError("cache_max_entries must be > 0 or None")
+        if cache_scope not in ("shared", "process"):
+            raise ValueError("cache_scope must be 'shared' or 'process'")
         self._cache_max_entries = cache_max_entries
+        self._cache_scope = cache_scope
+        if cache_max_entries is None:
+            self._cache_prune_buffer = 0
+        else:
+            resolved_buffer = (
+                min(max(cache_max_entries // 4, 1), 1024)
+                if cache_prune_buffer is None
+                else cache_prune_buffer
+            )
+            if resolved_buffer < 0:
+                raise ValueError("cache_prune_buffer must be >= 0")
+            self._cache_prune_buffer = min(resolved_buffer, cache_max_entries - 1)
+        self._cache_lru_lock = threading.RLock()
+        self._cache_lru_dirty: dict[str, dict[str, Any]] = {}
+        self._cache_lru_estimated_entries: int | None = None
 
         is_remote = backend is not None and not isinstance(backend, (str, Path, LocalRegistryBackend))
 
@@ -140,7 +171,7 @@ class Registry(Mindtrace):
                 versions_cache_ttl=versions_cache_ttl,
                 **kwargs,
             )
-            cache_dir = self._get_cache_dir(self._remote.backend.uri)
+            cache_dir = self._get_cache_dir(self._remote.backend.uri, cache_scope=cache_scope)
             self._cache: _RegistryCore = _RegistryCore(
                 backend=LocalRegistryBackend(uri=cache_dir),
                 version_objects=self._remote.version_objects,
@@ -273,20 +304,31 @@ class Registry(Mindtrace):
     # ─────────────────────────────────────────────────────────────────────────
 
     @staticmethod
-    def _get_cache_dir(backend_uri: str | Path, config: Dict[str, Any] | None = None) -> Path:
+    def _get_cache_dir(
+        backend_uri: str | Path,
+        config: Dict[str, Any] | None = None,
+        cache_scope: Literal["shared", "process"] = "shared",
+    ) -> Path:
         """Generate a deterministic cache directory path based on backend URI hash.
 
         Args:
             backend_uri: URI of the remote backend.
             config: Optional config dict. If ``None``, uses the class-level config.
+            cache_scope: ``"shared"`` uses one cache per backend URI. ``"process"``
+                adds the current process id to avoid cross-process sharing.
         """
+        if cache_scope not in ("shared", "process"):
+            raise ValueError("cache_scope must be 'shared' or 'process'")
         uri_hash = hashlib.sha256(str(backend_uri).encode()).hexdigest()[:16]
         if config is None:
             from mindtrace.core.config import CoreConfig
 
             config = CoreConfig()
         temp_dir = Path(config["MINDTRACE_DIR_PATHS"]["TEMP_DIR"]).expanduser().resolve()
-        return temp_dir / f"registry_cache_{uri_hash}"
+        cache_dir = temp_dir / f"registry_cache_{uri_hash}"
+        if cache_scope == "process":
+            cache_dir = cache_dir.with_name(f"{cache_dir.name}_pid_{os.getpid()}")
+        return cache_dir
 
     def _is_cache_stale(self, name: str, version: str | None) -> bool:
         """Check if a cached item is stale by comparing hashes with remote."""
@@ -350,11 +392,34 @@ class Registry(Mindtrace):
         if self._cached:
             self._cache.clear()
             self._clear_cache_lru_index()
+            with self._cache_lru_lock:
+                self._cache_lru_dirty.clear()
+                self._cache_lru_estimated_entries = 0
             self.logger.debug("Cleared local cache.")
 
     def _cache_lru_index_path(self) -> Path:
         """Return the sidecar path used to persist cache LRU recency."""
         return Path(self._cache.backend.uri) / ".registry_cache_lru.json"
+
+    def _cache_lru_lock_path(self) -> Path:
+        """Return the lock file path used for shared cache LRU maintenance."""
+        return self._cache_lru_index_path().with_suffix(".lock")
+
+    @contextmanager
+    def _cache_lru_file_lock(self):
+        """Serialize sidecar/prune maintenance across processes for shared caches."""
+        if not self._cached or self._cache_scope != "shared":
+            yield
+            return
+
+        lock_path = self._cache_lru_lock_path()
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(lock_path, "a+") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
 
     @staticmethod
     def _cache_lru_key(name: str, version: str) -> str:
@@ -386,14 +451,22 @@ class Registry(Mindtrace):
             return
 
         index_path = self._cache_lru_index_path()
+        tmp_path: Path | None = None
         try:
             index_path.parent.mkdir(parents=True, exist_ok=True)
-            tmp_path = index_path.with_suffix(f"{index_path.suffix}.tmp")
-            with open(tmp_path, "w") as f:
+            tmp_path = index_path.with_name(
+                f"{index_path.name}.{os.getpid()}.{threading.get_ident()}.{uuid.uuid4().hex}.tmp"
+            )
+            with open(tmp_path, "w", encoding="utf-8") as f:
                 json.dump({"version": 1, "entries": index.get("entries", {})}, f, sort_keys=True)
             tmp_path.replace(index_path)
         except Exception as e:
             self.logger.debug(f"Could not save cache LRU index {index_path}: {e}")
+            if tmp_path is not None:
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
 
     def _clear_cache_lru_index(self) -> None:
         """Remove the cache LRU sidecar if it exists."""
@@ -429,66 +502,101 @@ class Registry(Mindtrace):
         return index
 
     def _touch_cache_entry(self, name: str, version: str) -> None:
-        """Mark a concrete cached object version as recently used."""
+        """Mark a concrete cached object version as recently used in memory."""
         if not self._cached or self._cache_max_entries is None:
             return
 
-        index = self._load_cache_lru_index()
-        index["entries"][self._cache_lru_key(name, version)] = {
-            "name": name,
-            "version": version,
-            "last_accessed": time.time(),
-        }
-        self._save_cache_lru_index(index)
+        with self._cache_lru_lock:
+            self._cache_lru_dirty[self._cache_lru_key(name, version)] = {
+                "name": name,
+                "version": version,
+                "last_accessed": time.time(),
+            }
+
+    def _note_cache_entries_added(self, count: int) -> None:
+        """Update the approximate cache entry count after successful cache writes."""
+        if not self._cached or self._cache_max_entries is None or count <= 0:
+            return
+        with self._cache_lru_lock:
+            if self._cache_lru_estimated_entries is not None:
+                self._cache_lru_estimated_entries += count
+
+    def _maybe_prune_cache_lru(self) -> None:
+        """Prune only when the estimated cache size exceeds the configured maximum."""
+        if not self._cached or self._cache_max_entries is None:
+            return
+        with self._cache_lru_lock:
+            if (
+                self._cache_lru_estimated_entries is not None
+                and self._cache_lru_estimated_entries <= self._cache_max_entries
+            ):
+                return
+        self._prune_cache_lru()
 
     def _remove_cache_lru_entries(self, entries: List[tuple[str, str]]) -> None:
         """Remove concrete object versions from the cache LRU index."""
         if not self._cached or self._cache_max_entries is None or not entries:
             return
 
-        index = self._load_cache_lru_index()
-        for name, version in entries:
-            index["entries"].pop(self._cache_lru_key(name, version), None)
-        self._save_cache_lru_index(index)
+        with self._cache_lru_lock:
+            with self._cache_lru_file_lock():
+                index = self._load_cache_lru_index()
+                removed = 0
+                for name, version in entries:
+                    key = self._cache_lru_key(name, version)
+                    if index["entries"].pop(key, None) is not None:
+                        removed += 1
+                    self._cache_lru_dirty.pop(key, None)
+                self._save_cache_lru_index(index)
+                if self._cache_lru_estimated_entries is not None and removed:
+                    self._cache_lru_estimated_entries = max(0, self._cache_lru_estimated_entries - removed)
 
     def _prune_cache_lru(self) -> None:
         """Evict least-recently-used cache entries until max entry count is satisfied."""
         if not self._cached or self._cache_max_entries is None:
             return
 
-        index = self._load_cache_lru_index()
-        if not index["entries"]:
-            index = self._rebuild_cache_lru_index()
+        with self._cache_lru_lock:
+            with self._cache_lru_file_lock():
+                sidecar_index = self._load_cache_lru_index()
+                rebuilt_index = self._rebuild_cache_lru_index()
+                dirty_entries = dict(self._cache_lru_dirty)
 
-        live_entries: dict[str, dict[str, Any]] = {}
-        for key, entry in index["entries"].items():
-            name = entry.get("name")
-            version = entry.get("version")
-            if not isinstance(name, str) or not isinstance(version, str):
-                continue
-            try:
-                if self._cache.has_object(name, version):
+                live_entries: dict[str, dict[str, Any]] = {}
+                for key, rebuilt_entry in rebuilt_index["entries"].items():
+                    entry = dict(rebuilt_entry)
+                    sidecar_entry = sidecar_index["entries"].get(key)
+                    if isinstance(sidecar_entry, dict) and isinstance(sidecar_entry.get("last_accessed"), (int, float)):
+                        entry["last_accessed"] = sidecar_entry["last_accessed"]
+                    dirty_entry = dirty_entries.get(key)
+                    if isinstance(dirty_entry, dict) and isinstance(dirty_entry.get("last_accessed"), (int, float)):
+                        entry["last_accessed"] = dirty_entry["last_accessed"]
                     live_entries[key] = entry
-            except Exception:
-                continue
 
-        pruned = 0
-        sorted_entries = sorted(live_entries.items(), key=lambda item: item[1].get("last_accessed", 0.0))
-        while len(sorted_entries) > self._cache_max_entries:
-            key, entry = sorted_entries.pop(0)
-            name = entry["name"]
-            version = entry["version"]
-            try:
-                self._cache.delete(name, version)
-                live_entries.pop(key, None)
-                pruned += 1
-            except Exception as e:
-                self.logger.warning(f"Error pruning cached object {name}@{version}: {e}")
-                live_entries.pop(key, None)
+                pruned = 0
+                target_entries = self._cache_max_entries
+                if len(live_entries) > self._cache_max_entries:
+                    target_entries = max(self._cache_max_entries - self._cache_prune_buffer, 0)
 
-        self._save_cache_lru_index({"version": 1, "entries": live_entries})
-        if pruned:
-            self.logger.debug(f"Pruned {pruned} registry cache entr{'y' if pruned == 1 else 'ies'}.")
+                sorted_entries = sorted(live_entries.items(), key=lambda item: item[1].get("last_accessed", 0.0))
+                while len(sorted_entries) > target_entries:
+                    key, entry = sorted_entries.pop(0)
+                    name = entry["name"]
+                    version = entry["version"]
+                    try:
+                        self._cache.delete(name, version)
+                        live_entries.pop(key, None)
+                        pruned += 1
+                    except Exception as e:
+                        self.logger.warning(f"Error pruning cached object {name}@{version}: {e}")
+                        live_entries.pop(key, None)
+
+                self._save_cache_lru_index({"version": 1, "entries": live_entries})
+                for key in dirty_entries:
+                    self._cache_lru_dirty.pop(key, None)
+                self._cache_lru_estimated_entries = len(live_entries)
+                if pruned:
+                    self.logger.debug(f"Pruned {pruned} registry cache entr{'y' if pruned == 1 else 'ies'}.")
 
     # ─────────────────────────────────────────────────────────────────────────
     # Core operations (cache-aware when _cached is True)
@@ -574,7 +682,8 @@ class Registry(Mindtrace):
         for cache_name, cache_version in touched_cache_entries:
             self._touch_cache_entry(cache_name, cache_version)
         if touched_cache_entries:
-            self._prune_cache_lru()
+            self._note_cache_entries_added(len(touched_cache_entries))
+            self._maybe_prune_cache_lru()
 
         return result
 
@@ -774,7 +883,8 @@ class Registry(Mindtrace):
             try:
                 self._cache.save(name, obj, version=cache_v, on_conflict=OnConflict.OVERWRITE)
                 self._touch_cache_entry(name, cache_v)
-                self._prune_cache_lru()
+                self._note_cache_entries_added(1)
+                self._maybe_prune_cache_lru()
             except Exception as e:
                 self.logger.warning(f"Error caching {name}: {e}")
 
@@ -864,7 +974,8 @@ class Registry(Mindtrace):
                     )
                     for cache_name, cache_version, _ in to_cache:
                         self._touch_cache_entry(cache_name, cache_version)
-                    self._prune_cache_lru()
+                    self._note_cache_entries_added(len(to_cache))
+                    self._maybe_prune_cache_lru()
                 except Exception as e:
                     self.logger.warning(f"Error updating cache: {e}")
 
@@ -951,6 +1062,9 @@ class Registry(Mindtrace):
             self._remote.clear(clear_registry_metadata)
             self._cache.clear()
             self._clear_cache_lru_index()
+            with self._cache_lru_lock:
+                self._cache_lru_dirty.clear()
+                self._cache_lru_estimated_entries = 0
         else:
             self._core.clear(clear_registry_metadata)
 

--- a/mindtrace/registry/mindtrace/registry/core/registry.py
+++ b/mindtrace/registry/mindtrace/registry/core/registry.py
@@ -156,9 +156,7 @@ class Registry(Mindtrace):
             self._cache_prune_buffer = 0
         else:
             resolved_buffer = (
-                min(max(cache_max_entries // 4, 1), 1024)
-                if cache_prune_buffer is None
-                else cache_prune_buffer
+                min(max(cache_max_entries // 4, 1), 1024) if cache_prune_buffer is None else cache_prune_buffer
             )
             if resolved_buffer < 0:
                 raise ValueError("cache_prune_buffer must be >= 0")
@@ -716,6 +714,35 @@ class Registry(Mindtrace):
             self._maybe_prune_cache_lru()
 
         return result
+
+    def serialization_hints_for_object(
+        self,
+        obj: Any,
+        *,
+        materializer: Type[BaseMaterializer] | None = None,
+    ) -> Dict[str, str]:
+        """Return ZenML ``class`` and ``materializer`` strings for embedding in other metadata (e.g. datalake assets)."""
+        return self._core.serialization_hints_for_object(obj, materializer=materializer)
+
+    def materialize_from_bytes(
+        self,
+        raw: bytes | bytearray,
+        *,
+        object_class: str,
+        materializer: str,
+        init_params: Dict[str, Any] | None = None,
+        relative_path: str = "data.txt",
+        **kwargs: Any,
+    ) -> Any:
+        """Materialize *raw* bytes laid out as a single file (default ZenML bytes layout: ``data.txt``)."""
+        return self._core.materialize_from_bytes(
+            raw,
+            object_class=object_class,
+            materializer=materializer,
+            init_params=init_params,
+            relative_path=relative_path,
+            **kwargs,
+        )
 
     def create_direct_upload_target(
         self,

--- a/mindtrace/registry/mindtrace/registry/core/registry.py
+++ b/mindtrace/registry/mindtrace/registry/core/registry.py
@@ -717,35 +717,6 @@ class Registry(Mindtrace):
 
         return result
 
-    def serialization_hints_for_object(
-        self,
-        obj: Any,
-        *,
-        materializer: Type[BaseMaterializer] | None = None,
-    ) -> Dict[str, str]:
-        """Return ZenML ``class`` and ``materializer`` strings for embedding in other metadata (e.g. datalake assets)."""
-        return self._core.serialization_hints_for_object(obj, materializer=materializer)
-
-    def materialize_from_bytes(
-        self,
-        raw: bytes | bytearray,
-        *,
-        object_class: str,
-        materializer: str,
-        init_params: Dict[str, Any] | None = None,
-        relative_path: str = "data.txt",
-        **kwargs: Any,
-    ) -> Any:
-        """Materialize *raw* bytes laid out as a single file (default ZenML bytes layout: ``data.txt``)."""
-        return self._core.materialize_from_bytes(
-            raw,
-            object_class=object_class,
-            materializer=materializer,
-            init_params=init_params,
-            relative_path=relative_path,
-            **kwargs,
-        )
-
     def create_direct_upload_target(
         self,
         upload_id: str,

--- a/mindtrace/registry/mindtrace/registry/core/registry.py
+++ b/mindtrace/registry/mindtrace/registry/core/registry.py
@@ -15,7 +15,15 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Type, overload
 
-import fcntl
+try:  # POSIX file locking.
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - exercised on non-POSIX platforms.
+    _fcntl = None  # type: ignore[assignment]
+
+try:  # Windows file locking.
+    import msvcrt as _msvcrt
+except ImportError:  # pragma: no cover - exercised on non-Windows platforms.
+    _msvcrt = None  # type: ignore[assignment]
 
 from zenml.materializers.base_materializer import BaseMaterializer
 
@@ -415,12 +423,33 @@ class Registry(Mindtrace):
 
         lock_path = self._cache_lru_lock_path()
         lock_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(lock_path, "a+") as lock_file:
-            fcntl.flock(lock_file, fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(lock_file, fcntl.LOCK_UN)
+        with open(lock_path, "a+b") as lock_file:
+            if _fcntl is not None:
+                _fcntl.flock(lock_file, _fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    _fcntl.flock(lock_file, _fcntl.LOCK_UN)
+                return
+
+            if _msvcrt is not None:
+                lock_file.seek(0, os.SEEK_END)
+                if lock_file.tell() == 0:
+                    lock_file.write(b"\0")
+                    lock_file.flush()
+                lock_file.seek(0)
+                _msvcrt.locking(lock_file.fileno(), _msvcrt.LK_LOCK, 1)
+                try:
+                    yield
+                finally:
+                    lock_file.seek(0)
+                    _msvcrt.locking(lock_file.fileno(), _msvcrt.LK_UNLCK, 1)
+                return
+
+            # Last-resort portability fallback for uncommon platforms without a
+            # stdlib file-locking primitive. In-process locking still applies.
+            self.logger.debug("No stdlib file-locking primitive available for shared registry cache LRU lock.")
+            yield
 
     @staticmethod
     def _cache_lru_key(name: str, version: str) -> str:

--- a/mindtrace/registry/mindtrace/registry/core/registry.py
+++ b/mindtrace/registry/mindtrace/registry/core/registry.py
@@ -8,8 +8,8 @@ and transparently adds local caching when a remote backend is used.
 import hashlib
 import os
 import threading
-from pathlib import Path
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Type, overload
 
 from zenml.materializers.base_materializer import BaseMaterializer

--- a/mindtrace/registry/mindtrace/registry/core/registry.py
+++ b/mindtrace/registry/mindtrace/registry/core/registry.py
@@ -6,24 +6,11 @@ and transparently adds local caching when a remote backend is used.
 """
 
 import hashlib
-import json
 import os
 import threading
-import time
-import uuid
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Type, overload
-
-try:  # POSIX file locking.
-    import fcntl as _fcntl
-except ImportError:  # pragma: no cover - exercised on non-POSIX platforms.
-    _fcntl = None  # type: ignore[assignment]
-
-try:  # Windows file locking.
-    import msvcrt as _msvcrt
-except ImportError:  # pragma: no cover - exercised on non-Windows platforms.
-    _msvcrt = None  # type: ignore[assignment]
+import time
+from typing import Any, Dict, List, Type, overload
 
 from zenml.materializers.base_materializer import BaseMaterializer
 
@@ -112,7 +99,6 @@ class Registry(Mindtrace):
         use_cache: bool = True,
         cache_max_entries: int | None = 1024,
         cache_prune_buffer: int | None = None,
-        cache_scope: Literal["shared", "process"] = "shared",
         **kwargs,
     ):
         """Initialize the registry.
@@ -135,9 +121,6 @@ class Registry(Mindtrace):
             cache_prune_buffer: Number of entries below ``cache_max_entries`` to
                 prune back to when the cache exceeds its maximum. Defaults to
                 ``min(max(cache_max_entries // 4, 1), 1024)``.
-            cache_scope: ``"shared"`` reuses one cache directory per remote backend
-                URI across processes. ``"process"`` uses a process-specific cache
-                directory to avoid cross-process cache/index contention.
             **kwargs: Additional arguments forwarded to the backend.
         """
         # Registry is a library-facing API; avoid leaking debug records into
@@ -148,10 +131,7 @@ class Registry(Mindtrace):
 
         if cache_max_entries is not None and cache_max_entries <= 0:
             raise ValueError("cache_max_entries must be > 0 or None")
-        if cache_scope not in ("shared", "process"):
-            raise ValueError("cache_scope must be 'shared' or 'process'")
         self._cache_max_entries = cache_max_entries
-        self._cache_scope = cache_scope
         if cache_max_entries is None:
             self._cache_prune_buffer = 0
         else:
@@ -162,7 +142,6 @@ class Registry(Mindtrace):
                 raise ValueError("cache_prune_buffer must be >= 0")
             self._cache_prune_buffer = min(resolved_buffer, cache_max_entries - 1)
         self._cache_lru_lock = threading.RLock()
-        self._cache_lru_dirty: dict[str, dict[str, Any]] = {}
         self._cache_lru_estimated_entries: int | None = None
 
         is_remote = backend is not None and not isinstance(backend, (str, Path, LocalRegistryBackend))
@@ -177,7 +156,7 @@ class Registry(Mindtrace):
                 versions_cache_ttl=versions_cache_ttl,
                 **kwargs,
             )
-            cache_dir = self._get_cache_dir(self._remote.backend.uri, cache_scope=cache_scope)
+            cache_dir = self._get_cache_dir(self._remote.backend.uri)
             self._cache: _RegistryCore = _RegistryCore(
                 backend=LocalRegistryBackend(uri=cache_dir),
                 version_objects=self._remote.version_objects,
@@ -313,28 +292,20 @@ class Registry(Mindtrace):
     def _get_cache_dir(
         backend_uri: str | Path,
         config: Dict[str, Any] | None = None,
-        cache_scope: Literal["shared", "process"] = "shared",
     ) -> Path:
         """Generate a deterministic cache directory path based on backend URI hash.
 
         Args:
             backend_uri: URI of the remote backend.
             config: Optional config dict. If ``None``, uses the class-level config.
-            cache_scope: ``"shared"`` uses one cache per backend URI. ``"process"``
-                adds the current process id to avoid cross-process sharing.
         """
-        if cache_scope not in ("shared", "process"):
-            raise ValueError("cache_scope must be 'shared' or 'process'")
         uri_hash = hashlib.sha256(str(backend_uri).encode()).hexdigest()[:16]
         if config is None:
             from mindtrace.core.config import CoreConfig
 
             config = CoreConfig()
         temp_dir = Path(config["MINDTRACE_DIR_PATHS"]["TEMP_DIR"]).expanduser().resolve()
-        cache_dir = temp_dir / f"registry_cache_{uri_hash}"
-        if cache_scope == "process":
-            cache_dir = cache_dir.with_name(f"{cache_dir.name}_pid_{os.getpid()}")
-        return cache_dir
+        return temp_dir / f"registry_cache_{uri_hash}"
 
     def _is_cache_stale(self, name: str, version: str | None) -> bool:
         """Check if a cached item is stale by comparing hashes with remote."""
@@ -397,119 +368,15 @@ class Registry(Mindtrace):
         """Clear the local cache. No-op if caching is not enabled."""
         if self._cached:
             with self._cache_lru_lock:
-                with self._cache_lru_file_lock():
-                    self._cache.clear()
-                    self._clear_cache_lru_index()
-                    self._cache_lru_dirty.clear()
-                    self._cache_lru_estimated_entries = 0
+                self._cache.clear()
+                self._cache_lru_estimated_entries = 0
             self.logger.debug("Cleared local cache.")
 
-    def _cache_lru_index_path(self) -> Path:
-        """Return the sidecar path used to persist cache LRU recency."""
-        return Path(self._cache.backend.uri) / ".registry_cache_lru.json"
-
-    def _cache_lru_lock_path(self) -> Path:
-        """Return the lock file path used for shared cache LRU maintenance."""
-        return self._cache_lru_index_path().with_suffix(".lock")
-
-    @contextmanager
-    def _cache_lru_file_lock(self):
-        """Serialize sidecar/prune maintenance across processes for shared caches."""
-        if not self._cached or self._cache_scope != "shared":
-            yield
-            return
-
-        lock_path = self._cache_lru_lock_path()
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(lock_path, "a+b") as lock_file:
-            if _fcntl is not None:
-                _fcntl.flock(lock_file, _fcntl.LOCK_EX)
-                try:
-                    yield
-                finally:
-                    _fcntl.flock(lock_file, _fcntl.LOCK_UN)
-                return
-
-            if _msvcrt is not None:
-                lock_file.seek(0, os.SEEK_END)
-                if lock_file.tell() == 0:
-                    lock_file.write(b"\0")
-                    lock_file.flush()
-                lock_file.seek(0)
-                _msvcrt.locking(lock_file.fileno(), _msvcrt.LK_LOCK, 1)
-                try:
-                    yield
-                finally:
-                    lock_file.seek(0)
-                    _msvcrt.locking(lock_file.fileno(), _msvcrt.LK_UNLCK, 1)
-                return
-
-            # Last-resort portability fallback for uncommon platforms without a
-            # stdlib file-locking primitive. In-process locking still applies.
-            self.logger.debug("No stdlib file-locking primitive available for shared registry cache LRU lock.")
-            yield
-
-    @staticmethod
-    def _cache_lru_key(name: str, version: str) -> str:
-        """Return a stable JSON key for a concrete cached object version."""
-        return json.dumps([name, version], separators=(",", ":"))
-
-    def _load_cache_lru_index(self) -> dict[str, Any]:
-        """Load the cache LRU index, tolerating missing or corrupt sidecars."""
+    def _list_cache_lru_entries(self) -> List[dict[str, Any]]:
+        """Return live cached object versions with metadata-mtime recency."""
+        entries: List[dict[str, Any]] = []
         if not self._cached:
-            return {"version": 1, "entries": {}}
-
-        index_path = self._cache_lru_index_path()
-        if not index_path.exists():
-            return {"version": 1, "entries": {}}
-
-        try:
-            with open(index_path, "r") as f:
-                index = json.load(f)
-            if not isinstance(index, dict) or not isinstance(index.get("entries"), dict):
-                raise ValueError("cache LRU index has invalid shape")
-            return {"version": 1, "entries": index.get("entries", {})}
-        except Exception as e:
-            self.logger.debug(f"Could not load cache LRU index {index_path}: {e}")
-            return {"version": 1, "entries": {}}
-
-    def _save_cache_lru_index(self, index: dict[str, Any]) -> None:
-        """Atomically save the cache LRU index."""
-        if not self._cached:
-            return
-
-        index_path = self._cache_lru_index_path()
-        tmp_path: Path | None = None
-        try:
-            index_path.parent.mkdir(parents=True, exist_ok=True)
-            tmp_path = index_path.with_name(
-                f"{index_path.name}.{os.getpid()}.{threading.get_ident()}.{uuid.uuid4().hex}.tmp"
-            )
-            with open(tmp_path, "w", encoding="utf-8") as f:
-                json.dump({"version": 1, "entries": index.get("entries", {})}, f, sort_keys=True)
-            tmp_path.replace(index_path)
-        except Exception as e:
-            self.logger.debug(f"Could not save cache LRU index {index_path}: {e}")
-            if tmp_path is not None:
-                try:
-                    tmp_path.unlink(missing_ok=True)
-                except Exception:
-                    pass
-
-    def _clear_cache_lru_index(self) -> None:
-        """Remove the cache LRU sidecar if it exists."""
-        if not self._cached:
-            return
-        try:
-            self._cache_lru_index_path().unlink(missing_ok=True)
-        except Exception as e:
-            self.logger.debug(f"Could not clear cache LRU index: {e}")
-
-    def _rebuild_cache_lru_index(self) -> dict[str, Any]:
-        """Build an approximate LRU index from the current local cache contents."""
-        index: dict[str, Any] = {"version": 1, "entries": {}}
-        if not self._cached:
-            return index
+            return entries
 
         try:
             for name in self._cache.list_objects():
@@ -520,26 +387,21 @@ class Registry(Mindtrace):
                         last_accessed = metadata_path.stat().st_mtime
                     except Exception:
                         pass
-                    index["entries"][self._cache_lru_key(name, version)] = {
-                        "name": name,
-                        "version": version,
-                        "last_accessed": last_accessed,
-                    }
+                    entries.append({"name": name, "version": version, "last_accessed": last_accessed})
         except Exception as e:
-            self.logger.debug(f"Could not rebuild cache LRU index: {e}")
-        return index
+            self.logger.debug(f"Could not list cache LRU entries: {e}")
+        return entries
 
     def _touch_cache_entry(self, name: str, version: str) -> None:
-        """Mark a concrete cached object version as recently used in memory."""
+        """Mark a concrete cached object version as recently used via metadata mtime."""
         if not self._cached or self._cache_max_entries is None:
             return
 
-        with self._cache_lru_lock:
-            self._cache_lru_dirty[self._cache_lru_key(name, version)] = {
-                "name": name,
-                "version": version,
-                "last_accessed": time.time(),
-            }
+        try:
+            metadata_path = self._cache.backend._object_metadata_path(name, version)
+            os.utime(metadata_path, None)
+        except Exception as e:
+            self.logger.debug(f"Could not touch cache metadata for {name}@{version}: {e}")
 
     def _count_new_cache_entries(self, entries: List[tuple[str, str]]) -> int:
         """Return how many cache entries are not already present before a cache write."""
@@ -580,22 +442,13 @@ class Registry(Mindtrace):
         self._prune_cache_lru()
 
     def _remove_cache_lru_entries(self, entries: List[tuple[str, str]]) -> None:
-        """Remove concrete object versions from the cache LRU index."""
+        """Update the approximate cache entry count after cache entries are removed."""
         if not self._cached or self._cache_max_entries is None or not entries:
             return
 
         with self._cache_lru_lock:
-            with self._cache_lru_file_lock():
-                index = self._load_cache_lru_index()
-                removed = 0
-                for name, version in entries:
-                    key = self._cache_lru_key(name, version)
-                    if index["entries"].pop(key, None) is not None:
-                        removed += 1
-                    self._cache_lru_dirty.pop(key, None)
-                self._save_cache_lru_index(index)
-                if self._cache_lru_estimated_entries is not None and removed:
-                    self._cache_lru_estimated_entries = max(0, self._cache_lru_estimated_entries - removed)
+            if self._cache_lru_estimated_entries is not None:
+                self._cache_lru_estimated_entries = max(0, self._cache_lru_estimated_entries - len(set(entries)))
 
     def _prune_cache_lru(self) -> None:
         """Evict least-recently-used cache entries until max entry count is satisfied."""
@@ -603,46 +456,27 @@ class Registry(Mindtrace):
             return
 
         with self._cache_lru_lock:
-            with self._cache_lru_file_lock():
-                sidecar_index = self._load_cache_lru_index()
-                rebuilt_index = self._rebuild_cache_lru_index()
-                dirty_entries = dict(self._cache_lru_dirty)
+            live_entries = self._list_cache_lru_entries()
+            pruned = 0
+            target_entries = self._cache_max_entries
+            if len(live_entries) > self._cache_max_entries:
+                target_entries = max(self._cache_max_entries - self._cache_prune_buffer, 0)
 
-                live_entries: dict[str, dict[str, Any]] = {}
-                for key, rebuilt_entry in rebuilt_index["entries"].items():
-                    entry = dict(rebuilt_entry)
-                    sidecar_entry = sidecar_index["entries"].get(key)
-                    if isinstance(sidecar_entry, dict) and isinstance(sidecar_entry.get("last_accessed"), (int, float)):
-                        entry["last_accessed"] = sidecar_entry["last_accessed"]
-                    dirty_entry = dirty_entries.get(key)
-                    if isinstance(dirty_entry, dict) and isinstance(dirty_entry.get("last_accessed"), (int, float)):
-                        entry["last_accessed"] = dirty_entry["last_accessed"]
-                    live_entries[key] = entry
+            sorted_entries = sorted(live_entries, key=lambda entry: entry.get("last_accessed", 0.0))
+            while len(live_entries) > target_entries and sorted_entries:
+                entry = sorted_entries.pop(0)
+                name = entry["name"]
+                version = entry["version"]
+                try:
+                    self._cache.delete(name, version)
+                    live_entries.remove(entry)
+                    pruned += 1
+                except Exception as e:
+                    self.logger.warning(f"Error pruning cached object {name}@{version}: {e}")
 
-                pruned = 0
-                target_entries = self._cache_max_entries
-                if len(live_entries) > self._cache_max_entries:
-                    target_entries = max(self._cache_max_entries - self._cache_prune_buffer, 0)
-
-                sorted_entries = sorted(live_entries.items(), key=lambda item: item[1].get("last_accessed", 0.0))
-                while len(sorted_entries) > target_entries:
-                    key, entry = sorted_entries.pop(0)
-                    name = entry["name"]
-                    version = entry["version"]
-                    try:
-                        self._cache.delete(name, version)
-                        live_entries.pop(key, None)
-                        pruned += 1
-                    except Exception as e:
-                        self.logger.warning(f"Error pruning cached object {name}@{version}: {e}")
-                        live_entries.pop(key, None)
-
-                self._save_cache_lru_index({"version": 1, "entries": live_entries})
-                for key in dirty_entries:
-                    self._cache_lru_dirty.pop(key, None)
-                self._cache_lru_estimated_entries = len(live_entries)
-                if pruned:
-                    self.logger.debug(f"Pruned {pruned} registry cache entr{'y' if pruned == 1 else 'ies'}.")
+            self._cache_lru_estimated_entries = len(live_entries)
+            if pruned:
+                self.logger.debug(f"Pruned {pruned} registry cache entr{'y' if pruned == 1 else 'ies'}.")
 
     # ─────────────────────────────────────────────────────────────────────────
     # Core operations (cache-aware when _cached is True)
@@ -1116,11 +950,8 @@ class Registry(Mindtrace):
         if self._cached:
             self._remote.clear(clear_registry_metadata)
             with self._cache_lru_lock:
-                with self._cache_lru_file_lock():
-                    self._cache.clear()
-                    self._clear_cache_lru_index()
-                    self._cache_lru_dirty.clear()
-                    self._cache_lru_estimated_entries = 0
+                self._cache.clear()
+                self._cache_lru_estimated_entries = 0
         else:
             self._core.clear(clear_registry_metadata)
 

--- a/tests/integration/mindtrace/registry/core/test_registry_cache_integration.py
+++ b/tests/integration/mindtrace/registry/core/test_registry_cache_integration.py
@@ -1,15 +1,14 @@
 """Integration tests for Registry local cache with a real non-local backend (S3/MinIO).
 
-Exercises LRU sidecar behavior, ``verify=full`` staleness, batch load with partial
-cache misses, explicit cache clearing, and lightweight concurrent reads. Skips when
-MinIO is unavailable (see ``tests/integration/conftest.py``).
+Exercises LRU pruning (metadata mtime ordering), ``verify=full`` staleness, batch load
+with partial cache misses, explicit cache clearing, and lightweight concurrent reads.
+Skips when MinIO is unavailable (see ``tests/integration/conftest.py``).
 """
 
 from __future__ import annotations
 
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from pathlib import Path
 
 import pytest
 
@@ -155,48 +154,18 @@ def test_integration_single_load_misses_amortize_pruning_with_buffer(s3_backend:
     assert (names[-1], "1.0.0") in cached
 
 
-def test_integration_process_cache_scope_uses_independent_local_cache(s3_backend: S3RegistryBackend):
-    """Process-scoped registries do not share the default backend cache directory."""
-    shared = Registry(
-        backend=s3_backend,
-        version_objects=True,
-        mutable=True,
-        use_cache=True,
-        cache_scope="shared",
-    )
-    process = Registry(
-        backend=s3_backend,
-        version_objects=True,
-        mutable=True,
-        use_cache=True,
-        cache_scope="process",
-    )
-    name = "integration:scope:process"
-    shared.save(name, {"scope": "shared"}, version="1.0.0")
-
-    shared.clear_cache()
-    process.clear_cache()
-    assert shared._cache.backend.uri != process._cache.backend.uri
-
-    assert process.load(name, version="1.0.0", verify=VerifyLevel.INTEGRITY) == {"scope": "shared"}
-    assert process._cache.has_object(name, "1.0.0")
-    assert not shared._cache.has_object(name, "1.0.0")
-
-
-def test_integration_clear_cache_removes_sidecar_and_artifacts(cached_registry_large):
-    """``clear_cache`` drops cached blobs and removes the LRU index file."""
+def test_integration_clear_cache_removes_cached_artifacts(cached_registry_large):
+    """``clear_cache`` drops cached blobs and resets the LRU entry estimate."""
     reg = cached_registry_large
     reg.save("integration:clr:x", {"x": 1}, version="1.0.0")
     reg.load("integration:clr:x", version="1.0.0")
 
-    lru_path = reg._cache_lru_index_path()
     assert reg._cache.has_object("integration:clr:x", "1.0.0")
-    assert isinstance(lru_path, Path)
 
     reg.clear_cache()
 
     assert not reg._cache.has_object("integration:clr:x", "1.0.0")
-    assert not lru_path.exists()
+    assert reg._cache_lru_estimated_entries == 0
 
 
 def test_integration_delete_removes_cached_version(cached_registry_large):
@@ -211,19 +180,6 @@ def test_integration_delete_removes_cached_version(cached_registry_large):
 
     assert not reg._cache.has_object("integration:del:a", "1.0.0")
     assert reg._cache.has_object("integration:del:b", "1.0.0")
-
-
-def test_integration_corrupt_lru_sidecar_does_not_block_save_and_load(cached_registry_large):
-    """A corrupt ``.registry_cache_lru.json`` is tolerated; save/load still succeed."""
-    reg = cached_registry_large
-    reg.save("integration:badidx", {"ok": True}, version="1.0.0")
-
-    lru = reg._cache_lru_index_path()
-    lru.write_text("not-json {{{", encoding="utf-8")
-
-    reg.save("integration:badidx", {"ok": True, "t": 2}, version="1.0.0", on_conflict="overwrite")
-    loaded = reg.load("integration:badidx", version="1.0.0", verify=VerifyLevel.FULL)
-    assert loaded == {"ok": True, "t": 2}
 
 
 def test_integration_concurrent_loads_on_hot_object(cached_registry_large):

--- a/tests/integration/mindtrace/registry/core/test_registry_cache_integration.py
+++ b/tests/integration/mindtrace/registry/core/test_registry_cache_integration.py
@@ -46,6 +46,7 @@ def cached_registry_lru_two(s3_backend: S3RegistryBackend) -> Registry:
         mutable=True,
         use_cache=True,
         cache_max_entries=2,
+        cache_prune_buffer=0,
     )
 
 

--- a/tests/integration/mindtrace/registry/core/test_registry_cache_integration.py
+++ b/tests/integration/mindtrace/registry/core/test_registry_cache_integration.py
@@ -1,0 +1,169 @@
+"""Integration tests for Registry local cache with a real non-local backend (S3/MinIO).
+
+Exercises LRU sidecar behavior, ``verify=full`` staleness, batch load with partial
+cache misses, explicit cache clearing, and lightweight concurrent reads. Skips when
+MinIO is unavailable (see ``tests/integration/conftest.py``).
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import pytest
+
+from mindtrace.registry import Registry, S3RegistryBackend
+from mindtrace.registry.core.types import BatchResult, VerifyLevel
+
+pytestmark = [pytest.mark.integration, pytest.mark.registry]
+
+
+def _cached_name_versions(registry: Registry) -> set[tuple[str, str]]:
+    """Concrete (name, version) pairs present in the local cache."""
+    cache = registry._cache
+    return {(name, version) for name in cache.list_objects() for version in cache.list_versions(name)}
+
+
+@pytest.fixture
+def cached_registry_large(s3_backend: S3RegistryBackend) -> Registry:
+    """Remote-backed registry with cache room for several objects."""
+    return Registry(
+        backend=s3_backend,
+        version_objects=True,
+        mutable=True,
+        use_cache=True,
+        cache_max_entries=64,
+    )
+
+
+@pytest.fixture
+def cached_registry_lru_two(s3_backend: S3RegistryBackend) -> Registry:
+    """Remote-backed registry with at most two cached object versions."""
+    return Registry(
+        backend=s3_backend,
+        version_objects=True,
+        mutable=True,
+        use_cache=True,
+        cache_max_entries=2,
+    )
+
+
+def test_integration_full_verify_refetches_after_remote_overwrite(cached_registry_large):
+    """FULL staleness refetches from remote after the authoritative object changes."""
+    reg = cached_registry_large
+    reg.save("integration:stale:fw", {"value": 1}, version="1.0.0")
+    assert reg.load(
+        "integration:stale:fw",
+        version="1.0.0",
+        verify=VerifyLevel.INTEGRITY,
+    ) == {"value": 1}
+
+    reg.save(
+        "integration:stale:fw",
+        {"value": 2},
+        version="1.0.0",
+        on_conflict="overwrite",
+    )
+
+    loaded = reg.load("integration:stale:fw", version="1.0.0", verify=VerifyLevel.FULL)
+    assert loaded == {"value": 2}
+
+
+def test_integration_lru_prune_drops_oldest_touch_across_saves(cached_registry_lru_two):
+    """With ``cache_max_entries=2``, saving a third distinct object evicts the least recent."""
+    reg = cached_registry_lru_two
+    # Separate wall-clock steps so LRU timestamps are strictly ordered.
+    reg.save("integration:lru:a", "a", version="1.0.0")
+    time.sleep(0.005)
+    reg.save("integration:lru:b", "b", version="1.0.0")
+    time.sleep(0.005)
+    reg.save("integration:lru:c", "c", version="1.0.0")
+
+    cached = _cached_name_versions(reg)
+    assert len(cached) == 2
+    assert ("integration:lru:a", "1.0.0") not in cached
+    assert ("integration:lru:b", "1.0.0") in cached
+    assert ("integration:lru:c", "1.0.0") in cached
+
+
+def test_integration_batch_load_miss_repops_cache(cached_registry_large):
+    """Batch load with one warm cache hit and one miss refetches and repopulates the cache."""
+    reg = cached_registry_large
+    reg.save("integration:batch:hit", {"k": "hit"}, version="1.0.0")
+    reg.save("integration:batch:miss", {"k": "miss"}, version="1.0.0")
+
+    reg._cache.delete("integration:batch:miss", "1.0.0")
+    assert not reg._cache.has_object("integration:batch:miss", "1.0.0")
+
+    out = reg.load(
+        ["integration:batch:hit", "integration:batch:miss"],
+        version=["1.0.0", "1.0.0"],
+    )
+    assert isinstance(out, BatchResult)
+    assert out.failure_count == 0
+    assert out.results == [{"k": "hit"}, {"k": "miss"}]
+
+    assert reg._cache.has_object("integration:batch:hit", "1.0.0")
+    assert reg._cache.has_object("integration:batch:miss", "1.0.0")
+
+
+def test_integration_clear_cache_removes_sidecar_and_artifacts(cached_registry_large):
+    """``clear_cache`` drops cached blobs and removes the LRU index file."""
+    reg = cached_registry_large
+    reg.save("integration:clr:x", {"x": 1}, version="1.0.0")
+    reg.load("integration:clr:x", version="1.0.0")
+
+    lru_path = reg._cache_lru_index_path()
+    assert reg._cache.has_object("integration:clr:x", "1.0.0")
+    assert isinstance(lru_path, Path)
+
+    reg.clear_cache()
+
+    assert not reg._cache.has_object("integration:clr:x", "1.0.0")
+    assert not lru_path.exists()
+
+
+def test_integration_delete_removes_cached_version(cached_registry_large):
+    """Deleting a version removes it from the remote and the local cache."""
+    reg = cached_registry_large
+    reg.save("integration:del:a", {"a": 1}, version="1.0.0")
+    reg.save("integration:del:b", {"b": 2}, version="1.0.0")
+    reg.load("integration:del:a", version="1.0.0")
+
+    assert reg._cache.has_object("integration:del:a", "1.0.0")
+    reg.delete("integration:del:a", "1.0.0")
+
+    assert not reg._cache.has_object("integration:del:a", "1.0.0")
+    assert reg._cache.has_object("integration:del:b", "1.0.0")
+
+
+def test_integration_corrupt_lru_sidecar_does_not_block_save_and_load(cached_registry_large):
+    """A corrupt ``.registry_cache_lru.json`` is tolerated; save/load still succeed."""
+    reg = cached_registry_large
+    reg.save("integration:badidx", {"ok": True}, version="1.0.0")
+
+    lru = reg._cache_lru_index_path()
+    lru.write_text("not-json {{{", encoding="utf-8")
+
+    reg.save("integration:badidx", {"ok": True, "t": 2}, version="1.0.0", on_conflict="overwrite")
+    loaded = reg.load("integration:badidx", version="1.0.0", verify=VerifyLevel.FULL)
+    assert loaded == {"ok": True, "t": 2}
+
+
+def test_integration_concurrent_loads_on_hot_object(cached_registry_large):
+    """Many threads can read the same cached object after a single remote write."""
+    reg = cached_registry_large
+    reg.save("integration:concurrent:hot", {"slot": 0}, version="1.0.0")
+
+    def read_once(i: int) -> dict:
+        data = reg.load("integration:concurrent:hot", version="1.0.0")
+        return {"i": i, "data": data}
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(read_once, i) for i in range(16)]
+        results = [f.result() for f in as_completed(futures)]
+
+    assert len(results) == 16
+    for row in results:
+        assert row["data"] == {"slot": 0}

--- a/tests/integration/mindtrace/registry/core/test_registry_cache_integration.py
+++ b/tests/integration/mindtrace/registry/core/test_registry_cache_integration.py
@@ -109,6 +109,80 @@ def test_integration_batch_load_miss_repops_cache(cached_registry_large):
     assert reg._cache.has_object("integration:batch:miss", "1.0.0")
 
 
+def test_integration_batch_load_misses_prune_to_buffered_target(s3_backend: S3RegistryBackend):
+    """Read-populated caches prune after batch misses, not just explicit saves."""
+    reg = Registry(
+        backend=s3_backend,
+        version_objects=True,
+        mutable=True,
+        use_cache=True,
+        cache_max_entries=4,
+        cache_prune_buffer=2,
+    )
+    names = [f"integration:batch-prune:{idx}" for idx in range(6)]
+    for name in names:
+        reg.save(name, {"name": name}, version="1.0.0")
+
+    reg.clear_cache()
+    out = reg.load(names, version=["1.0.0"] * len(names), verify=VerifyLevel.INTEGRITY)
+
+    assert isinstance(out, BatchResult)
+    assert out.failure_count == 0
+    assert out.results == [{"name": name} for name in names]
+    assert len(_cached_name_versions(reg)) == 2
+
+
+def test_integration_single_load_misses_amortize_pruning_with_buffer(s3_backend: S3RegistryBackend):
+    """Bursts of single-object read misses prune below max, leaving buffer for later misses."""
+    reg = Registry(
+        backend=s3_backend,
+        version_objects=True,
+        mutable=True,
+        use_cache=True,
+        cache_max_entries=4,
+        cache_prune_buffer=2,
+    )
+    names = [f"integration:single-prune:{idx}" for idx in range(5)]
+    for name in names:
+        reg.save(name, {"name": name}, version="1.0.0")
+
+    reg.clear_cache()
+    for name in names:
+        assert reg.load(name, version="1.0.0", verify=VerifyLevel.INTEGRITY) == {"name": name}
+
+    cached = _cached_name_versions(reg)
+    assert len(cached) == 2
+    assert (names[-1], "1.0.0") in cached
+
+
+def test_integration_process_cache_scope_uses_independent_local_cache(s3_backend: S3RegistryBackend):
+    """Process-scoped registries do not share the default backend cache directory."""
+    shared = Registry(
+        backend=s3_backend,
+        version_objects=True,
+        mutable=True,
+        use_cache=True,
+        cache_scope="shared",
+    )
+    process = Registry(
+        backend=s3_backend,
+        version_objects=True,
+        mutable=True,
+        use_cache=True,
+        cache_scope="process",
+    )
+    name = "integration:scope:process"
+    shared.save(name, {"scope": "shared"}, version="1.0.0")
+
+    shared.clear_cache()
+    process.clear_cache()
+    assert shared._cache.backend.uri != process._cache.backend.uri
+
+    assert process.load(name, version="1.0.0", verify=VerifyLevel.INTEGRITY) == {"scope": "shared"}
+    assert process._cache.has_object(name, "1.0.0")
+    assert not shared._cache.has_object(name, "1.0.0")
+
+
 def test_integration_clear_cache_removes_sidecar_and_artifacts(cached_registry_large):
     """``clear_cache`` drops cached blobs and removes the LRU index file."""
     reg = cached_registry_large

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -117,7 +117,7 @@ def test_registry_initialization(registry, temp_registry_dir):
 
 
 def test_registry_serialization_hints_for_object_uses_core_materializer_lookup(registry, test_bytes):
-    hints = registry._core.serialization_hints_for_object(test_bytes)
+    hints = registry.serialization_hints_for_object(test_bytes)
 
     assert hints == {
         "class": "builtins.bytes",
@@ -125,10 +125,10 @@ def test_registry_serialization_hints_for_object_uses_core_materializer_lookup(r
     }
 
 
-def test_registry_core_materialize_from_bytes_with_bytes_materializer(registry):
+def test_registry_materialize_from_bytes_delegates_to_core(registry):
     raw = b"hello-bytes"
 
-    out = registry._core.materialize_from_bytes(
+    out = registry.materialize_from_bytes(
         raw,
         object_class="builtins.bytes",
         materializer="zenml.materializers.BytesMaterializer",

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import threading
 import time
@@ -2856,7 +2857,7 @@ class TestRegistryCacheLRU:
     """Unit tests for remote registry local-cache LRU pruning."""
 
     @staticmethod
-    def make_remote_registry(temp_registry_dir, *, cache_max_entries=1024, use_cache=True):
+    def make_remote_registry(temp_registry_dir, *, cache_max_entries=1024, use_cache=True, **kwargs):
         """Create a cached Registry facade around a mock remote backend."""
         mock_backend = Mock(spec=RegistryBackend)
         mock_backend.uri = Path(temp_registry_dir) / "remote"
@@ -2867,6 +2868,7 @@ class TestRegistryCacheLRU:
             version_objects=True,
             use_cache=use_cache,
             cache_max_entries=cache_max_entries,
+            **kwargs,
         )
 
     @staticmethod
@@ -2889,10 +2891,36 @@ class TestRegistryCacheLRU:
 
         assert registry._cached is True
         assert registry._cache_max_entries == 1024
+        assert registry._cache_prune_buffer == 256
+        assert registry._cache_scope == "shared"
 
-    def test_negative_cache_max_entries_is_rejected(self, temp_registry_dir):
+    def test_non_positive_cache_max_entries_is_rejected(self, temp_registry_dir):
         with pytest.raises(ValueError, match="cache_max_entries"):
             self.make_remote_registry(temp_registry_dir, cache_max_entries=-1)
+        with pytest.raises(ValueError, match="cache_max_entries"):
+            self.make_remote_registry(temp_registry_dir, cache_max_entries=0)
+
+    def test_cache_prune_buffer_defaults_and_validation(self, temp_registry_dir):
+        assert self.make_remote_registry(temp_registry_dir, cache_max_entries=1)._cache_prune_buffer == 0
+        assert self.make_remote_registry(temp_registry_dir, cache_max_entries=10)._cache_prune_buffer == 2
+        assert self.make_remote_registry(temp_registry_dir, cache_max_entries=1000)._cache_prune_buffer == 250
+        assert self.make_remote_registry(temp_registry_dir, cache_max_entries=10000)._cache_prune_buffer == 1024
+        assert self.make_remote_registry(temp_registry_dir, cache_max_entries=10, cache_prune_buffer=99)._cache_prune_buffer == 9
+        with pytest.raises(ValueError, match="cache_prune_buffer"):
+            self.make_remote_registry(temp_registry_dir, cache_max_entries=10, cache_prune_buffer=-1)
+
+    def test_cache_scope_process_uses_process_specific_cache_dir(self, temp_registry_dir):
+        shared = self.make_remote_registry(temp_registry_dir, cache_scope="shared")
+        process = self.make_remote_registry(temp_registry_dir, cache_scope="process")
+
+        assert shared._cache_scope == "shared"
+        assert process._cache_scope == "process"
+        assert shared._cache.backend.uri != process._cache.backend.uri
+        assert f"pid_{os.getpid()}" in str(process._cache.backend.uri)
+
+    def test_invalid_cache_scope_is_rejected(self, temp_registry_dir):
+        with pytest.raises(ValueError, match="cache_scope"):
+            self.make_remote_registry(temp_registry_dir, cache_scope="worker")
 
     def test_none_cache_max_entries_disables_lru_sidecar_and_pruning(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=None)
@@ -2906,21 +2934,9 @@ class TestRegistryCacheLRU:
         assert self.cache_names(registry) == set(entries)
         assert not registry._cache_lru_index_path().exists()
 
-    def test_zero_cache_max_entries_prunes_all_entries(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=0)
-        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0")]
-        self.save_cache_entries(registry, entries)
-
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(1.0, 2.0)):
-            for name, version in entries:
-                registry._touch_cache_entry(name, version)
-        registry._prune_cache_lru()
-
-        assert self.cache_names(registry) == set()
-
     def test_prune_keeps_most_recent_entries(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
-        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=3, cache_prune_buffer=1)
+        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0"), ("test:d", "1.0.0")]
         self.save_cache_entries(registry, entries)
 
         with patch(
@@ -2930,10 +2946,10 @@ class TestRegistryCacheLRU:
                 registry._touch_cache_entry(name, version)
         registry._prune_cache_lru()
 
-        assert self.cache_names(registry) == {("test:b", "1.0.0"), ("test:c", "1.0.0")}
+        assert self.cache_names(registry) == {("test:c", "1.0.0"), ("test:d", "1.0.0")}
 
     def test_recency_update_preserves_cache_hit(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2, cache_prune_buffer=0)
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
         self.save_cache_entries(registry, entries)
 
@@ -2949,7 +2965,7 @@ class TestRegistryCacheLRU:
         assert self.cache_names(registry) == {("test:a", "1.0.0"), ("test:c", "1.0.0")}
 
     def test_versions_are_independent_lru_entries(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2, cache_prune_buffer=0)
         entries = [("test:obj", "1.0.0"), ("test:obj", "2.0.0"), ("test:other", "1.0.0")]
         self.save_cache_entries(registry, entries)
 
@@ -2967,22 +2983,36 @@ class TestRegistryCacheLRU:
 
         assert json.loads(key) == ["path/to:test", "1.2.3"]
 
-    def test_touch_creates_and_updates_index_entry(self, temp_registry_dir):
+    def test_touch_records_dirty_entry_without_writing_sidecar(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
 
         with patch("mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(10.0, 20.0)):
             registry._touch_cache_entry("test:obj", "1.0.0")
             registry._touch_cache_entry("test:obj", "1.0.0")
 
-        index = registry._load_cache_lru_index()
-        entry = index["entries"][Registry._cache_lru_key("test:obj", "1.0.0")]
+        assert not registry._cache_lru_index_path().exists()
+        entry = registry._cache_lru_dirty[Registry._cache_lru_key("test:obj", "1.0.0")]
         assert entry == {"name": "test:obj", "version": "1.0.0", "last_accessed": 20.0}
 
     def test_remove_cache_lru_entries_removes_only_requested_entries(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(1.0, 2.0)):
-            registry._touch_cache_entry("test:a", "1.0.0")
-            registry._touch_cache_entry("test:b", "1.0.0")
+        registry._save_cache_lru_index(
+            {
+                "version": 1,
+                "entries": {
+                    Registry._cache_lru_key("test:a", "1.0.0"): {
+                        "name": "test:a",
+                        "version": "1.0.0",
+                        "last_accessed": 1.0,
+                    },
+                    Registry._cache_lru_key("test:b", "1.0.0"): {
+                        "name": "test:b",
+                        "version": "1.0.0",
+                        "last_accessed": 2.0,
+                    },
+                },
+            }
+        )
 
         registry._remove_cache_lru_entries([("test:a", "1.0.0")])
 
@@ -3048,6 +3078,7 @@ class TestRegistryCacheLRU:
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
         registry._cache.save("test:obj", "value", version="1.0.0")
         registry._touch_cache_entry("test:obj", "1.0.0")
+        registry._prune_cache_lru()
         assert registry._cache_lru_index_path().exists()
 
         registry.clear_cache()
@@ -3059,6 +3090,7 @@ class TestRegistryCacheLRU:
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
         registry._cache.save("test:obj", "value", version="1.0.0")
         registry._touch_cache_entry("test:obj", "1.0.0")
+        registry._prune_cache_lru()
         registry._remote.clear = Mock()
 
         registry.clear()
@@ -3088,8 +3120,8 @@ class TestRegistryCacheLRU:
         with patch("mindtrace.registry.core.registry.time.time", return_value=123.0):
             assert registry._load_single_cached("test:obj", "1.0.0", verify=VerifyLevel.INTEGRITY) == "value"
 
-        index = registry._load_cache_lru_index()
-        assert index["entries"][Registry._cache_lru_key("test:obj", "1.0.0")]["last_accessed"] == 123.0
+        dirty = registry._cache_lru_dirty
+        assert dirty[Registry._cache_lru_key("test:obj", "1.0.0")]["last_accessed"] == 123.0
 
     def test_batch_cache_hits_touch_all_lru_entries(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
@@ -3100,14 +3132,14 @@ class TestRegistryCacheLRU:
         result = registry._load_batch_cached(["test:a", "test:b"], ["1.0.0", "1.0.0"], verify=VerifyLevel.INTEGRITY)
 
         assert result.results == ["test:a@1.0.0", "test:b@1.0.0"]
-        index = registry._load_cache_lru_index()
         key_a = Registry._cache_lru_key("test:a", "1.0.0")
         key_b = Registry._cache_lru_key("test:b", "1.0.0")
-        assert key_a in index["entries"]
-        assert key_b in index["entries"]
+        dirty = registry._cache_lru_dirty
+        assert key_a in dirty
+        assert key_b in dirty
         # `_touch_cache_entry` runs in batch order for cache hits; recency timestamps should
         # reflect that ordering (later touch >= earlier; typically strict on real clocks).
-        assert index["entries"][key_a]["last_accessed"] <= index["entries"][key_b]["last_accessed"]
+        assert dirty[key_a]["last_accessed"] <= dirty[key_b]["last_accessed"]
 
     def test_save_cache_update_prunes_after_remote_save(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=1)
@@ -3121,6 +3153,54 @@ class TestRegistryCacheLRU:
             registry.save("test:b", "b", version="1.0.0")
 
         assert self.cache_names(registry) == {("test:b", "1.0.0")}
+
+    def test_maybe_prune_uses_estimate_to_avoid_unneeded_rebuild(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=4)
+        registry._cache_lru_estimated_entries = 3
+
+        with patch.object(registry, "_prune_cache_lru") as pruner:
+            registry._maybe_prune_cache_lru()
+
+        pruner.assert_not_called()
+
+    def test_prune_reduces_to_max_minus_buffer_and_updates_estimate(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=4, cache_prune_buffer=2)
+        entries = [(f"test:{idx}", "1.0.0") for idx in range(6)]
+        self.save_cache_entries(registry, entries)
+        with patch(
+            "mindtrace.registry.core.registry.time.time",
+            side_effect=_patch_registry_time_sequence(1.0, 2.0, 3.0, 4.0, 5.0, 6.0),
+        ):
+            for name, version in entries:
+                registry._touch_cache_entry(name, version)
+
+        registry._prune_cache_lru()
+
+        assert self.cache_names(registry) == {("test:4", "1.0.0"), ("test:5", "1.0.0")}
+        assert registry._cache_lru_estimated_entries == 2
+        assert registry._cache_lru_dirty == {}
+
+    def test_prune_counts_cache_entries_missing_from_partial_sidecar(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2, cache_prune_buffer=0)
+        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
+        self.save_cache_entries(registry, entries)
+        registry._save_cache_lru_index(
+            {
+                "version": 1,
+                "entries": {
+                    Registry._cache_lru_key("test:c", "1.0.0"): {
+                        "name": "test:c",
+                        "version": "1.0.0",
+                        "last_accessed": 3.0,
+                    }
+                },
+            }
+        )
+
+        registry._prune_cache_lru()
+
+        assert len(self.cache_names(registry)) == 2
+        assert ("test:c", "1.0.0") in self.cache_names(registry)
 
     def test_delete_removes_cache_and_lru_entry(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
@@ -3144,6 +3224,7 @@ class TestRegistryCacheLRU:
         ):
             for name, version in entries:
                 registry._touch_cache_entry(name, version)
+        registry._prune_cache_lru()
 
         registry.delete("test:obj")
 

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -3304,6 +3304,52 @@ class TestRegistryCacheLRU:
 
         assert registry._cache_lru_estimated_entries is None
 
+    def test_count_new_cache_entries_uses_batch_backend_has_object(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=10)
+        registry._cache.backend.has_object = Mock(
+            return_value={
+                ("test:existing", "1.0.0"): True,
+                ("test:new", "1.0.0"): False,
+            }
+        )
+
+        added = registry._count_new_cache_entries(
+            [("test:existing", "1.0.0"), ("test:new", "1.0.0"), ("test:new", "1.0.0")]
+        )
+
+        assert added == 1
+        registry._cache.backend.has_object.assert_called_once_with(
+            ["test:existing", "test:new"],
+            ["1.0.0", "1.0.0"],
+        )
+
+    def test_save_overwrite_does_not_increment_cache_lru_estimate(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=10)
+        self.save_cache_entries(registry, [("test:obj", "1.0.0")])
+        registry._cache_lru_estimated_entries = 1
+        registry._remote.save = Mock(return_value="1.0.0")
+
+        with patch.object(registry, "_maybe_prune_cache_lru") as pruner:
+            registry.save("test:obj", "updated", version="1.0.0")
+
+        assert registry._cache_lru_estimated_entries == 1
+        pruner.assert_called_once_with()
+
+    def test_batch_save_counts_only_new_cache_lru_entries(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=10)
+        self.save_cache_entries(registry, [("test:existing", "1.0.0")])
+        registry._cache_lru_estimated_entries = 1
+        result = BatchResult()
+        result.results = ["1.0.0", "1.0.0"]
+        result.succeeded = [("test:existing", "1.0.0"), ("test:new", "1.0.0")]
+        registry._remote.save = Mock(return_value=result)
+
+        with patch.object(registry, "_maybe_prune_cache_lru") as pruner:
+            registry.save(["test:existing", "test:new"], ["updated", "fresh"], version=["1.0.0", "1.0.0"])
+
+        assert registry._cache_lru_estimated_entries == 2
+        pruner.assert_called_once_with()
+
     def test_maybe_prune_noops_when_uncached(self, temp_registry_dir):
         uncached = self.make_remote_registry(temp_registry_dir, use_cache=False)
 

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -3150,6 +3150,134 @@ class TestRegistryCacheLRU:
         assert self.cache_names(registry) == {("test:other", "1.0.0")}
         index = registry._load_cache_lru_index()
         assert set(index["entries"]) == {Registry._cache_lru_key("test:other", "1.0.0")}
+
+    def test_save_cache_lru_index_swallows_dump_failure(self, temp_registry_dir):
+        """``_save_cache_lru_index`` logs and ignores IO errors from ``json.dump``."""
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        with patch("mindtrace.registry.core.registry.json.dump", side_effect=OSError("disk full")):
+            registry._save_cache_lru_index({"version": 1, "entries": {}})
+
+    def test_clear_cache_lru_index_swallows_unlink_failure(self, temp_registry_dir):
+        """``_clear_cache_lru_index`` tolerates ``unlink`` raising."""
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        mock_path = MagicMock()
+        mock_path.unlink.side_effect = OSError("permission denied")
+        with patch.object(registry, "_cache_lru_index_path", return_value=mock_path):
+            registry._clear_cache_lru_index()
+        mock_path.unlink.assert_called_once_with(missing_ok=True)
+
+    def test_rebuild_cache_lru_index_empty_when_registry_not_cached(self, temp_registry_dir):
+        """Uncached registries return an empty index without touching ``_cache``."""
+        uncached = self.make_remote_registry(temp_registry_dir, use_cache=False, cache_max_entries=2)
+        assert uncached._rebuild_cache_lru_index() == {"version": 1, "entries": {}}
+
+    def test_rebuild_cache_lru_index_uses_mtime_or_falls_back_when_stat_fails(self, temp_registry_dir):
+        """If metadata ``stat`` fails, rebuild still records the object using ``time.time()``."""
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=8)
+        registry._cache.save("test:stat", "x", version="1.0.0")
+        bad_meta = MagicMock()
+        bad_meta.stat.side_effect = OSError("no stat")
+        with patch.object(registry._cache.backend, "_object_metadata_path", return_value=bad_meta):
+            with patch("mindtrace.registry.core.registry.time.time", return_value=999.0):
+                idx = registry._rebuild_cache_lru_index()
+
+        entry = idx["entries"][Registry._cache_lru_key("test:stat", "1.0.0")]
+        assert entry["name"] == "test:stat"
+        assert entry["version"] == "1.0.0"
+        assert entry["last_accessed"] == 999.0
+
+    def test_rebuild_cache_lru_index_swallows_list_objects_failure(self, temp_registry_dir):
+        """Rebuild returns the default shell if enumerating cached objects blows up."""
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=8)
+        with patch.object(registry._cache, "list_objects", side_effect=RuntimeError("boom")):
+            assert registry._rebuild_cache_lru_index() == {"version": 1, "entries": {}}
+
+    def test_prune_skips_malformed_lru_index_entries(self, temp_registry_dir):
+        """Non-string ``name``/``version`` in the sidecar are ignored during pruning."""
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=1)
+        registry._cache.save("test:x", "x", version="1.0.0")
+        registry._cache.save("test:y", "y", version="1.0.0")
+        registry._save_cache_lru_index(
+            {
+                "version": 1,
+                "entries": {
+                    "not-a-valid-key-shape": {
+                        "name": 123,
+                        "version": "1.0.0",
+                        "last_accessed": 0.0,
+                    },
+                    Registry._cache_lru_key("test:x", "1.0.0"): {
+                        "name": "test:x",
+                        "version": "1.0.0",
+                        "last_accessed": 1.0,
+                    },
+                    Registry._cache_lru_key("test:y", "1.0.0"): {
+                        "name": "test:y",
+                        "version": "1.0.0",
+                        "last_accessed": 2.0,
+                    },
+                },
+            }
+        )
+        registry._prune_cache_lru()
+        assert len(self.cache_names(registry)) == 1
+        assert ("test:y", "1.0.0") in self.cache_names(registry)
+
+    def test_prune_warns_and_continues_when_cache_delete_raises(self, temp_registry_dir):
+        """If eviction ``delete`` fails, prune logs and drops the row from the sidecar."""
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
+        self.save_cache_entries(registry, entries)
+        with patch(
+            "mindtrace.registry.core.registry.time.time",
+            side_effect=_patch_registry_time_sequence(1.0, 2.0, 3.0),
+        ):
+            for name, version in entries:
+                registry._touch_cache_entry(name, version)
+
+        real_delete = registry._cache.delete
+
+        def delete_side_effect(name, version):
+            if name == "test:a":
+                raise RuntimeError("simulated delete failure")
+            return real_delete(name, version)
+
+        with patch.object(registry._cache, "delete", side_effect=delete_side_effect):
+            registry._prune_cache_lru()
+
+        # Oldest (test:a) delete failed; object may still exist on disk, but index no longer tracks it.
+        index = registry._load_cache_lru_index()
+        assert Registry._cache_lru_key("test:a", "1.0.0") not in index["entries"]
+
+    def test_load_single_cached_valueerror_invokes_lru_removal(self, temp_registry_dir):
+        """Corrupt cache materialization removes artifacts and LRU keys before remote load."""
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=8)
+        registry._cache.save("test:corrupt", "cached", version="1.0.0")
+        registry._touch_cache_entry("test:corrupt", "1.0.0")
+        registry._remote._latest = Mock(return_value="1.0.0")
+        registry._remote.load = Mock(return_value="fresh")
+
+        with patch.object(registry, "_remove_cache_lru_entries") as remover:
+            with patch.object(registry._cache, "load", side_effect=ValueError("corrupt")):
+                out = registry._load_single_cached("test:corrupt", "1.0.0", verify=VerifyLevel.INTEGRITY)
+
+        assert out == "fresh"
+        remover.assert_called_once_with([("test:corrupt", "1.0.0")])
+        registry._remote.load.assert_called_once()
+
+    def test_load_single_cached_valueerror_swallows_delete_cleanup_failure(self, temp_registry_dir):
+        """If cleanup after corrupt cache fails, load still proceeds from remote."""
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=8)
+        registry._cache.save("test:corrupt", "cached", version="1.0.0")
+        registry._remote._latest = Mock(return_value="1.0.0")
+        registry._remote.load = Mock(return_value="fresh")
+
+        with patch.object(registry._cache, "load", side_effect=ValueError("corrupt")):
+            with patch.object(registry._cache, "delete", side_effect=OSError("delete failed")):
+                out = registry._load_single_cached("test:corrupt", "1.0.0", verify=VerifyLevel.INTEGRITY)
+
+        assert out == "fresh"
+        registry._remote.load.assert_called_once()
 
 
 def _make_op_results(*results: OpResult) -> OpResults:

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -3234,7 +3234,11 @@ class TestRegistryCacheLRU:
         assert registry._cache_lru_estimated_entries == 1
 
     def test_prune_warns_and_continues_when_cache_delete_raises(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        # buffer=0 so prune target is exactly cache_max_entries (default buffer would
+        # target max - buffer and over-evict after a failed delete on the LRU entry).
+        registry = self.make_remote_registry(
+            temp_registry_dir, cache_max_entries=2, cache_prune_buffer=0
+        )
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
         self.save_cache_entries(registry, entries)
         for timestamp, (name, version) in enumerate(entries, start=1):
@@ -3250,8 +3254,8 @@ class TestRegistryCacheLRU:
         with patch.object(registry._cache, "delete", side_effect=delete_side_effect):
             registry._prune_cache_lru()
 
-        assert ("test:a", "1.0.0") in self.cache_names(registry)
-        assert len(self.cache_names(registry)) == 2
+        # LRU is test:a; delete fails. Next oldest (test:b) is removed so size <= max.
+        assert self.cache_names(registry) == {("test:a", "1.0.0"), ("test:c", "1.0.0")}
         assert registry._cache_lru_estimated_entries == 2
 
     def test_load_single_cached_valueerror_invokes_lru_removal(self, temp_registry_dir):

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -3163,6 +3163,81 @@ class TestRegistryCacheLRU:
 
         pruner.assert_not_called()
 
+    def test_maybe_prune_invokes_prune_when_estimate_exceeds_max(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=4)
+        registry._cache_lru_estimated_entries = 5
+
+        with patch.object(registry, "_prune_cache_lru") as pruner:
+            registry._maybe_prune_cache_lru()
+
+        pruner.assert_called_once_with()
+
+    def test_single_load_miss_updates_estimate_without_pruning_under_max(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=4)
+        registry._cache_lru_estimated_entries = 1
+        registry._remote.load = Mock(return_value="fresh")
+
+        with patch.object(registry, "_prune_cache_lru") as pruner:
+            out = registry._load_single_cached("test:miss", "1.0.0", verify=VerifyLevel.INTEGRITY)
+
+        assert out == "fresh"
+        assert registry._cache.load("test:miss", "1.0.0") == "fresh"
+        assert registry._cache_lru_estimated_entries == 2
+        pruner.assert_not_called()
+
+    def test_single_load_miss_prunes_when_estimate_exceeds_max(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        registry._cache_lru_estimated_entries = 2
+        registry._remote.load = Mock(return_value="fresh")
+
+        with patch.object(registry, "_prune_cache_lru") as pruner:
+            out = registry._load_single_cached("test:miss", "1.0.0", verify=VerifyLevel.INTEGRITY)
+
+        assert out == "fresh"
+        assert registry._cache_lru_estimated_entries == 3
+        pruner.assert_called_once_with()
+
+    def test_batch_load_misses_note_entries_and_prune_once(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=3)
+        registry._cache_lru_estimated_entries = 2
+        registry._remote._resolve_load_version = Mock(side_effect=lambda name, version: version)
+        remote_result = BatchResult()
+        remote_result.results = ["fresh-a", "fresh-b"]
+        remote_result.succeeded = [("test:a", "1.0.0"), ("test:b", "1.0.0")]
+        registry._remote.load = Mock(return_value=remote_result)
+
+        with patch.object(registry, "_prune_cache_lru") as pruner:
+            out = registry._load_batch_cached(["test:a", "test:b"], ["1.0.0", "1.0.0"], verify=VerifyLevel.INTEGRITY)
+
+        assert out.results == ["fresh-a", "fresh-b"]
+        assert registry._cache_lru_estimated_entries == 4
+        pruner.assert_called_once_with()
+
+    def test_prune_noops_below_max_but_flushes_dirty_touches(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=4)
+        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0")]
+        self.save_cache_entries(registry, entries)
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(10.0, 20.0)):
+            for name, version in entries:
+                registry._touch_cache_entry(name, version)
+
+        registry._prune_cache_lru()
+
+        assert self.cache_names(registry) == set(entries)
+        assert registry._cache_lru_dirty == {}
+        assert registry._cache_lru_estimated_entries == 2
+        index = registry._load_cache_lru_index()
+        assert index["entries"][Registry._cache_lru_key("test:a", "1.0.0")]["last_accessed"] == 10.0
+        assert index["entries"][Registry._cache_lru_key("test:b", "1.0.0")]["last_accessed"] == 20.0
+
+    def test_remove_cache_lru_entries_clears_dirty_without_sidecar_row(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        registry._touch_cache_entry("test:dirty", "1.0.0")
+
+        registry._remove_cache_lru_entries([("test:dirty", "1.0.0")])
+
+        assert registry._cache_lru_dirty == {}
+
     def test_prune_reduces_to_max_minus_buffer_and_updates_estimate(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=4, cache_prune_buffer=2)
         entries = [(f"test:{idx}", "1.0.0") for idx in range(6)]

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -2823,6 +2823,135 @@ def test_cache_initialization_remote_backend(temp_registry_dir):
     assert registry._cache is not None
     assert isinstance(registry._cache.backend, LocalRegistryBackend)
     assert registry._cache.version_objects == registry.version_objects
+    assert registry._cache_max_entries == 1024
+
+
+def test_cache_lru_prunes_to_max_entries(temp_registry_dir):
+    """Registry cache LRU pruning keeps only the configured number of entries."""
+    mock_backend = Mock(spec=RegistryBackend)
+    mock_backend.uri = Path(temp_registry_dir) / "remote"
+    mock_backend.registered_materializers = Mock(return_value={})
+    mock_backend.fetch_registry_metadata = Mock(return_value={})
+
+    registry = Registry(backend=mock_backend, version_objects=True, cache_max_entries=2)
+    registry._cache.save("test:a", "a", version="1.0.0")
+    registry._cache.save("test:b", "b", version="1.0.0")
+    registry._cache.save("test:c", "c", version="1.0.0")
+
+    with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0]):
+        registry._touch_cache_entry("test:a", "1.0.0")
+        registry._touch_cache_entry("test:b", "1.0.0")
+        registry._touch_cache_entry("test:c", "1.0.0")
+
+    registry._prune_cache_lru()
+
+    assert not registry._cache.has_object("test:a", "1.0.0")
+    assert registry._cache.has_object("test:b", "1.0.0")
+    assert registry._cache.has_object("test:c", "1.0.0")
+
+
+def test_cache_lru_recency_update_preserves_cache_hit(temp_registry_dir):
+    """Touching an existing cache entry moves it to the most-recently-used position."""
+    mock_backend = Mock(spec=RegistryBackend)
+    mock_backend.uri = Path(temp_registry_dir) / "remote"
+    mock_backend.registered_materializers = Mock(return_value={})
+    mock_backend.fetch_registry_metadata = Mock(return_value={})
+
+    registry = Registry(backend=mock_backend, version_objects=True, cache_max_entries=2)
+    registry._cache.save("test:a", "a", version="1.0.0")
+    registry._cache.save("test:b", "b", version="1.0.0")
+    registry._cache.save("test:c", "c", version="1.0.0")
+
+    with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0, 4.0]):
+        registry._touch_cache_entry("test:a", "1.0.0")
+        registry._touch_cache_entry("test:b", "1.0.0")
+        registry._touch_cache_entry("test:a", "1.0.0")
+        registry._touch_cache_entry("test:c", "1.0.0")
+
+    registry._prune_cache_lru()
+
+    assert registry._cache.has_object("test:a", "1.0.0")
+    assert not registry._cache.has_object("test:b", "1.0.0")
+    assert registry._cache.has_object("test:c", "1.0.0")
+
+
+def test_cache_lru_versions_are_independent_entries(temp_registry_dir):
+    """Different versions of the same object count as distinct LRU entries."""
+    mock_backend = Mock(spec=RegistryBackend)
+    mock_backend.uri = Path(temp_registry_dir) / "remote"
+    mock_backend.registered_materializers = Mock(return_value={})
+    mock_backend.fetch_registry_metadata = Mock(return_value={})
+
+    registry = Registry(backend=mock_backend, version_objects=True, cache_max_entries=2)
+    registry._cache.save("test:obj", "v1", version="1.0.0")
+    registry._cache.save("test:obj", "v2", version="2.0.0")
+    registry._cache.save("test:other", "v1", version="1.0.0")
+
+    with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0]):
+        registry._touch_cache_entry("test:obj", "1.0.0")
+        registry._touch_cache_entry("test:obj", "2.0.0")
+        registry._touch_cache_entry("test:other", "1.0.0")
+
+    registry._prune_cache_lru()
+
+    assert not registry._cache.has_object("test:obj", "1.0.0")
+    assert registry._cache.has_object("test:obj", "2.0.0")
+    assert registry._cache.has_object("test:other", "1.0.0")
+
+
+def test_clear_cache_removes_lru_index(temp_registry_dir):
+    """clear_cache removes cached objects and the LRU sidecar."""
+    mock_backend = Mock(spec=RegistryBackend)
+    mock_backend.uri = Path(temp_registry_dir) / "remote"
+    mock_backend.registered_materializers = Mock(return_value={})
+    mock_backend.fetch_registry_metadata = Mock(return_value={})
+
+    registry = Registry(backend=mock_backend, version_objects=True, cache_max_entries=2)
+    registry._cache.save("test:obj", "value", version="1.0.0")
+    registry._touch_cache_entry("test:obj", "1.0.0")
+    assert registry._cache_lru_index_path().exists()
+
+    registry.clear_cache()
+
+    assert not registry._cache.has_object("test:obj", "1.0.0")
+    assert not registry._cache_lru_index_path().exists()
+
+
+def test_cache_lru_ignored_for_uncached_registries(temp_registry_dir):
+    """cache_max_entries does not enable caching for local or explicitly uncached registries."""
+    local_registry = Registry(backend=temp_registry_dir, cache_max_entries=1)
+    assert local_registry._cached is False
+    assert local_registry._cache_max_entries == 1
+
+    mock_backend = Mock(spec=RegistryBackend)
+    mock_backend.uri = Path(temp_registry_dir) / "remote"
+    mock_backend.registered_materializers = Mock(return_value={})
+    mock_backend.fetch_registry_metadata = Mock(return_value={})
+
+    uncached_remote = Registry(backend=mock_backend, use_cache=False, cache_max_entries=1)
+    assert uncached_remote._cached is False
+    assert uncached_remote._cache_max_entries == 1
+
+
+def test_cache_lru_corrupt_index_does_not_break_pruning(temp_registry_dir):
+    """A corrupt LRU sidecar is ignored and rebuilt from cache contents."""
+    mock_backend = Mock(spec=RegistryBackend)
+    mock_backend.uri = Path(temp_registry_dir) / "remote"
+    mock_backend.registered_materializers = Mock(return_value={})
+    mock_backend.fetch_registry_metadata = Mock(return_value={})
+
+    registry = Registry(backend=mock_backend, version_objects=True, cache_max_entries=1)
+    registry._cache.save("test:a", "a", version="1.0.0")
+    registry._cache.save("test:b", "b", version="1.0.0")
+    registry._cache_lru_index_path().write_text("not json")
+
+    registry._prune_cache_lru()
+
+    remaining = [
+        registry._cache.has_object("test:a", "1.0.0"),
+        registry._cache.has_object("test:b", "1.0.0"),
+    ]
+    assert remaining.count(True) == 1
 
 
 def _make_op_results(*results: OpResult) -> OpResults:

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -2905,7 +2905,12 @@ class TestRegistryCacheLRU:
         assert self.make_remote_registry(temp_registry_dir, cache_max_entries=10)._cache_prune_buffer == 2
         assert self.make_remote_registry(temp_registry_dir, cache_max_entries=1000)._cache_prune_buffer == 250
         assert self.make_remote_registry(temp_registry_dir, cache_max_entries=10000)._cache_prune_buffer == 1024
-        assert self.make_remote_registry(temp_registry_dir, cache_max_entries=10, cache_prune_buffer=99)._cache_prune_buffer == 9
+        assert (
+            self.make_remote_registry(
+                temp_registry_dir, cache_max_entries=10, cache_prune_buffer=99
+            )._cache_prune_buffer
+            == 9
+        )
         with pytest.raises(ValueError, match="cache_prune_buffer"):
             self.make_remote_registry(temp_registry_dir, cache_max_entries=10, cache_prune_buffer=-1)
 
@@ -3272,9 +3277,16 @@ class TestRegistryCacheLRU:
         assert registry._cache_lru_dirty == {}
 
     def test_prune_counts_cache_entries_missing_from_partial_sidecar(self, temp_registry_dir):
+        """Rebuild sees all on-disk objects; a partial sidecar must not drop unknown keys from disk.
+
+        Sidecar ``last_accessed`` must be comparable to rebuild's mtime-based timestamps
+        (both are wall-clock style floats); a small constant like ``3.0`` is incorrectly
+        interpreted as ancient next to ``st_mtime``.
+        """
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2, cache_prune_buffer=0)
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
         self.save_cache_entries(registry, entries)
+        mtime_floor = max(registry._cache.backend._object_metadata_path(n, v).stat().st_mtime for n, v in entries)
         registry._save_cache_lru_index(
             {
                 "version": 1,
@@ -3282,7 +3294,7 @@ class TestRegistryCacheLRU:
                     Registry._cache_lru_key("test:c", "1.0.0"): {
                         "name": "test:c",
                         "version": "1.0.0",
-                        "last_accessed": 3.0,
+                        "last_accessed": mtime_floor + 3600.0,
                     }
                 },
             }

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -2827,6 +2827,31 @@ def test_cache_initialization_remote_backend(temp_registry_dir):
     assert registry._cache_max_entries == 1024
 
 
+def _patch_registry_time_sequence(*values: float):
+    """Callable for patching ``registry.time.time`` without exhausting mocks.
+
+    ``unittest.mock.patch('mindtrace.registry.core.registry.time.time', ...)``
+    replaces the stdlib ``time.time`` implementation, which is shared with
+    ``logging``, backends, etc. Using a finite ``side_effect`` list therefore
+    raises ``StopIteration`` once those incidental calls exceed the sequence.
+    This helper yields the given floats in order, then repeats the last value.
+    """
+    if not values:
+        return lambda: 0.0
+
+    seq = list(values)
+
+    def tick() -> float:
+        i = tick._i
+        if i < len(seq):
+            tick._i = i + 1
+            return seq[i]
+        return seq[-1]
+
+    tick._i = 0  # type: ignore[attr-defined]
+    return tick
+
+
 class TestRegistryCacheLRU:
     """Unit tests for remote registry local-cache LRU pruning."""
 
@@ -2886,7 +2911,7 @@ class TestRegistryCacheLRU:
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0")]
         self.save_cache_entries(registry, entries)
 
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0]):
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(1.0, 2.0)):
             for name, version in entries:
                 registry._touch_cache_entry(name, version)
         registry._prune_cache_lru()
@@ -2898,7 +2923,9 @@ class TestRegistryCacheLRU:
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
         self.save_cache_entries(registry, entries)
 
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0]):
+        with patch(
+            "mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(1.0, 2.0, 3.0)
+        ):
             for name, version in entries:
                 registry._touch_cache_entry(name, version)
         registry._prune_cache_lru()
@@ -2910,7 +2937,9 @@ class TestRegistryCacheLRU:
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
         self.save_cache_entries(registry, entries)
 
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0, 4.0]):
+        with patch(
+            "mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(1.0, 2.0, 3.0, 4.0)
+        ):
             registry._touch_cache_entry("test:a", "1.0.0")
             registry._touch_cache_entry("test:b", "1.0.0")
             registry._touch_cache_entry("test:a", "1.0.0")
@@ -2924,7 +2953,9 @@ class TestRegistryCacheLRU:
         entries = [("test:obj", "1.0.0"), ("test:obj", "2.0.0"), ("test:other", "1.0.0")]
         self.save_cache_entries(registry, entries)
 
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0]):
+        with patch(
+            "mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(1.0, 2.0, 3.0)
+        ):
             for name, version in entries:
                 registry._touch_cache_entry(name, version)
         registry._prune_cache_lru()
@@ -2939,7 +2970,7 @@ class TestRegistryCacheLRU:
     def test_touch_creates_and_updates_index_entry(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
 
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=[10.0, 20.0]):
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(10.0, 20.0)):
             registry._touch_cache_entry("test:obj", "1.0.0")
             registry._touch_cache_entry("test:obj", "1.0.0")
 
@@ -2949,7 +2980,7 @@ class TestRegistryCacheLRU:
 
     def test_remove_cache_lru_entries_removes_only_requested_entries(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0]):
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(1.0, 2.0)):
             registry._touch_cache_entry("test:a", "1.0.0")
             registry._touch_cache_entry("test:b", "1.0.0")
 
@@ -3053,8 +3084,9 @@ class TestRegistryCacheLRU:
         registry._cache.save("test:obj", "value", version="1.0.0")
         registry._remote._latest = Mock(return_value="1.0.0")
 
+        # INTEGRITY avoids FULL staleness (remote mock has no matching metadata hashes).
         with patch("mindtrace.registry.core.registry.time.time", return_value=123.0):
-            assert registry._load_single_cached("test:obj", "1.0.0") == "value"
+            assert registry._load_single_cached("test:obj", "1.0.0", verify=VerifyLevel.INTEGRITY) == "value"
 
         index = registry._load_cache_lru_index()
         assert index["entries"][Registry._cache_lru_key("test:obj", "1.0.0")]["last_accessed"] == 123.0
@@ -3065,19 +3097,26 @@ class TestRegistryCacheLRU:
         self.save_cache_entries(registry, entries)
         registry._remote._resolve_load_version = Mock(side_effect=lambda name, version: version)
 
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=[11.0, 22.0]):
-            result = registry._load_batch_cached(["test:a", "test:b"], ["1.0.0", "1.0.0"])
+        result = registry._load_batch_cached(["test:a", "test:b"], ["1.0.0", "1.0.0"], verify=VerifyLevel.INTEGRITY)
 
         assert result.results == ["test:a@1.0.0", "test:b@1.0.0"]
         index = registry._load_cache_lru_index()
-        assert index["entries"][Registry._cache_lru_key("test:a", "1.0.0")]["last_accessed"] == 11.0
-        assert index["entries"][Registry._cache_lru_key("test:b", "1.0.0")]["last_accessed"] == 22.0
+        key_a = Registry._cache_lru_key("test:a", "1.0.0")
+        key_b = Registry._cache_lru_key("test:b", "1.0.0")
+        assert key_a in index["entries"]
+        assert key_b in index["entries"]
+        # `_touch_cache_entry` runs in batch order for cache hits; recency timestamps should
+        # reflect that ordering (later touch >= earlier; typically strict on real clocks).
+        assert index["entries"][key_a]["last_accessed"] <= index["entries"][key_b]["last_accessed"]
 
     def test_save_cache_update_prunes_after_remote_save(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=1)
         registry._remote.save = Mock(side_effect=["1.0.0", "1.0.0"])
 
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0]):
+        with patch(
+            "mindtrace.registry.core.registry.time.time",
+            side_effect=_patch_registry_time_sequence(1.0, 2.0),
+        ):
             registry.save("test:a", "a", version="1.0.0")
             registry.save("test:b", "b", version="1.0.0")
 
@@ -3099,7 +3138,10 @@ class TestRegistryCacheLRU:
         registry._remote.delete = Mock(return_value=None)
         entries = [("test:obj", "1.0.0"), ("test:obj", "2.0.0"), ("test:other", "1.0.0")]
         self.save_cache_entries(registry, entries)
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0]):
+        with patch(
+            "mindtrace.registry.core.registry.time.time",
+            side_effect=_patch_registry_time_sequence(1.0, 2.0, 3.0),
+        ):
             for name, version in entries:
                 registry._touch_cache_entry(name, version)
 

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -117,7 +117,7 @@ def test_registry_initialization(registry, temp_registry_dir):
 
 
 def test_registry_serialization_hints_for_object_uses_core_materializer_lookup(registry, test_bytes):
-    hints = registry.serialization_hints_for_object(test_bytes)
+    hints = registry._core.serialization_hints_for_object(test_bytes)
 
     assert hints == {
         "class": "builtins.bytes",
@@ -125,10 +125,10 @@ def test_registry_serialization_hints_for_object_uses_core_materializer_lookup(r
     }
 
 
-def test_registry_materialize_from_bytes_delegates_to_core(registry):
+def test_registry_core_materialize_from_bytes_with_bytes_materializer(registry):
     raw = b"hello-bytes"
 
-    out = registry.materialize_from_bytes(
+    out = registry._core.materialize_from_bytes(
         raw,
         object_class="builtins.bytes",
         materializer="zenml.materializers.BytesMaterializer",
@@ -3258,6 +3258,67 @@ class TestRegistryCacheLRU:
         registry._remove_cache_lru_entries([("test:dirty", "1.0.0")])
 
         assert registry._cache_lru_dirty == {}
+
+    def test_registry_get_cache_dir_rejects_invalid_cache_scope(self):
+        """Defense-in-depth: callers must pass ``cache_scope='shared'`` or ``'process'``."""
+        with pytest.raises(ValueError, match="cache_scope"):
+            Registry._get_cache_dir("mock://backend", cache_scope="invalid-scope")
+
+    def test_save_cache_lru_index_best_effort_unlink_after_failed_replace(self, temp_registry_dir):
+        """If rename fails after writing the temporary sidecar, cleanup unlink errors are swallowed."""
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+
+        def synthetic_replace(self_inner: Path, target: Path, **_kwargs):  # type: ignore[misc]
+            raise OSError("simulated rename failure")
+
+        unlink_attempts_on_tmp = []
+
+        original_unlink = Path.unlink
+
+        def unlink_maybe_fail(self_inner: Path, missing_ok: bool = False):
+            stem = self_inner.name
+            if stem.endswith(".tmp") and ".registry_cache_lru.json." in stem:
+                unlink_attempts_on_tmp.append(self_inner.name)
+                if len(unlink_attempts_on_tmp) == 1:
+                    raise RuntimeError("simulated unlink failure")
+            return original_unlink(self_inner, missing_ok=missing_ok)
+
+        with patch.object(Path, "replace", synthetic_replace):
+            with patch.object(Path, "unlink", unlink_maybe_fail):
+                registry._save_cache_lru_index({"version": 1, "entries": {}})
+        assert len(unlink_attempts_on_tmp) == 1
+
+    def test_note_cache_entries_added_noop_when_count_not_positive(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=10)
+        registry._cache_lru_estimated_entries = 7
+
+        registry._note_cache_entries_added(0)
+        registry._note_cache_entries_added(-5)
+
+        assert registry._cache_lru_estimated_entries == 7
+
+    def test_note_cache_entries_added_noop_when_pruning_disabled(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=None)
+
+        registry._note_cache_entries_added(3)
+
+        assert registry._cache_lru_estimated_entries is None
+
+    def test_maybe_prune_noops_when_uncached(self, temp_registry_dir):
+        uncached = self.make_remote_registry(temp_registry_dir, use_cache=False)
+
+        with patch.object(uncached, "_prune_cache_lru") as pruner:
+            uncached._maybe_prune_cache_lru()
+
+        pruner.assert_not_called()
+
+    def test_maybe_prune_noops_when_lru_disabled(self, temp_registry_dir):
+        no_cap = self.make_remote_registry(temp_registry_dir, cache_max_entries=None)
+
+        with patch.object(no_cap, "_prune_cache_lru") as pruner:
+            no_cap._maybe_prune_cache_lru()
+
+        pruner.assert_not_called()
 
     def test_prune_reduces_to_max_minus_buffer_and_updates_estimate(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=4, cache_prune_buffer=2)

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 import threading
 import time
@@ -2826,132 +2827,287 @@ def test_cache_initialization_remote_backend(temp_registry_dir):
     assert registry._cache_max_entries == 1024
 
 
-def test_cache_lru_prunes_to_max_entries(temp_registry_dir):
-    """Registry cache LRU pruning keeps only the configured number of entries."""
-    mock_backend = Mock(spec=RegistryBackend)
-    mock_backend.uri = Path(temp_registry_dir) / "remote"
-    mock_backend.registered_materializers = Mock(return_value={})
-    mock_backend.fetch_registry_metadata = Mock(return_value={})
+class TestRegistryCacheLRU:
+    """Unit tests for remote registry local-cache LRU pruning."""
 
-    registry = Registry(backend=mock_backend, version_objects=True, cache_max_entries=2)
-    registry._cache.save("test:a", "a", version="1.0.0")
-    registry._cache.save("test:b", "b", version="1.0.0")
-    registry._cache.save("test:c", "c", version="1.0.0")
+    @staticmethod
+    def make_remote_registry(temp_registry_dir, *, cache_max_entries=1024, use_cache=True):
+        """Create a cached Registry facade around a mock remote backend."""
+        mock_backend = Mock(spec=RegistryBackend)
+        mock_backend.uri = Path(temp_registry_dir) / "remote"
+        mock_backend.registered_materializers = Mock(return_value={})
+        mock_backend.fetch_registry_metadata = Mock(return_value={})
+        return Registry(
+            backend=mock_backend,
+            version_objects=True,
+            use_cache=use_cache,
+            cache_max_entries=cache_max_entries,
+        )
 
-    with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0]):
-        registry._touch_cache_entry("test:a", "1.0.0")
-        registry._touch_cache_entry("test:b", "1.0.0")
-        registry._touch_cache_entry("test:c", "1.0.0")
+    @staticmethod
+    def cache_names(registry):
+        """Return cached ``name@version`` pairs for assertions."""
+        return {
+            (name, version)
+            for name in registry._cache.list_objects()
+            for version in registry._cache.list_versions(name)
+        }
 
-    registry._prune_cache_lru()
+    @staticmethod
+    def save_cache_entries(registry, entries):
+        """Save lightweight string objects directly into the local cache."""
+        for name, version in entries:
+            registry._cache.save(name, f"{name}@{version}", version=version)
 
-    assert not registry._cache.has_object("test:a", "1.0.0")
-    assert registry._cache.has_object("test:b", "1.0.0")
-    assert registry._cache.has_object("test:c", "1.0.0")
+    def test_default_cache_max_entries_is_1024(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir)
 
+        assert registry._cached is True
+        assert registry._cache_max_entries == 1024
 
-def test_cache_lru_recency_update_preserves_cache_hit(temp_registry_dir):
-    """Touching an existing cache entry moves it to the most-recently-used position."""
-    mock_backend = Mock(spec=RegistryBackend)
-    mock_backend.uri = Path(temp_registry_dir) / "remote"
-    mock_backend.registered_materializers = Mock(return_value={})
-    mock_backend.fetch_registry_metadata = Mock(return_value={})
+    def test_negative_cache_max_entries_is_rejected(self, temp_registry_dir):
+        with pytest.raises(ValueError, match="cache_max_entries"):
+            self.make_remote_registry(temp_registry_dir, cache_max_entries=-1)
 
-    registry = Registry(backend=mock_backend, version_objects=True, cache_max_entries=2)
-    registry._cache.save("test:a", "a", version="1.0.0")
-    registry._cache.save("test:b", "b", version="1.0.0")
-    registry._cache.save("test:c", "c", version="1.0.0")
+    def test_none_cache_max_entries_disables_lru_sidecar_and_pruning(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=None)
+        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
+        self.save_cache_entries(registry, entries)
 
-    with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0, 4.0]):
-        registry._touch_cache_entry("test:a", "1.0.0")
-        registry._touch_cache_entry("test:b", "1.0.0")
-        registry._touch_cache_entry("test:a", "1.0.0")
-        registry._touch_cache_entry("test:c", "1.0.0")
+        for name, version in entries:
+            registry._touch_cache_entry(name, version)
+        registry._prune_cache_lru()
 
-    registry._prune_cache_lru()
+        assert self.cache_names(registry) == set(entries)
+        assert not registry._cache_lru_index_path().exists()
 
-    assert registry._cache.has_object("test:a", "1.0.0")
-    assert not registry._cache.has_object("test:b", "1.0.0")
-    assert registry._cache.has_object("test:c", "1.0.0")
+    def test_zero_cache_max_entries_prunes_all_entries(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=0)
+        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0")]
+        self.save_cache_entries(registry, entries)
 
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0]):
+            for name, version in entries:
+                registry._touch_cache_entry(name, version)
+        registry._prune_cache_lru()
 
-def test_cache_lru_versions_are_independent_entries(temp_registry_dir):
-    """Different versions of the same object count as distinct LRU entries."""
-    mock_backend = Mock(spec=RegistryBackend)
-    mock_backend.uri = Path(temp_registry_dir) / "remote"
-    mock_backend.registered_materializers = Mock(return_value={})
-    mock_backend.fetch_registry_metadata = Mock(return_value={})
+        assert self.cache_names(registry) == set()
 
-    registry = Registry(backend=mock_backend, version_objects=True, cache_max_entries=2)
-    registry._cache.save("test:obj", "v1", version="1.0.0")
-    registry._cache.save("test:obj", "v2", version="2.0.0")
-    registry._cache.save("test:other", "v1", version="1.0.0")
+    def test_prune_keeps_most_recent_entries(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
+        self.save_cache_entries(registry, entries)
 
-    with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0]):
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0]):
+            for name, version in entries:
+                registry._touch_cache_entry(name, version)
+        registry._prune_cache_lru()
+
+        assert self.cache_names(registry) == {("test:b", "1.0.0"), ("test:c", "1.0.0")}
+
+    def test_recency_update_preserves_cache_hit(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
+        self.save_cache_entries(registry, entries)
+
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0, 4.0]):
+            registry._touch_cache_entry("test:a", "1.0.0")
+            registry._touch_cache_entry("test:b", "1.0.0")
+            registry._touch_cache_entry("test:a", "1.0.0")
+            registry._touch_cache_entry("test:c", "1.0.0")
+        registry._prune_cache_lru()
+
+        assert self.cache_names(registry) == {("test:a", "1.0.0"), ("test:c", "1.0.0")}
+
+    def test_versions_are_independent_lru_entries(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        entries = [("test:obj", "1.0.0"), ("test:obj", "2.0.0"), ("test:other", "1.0.0")]
+        self.save_cache_entries(registry, entries)
+
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0]):
+            for name, version in entries:
+                registry._touch_cache_entry(name, version)
+        registry._prune_cache_lru()
+
+        assert self.cache_names(registry) == {("test:obj", "2.0.0"), ("test:other", "1.0.0")}
+
+    def test_lru_key_is_stable_json_and_round_trips_colons_and_slashes(self):
+        key = Registry._cache_lru_key("path/to:test", "1.2.3")
+
+        assert json.loads(key) == ["path/to:test", "1.2.3"]
+
+    def test_touch_creates_and_updates_index_entry(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=[10.0, 20.0]):
+            registry._touch_cache_entry("test:obj", "1.0.0")
+            registry._touch_cache_entry("test:obj", "1.0.0")
+
+        index = registry._load_cache_lru_index()
+        entry = index["entries"][Registry._cache_lru_key("test:obj", "1.0.0")]
+        assert entry == {"name": "test:obj", "version": "1.0.0", "last_accessed": 20.0}
+
+    def test_remove_cache_lru_entries_removes_only_requested_entries(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0]):
+            registry._touch_cache_entry("test:a", "1.0.0")
+            registry._touch_cache_entry("test:b", "1.0.0")
+
+        registry._remove_cache_lru_entries([("test:a", "1.0.0")])
+
+        index = registry._load_cache_lru_index()
+        assert Registry._cache_lru_key("test:a", "1.0.0") not in index["entries"]
+        assert Registry._cache_lru_key("test:b", "1.0.0") in index["entries"]
+
+    def test_prune_drops_stale_index_entries_without_deleting_live_cache(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        registry._cache.save("test:live", "live", version="1.0.0")
+        registry._save_cache_lru_index(
+            {
+                "version": 1,
+                "entries": {
+                    Registry._cache_lru_key("test:missing", "1.0.0"): {
+                        "name": "test:missing",
+                        "version": "1.0.0",
+                        "last_accessed": 1.0,
+                    },
+                    Registry._cache_lru_key("test:live", "1.0.0"): {
+                        "name": "test:live",
+                        "version": "1.0.0",
+                        "last_accessed": 2.0,
+                    },
+                },
+            }
+        )
+
+        registry._prune_cache_lru()
+
+        index = registry._load_cache_lru_index()
+        assert set(index["entries"]) == {Registry._cache_lru_key("test:live", "1.0.0")}
+        assert self.cache_names(registry) == {("test:live", "1.0.0")}
+
+    def test_corrupt_index_does_not_break_pruning(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=1)
+        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0")]
+        self.save_cache_entries(registry, entries)
+        registry._cache_lru_index_path().write_text("not json")
+
+        registry._prune_cache_lru()
+
+        assert len(self.cache_names(registry)) == 1
+
+    def test_invalid_index_shape_loads_as_empty_index(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=1)
+        registry._cache_lru_index_path().write_text(json.dumps({"version": 1, "entries": []}))
+
+        assert registry._load_cache_lru_index() == {"version": 1, "entries": {}}
+
+    def test_missing_index_is_rebuilt_from_cache_contents(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=1)
+        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0")]
+        self.save_cache_entries(registry, entries)
+        registry._clear_cache_lru_index()
+
+        registry._prune_cache_lru()
+
+        assert len(self.cache_names(registry)) == 1
+        assert registry._cache_lru_index_path().exists()
+
+    def test_clear_cache_removes_cached_objects_and_lru_index(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        registry._cache.save("test:obj", "value", version="1.0.0")
         registry._touch_cache_entry("test:obj", "1.0.0")
-        registry._touch_cache_entry("test:obj", "2.0.0")
-        registry._touch_cache_entry("test:other", "1.0.0")
+        assert registry._cache_lru_index_path().exists()
 
-    registry._prune_cache_lru()
+        registry.clear_cache()
 
-    assert not registry._cache.has_object("test:obj", "1.0.0")
-    assert registry._cache.has_object("test:obj", "2.0.0")
-    assert registry._cache.has_object("test:other", "1.0.0")
+        assert self.cache_names(registry) == set()
+        assert not registry._cache_lru_index_path().exists()
 
+    def test_clear_removes_lru_index_for_cached_registry(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        registry._cache.save("test:obj", "value", version="1.0.0")
+        registry._touch_cache_entry("test:obj", "1.0.0")
+        registry._remote.clear = Mock()
 
-def test_clear_cache_removes_lru_index(temp_registry_dir):
-    """clear_cache removes cached objects and the LRU sidecar."""
-    mock_backend = Mock(spec=RegistryBackend)
-    mock_backend.uri = Path(temp_registry_dir) / "remote"
-    mock_backend.registered_materializers = Mock(return_value={})
-    mock_backend.fetch_registry_metadata = Mock(return_value={})
+        registry.clear()
 
-    registry = Registry(backend=mock_backend, version_objects=True, cache_max_entries=2)
-    registry._cache.save("test:obj", "value", version="1.0.0")
-    registry._touch_cache_entry("test:obj", "1.0.0")
-    assert registry._cache_lru_index_path().exists()
+        registry._remote.clear.assert_called_once_with(False)
+        assert self.cache_names(registry) == set()
+        assert not registry._cache_lru_index_path().exists()
 
-    registry.clear_cache()
+    def test_local_and_uncached_registries_ignore_lru_helpers(self, temp_registry_dir):
+        local_registry = Registry(backend=temp_registry_dir, cache_max_entries=1)
+        assert local_registry._cached is False
+        assert local_registry._cache_max_entries == 1
 
-    assert not registry._cache.has_object("test:obj", "1.0.0")
-    assert not registry._cache_lru_index_path().exists()
+        uncached_remote = self.make_remote_registry(temp_registry_dir, use_cache=False, cache_max_entries=1)
+        assert uncached_remote._cached is False
+        assert uncached_remote._cache_max_entries == 1
+        assert uncached_remote._load_cache_lru_index() == {"version": 1, "entries": {}}
+        uncached_remote._save_cache_lru_index({"version": 1, "entries": {}})
+        uncached_remote._clear_cache_lru_index()
 
+    def test_load_cache_hit_touches_lru_entry(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        registry._cache.save("test:obj", "value", version="1.0.0")
+        registry._remote._latest = Mock(return_value="1.0.0")
 
-def test_cache_lru_ignored_for_uncached_registries(temp_registry_dir):
-    """cache_max_entries does not enable caching for local or explicitly uncached registries."""
-    local_registry = Registry(backend=temp_registry_dir, cache_max_entries=1)
-    assert local_registry._cached is False
-    assert local_registry._cache_max_entries == 1
+        with patch("mindtrace.registry.core.registry.time.time", return_value=123.0):
+            assert registry._load_single_cached("test:obj", "1.0.0") == "value"
 
-    mock_backend = Mock(spec=RegistryBackend)
-    mock_backend.uri = Path(temp_registry_dir) / "remote"
-    mock_backend.registered_materializers = Mock(return_value={})
-    mock_backend.fetch_registry_metadata = Mock(return_value={})
+        index = registry._load_cache_lru_index()
+        assert index["entries"][Registry._cache_lru_key("test:obj", "1.0.0")]["last_accessed"] == 123.0
 
-    uncached_remote = Registry(backend=mock_backend, use_cache=False, cache_max_entries=1)
-    assert uncached_remote._cached is False
-    assert uncached_remote._cache_max_entries == 1
+    def test_batch_cache_hits_touch_all_lru_entries(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0")]
+        self.save_cache_entries(registry, entries)
+        registry._remote._resolve_load_version = Mock(side_effect=lambda name, version: version)
 
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=[11.0, 22.0]):
+            result = registry._load_batch_cached(["test:a", "test:b"], ["1.0.0", "1.0.0"])
 
-def test_cache_lru_corrupt_index_does_not_break_pruning(temp_registry_dir):
-    """A corrupt LRU sidecar is ignored and rebuilt from cache contents."""
-    mock_backend = Mock(spec=RegistryBackend)
-    mock_backend.uri = Path(temp_registry_dir) / "remote"
-    mock_backend.registered_materializers = Mock(return_value={})
-    mock_backend.fetch_registry_metadata = Mock(return_value={})
+        assert result.results == ["test:a@1.0.0", "test:b@1.0.0"]
+        index = registry._load_cache_lru_index()
+        assert index["entries"][Registry._cache_lru_key("test:a", "1.0.0")]["last_accessed"] == 11.0
+        assert index["entries"][Registry._cache_lru_key("test:b", "1.0.0")]["last_accessed"] == 22.0
 
-    registry = Registry(backend=mock_backend, version_objects=True, cache_max_entries=1)
-    registry._cache.save("test:a", "a", version="1.0.0")
-    registry._cache.save("test:b", "b", version="1.0.0")
-    registry._cache_lru_index_path().write_text("not json")
+    def test_save_cache_update_prunes_after_remote_save(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=1)
+        registry._remote.save = Mock(side_effect=["1.0.0", "1.0.0"])
 
-    registry._prune_cache_lru()
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0]):
+            registry.save("test:a", "a", version="1.0.0")
+            registry.save("test:b", "b", version="1.0.0")
 
-    remaining = [
-        registry._cache.has_object("test:a", "1.0.0"),
-        registry._cache.has_object("test:b", "1.0.0"),
-    ]
-    assert remaining.count(True) == 1
+        assert self.cache_names(registry) == {("test:b", "1.0.0")}
+
+    def test_delete_removes_cache_and_lru_entry(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        registry._remote.delete = Mock(return_value=None)
+        registry._cache.save("test:obj", "value", version="1.0.0")
+        registry._touch_cache_entry("test:obj", "1.0.0")
+
+        registry.delete("test:obj", "1.0.0")
+
+        assert self.cache_names(registry) == set()
+        assert registry._load_cache_lru_index()["entries"] == {}
+
+    def test_delete_all_versions_removes_all_cache_and_lru_entries_for_name(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=3)
+        registry._remote.delete = Mock(return_value=None)
+        entries = [("test:obj", "1.0.0"), ("test:obj", "2.0.0"), ("test:other", "1.0.0")]
+        self.save_cache_entries(registry, entries)
+        with patch("mindtrace.registry.core.registry.time.time", side_effect=[1.0, 2.0, 3.0]):
+            for name, version in entries:
+                registry._touch_cache_entry(name, version)
+
+        registry.delete("test:obj")
+
+        assert self.cache_names(registry) == {("test:other", "1.0.0")}
+        index = registry._load_cache_lru_index()
+        assert set(index["entries"]) == {Registry._cache_lru_key("test:other", "1.0.0")}
 
 
 def _make_op_results(*results: OpResult) -> OpResults:

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -3236,9 +3236,7 @@ class TestRegistryCacheLRU:
     def test_prune_warns_and_continues_when_cache_delete_raises(self, temp_registry_dir):
         # buffer=0 so prune target is exactly cache_max_entries (default buffer would
         # target max - buffer and over-evict after a failed delete on the LRU entry).
-        registry = self.make_remote_registry(
-            temp_registry_dir, cache_max_entries=2, cache_prune_buffer=0
-        )
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2, cache_prune_buffer=0)
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
         self.save_cache_entries(registry, entries)
         for timestamp, (name, version) in enumerate(entries, start=1):

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 import threading
@@ -2886,13 +2885,23 @@ class TestRegistryCacheLRU:
         for name, version in entries:
             registry._cache.save(name, f"{name}@{version}", version=version)
 
+    @staticmethod
+    def set_cache_mtime(registry, name, version, timestamp):
+        """Set cached metadata mtime for deterministic LRU assertions."""
+        metadata_path = registry._cache.backend._object_metadata_path(name, version)
+        os.utime(metadata_path, (timestamp, timestamp))
+
+    @staticmethod
+    def cache_mtime(registry, name, version):
+        """Return cached metadata mtime."""
+        return registry._cache.backend._object_metadata_path(name, version).stat().st_mtime
+
     def test_default_cache_max_entries_is_1024(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir)
 
         assert registry._cached is True
         assert registry._cache_max_entries == 1024
         assert registry._cache_prune_buffer == 256
-        assert registry._cache_scope == "shared"
 
     def test_non_positive_cache_max_entries_is_rejected(self, temp_registry_dir):
         with pytest.raises(ValueError, match="cache_max_entries"):
@@ -2914,73 +2923,84 @@ class TestRegistryCacheLRU:
         with pytest.raises(ValueError, match="cache_prune_buffer"):
             self.make_remote_registry(temp_registry_dir, cache_max_entries=10, cache_prune_buffer=-1)
 
-    def test_cache_scope_process_uses_process_specific_cache_dir(self, temp_registry_dir):
-        shared = self.make_remote_registry(temp_registry_dir, cache_scope="shared")
-        process = self.make_remote_registry(temp_registry_dir, cache_scope="process")
+    def test_cache_dir_is_deterministic_per_backend_uri(self, temp_registry_dir):
+        first = self.make_remote_registry(temp_registry_dir)
+        second = self.make_remote_registry(temp_registry_dir)
 
-        assert shared._cache_scope == "shared"
-        assert process._cache_scope == "process"
-        assert shared._cache.backend.uri != process._cache.backend.uri
-        assert f"pid_{os.getpid()}" in str(process._cache.backend.uri)
+        assert first._cache.backend.uri == second._cache.backend.uri
 
-    def test_invalid_cache_scope_is_rejected(self, temp_registry_dir):
-        with pytest.raises(ValueError, match="cache_scope"):
-            self.make_remote_registry(temp_registry_dir, cache_scope="worker")
-
-    def test_shared_cache_file_lock_degrades_when_platform_locking_unavailable(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_scope="shared")
-
-        with patch("mindtrace.registry.core.registry._fcntl", None):
-            with patch("mindtrace.registry.core.registry._msvcrt", None):
-                with registry._cache_lru_file_lock():
-                    assert registry._cache_lru_lock_path().exists()
-
-    def test_process_cache_scope_skips_file_lock_creation(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_scope="process")
-
-        with registry._cache_lru_file_lock():
-            pass
-
-        assert not registry._cache_lru_lock_path().exists()
-
-    def test_none_cache_max_entries_disables_lru_sidecar_and_pruning(self, temp_registry_dir):
+    def test_none_cache_max_entries_disables_lru_touch_and_pruning(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=None)
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
         self.save_cache_entries(registry, entries)
+        before = self.cache_mtime(registry, "test:a", "1.0.0")
 
-        for name, version in entries:
-            registry._touch_cache_entry(name, version)
+        registry._touch_cache_entry("test:a", "1.0.0")
         registry._prune_cache_lru()
 
         assert self.cache_names(registry) == set(entries)
-        assert not registry._cache_lru_index_path().exists()
+        assert self.cache_mtime(registry, "test:a", "1.0.0") == before
 
-    def test_prune_keeps_most_recent_entries(self, temp_registry_dir):
+    def test_touch_updates_cached_metadata_mtime(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        self.save_cache_entries(registry, [("test:obj", "1.0.0")])
+        self.set_cache_mtime(registry, "test:obj", "1.0.0", 100.0)
+
+        registry._touch_cache_entry("test:obj", "1.0.0")
+
+        assert self.cache_mtime(registry, "test:obj", "1.0.0") >= 100.0
+
+    def test_touch_swallows_metadata_update_failure(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
+        with patch.object(registry._cache.backend, "_object_metadata_path", side_effect=OSError("missing")):
+            registry._touch_cache_entry("test:missing", "1.0.0")
+
+    def test_list_cache_lru_entries_uses_metadata_mtime(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=8)
+        self.save_cache_entries(registry, [("test:obj", "1.0.0")])
+        self.set_cache_mtime(registry, "test:obj", "1.0.0", 123.0)
+
+        entries = registry._list_cache_lru_entries()
+
+        assert entries == [{"name": "test:obj", "version": "1.0.0", "last_accessed": 123.0}]
+
+    def test_list_cache_lru_entries_falls_back_when_stat_fails(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=8)
+        registry._cache.save("test:stat", "x", version="1.0.0")
+        bad_meta = MagicMock()
+        bad_meta.stat.side_effect = OSError("no stat")
+        with patch.object(registry._cache.backend, "_object_metadata_path", return_value=bad_meta):
+            with patch("mindtrace.registry.core.registry.time.time", return_value=999.0):
+                entries = registry._list_cache_lru_entries()
+
+        assert entries == [{"name": "test:stat", "version": "1.0.0", "last_accessed": 999.0}]
+
+    def test_list_cache_lru_entries_swallows_list_objects_failure(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=8)
+        with patch.object(registry._cache, "list_objects", side_effect=RuntimeError("boom")):
+            assert registry._list_cache_lru_entries() == []
+
+    def test_prune_keeps_most_recent_metadata_mtimes(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=3, cache_prune_buffer=1)
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0"), ("test:d", "1.0.0")]
         self.save_cache_entries(registry, entries)
+        for timestamp, (name, version) in enumerate(entries, start=1):
+            self.set_cache_mtime(registry, name, version, float(timestamp))
 
-        with patch(
-            "mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(1.0, 2.0, 3.0)
-        ):
-            for name, version in entries:
-                registry._touch_cache_entry(name, version)
         registry._prune_cache_lru()
 
         assert self.cache_names(registry) == {("test:c", "1.0.0"), ("test:d", "1.0.0")}
+        assert registry._cache_lru_estimated_entries == 2
 
     def test_recency_update_preserves_cache_hit(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2, cache_prune_buffer=0)
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
         self.save_cache_entries(registry, entries)
+        self.set_cache_mtime(registry, "test:a", "1.0.0", 1.0)
+        self.set_cache_mtime(registry, "test:b", "1.0.0", 2.0)
+        self.set_cache_mtime(registry, "test:c", "1.0.0", 3.0)
+        registry._touch_cache_entry("test:a", "1.0.0")
 
-        with patch(
-            "mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(1.0, 2.0, 3.0, 4.0)
-        ):
-            registry._touch_cache_entry("test:a", "1.0.0")
-            registry._touch_cache_entry("test:b", "1.0.0")
-            registry._touch_cache_entry("test:a", "1.0.0")
-            registry._touch_cache_entry("test:c", "1.0.0")
         registry._prune_cache_lru()
 
         assert self.cache_names(registry) == {("test:a", "1.0.0"), ("test:c", "1.0.0")}
@@ -2989,136 +3009,34 @@ class TestRegistryCacheLRU:
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2, cache_prune_buffer=0)
         entries = [("test:obj", "1.0.0"), ("test:obj", "2.0.0"), ("test:other", "1.0.0")]
         self.save_cache_entries(registry, entries)
+        for timestamp, (name, version) in enumerate(entries, start=1):
+            self.set_cache_mtime(registry, name, version, float(timestamp))
 
-        with patch(
-            "mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(1.0, 2.0, 3.0)
-        ):
-            for name, version in entries:
-                registry._touch_cache_entry(name, version)
         registry._prune_cache_lru()
 
         assert self.cache_names(registry) == {("test:obj", "2.0.0"), ("test:other", "1.0.0")}
 
-    def test_lru_key_is_stable_json_and_round_trips_colons_and_slashes(self):
-        key = Registry._cache_lru_key("path/to:test", "1.2.3")
-
-        assert json.loads(key) == ["path/to:test", "1.2.3"]
-
-    def test_touch_records_dirty_entry_without_writing_sidecar(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
-
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(10.0, 20.0)):
-            registry._touch_cache_entry("test:obj", "1.0.0")
-            registry._touch_cache_entry("test:obj", "1.0.0")
-
-        assert not registry._cache_lru_index_path().exists()
-        entry = registry._cache_lru_dirty[Registry._cache_lru_key("test:obj", "1.0.0")]
-        assert entry == {"name": "test:obj", "version": "1.0.0", "last_accessed": 20.0}
-
-    def test_remove_cache_lru_entries_removes_only_requested_entries(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
-        registry._save_cache_lru_index(
-            {
-                "version": 1,
-                "entries": {
-                    Registry._cache_lru_key("test:a", "1.0.0"): {
-                        "name": "test:a",
-                        "version": "1.0.0",
-                        "last_accessed": 1.0,
-                    },
-                    Registry._cache_lru_key("test:b", "1.0.0"): {
-                        "name": "test:b",
-                        "version": "1.0.0",
-                        "last_accessed": 2.0,
-                    },
-                },
-            }
-        )
-
-        registry._remove_cache_lru_entries([("test:a", "1.0.0")])
-
-        index = registry._load_cache_lru_index()
-        assert Registry._cache_lru_key("test:a", "1.0.0") not in index["entries"]
-        assert Registry._cache_lru_key("test:b", "1.0.0") in index["entries"]
-
-    def test_prune_drops_stale_index_entries_without_deleting_live_cache(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
-        registry._cache.save("test:live", "live", version="1.0.0")
-        registry._save_cache_lru_index(
-            {
-                "version": 1,
-                "entries": {
-                    Registry._cache_lru_key("test:missing", "1.0.0"): {
-                        "name": "test:missing",
-                        "version": "1.0.0",
-                        "last_accessed": 1.0,
-                    },
-                    Registry._cache_lru_key("test:live", "1.0.0"): {
-                        "name": "test:live",
-                        "version": "1.0.0",
-                        "last_accessed": 2.0,
-                    },
-                },
-            }
-        )
-
-        registry._prune_cache_lru()
-
-        index = registry._load_cache_lru_index()
-        assert set(index["entries"]) == {Registry._cache_lru_key("test:live", "1.0.0")}
-        assert self.cache_names(registry) == {("test:live", "1.0.0")}
-
-    def test_corrupt_index_does_not_break_pruning(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=1)
-        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0")]
-        self.save_cache_entries(registry, entries)
-        registry._cache_lru_index_path().write_text("not json")
-
-        registry._prune_cache_lru()
-
-        assert len(self.cache_names(registry)) == 1
-
-    def test_invalid_index_shape_loads_as_empty_index(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=1)
-        registry._cache_lru_index_path().write_text(json.dumps({"version": 1, "entries": []}))
-
-        assert registry._load_cache_lru_index() == {"version": 1, "entries": {}}
-
-    def test_missing_index_is_rebuilt_from_cache_contents(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=1)
-        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0")]
-        self.save_cache_entries(registry, entries)
-        registry._clear_cache_lru_index()
-
-        registry._prune_cache_lru()
-
-        assert len(self.cache_names(registry)) == 1
-        assert registry._cache_lru_index_path().exists()
-
-    def test_clear_cache_removes_cached_objects_and_lru_index(self, temp_registry_dir):
+    def test_clear_cache_removes_cached_objects_and_resets_estimate(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
         registry._cache.save("test:obj", "value", version="1.0.0")
-        registry._touch_cache_entry("test:obj", "1.0.0")
-        registry._prune_cache_lru()
-        assert registry._cache_lru_index_path().exists()
+        registry._cache_lru_estimated_entries = 1
 
         registry.clear_cache()
 
         assert self.cache_names(registry) == set()
-        assert not registry._cache_lru_index_path().exists()
+        assert registry._cache_lru_estimated_entries == 0
 
-    def test_clear_removes_lru_index_for_cached_registry(self, temp_registry_dir):
+    def test_clear_removes_cache_for_cached_registry_and_resets_estimate(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
         registry._cache.save("test:obj", "value", version="1.0.0")
-        registry._touch_cache_entry("test:obj", "1.0.0")
-        registry._prune_cache_lru()
+        registry._cache_lru_estimated_entries = 1
         registry._remote.clear = Mock()
 
         registry.clear()
 
         registry._remote.clear.assert_called_once_with(False)
         assert self.cache_names(registry) == set()
-        assert not registry._cache_lru_index_path().exists()
+        assert registry._cache_lru_estimated_entries == 0
 
     def test_local_and_uncached_registries_ignore_lru_helpers(self, temp_registry_dir):
         local_registry = Registry(backend=temp_registry_dir, cache_max_entries=1)
@@ -3128,50 +3046,38 @@ class TestRegistryCacheLRU:
         uncached_remote = self.make_remote_registry(temp_registry_dir, use_cache=False, cache_max_entries=1)
         assert uncached_remote._cached is False
         assert uncached_remote._cache_max_entries == 1
-        assert uncached_remote._load_cache_lru_index() == {"version": 1, "entries": {}}
-        uncached_remote._save_cache_lru_index({"version": 1, "entries": {}})
-        uncached_remote._clear_cache_lru_index()
+        assert uncached_remote._list_cache_lru_entries() == []
 
     def test_load_cache_hit_touches_lru_entry(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
         registry._cache.save("test:obj", "value", version="1.0.0")
         registry._remote._latest = Mock(return_value="1.0.0")
+        self.set_cache_mtime(registry, "test:obj", "1.0.0", 100.0)
 
-        # INTEGRITY avoids FULL staleness (remote mock has no matching metadata hashes).
-        with patch("mindtrace.registry.core.registry.time.time", return_value=123.0):
-            assert registry._load_single_cached("test:obj", "1.0.0", verify=VerifyLevel.INTEGRITY) == "value"
+        assert registry._load_single_cached("test:obj", "1.0.0", verify=VerifyLevel.INTEGRITY) == "value"
 
-        dirty = registry._cache_lru_dirty
-        assert dirty[Registry._cache_lru_key("test:obj", "1.0.0")]["last_accessed"] == 123.0
+        assert self.cache_mtime(registry, "test:obj", "1.0.0") >= 100.0
 
     def test_batch_cache_hits_touch_all_lru_entries(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0")]
         self.save_cache_entries(registry, entries)
+        for name, version in entries:
+            self.set_cache_mtime(registry, name, version, 100.0)
         registry._remote._resolve_load_version = Mock(side_effect=lambda name, version: version)
 
         result = registry._load_batch_cached(["test:a", "test:b"], ["1.0.0", "1.0.0"], verify=VerifyLevel.INTEGRITY)
 
         assert result.results == ["test:a@1.0.0", "test:b@1.0.0"]
-        key_a = Registry._cache_lru_key("test:a", "1.0.0")
-        key_b = Registry._cache_lru_key("test:b", "1.0.0")
-        dirty = registry._cache_lru_dirty
-        assert key_a in dirty
-        assert key_b in dirty
-        # `_touch_cache_entry` runs in batch order for cache hits; recency timestamps should
-        # reflect that ordering (later touch >= earlier; typically strict on real clocks).
-        assert dirty[key_a]["last_accessed"] <= dirty[key_b]["last_accessed"]
+        for name, version in entries:
+            assert self.cache_mtime(registry, name, version) >= 100.0
 
     def test_save_cache_update_prunes_after_remote_save(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=1)
         registry._remote.save = Mock(side_effect=["1.0.0", "1.0.0"])
 
-        with patch(
-            "mindtrace.registry.core.registry.time.time",
-            side_effect=_patch_registry_time_sequence(1.0, 2.0),
-        ):
-            registry.save("test:a", "a", version="1.0.0")
-            registry.save("test:b", "b", version="1.0.0")
+        registry.save("test:a", "a", version="1.0.0")
+        registry.save("test:b", "b", version="1.0.0")
 
         assert self.cache_names(registry) == {("test:b", "1.0.0")}
 
@@ -3234,59 +3140,13 @@ class TestRegistryCacheLRU:
         assert registry._cache_lru_estimated_entries == 4
         pruner.assert_called_once_with()
 
-    def test_prune_noops_below_max_but_flushes_dirty_touches(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=4)
-        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0")]
-        self.save_cache_entries(registry, entries)
-        with patch("mindtrace.registry.core.registry.time.time", side_effect=_patch_registry_time_sequence(10.0, 20.0)):
-            for name, version in entries:
-                registry._touch_cache_entry(name, version)
-
-        registry._prune_cache_lru()
-
-        assert self.cache_names(registry) == set(entries)
-        assert registry._cache_lru_dirty == {}
-        assert registry._cache_lru_estimated_entries == 2
-        index = registry._load_cache_lru_index()
-        assert index["entries"][Registry._cache_lru_key("test:a", "1.0.0")]["last_accessed"] == 10.0
-        assert index["entries"][Registry._cache_lru_key("test:b", "1.0.0")]["last_accessed"] == 20.0
-
-    def test_remove_cache_lru_entries_clears_dirty_without_sidecar_row(self, temp_registry_dir):
+    def test_remove_cache_lru_entries_decrements_estimate(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
-        registry._touch_cache_entry("test:dirty", "1.0.0")
+        registry._cache_lru_estimated_entries = 2
 
-        registry._remove_cache_lru_entries([("test:dirty", "1.0.0")])
+        registry._remove_cache_lru_entries([("test:dirty", "1.0.0"), ("test:dirty", "1.0.0")])
 
-        assert registry._cache_lru_dirty == {}
-
-    def test_registry_get_cache_dir_rejects_invalid_cache_scope(self):
-        """Defense-in-depth: callers must pass ``cache_scope='shared'`` or ``'process'``."""
-        with pytest.raises(ValueError, match="cache_scope"):
-            Registry._get_cache_dir("mock://backend", cache_scope="invalid-scope")
-
-    def test_save_cache_lru_index_best_effort_unlink_after_failed_replace(self, temp_registry_dir):
-        """If rename fails after writing the temporary sidecar, cleanup unlink errors are swallowed."""
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
-
-        def synthetic_replace(self_inner: Path, target: Path, **_kwargs):  # type: ignore[misc]
-            raise OSError("simulated rename failure")
-
-        unlink_attempts_on_tmp = []
-
-        original_unlink = Path.unlink
-
-        def unlink_maybe_fail(self_inner: Path, missing_ok: bool = False):
-            stem = self_inner.name
-            if stem.endswith(".tmp") and ".registry_cache_lru.json." in stem:
-                unlink_attempts_on_tmp.append(self_inner.name)
-                if len(unlink_attempts_on_tmp) == 1:
-                    raise RuntimeError("simulated unlink failure")
-            return original_unlink(self_inner, missing_ok=missing_ok)
-
-        with patch.object(Path, "replace", synthetic_replace):
-            with patch.object(Path, "unlink", unlink_maybe_fail):
-                registry._save_cache_lru_index({"version": 1, "entries": {}})
-        assert len(unlink_attempts_on_tmp) == 1
+        assert registry._cache_lru_estimated_entries == 1
 
     def test_note_cache_entries_added_noop_when_count_not_positive(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=10)
@@ -3350,181 +3210,35 @@ class TestRegistryCacheLRU:
         assert registry._cache_lru_estimated_entries == 2
         pruner.assert_called_once_with()
 
-    def test_maybe_prune_noops_when_uncached(self, temp_registry_dir):
-        uncached = self.make_remote_registry(temp_registry_dir, use_cache=False)
-
-        with patch.object(uncached, "_prune_cache_lru") as pruner:
-            uncached._maybe_prune_cache_lru()
-
-        pruner.assert_not_called()
-
-    def test_maybe_prune_noops_when_lru_disabled(self, temp_registry_dir):
-        no_cap = self.make_remote_registry(temp_registry_dir, cache_max_entries=None)
-
-        with patch.object(no_cap, "_prune_cache_lru") as pruner:
-            no_cap._maybe_prune_cache_lru()
-
-        pruner.assert_not_called()
-
-    def test_prune_reduces_to_max_minus_buffer_and_updates_estimate(self, temp_registry_dir):
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=4, cache_prune_buffer=2)
-        entries = [(f"test:{idx}", "1.0.0") for idx in range(6)]
-        self.save_cache_entries(registry, entries)
-        with patch(
-            "mindtrace.registry.core.registry.time.time",
-            side_effect=_patch_registry_time_sequence(1.0, 2.0, 3.0, 4.0, 5.0, 6.0),
-        ):
-            for name, version in entries:
-                registry._touch_cache_entry(name, version)
-
-        registry._prune_cache_lru()
-
-        assert self.cache_names(registry) == {("test:4", "1.0.0"), ("test:5", "1.0.0")}
-        assert registry._cache_lru_estimated_entries == 2
-        assert registry._cache_lru_dirty == {}
-
-    def test_prune_counts_cache_entries_missing_from_partial_sidecar(self, temp_registry_dir):
-        """Rebuild sees all on-disk objects; a partial sidecar must not drop unknown keys from disk.
-
-        Sidecar ``last_accessed`` must be comparable to rebuild's mtime-based timestamps
-        (both are wall-clock style floats); a small constant like ``3.0`` is incorrectly
-        interpreted as ancient next to ``st_mtime``.
-        """
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2, cache_prune_buffer=0)
-        entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
-        self.save_cache_entries(registry, entries)
-        mtime_floor = max(registry._cache.backend._object_metadata_path(n, v).stat().st_mtime for n, v in entries)
-        registry._save_cache_lru_index(
-            {
-                "version": 1,
-                "entries": {
-                    Registry._cache_lru_key("test:c", "1.0.0"): {
-                        "name": "test:c",
-                        "version": "1.0.0",
-                        "last_accessed": mtime_floor + 3600.0,
-                    }
-                },
-            }
-        )
-
-        registry._prune_cache_lru()
-
-        assert len(self.cache_names(registry)) == 2
-        assert ("test:c", "1.0.0") in self.cache_names(registry)
-
-    def test_delete_removes_cache_and_lru_entry(self, temp_registry_dir):
+    def test_delete_removes_cache_and_decrements_lru_estimate(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
         registry._remote.delete = Mock(return_value=None)
         registry._cache.save("test:obj", "value", version="1.0.0")
-        registry._touch_cache_entry("test:obj", "1.0.0")
+        registry._cache_lru_estimated_entries = 1
 
         registry.delete("test:obj", "1.0.0")
 
         assert self.cache_names(registry) == set()
-        assert registry._load_cache_lru_index()["entries"] == {}
+        assert registry._cache_lru_estimated_entries == 0
 
-    def test_delete_all_versions_removes_all_cache_and_lru_entries_for_name(self, temp_registry_dir):
+    def test_delete_all_versions_removes_all_cache_entries_for_name(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=3)
         registry._remote.delete = Mock(return_value=None)
         entries = [("test:obj", "1.0.0"), ("test:obj", "2.0.0"), ("test:other", "1.0.0")]
         self.save_cache_entries(registry, entries)
-        with patch(
-            "mindtrace.registry.core.registry.time.time",
-            side_effect=_patch_registry_time_sequence(1.0, 2.0, 3.0),
-        ):
-            for name, version in entries:
-                registry._touch_cache_entry(name, version)
-        registry._prune_cache_lru()
+        registry._cache_lru_estimated_entries = 3
 
         registry.delete("test:obj")
 
         assert self.cache_names(registry) == {("test:other", "1.0.0")}
-        index = registry._load_cache_lru_index()
-        assert set(index["entries"]) == {Registry._cache_lru_key("test:other", "1.0.0")}
-
-    def test_save_cache_lru_index_swallows_dump_failure(self, temp_registry_dir):
-        """``_save_cache_lru_index`` logs and ignores IO errors from ``json.dump``."""
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
-        with patch("mindtrace.registry.core.registry.json.dump", side_effect=OSError("disk full")):
-            registry._save_cache_lru_index({"version": 1, "entries": {}})
-
-    def test_clear_cache_lru_index_swallows_unlink_failure(self, temp_registry_dir):
-        """``_clear_cache_lru_index`` tolerates ``unlink`` raising."""
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
-        mock_path = MagicMock()
-        mock_path.unlink.side_effect = OSError("permission denied")
-        with patch.object(registry, "_cache_lru_index_path", return_value=mock_path):
-            registry._clear_cache_lru_index()
-        mock_path.unlink.assert_called_once_with(missing_ok=True)
-
-    def test_rebuild_cache_lru_index_empty_when_registry_not_cached(self, temp_registry_dir):
-        """Uncached registries return an empty index without touching ``_cache``."""
-        uncached = self.make_remote_registry(temp_registry_dir, use_cache=False, cache_max_entries=2)
-        assert uncached._rebuild_cache_lru_index() == {"version": 1, "entries": {}}
-
-    def test_rebuild_cache_lru_index_uses_mtime_or_falls_back_when_stat_fails(self, temp_registry_dir):
-        """If metadata ``stat`` fails, rebuild still records the object using ``time.time()``."""
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=8)
-        registry._cache.save("test:stat", "x", version="1.0.0")
-        bad_meta = MagicMock()
-        bad_meta.stat.side_effect = OSError("no stat")
-        with patch.object(registry._cache.backend, "_object_metadata_path", return_value=bad_meta):
-            with patch("mindtrace.registry.core.registry.time.time", return_value=999.0):
-                idx = registry._rebuild_cache_lru_index()
-
-        entry = idx["entries"][Registry._cache_lru_key("test:stat", "1.0.0")]
-        assert entry["name"] == "test:stat"
-        assert entry["version"] == "1.0.0"
-        assert entry["last_accessed"] == 999.0
-
-    def test_rebuild_cache_lru_index_swallows_list_objects_failure(self, temp_registry_dir):
-        """Rebuild returns the default shell if enumerating cached objects blows up."""
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=8)
-        with patch.object(registry._cache, "list_objects", side_effect=RuntimeError("boom")):
-            assert registry._rebuild_cache_lru_index() == {"version": 1, "entries": {}}
-
-    def test_prune_skips_malformed_lru_index_entries(self, temp_registry_dir):
-        """Non-string ``name``/``version`` in the sidecar are ignored during pruning."""
-        registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=1)
-        registry._cache.save("test:x", "x", version="1.0.0")
-        registry._cache.save("test:y", "y", version="1.0.0")
-        registry._save_cache_lru_index(
-            {
-                "version": 1,
-                "entries": {
-                    "not-a-valid-key-shape": {
-                        "name": 123,
-                        "version": "1.0.0",
-                        "last_accessed": 0.0,
-                    },
-                    Registry._cache_lru_key("test:x", "1.0.0"): {
-                        "name": "test:x",
-                        "version": "1.0.0",
-                        "last_accessed": 1.0,
-                    },
-                    Registry._cache_lru_key("test:y", "1.0.0"): {
-                        "name": "test:y",
-                        "version": "1.0.0",
-                        "last_accessed": 2.0,
-                    },
-                },
-            }
-        )
-        registry._prune_cache_lru()
-        assert len(self.cache_names(registry)) == 1
-        assert ("test:y", "1.0.0") in self.cache_names(registry)
+        assert registry._cache_lru_estimated_entries == 1
 
     def test_prune_warns_and_continues_when_cache_delete_raises(self, temp_registry_dir):
-        """If eviction ``delete`` fails, prune logs and drops the row from the sidecar."""
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=2)
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]
         self.save_cache_entries(registry, entries)
-        with patch(
-            "mindtrace.registry.core.registry.time.time",
-            side_effect=_patch_registry_time_sequence(1.0, 2.0, 3.0),
-        ):
-            for name, version in entries:
-                registry._touch_cache_entry(name, version)
+        for timestamp, (name, version) in enumerate(entries, start=1):
+            self.set_cache_mtime(registry, name, version, float(timestamp))
 
         real_delete = registry._cache.delete
 
@@ -3536,15 +3250,13 @@ class TestRegistryCacheLRU:
         with patch.object(registry._cache, "delete", side_effect=delete_side_effect):
             registry._prune_cache_lru()
 
-        # Oldest (test:a) delete failed; object may still exist on disk, but index no longer tracks it.
-        index = registry._load_cache_lru_index()
-        assert Registry._cache_lru_key("test:a", "1.0.0") not in index["entries"]
+        assert ("test:a", "1.0.0") in self.cache_names(registry)
+        assert len(self.cache_names(registry)) == 2
+        assert registry._cache_lru_estimated_entries == 2
 
     def test_load_single_cached_valueerror_invokes_lru_removal(self, temp_registry_dir):
-        """Corrupt cache materialization removes artifacts and LRU keys before remote load."""
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=8)
         registry._cache.save("test:corrupt", "cached", version="1.0.0")
-        registry._touch_cache_entry("test:corrupt", "1.0.0")
         registry._remote._latest = Mock(return_value="1.0.0")
         registry._remote.load = Mock(return_value="fresh")
 
@@ -3557,7 +3269,6 @@ class TestRegistryCacheLRU:
         registry._remote.load.assert_called_once()
 
     def test_load_single_cached_valueerror_swallows_delete_cleanup_failure(self, temp_registry_dir):
-        """If cleanup after corrupt cache fails, load still proceeds from remote."""
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=8)
         registry._cache.save("test:corrupt", "cached", version="1.0.0")
         registry._remote._latest = Mock(return_value="1.0.0")

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -2922,6 +2922,22 @@ class TestRegistryCacheLRU:
         with pytest.raises(ValueError, match="cache_scope"):
             self.make_remote_registry(temp_registry_dir, cache_scope="worker")
 
+    def test_shared_cache_file_lock_degrades_when_platform_locking_unavailable(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_scope="shared")
+
+        with patch("mindtrace.registry.core.registry._fcntl", None):
+            with patch("mindtrace.registry.core.registry._msvcrt", None):
+                with registry._cache_lru_file_lock():
+                    assert registry._cache_lru_lock_path().exists()
+
+    def test_process_cache_scope_skips_file_lock_creation(self, temp_registry_dir):
+        registry = self.make_remote_registry(temp_registry_dir, cache_scope="process")
+
+        with registry._cache_lru_file_lock():
+            pass
+
+        assert not registry._cache_lru_lock_path().exists()
+
     def test_none_cache_max_entries_disables_lru_sidecar_and_pruning(self, temp_registry_dir):
         registry = self.make_remote_registry(temp_registry_dir, cache_max_entries=None)
         entries = [("test:a", "1.0.0"), ("test:b", "1.0.0"), ("test:c", "1.0.0")]


### PR DESCRIPTION
## Summary

Closes #467.

This PR adds configurable LRU pruning to the local cache used by remote `Registry` backends, so registry caches no longer grow without bound during normal save/load workflows.

The main changes are:

- add `cache_max_entries` and `cache_prune_buffer` options to `Registry`
- keep at most a configurable number of concrete cached object versions for remote registries
- update cache recency by touching cached object metadata mtimes with `os.utime(...)`
- make cache-hit recency visible across processes that share the same cache directory
- prune by rebuilding the live cache view and sorting cached object versions by metadata `st_mtime`
- avoid LRU estimate drift on overwrite-heavy workloads by counting only genuinely new cache entries
- keep cache cleanup aligned with `clear_cache()`, `clear()`, `delete()`, and corruption recovery paths
- document the new cache controls in the registry README
- expand unit and integration coverage around cache pruning, mtime recency, overwrite accounting, and defensive paths

## What changed

### Configurable LRU limits for remote registry caches

Remote-backed registries now accept cache pruning controls directly on `Registry` construction:

- `cache_max_entries`: maximum number of concrete object versions to retain in the local cache
- `cache_prune_buffer`: how far below the maximum to prune once the cache exceeds the limit

The default behavior keeps remote caches bounded at `1024` concrete object versions. Setting `cache_max_entries=None` disables automatic LRU pruning and preserves unbounded-cache behavior.

### Buffered pruning behavior

Cache pruning is intentionally amortized rather than pruning on every touch.

When cache writes push the estimated cache size above `cache_max_entries`, the cache is pruned back to:

```python
cache_max_entries - cache_prune_buffer
```

If `cache_prune_buffer` is omitted, it defaults to:

```python
min(max(cache_max_entries // 4, 1), 1024)
```

This avoids repeatedly pruning one entry at a time in workloads that save or load many registry objects in bursts.

### Filesystem-backed recency via metadata mtimes

The cache tracks recency per concrete `(name, version)` pair using the cached object metadata file timestamp.

On cache hits and cache fills, the registry touches the cached metadata file:

```python
os.utime(metadata_path, None)
```

Pruning then rebuilds the live cache view from the cache directory and sorts cached entries by metadata `st_mtime`.

This removes the previous sidecar-index approach and makes recency naturally visible across processes sharing the same cache directory.

### Accurate new-entry accounting for cache writes

Cache writes can overwrite an existing cached `(name, version)` without increasing the number of concrete cached entries.

Before updating the local cache, the LRU accounting now preflights existing entries with the cache backend’s batch `has_object(...)` API and increments the estimate only for genuinely new entries. This avoids unnecessary prune work in overwrite-heavy workloads.

### Cache lifecycle cleanup

The LRU estimate is kept aligned with cache lifecycle operations:

- `clear_cache()` clears the local cache and resets the estimate
- `clear()` clears both remote registry contents and local cache state when caching is enabled
- `delete(...)` removes matching local cache entries and decrements the estimate where possible
- corrupted local cache entries are removed from the cache and estimate before being re-downloaded

## General design

The design keeps the registry cache as a best-effort acceleration layer:

1. Remote backends remain authoritative.
2. Cache reads continue to validate according to the existing `verify` behavior.
3. Cache writes happen after successful remote saves/loads.
4. LRU metadata is derived from local cache metadata file mtimes, so the cached object layout stays simple and no sidecar is needed.
5. Pruning rebuilds from the actual local cache before deleting entries, so transient estimate drift does not decide eviction by itself.
6. Any metadata timestamp/stat issue is logged at debug level and degrades to a safe fallback timestamp/default path.

The result is a bounded cache for common remote-registry usage without making cache metadata part of the remote registry contract.

## Validation / coverage added

This branch adds or expands coverage for:

- constructor validation for cache limits
- deterministic shared cache directory behavior
- max-entry LRU pruning on remote cache fills
- buffered pruning behavior once the cache exceeds the configured maximum
- cache-hit recency updates via cached metadata mtimes
- pruning by metadata `st_mtime`
- stat/touch/list failure tolerance in LRU helpers
- overwrite-heavy save paths that should not inflate the estimated cache count
- shared-cache clear/delete paths that keep the estimate in sync
- integration-style S3 cache behavior around LRU pruning

Relevant touched test areas include:

- `tests/unit/mindtrace/registry/core/test_registry.py`
- `tests/integration/mindtrace/registry/core/test_registry_cache_integration.py`

## Tests

Both unit and integration tests have been added and should all pass.

- `ds test: --unit` should have **99% coverage**

## Example snippets

Below are compact examples for the new user-facing cache controls.

### Default bounded cache

Remote registries keep a bounded local cache by default:

```python
from mindtrace.registry import Registry

registry = Registry(
    backend=remote_backend,
    use_cache=True,
)

# Defaults:
# cache_max_entries = 1024
# cache_prune_buffer = min(max(1024 // 4, 1), 1024) == 256
```

### Custom cache size

Use `cache_max_entries` to tune the number of concrete object versions retained locally:

```python
registry = Registry(
    backend=remote_backend,
    use_cache=True,
    cache_max_entries=10_000,
)
```

### Custom prune buffer

Use `cache_prune_buffer` to control how much headroom pruning creates after the cache exceeds the maximum:

```python
registry = Registry(
    backend=remote_backend,
    use_cache=True,
    cache_max_entries=1_000,
    cache_prune_buffer=250,
)

# Once the cache grows past 1,000 entries, it prunes back toward 750.
```

### Disable automatic pruning

Set `cache_max_entries=None` to keep the cache unbounded:

```python
registry = Registry(
    backend=remote_backend,
    use_cache=True,
    cache_max_entries=None,
)
```

### Cache recency from normal registry operations

Callers do not need to manage recency directly. Normal cache-aware registry operations update the cached object metadata `mtime`:

```python
registry.save("models:classifier", model, version="1")
registry.load("models:classifier", version="1")
registry.load(["models:classifier", "models:segmenter"], version=["1", "3"])
```

## Notable commits

- `68e088ac` — `feat(registry): add max-entry LRU cache pruning`
- `5644c7e3` — `test(registry): cover max-entry cache LRU`
- `e83624c7` — `test(registry): expand LRU cache unit coverage`
- `00c1f196` — `test(registry): fix LRU unit mocks and add S3 cache integration suite`
- `2d0b886c` — `test(registry): extend LRU unit tests for defensive cache index paths`
- `d5b954cd` — `feat(registry): buffer remote cache LRU pruning`
- `201daca0` — `fix(registry): guard shared cache clears`
- `56639529` — `test(registry): cover buffered cache LRU pruning`
- `e928a3fc` — `test(registry): expand buffered LRU cache coverage`
- `40a57b4e` — `fix(registry): make cache file locking portable`
- `19d54074` — `test(registry): align partial LRU sidecar recency with mtime prune sort`
- `93428b9e` — `refactor(registry): route vault serialization via _RegistryCore`
- `d4c76b8d` — `fix(registry): keep serialization API aligned with dev for LRU PR`
- `c8c3c1d4` — `fix(registry): avoid LRU estimate drift on cache overwrites`
- `00c6f007` — `refactor(registry): use metadata mtimes for cache LRU`

## Notes

- This PR focuses only on local cache retention for remote registry backends.
- LRU pruning operates on concrete cached object versions, not logical object names.
- The remote registry remains authoritative; cache recency is local and best-effort.
- Cache recency is based on cached metadata file `mtime`, making it visible across processes that share the same local cache directory.
