### PR TITLE
fix: rstrip trailing slash when appending paths to service URLs

### DIFF
--- a/mindtrace/cluster/mindtrace/cluster/core/cluster.py
+++ b/mindtrace/cluster/mindtrace/cluster/core/cluster.py
@@ -324,7 +324,7 @@ class ClusterManager(Gateway):
         job_status = cluster_types.JobStatus(
             job_id=job.id, status=cluster_types.JobStatusEnum.RUNNING, output={}, worker_id=endpoint, job=job
         )
-        endpoint_url = f"{self._url}{endpoint}"
+        endpoint_url = f"{str(self._url).rstrip('/')}/{endpoint.lstrip('/')}"
         self.job_status_database.insert(job_status)
         self.logger.info(f"Submitted job {job.id} to {endpoint_url}")
 

--- a/mindtrace/services/mindtrace/services/core/service.py
+++ b/mindtrace/services/mindtrace/services/core/service.py
@@ -227,7 +227,7 @@ class Service(Mindtrace):
         """
         url = parse_url(url) if isinstance(url, str) else url
         try:
-            response = requests.request("POST", str(url) + "/status", timeout=timeout)
+            response = requests.request("POST", str(url).rstrip("/") + "/status", timeout=timeout)
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             return ServerStatus.DOWN
         if response.status_code != 200:

--- a/mindtrace/services/mindtrace/services/discord/discord_service.py
+++ b/mindtrace/services/mindtrace/services/discord/discord_service.py
@@ -471,7 +471,7 @@ class DiscordService(Service):
             try:
                 import requests
 
-                response = requests.post(f"{connection_manager.url}/discord.status", json={})
+                response = requests.post(f"{str(connection_manager.url).rstrip('/')}/discord.status", json={})
                 if response.status_code == 200:
                     data = response.json()
                     # Bot is ready if it has a name and is not in "not_started" status

--- a/tests/integration/mindtrace/services/test_discord_samples_integration.py
+++ b/tests/integration/mindtrace/services/test_discord_samples_integration.py
@@ -50,7 +50,7 @@ class TestDiscordSamplesIntegration:
 
     def test_custom_discord_bot_service_status(self, custom_discord_bot_service):
         """Test the custom Discord bot service status endpoint."""
-        response = requests.post(f"{custom_discord_bot_service.url}/discord.status", json={})
+        response = requests.post(f"{str(custom_discord_bot_service.url).rstrip('/')}/discord.status", json={})
 
         assert response.status_code == 200
         data = response.json()
@@ -80,7 +80,7 @@ class TestDiscordSamplesIntegration:
 
     def test_custom_discord_bot_service_commands(self, custom_discord_bot_service):
         """Test the custom Discord bot service commands endpoint."""
-        response = requests.post(f"{custom_discord_bot_service.url}/discord.commands", json={})
+        response = requests.post(f"{str(custom_discord_bot_service.url).rstrip('/')}/discord.commands", json={})
 
         assert response.status_code == 200
         data = response.json()
@@ -115,7 +115,7 @@ class TestDiscordSamplesIntegration:
         for test_case in test_cases:
             payload = {"content": test_case["content"], "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-            response = requests.post(f"{custom_discord_bot_service.url}/discord.execute", json=payload)
+            response = requests.post(f"{str(custom_discord_bot_service.url).rstrip('/')}/discord.execute", json=payload)
             assert response.status_code == 200
 
             data = response.json()
@@ -136,7 +136,7 @@ class TestDiscordSamplesIntegration:
         """Test the info command functionality."""
         payload = {"content": "/info", "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-        response = requests.post(f"{custom_discord_bot_service.url}/discord.execute", json=payload)
+        response = requests.post(f"{str(custom_discord_bot_service.url).rstrip('/')}/discord.execute", json=payload)
         assert response.status_code == 200
 
         data = response.json()
@@ -154,7 +154,7 @@ class TestDiscordSamplesIntegration:
         """Test the help command functionality."""
         payload = {"content": "/help", "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-        response = requests.post(f"{custom_discord_bot_service.url}/discord.execute", json=payload)
+        response = requests.post(f"{str(custom_discord_bot_service.url).rstrip('/')}/discord.execute", json=payload)
         assert response.status_code == 200
 
         data = response.json()
@@ -167,7 +167,7 @@ class TestDiscordSamplesIntegration:
         """Test the cleanup command functionality."""
         payload = {"content": "/cleanup 5", "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-        response = requests.post(f"{custom_discord_bot_service.url}/discord.execute", json=payload)
+        response = requests.post(f"{str(custom_discord_bot_service.url).rstrip('/')}/discord.execute", json=payload)
         assert response.status_code == 200
 
         data = response.json()
@@ -185,7 +185,7 @@ class TestDiscordSamplesIntegration:
         """Test the service command functionality."""
         payload = {"content": "/service", "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-        response = requests.post(f"{custom_discord_bot_service.url}/discord.execute", json=payload)
+        response = requests.post(f"{str(custom_discord_bot_service.url).rstrip('/')}/discord.execute", json=payload)
         assert response.status_code == 200
 
         data = response.json()
@@ -204,7 +204,9 @@ class TestDiscordSamplesIntegration:
             # No guild_id
         }
 
-        response = requests.post(f"{custom_discord_bot_service.url}/discord.execute", json=payload_no_guild)
+        response = requests.post(
+            f"{str(custom_discord_bot_service.url).rstrip('/')}/discord.execute", json=payload_no_guild
+        )
         assert response.status_code == 200
 
         data = response.json()
@@ -216,7 +218,7 @@ class TestDiscordSamplesIntegration:
         # Test cleanup command (requires manage messages permission)
         payload = {"content": "/cleanup 5", "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-        response = requests.post(f"{custom_discord_bot_service.url}/discord.execute", json=payload)
+        response = requests.post(f"{str(custom_discord_bot_service.url).rstrip('/')}/discord.execute", json=payload)
         assert response.status_code == 200
 
         data = response.json()
@@ -235,7 +237,9 @@ class TestDiscordSamplesIntegration:
             payload = {"content": command, "author_id": author_id, "channel_id": 456, "guild_id": 789}
 
             try:
-                response = requests.post(f"{custom_discord_bot_service.url}/discord.execute", json=payload)
+                response = requests.post(
+                    f"{str(custom_discord_bot_service.url).rstrip('/')}/discord.execute", json=payload
+                )
                 results.put((command, response.status_code, response.json()))
             except Exception as e:
                 results.put((command, None, str(e)))
@@ -266,7 +270,7 @@ class TestDiscordSamplesIntegration:
         for command in unicode_commands:
             payload = {"content": command, "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-            response = requests.post(f"{custom_discord_bot_service.url}/discord.execute", json=payload)
+            response = requests.post(f"{str(custom_discord_bot_service.url).rstrip('/')}/discord.execute", json=payload)
             assert response.status_code == 200
 
             data = response.json()

--- a/tests/integration/mindtrace/services/test_discord_service_integration.py
+++ b/tests/integration/mindtrace/services/test_discord_service_integration.py
@@ -12,7 +12,7 @@ class TestDiscordServiceIntegration:
 
     def test_discord_service_status_endpoint(self, discord_service_manager):
         """Test the Discord service status endpoint."""
-        response = requests.post(f"{discord_service_manager.url}/discord.status", json={})
+        response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/discord.status", json={})
 
         assert response.status_code == 200
         data = response.json()
@@ -36,7 +36,7 @@ class TestDiscordServiceIntegration:
 
     def test_discord_service_commands_endpoint(self, discord_service_manager):
         """Test the Discord service commands endpoint."""
-        response = requests.post(f"{discord_service_manager.url}/discord.commands", json={})
+        response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/discord.commands", json={})
 
         assert response.status_code == 200
         data = response.json()
@@ -49,7 +49,7 @@ class TestDiscordServiceIntegration:
         """Test the Discord service execute endpoint."""
         payload = {"content": "!roll", "author_id": 123, "channel_id": 456, "guild_id": 789, "message_id": 101112}
 
-        response = requests.post(f"{discord_service_manager.url}/discord.execute", json=payload)
+        response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/discord.execute", json=payload)
 
         assert response.status_code == 200
         data = response.json()
@@ -63,15 +63,15 @@ class TestDiscordServiceIntegration:
     def test_discord_service_health_endpoints(self, discord_service_manager):
         """Test that standard service health endpoints work."""
         # Test status endpoint
-        response = requests.post(f"{discord_service_manager.url}/status", json={})
+        response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/status", json={})
         assert response.status_code == 200
 
         # Test heartbeat endpoint
-        response = requests.post(f"{discord_service_manager.url}/heartbeat", json={})
+        response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/heartbeat", json={})
         assert response.status_code == 200
 
         # Test endpoints endpoint
-        response = requests.post(f"{discord_service_manager.url}/endpoints", json={})
+        response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/endpoints", json={})
         assert response.status_code == 200
 
         data = response.json()
@@ -86,20 +86,20 @@ class TestDiscordServiceIntegration:
     def test_discord_service_mcp_endpoints(self, discord_service_manager):
         """Test that MCP endpoints are available."""
         # Test MCP tools endpoint
-        response = requests.get(f"{discord_service_manager.url}/mcp/tools")
+        response = requests.get(f"{str(discord_service_manager.url).rstrip('/')}/mcp/tools")
         # MCP endpoints may not be available if no tools are registered
         # This is acceptable for DiscordService as it doesn't require MCP tools
         assert response.status_code in [200, 404]
 
         # Test MCP resources endpoint
-        response = requests.get(f"{discord_service_manager.url}/mcp/resources")
+        response = requests.get(f"{str(discord_service_manager.url).rstrip('/')}/mcp/resources")
         # MCP endpoints may not be available if no tools are registered
         assert response.status_code in [200, 404]
 
     def test_discord_service_error_handling(self, discord_service_manager):
         """Test error handling in Discord service endpoints."""
         # Test execute endpoint with invalid payload (missing required content field)
-        response = requests.post(f"{discord_service_manager.url}/discord.execute", json={})
+        response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/discord.execute", json={})
         assert response.status_code == 422  # Validation error
 
         # Test execute endpoint with valid payload (content is the only required field)
@@ -107,7 +107,7 @@ class TestDiscordServiceIntegration:
             "content": "!test"
             # Other fields are optional
         }
-        response = requests.post(f"{discord_service_manager.url}/discord.execute", json=valid_payload)
+        response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/discord.execute", json=valid_payload)
         assert response.status_code == 200  # Should succeed since content is provided
 
     def test_discord_service_command_parsing(self, discord_service_manager):
@@ -118,7 +118,7 @@ class TestDiscordServiceIntegration:
         for command in test_commands:
             payload = {"content": command, "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-            response = requests.post(f"{discord_service_manager.url}/discord.execute", json=payload)
+            response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/discord.execute", json=payload)
             assert response.status_code == 200
 
             data = response.json()
@@ -138,7 +138,7 @@ class TestDiscordServiceIntegration:
         for test_case in test_cases:
             payload = {"content": test_case["content"], "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-            response = requests.post(f"{discord_service_manager.url}/discord.execute", json=payload)
+            response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/discord.execute", json=payload)
             assert response.status_code == 200
 
             data = response.json()
@@ -158,7 +158,9 @@ class TestDiscordServiceIntegration:
             # No guild_id
         }
 
-        response = requests.post(f"{discord_service_manager.url}/discord.execute", json=payload_no_guild)
+        response = requests.post(
+            f"{str(discord_service_manager.url).rstrip('/')}/discord.execute", json=payload_no_guild
+        )
         assert response.status_code == 200
 
         data = response.json()
@@ -168,7 +170,9 @@ class TestDiscordServiceIntegration:
         # Test command with guild
         payload_with_guild = {"content": "!info", "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-        response = requests.post(f"{discord_service_manager.url}/discord.execute", json=payload_with_guild)
+        response = requests.post(
+            f"{str(discord_service_manager.url).rstrip('/')}/discord.execute", json=payload_with_guild
+        )
         assert response.status_code == 200
 
         data = response.json()
@@ -180,7 +184,7 @@ class TestDiscordServiceIntegration:
         # Test cleanup command (basic service doesn't have custom commands)
         payload = {"content": "!cleanup 5", "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-        response = requests.post(f"{discord_service_manager.url}/discord.execute", json=payload)
+        response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/discord.execute", json=payload)
         assert response.status_code == 200
 
         data = response.json()
@@ -199,7 +203,9 @@ class TestDiscordServiceIntegration:
             payload = {"content": command, "author_id": author_id, "channel_id": 456, "guild_id": 789}
 
             try:
-                response = requests.post(f"{discord_service_manager.url}/discord.execute", json=payload)
+                response = requests.post(
+                    f"{str(discord_service_manager.url).rstrip('/')}/discord.execute", json=payload
+                )
                 results.put((command, response.status_code, response.json()))
             except Exception as e:
                 results.put((command, None, str(e)))
@@ -230,7 +236,7 @@ class TestDiscordServiceIntegration:
 
         payload = {"content": large_content, "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-        response = requests.post(f"{discord_service_manager.url}/discord.execute", json=payload)
+        response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/discord.execute", json=payload)
         assert response.status_code == 200
 
         data = response.json()
@@ -243,7 +249,7 @@ class TestDiscordServiceIntegration:
         for command in unicode_commands:
             payload = {"content": command, "author_id": 123, "channel_id": 456, "guild_id": 789}
 
-            response = requests.post(f"{discord_service_manager.url}/discord.execute", json=payload)
+            response = requests.post(f"{str(discord_service_manager.url).rstrip('/')}/discord.execute", json=payload)
             assert response.status_code == 200
 
             data = response.json()


### PR DESCRIPTION
#### Summary
- Service.status_at_host, DiscordService.check_discord_ready, ClusterManager._submit_job_to_endpoint, and many tests all built URLs as `f"{url}/path"` where url (from `build_url()` which always ensures a trailing slash, unchanged in this PR) ends in /, producing a double slash (`host//path`).
- requests<=2.33 / urllib3<=2.6 normalized the double slash silently; requests==2.34.0 / urllib3==2.7.0 send it verbatim, and Starlette returns 404 → `status_at_host` reports DOWN and the caller 503s.
- Added `.rstrip("/")` normalizations at the calling sites; the only remaining and expected failure is `test_cluster_integration_git_launch`, which clones `dev` and will pass once this lands.
