### PR TITLE
Mindtrace UI Library Primitives 

### DIFF
--- a/packages/ui/.gitignore
+++ b/packages/ui/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+*.log
+.DS_Store

--- a/packages/ui/.gitignore
+++ b/packages/ui/.gitignore
@@ -1,4 +1,6 @@
 node_modules
 dist
+storybook-static
+coverage
 *.log
 .DS_Store

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -1,0 +1,38 @@
+import type { StorybookConfig } from '@storybook/react-vite'
+
+/**
+ * Storybook config — picks up stories co-located in
+ * `src/components/<Name>/<Name>.stories.tsx` and foundation stories in
+ * `src/stories/*.stories.@(ts|tsx)`.
+ */
+const config: StorybookConfig = {
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  addons: [
+    '@storybook/addon-essentials',
+    '@storybook/addon-a11y',
+    '@storybook/addon-themes',
+    '@storybook/addon-interactions',
+  ],
+  framework: { name: '@storybook/react-vite', options: {} },
+  docs: { autodocs: 'tag' },
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      shouldRemoveUndefinedFromOptional: true,
+      // Skip props inherited from node_modules (MUI, React) so the controls
+      // panel shows only props this component actually defines + whatever
+      // the story author has explicitly added via `argTypes`. Without this
+      // filter MUI wrappers like Button or TextField produce hundreds of
+      // inherited controls and drown out the relevant ones.
+      propFilter: (prop) => {
+        if (prop.parent) {
+          return !/node_modules/.test(prop.parent.fileName)
+        }
+        return true
+      },
+    },
+  },
+}
+
+export default config

--- a/packages/ui/.storybook/manager.ts
+++ b/packages/ui/.storybook/manager.ts
@@ -1,0 +1,21 @@
+import { addons } from '@storybook/manager-api'
+import { create } from '@storybook/theming'
+
+/**
+ * Storybook manager theme — sidebar / toolbar chrome only. Kept neutral
+ * (Storybook's default light) so the canvas toggle drives the story
+ * preview without flipping the surrounding app. Brand wordmark only.
+ */
+const mindtraceTheme = create({
+  base: 'light',
+  brandTitle: 'Mindtrace UI',
+  brandUrl: 'https://github.com/Mindtrace',
+  brandTarget: '_blank',
+  colorPrimary: '#7C3AED',
+  colorSecondary: '#7C3AED',
+})
+
+addons.setConfig({
+  theme: mindtraceTheme,
+  sidebar: { showRoots: true },
+})

--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -1,0 +1,39 @@
+import CssBaseline from '@mui/material/CssBaseline'
+import { ThemeProvider } from '@mui/material/styles'
+import type { Preview } from '@storybook/react'
+import { withThemeFromJSXProvider } from '@storybook/addon-themes'
+
+import { defaultThemeKey, themes } from './themes'
+
+const preview: Preview = {
+  parameters: {
+    layout: 'padded',
+    controls: {
+      matchers: { color: /(background|color)$/i, date: /Date$/i },
+      expanded: true,
+    },
+    backgrounds: { disable: true },
+    options: {
+      storySort: {
+        order: [
+          'Introduction',
+          'Foundations',
+          ['Theme Builder', 'Palette', 'Typography', 'Shape', 'Shadows', 'Stack & Grid'],
+          'Components',
+          'Layout',
+          'Patterns',
+        ],
+      },
+    },
+  },
+  decorators: [
+    withThemeFromJSXProvider({
+      themes,
+      defaultTheme: defaultThemeKey,
+      Provider: ThemeProvider,
+      GlobalStyles: CssBaseline,
+    }),
+  ],
+}
+
+export default preview

--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -6,6 +6,15 @@ import { withThemeFromJSXProvider } from '@storybook/addon-themes'
 import { defaultThemeKey, themes } from './themes'
 
 const preview: Preview = {
+  // Run the a11y (axe-core) addon on demand rather than automatically. By
+  // default addon-a11y runs a full axe pass on *every* story render — which
+  // means once per story, again per preview on a Docs/autodocs page (so the
+  // composite "Patterns/PageLayout" docs page ran several heavy passes and
+  // could lock the tab), and again on every navigation and every controls
+  // change (the "navigation feels slow / delayed updates" symptom). With
+  // `manual: true` the panel still works — reviewers click "Run test" — but
+  // nothing runs axe unprompted. Flip back to `false` to restore auto-runs.
+  initialGlobals: { a11y: { manual: true } },
   parameters: {
     layout: 'padded',
     controls: {

--- a/packages/ui/.storybook/themes.ts
+++ b/packages/ui/.storybook/themes.ts
@@ -1,0 +1,128 @@
+/**
+ * Storybook-only theme presets. These exist so reviewers can preview the
+ * library against multiple brand palettes from the toolbar without
+ * editing code. They are NOT exported from the public package — apps
+ * build their own themes with `createTheme` (see `Foundations/Theme
+ * Builder` for a worked example).
+ */
+
+import { createTheme, type Theme } from '@mui/material/styles'
+
+import { darkTheme as builtinDark, lightTheme as builtinLight, getTheme } from '../src/theme'
+
+type PresetInput = {
+  mode: 'light' | 'dark'
+  primary: string
+  secondary?: string
+  success?: string
+  warning?: string
+  error?: string
+  info?: string
+  backgroundDefault?: string
+  backgroundPaper?: string
+  textPrimary?: string
+  borderRadius?: number
+}
+
+function preset(p: PresetInput): Theme {
+  const root = getTheme(p.mode)
+  return createTheme({
+    ...root,
+    palette: {
+      ...root.palette,
+      mode: p.mode,
+      primary: { main: p.primary },
+      ...(p.secondary ? { secondary: { main: p.secondary } } : {}),
+      ...(p.success ? { success: { main: p.success } } : {}),
+      ...(p.warning ? { warning: { main: p.warning } } : {}),
+      ...(p.error ? { error: { main: p.error } } : {}),
+      ...(p.info ? { info: { main: p.info } } : {}),
+      background: {
+        default: p.backgroundDefault ?? root.palette.background.default,
+        paper: p.backgroundPaper ?? root.palette.background.paper,
+      },
+      text: {
+        ...root.palette.text,
+        primary: p.textPrimary ?? root.palette.text.primary,
+      },
+    },
+    ...(p.borderRadius !== undefined ? { shape: { borderRadius: p.borderRadius } } : {}),
+  })
+}
+
+export const themes: Record<string, Theme> = {
+  'Mindtrace · Light': builtinLight,
+  'Mindtrace · Dark': builtinDark,
+
+  'Slate · Light': preset({
+    mode: 'light',
+    primary: '#2563EB',
+    secondary: '#475569',
+    success: '#059669',
+    warning: '#D97706',
+    error: '#DC2626',
+    info: '#0EA5E9',
+    backgroundDefault: '#F8FAFC',
+    backgroundPaper: '#FFFFFF',
+    textPrimary: '#0F172A',
+    borderRadius: 6,
+  }),
+
+  'Emerald · Light': preset({
+    mode: 'light',
+    primary: '#15803D',
+    secondary: '#3F3F46',
+    success: '#16A34A',
+    warning: '#CA8A04',
+    error: '#B91C1C',
+    info: '#0E7490',
+    backgroundDefault: '#FAFAF9',
+    backgroundPaper: '#FFFFFF',
+    textPrimary: '#0C0A09',
+    borderRadius: 14,
+  }),
+
+  'Amber · Light': preset({
+    mode: 'light',
+    primary: '#B45309',
+    secondary: '#525252',
+    success: '#16A34A',
+    warning: '#D97706',
+    error: '#DC2626',
+    info: '#0891B2',
+    backgroundDefault: '#FAF5EE',
+    backgroundPaper: '#FFFFFF',
+    textPrimary: '#1C1917',
+    borderRadius: 10,
+  }),
+
+  'Indigo · Dark': preset({
+    mode: 'dark',
+    primary: '#818CF8',
+    secondary: '#A1A1AA',
+    success: '#4ADE80',
+    warning: '#FBBF24',
+    error: '#F87171',
+    info: '#22D3EE',
+    backgroundDefault: '#0B1020',
+    backgroundPaper: '#141A2E',
+    textPrimary: '#E2E8F0',
+    borderRadius: 8,
+  }),
+
+  'Cyan · Dark': preset({
+    mode: 'dark',
+    primary: '#22D3EE',
+    secondary: '#A1A1AA',
+    success: '#4ADE80',
+    warning: '#FBBF24',
+    error: '#F87171',
+    info: '#67E8F9',
+    backgroundDefault: '#0A0A0A',
+    backgroundPaper: '#171717',
+    textPrimary: '#FAFAFA',
+    borderRadius: 12,
+  }),
+}
+
+export const defaultThemeKey = 'Mindtrace · Light'

--- a/packages/ui/LICENSE
+++ b/packages/ui/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,234 @@
+# @mindtrace/ui
+
+React components and theme primitives for calm, data-heavy operational
+interfaces. Built on MUI, themed and pre-wrapped so the same components work
+the same way across every surface that consumes it.
+
+## Install
+
+```bash
+npm install @mindtrace/ui @mui/material @emotion/react @emotion/styled
+```
+
+`@mui/icons-material` is an optional peer — install it if you use any
+icon-bearing primitive (KpiCard, SearchField, etc.) or want icons in your
+own UI:
+
+```bash
+npm install @mui/icons-material
+```
+
+## Quick start
+
+```tsx
+import { MindtraceProvider, Button } from '@mindtrace/ui'
+
+export function App() {
+  return (
+    <MindtraceProvider>
+      <Button variant="contained">Save changes</Button>
+    </MindtraceProvider>
+  )
+}
+```
+
+`MindtraceProvider` wraps your app with the MUI theme stack
+(`StyledEngineProvider` → `ThemeProvider` → `CssBaseline`). It accepts:
+
+- `mode` — `'light' | 'dark'` (default `'light'`)
+- `theme` — caller-supplied MUI theme (skip if you want the built-in one)
+- `disableCssBaseline` — opt out of `<CssBaseline>` if the host already
+  resets styles
+
+## What ships
+
+- **Provider** — `MindtraceProvider`
+- **Theme** — `lightTheme`, `darkTheme`, `getTheme(mode)`, palette,
+  typography, design tokens. Available at the package root and at the
+  `@mindtrace/ui/theme` and `@mindtrace/ui/tokens` subpaths for finer-grained
+  imports.
+- **Thin MUI wrappers** — `Button`, `TextField`, `Select`, `Card`, `Badge`,
+  `Alert`, `Modal`, `Drawer`
+- **Generic patterns** — `PageHeader`, `FormSection`, `EmptyState`,
+  `DataTable`, `KpiCard`, `SectionCard`, `FilterChips`, `SearchField`,
+  `StatusDot`, `StatusBadge`, `SeverityBadge`, `NumberBadge`, `Mono`
+- **MUI primitive re-exports** — `Box`, `Stack`, `Grid`, `Container`,
+  `Typography`, `Tooltip`, `Chip`, `Tabs`, `Menu`, `Table`, etc. Convenient
+  so app code rarely has to reach for `@mui/material` directly.
+
+## Storybook
+
+Storybook is the canonical visual catalogue. Every component here ships with
+at least one story.
+
+```bash
+npm run storybook         # dev server on :6006
+npm run build:storybook   # static build → storybook-static/
+```
+
+See [`docs/STORYBOOK_USAGE.md`](./docs/STORYBOOK_USAGE.md) for conventions.
+
+## Public package boundary
+
+This package is intended for public publication. It contains **primitives and
+generic patterns only** — no internal customer names, no private product
+terminology, no business-specific workflows. See
+[`docs/PUBLIC_PACKAGE_BOUNDARIES.md`](./docs/PUBLIC_PACKAGE_BOUNDARIES.md).
+
+## Develop
+
+```bash
+npm install
+npm run storybook         # dev server on :6006
+npm run build:storybook   # static build → storybook-static/
+npm run build             # tsup → dist/ (ESM + CJS + .d.ts)
+npm run typecheck         # tsc --noEmit
+```
+
+## Testing
+
+Tests run on **vitest** + **@testing-library/react** + **jsdom**. Every
+component ships a smoke test, plus interaction tests on the behavioral
+ones (forms, dialogs, navigation, toasts, etc.).
+
+### Standard entry — `npm test`
+
+From the package directory (or via any consumer's CI):
+
+```bash
+npm test                  # full suite, one shot
+npm run test:watch        # watch mode
+npm run test:coverage     # coverage report → coverage/
+```
+
+All three are thin wrappers around vitest; flags after the script name
+pass through.
+
+```bash
+npm test -- src/components/Button   # specific path / glob
+npm test -- --reporter=verbose      # any vitest flag
+```
+
+### Inside a vitest invocation
+
+If you want full control, call vitest directly:
+
+```bash
+npx vitest run                      # one shot
+npx vitest                          # watch mode
+npx vitest run src/components/Button
+```
+
+### Optional: monorepo `ds` shortcut
+
+When this package lives inside the Mindtrace monorepo, the repo's
+`ds-run` workflow exposes a thin wrapper so the team has the same
+`ds`-flavored UX as the Python suite:
+
+```bash
+ds test_ui                          # full suite — same as `npm test`
+ds test_ui --watch
+ds test_ui --coverage
+ds test_ui: src/components/Button
+```
+
+Under the hood `ds test_ui` shells into
+[`scripts/run-tests.sh`](./scripts/run-tests.sh) in this package, so
+either entry point ends up at the same vitest run.
+
+### Where tests live
+
+Co-located with the code, ending in `.test.ts(x)`:
+
+```
+src/
+├── components/
+│   ├── Button/
+│   │   ├── Button.tsx
+│   │   ├── Button.test.tsx          ← smoke + interaction
+│   │   └── Button.stories.tsx
+│   └── …
+├── hooks/
+│   └── useCopyToClipboard.test.ts
+├── providers/
+│   └── MindtraceProvider.test.tsx
+└── test-utils.tsx                   ← wraps render() in MindtraceProvider
+```
+
+Use `render` / `screen` / `userEvent` from `src/test-utils.tsx` — it
+wraps every render in `MindtraceProvider` so theme tokens (`palette.surface.*`,
+`palette.border.*`) resolve.
+
+### Writing a new test
+
+```tsx
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, userEvent } from '../../test-utils'
+import { MyComponent } from './MyComponent'
+
+describe('MyComponent', () => {
+  it('does the thing', async () => {
+    const onAction = vi.fn()
+    const user = userEvent.setup()
+    render(<MyComponent onAction={onAction} />)
+    await user.click(screen.getByRole('button', { name: /do it/i }))
+    expect(onAction).toHaveBeenCalledOnce()
+  })
+})
+```
+
+Two gotchas worth remembering:
+
+- **Disabled MUI elements** have `pointer-events: none`. `userEvent.click`
+  refuses to click them — assert `.toBeDisabled()` directly instead.
+- **Clipboard tests** must stub `navigator` with `vi.stubGlobal('navigator',
+  { clipboard: { writeText } })`, and the `CopyButton` interaction needs
+  `fireEvent.click` (not `userEvent.click`) — see
+  `src/components/CopyButton/CopyButton.test.tsx` for the pattern.
+
+### Layout
+
+```
+packages/ui/
+├── docs/                  ← AI / human guides (see below)
+├── src/
+│   ├── index.ts           ← top-level barrel
+│   ├── providers/
+│   │   └── MindtraceProvider.tsx
+│   ├── theme/             ← palette, typography, tokens, etc.
+│   ├── components/        ← wrappers + bespoke + MUI re-exports
+│   │   ├── Button/
+│   │   │   ├── Button.tsx
+│   │   │   ├── Button.stories.tsx
+│   │   │   └── index.ts
+│   │   └── …
+│   └── stories/           ← foundation stories (palette, type, shape, …)
+├── .storybook/
+└── package.json
+```
+
+### Docs
+
+The [`docs/`](./docs) folder is designed for both humans and AI tools:
+
+- [`AI_USAGE_GUIDE.md`](./docs/AI_USAGE_GUIDE.md) — rules for AI coding tools
+- [`UI_PHILOSOPHY.md`](./docs/UI_PHILOSOPHY.md) — what this UI is for
+- [`COMPONENT_GUIDELINES.md`](./docs/COMPONENT_GUIDELINES.md) — when to use each component
+- [`STORYBOOK_USAGE.md`](./docs/STORYBOOK_USAGE.md) — Storybook as source of truth
+- [`DESIGN_TOKENS.md`](./docs/DESIGN_TOKENS.md) — tokens and how to use them
+- [`PUBLIC_PACKAGE_BOUNDARIES.md`](./docs/PUBLIC_PACKAGE_BOUNDARIES.md) — what's allowed / forbidden in this package
+
+## Publishing
+
+Because this is a scoped package, **public publishing requires
+`--access public` on first publish**:
+
+```bash
+npm run build             # build artefacts into dist/
+npm pack --dry-run        # inspect what would ship
+npm publish --access public
+```
+
+## License
+
+Apache-2.0.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -7,16 +7,30 @@ the same way across every surface that consumes it.
 ## Install
 
 ```bash
-npm install @mindtrace/ui @mui/material @emotion/react @emotion/styled
+npm install @mindtrace/ui @mui/material @mui/icons-material @emotion/react @emotion/styled
 ```
 
-`@mui/icons-material` is an optional peer — install it if you use any
-icon-bearing primitive (KpiCard, SearchField, etc.) or want icons in your
-own UI:
+All four are required peers. `@mui/icons-material` is **not** optional: several
+components exported from the package root render Material icons at runtime
+(`SearchField`, `CopyButton`, `PrimaryRail`, `Wizard`, `PathBreadcrumb`,
+`UserMenu`), so the package depends on it being resolvable even if you only
+import `Button`.
 
-```bash
-npm install @mui/icons-material
-```
+### MUI version
+
+This package is built and tested against **MUI v9** (`@mui/material` and
+`@mui/icons-material` `^9`). It re-exports MUI primitives, whose prop
+interfaces differ across majors (e.g. the Grid v2 migration), so older majors
+are intentionally not in the peer range. Pin your app to v9 to match.
+
+### Fonts (optional)
+
+The reference design uses **Inter** (and **JetBrains Mono** for code/IDs), but
+the package does **not** ship or load any webfont — the font stacks list Inter
+first purely as a progressive enhancement. To match the Storybook screenshots,
+install and load Inter in your app (e.g. via `@fontsource/inter` or a `<link>`
+to Google Fonts). Without it the UI falls back to Roboto / system-ui, which
+renders cleanly — no Inter-specific OpenType features are forced.
 
 ## Quick start
 

--- a/packages/ui/docs/AI_USAGE_GUIDE.md
+++ b/packages/ui/docs/AI_USAGE_GUIDE.md
@@ -1,0 +1,57 @@
+# AI usage guide
+
+How AI coding tools (and humans pairing with them) should use `@mindtrace/ui`.
+
+## Rules
+
+1. **Always import UI from `@mindtrace/ui`.** Do not reach for raw MUI in app code
+   when a wrapper exists. The wrappers exist so theme/behavior overrides stay
+   centralized.
+
+   ```tsx
+   // ✅ Preferred
+   import { Button, TextField, Card } from '@mindtrace/ui'
+
+   // ❌ Avoid in app code
+   import Button from '@mui/material/Button'
+   ```
+
+   Raw MUI imports are acceptable when there's no wrapper *and* the primitive
+   isn't already re-exported from `@mindtrace/ui` (we re-export layout, list,
+   navigation, and overlay primitives — check `src/components/index.ts`).
+
+2. **Wrap the app root in `MindtraceProvider`.** Theme + `CssBaseline` resets
+   come from the provider — no per-page wrappers, no manual `ThemeProvider`.
+
+   ```tsx
+   import { MindtraceProvider } from '@mindtrace/ui'
+
+   export function App() {
+     return (
+       <MindtraceProvider mode="light">
+         <Router />
+       </MindtraceProvider>
+     )
+   }
+   ```
+
+3. **Reuse before creating.** If a component already exists in this package,
+   use it. Do not author a local lookalike in an app.
+
+4. **Promote, don't duplicate.** If a generic UI pattern appears in two or more
+   apps, promote it into `@mindtrace/ui`. App-local duplicates drift quickly.
+
+5. **Keep the public surface generic.** Never add business-specific
+   terminology to component names, prop names, defaults, or stories. See
+   `PUBLIC_PACKAGE_BOUNDARIES.md` for the boundary rules.
+
+6. **Storybook is the catalogue.** Before designing new UI, browse Storybook
+   to find an existing pattern. See `STORYBOOK_USAGE.md`.
+
+7. **Use design tokens.** Do not hardcode colors, spacing units, or radii. See
+   `DESIGN_TOKENS.md`.
+
+## When you don't know which component to use
+
+Check `COMPONENT_GUIDELINES.md` — it covers when to reach for each component
+(e.g. `Modal` vs `Drawer`, `Badge` vs `Chip`).

--- a/packages/ui/docs/COMPONENT_GUIDELINES.md
+++ b/packages/ui/docs/COMPONENT_GUIDELINES.md
@@ -1,0 +1,129 @@
+# Component guidelines
+
+When to reach for which component.
+
+## Inputs
+
+### `Button`
+
+Standard action button. Use `variant="contained"` for the primary action on a
+page or in a form; `variant="outlined"` for secondary; `variant="text"` for
+tertiary (e.g. "Cancel", "Dismiss"). Don't put more than one `contained`
+button in the same action group.
+
+### `TextField`
+
+Single- or multi-line text input. Always provide a `label`. Use `helperText`
+for guidance and `error` + `helperText` together for validation messages.
+
+### `Select`
+
+Single-value picker with a labelled dropdown. Use the `options` shortcut for a
+flat list; pass children for grouped or custom-rendered items. For free-typed
+or async-loaded values reach for MUI `Autocomplete` instead.
+
+## Surfaces
+
+### `Card`
+
+A neutral surface. Use `CardHeader`, `CardContent`, `CardActions` for
+structured layouts. For the common "panel under a heading" pattern use
+`SectionCard` (less verbose).
+
+### `SectionCard`
+
+Card + title/subtitle/actions header in one element. Use this everywhere
+inside a page body — it's the standard panel pattern.
+
+## Feedback
+
+### `Alert`
+
+Inline feedback message — connection errors, validation summaries, deprecation
+notices. Use a severity (`info`, `success`, `warning`, `error`). For
+transient notifications, prefer `Snackbar`.
+
+### `Badge`
+
+Small labelled token. Wraps MUI Chip rather than MUI Badge. Use for tags,
+inline labels, "active" markers. For severity ladders use `SeverityBadge`;
+for status with a dot indicator use `StatusBadge`; for counters use
+`NumberBadge`.
+
+### `StatusBadge`
+
+A chip with a colored dot indicator. Use for run state, alert state, job
+status — anywhere you want to convey both a label and a tone at a glance.
+
+### `SeverityBadge`
+
+Severity ladder (`critical > major > minor > info`) styled with palette tones.
+Use only for severity contexts — events, alerts, incidents — not generic
+status.
+
+### `StatusDot`
+
+Just the dot. Use inline with a label when a full `StatusBadge` is too heavy.
+
+### `NumberBadge`
+
+Tiny pill for counts (e.g. "3 next to a sidebar item"). Distinct from MUI's
+overlay Badge.
+
+## Overlays
+
+### `Modal` vs `Drawer`
+
+- **`Modal`** for focused, blocking decisions: confirms, destructive actions,
+  short forms the user must finish before continuing.
+- **`Drawer`** for secondary context that needs to stay scoped to the current
+  page but doesn't fully block the underlying surface: detail views, filters,
+  side-panel editors.
+
+Rule of thumb: if dismissing the overlay should leave the user exactly where
+they were, `Drawer`. If they're committing or cancelling something, `Modal`.
+
+## Patterns
+
+### `PageHeader`
+
+Standard top-of-page block. Every full page mounts one. Never style page
+titles ad-hoc.
+
+### `FormSection`
+
+Grouped section of form fields with a heading, optional description, and
+optional action slot (e.g. "Add row"). Stack multiple `FormSection`s for long
+settings pages.
+
+### `EmptyState`
+
+Use for empty lists, "nothing here yet", and recoverable error views. Always
+include a `title`; usually include a `description`; include an `action` only
+if there's a meaningful next step.
+
+### `DataTable`
+
+Thin, typed wrapper around MUI Table for the common "list of objects with
+named columns" case. For sorting, filtering, virtualization, or server-side
+paging, reach for `@mui/x-data-grid` directly.
+
+### `KpiCard`
+
+Single metric tile for dashboards. Pair with `delta` for trend, `icon` for
+visual anchor, `hint` for context.
+
+### `FilterChips`
+
+Row of selectable filter chips, multi-select or exclusive. Use above a list
+or table for quick faceted filtering.
+
+### `SearchField`
+
+`TextField` preconfigured for search use, with a leading icon and clear
+button. Use for any list/table filter input.
+
+### `Mono`
+
+Monospaced inline text for IDs, hashes, file paths, codes. Use this instead
+of raw `<code>` so columns of IDs line up (tabular figures).

--- a/packages/ui/docs/DESIGN_TOKENS.md
+++ b/packages/ui/docs/DESIGN_TOKENS.md
@@ -1,0 +1,67 @@
+# Design tokens
+
+Tokens are the source of truth for color, spacing, type, radius, and z-index.
+Components read from tokens via the MUI theme; app code should do the same.
+
+Tokens live in `src/theme/tokens.ts` and the theme assembly in
+`src/theme/index.ts`. Both are re-exported from `@mindtrace/ui/theme` and
+`@mindtrace/ui/tokens`.
+
+## Categories
+
+### Spacing
+
+Base unit is `8px`. Use MUI's `sx` spacing shorthand — `sx={{ p: 2 }}` ==
+`padding: 16px`. Never inline raw pixel values.
+
+### Typography
+
+Standard MUI variants (`h1`–`h6`, `body1`, `body2`, `caption`, …) plus custom
+variants for dense operational surfaces:
+
+- `subheading` — h3-equivalent inline heading
+- `sectionLabel` — small uppercase section label
+- `metricLabel` — KPI tile label
+- `tinyLabel` — micro uppercase label
+- `microCaption` — smaller caption
+- `mono` — IDs, hashes, code
+
+The full scale lives in `src/theme/typography.ts`.
+
+### Semantic colors
+
+Use the palette tones (`primary`, `secondary`, `success`, `warning`, `error`,
+`info`) for anything where meaning matters. Do not pick raw color values for
+"a green button" — use `color="success"`.
+
+### Status tones
+
+`StatusBadge`, `StatusDot`, `NumberBadge`, and `KpiCard.delta` accept a
+`tone` of `neutral | success | warning | error | info`. The mapping to actual
+colors is centralized in tokens so dark mode and theme overrides stay in
+sync.
+
+### Surfaces and borders
+
+`palette.surface.{subtle,muted,strong}` and `palette.border.{subtle,default,
+strong}` give you neutral panel backgrounds and outlines that adapt to
+light/dark mode. Prefer these over picking grey ramp values directly.
+
+### Radii
+
+`radii.{xs,sm,md,lg,xl,pill}`. `borderRadius` on `Card`, `Button`, etc. is
+set by the theme — you should rarely need to override.
+
+### Z-index
+
+`zIndex.{content,rail,topBar,drawer,modal,snackbar,tooltip}`. Use these
+instead of inventing magic numbers when stacking overlays.
+
+## Rules
+
+- **No raw hex in app code.** If you need a color, find a token. If no token
+  fits, propose adding one — don't reach for `#7c3aed` in JSX.
+- **No magic pixel values for spacing.** Use the spacing scale.
+- **Use semantic names.** `palette.success.main`, not `'#16A34A'`.
+- **Adapt to theme mode.** Use palette values (which switch with the theme)
+  rather than mode-specific overrides where possible.

--- a/packages/ui/docs/PUBLIC_PACKAGE_BOUNDARIES.md
+++ b/packages/ui/docs/PUBLIC_PACKAGE_BOUNDARIES.md
@@ -1,0 +1,63 @@
+# Public package boundaries
+
+`@mindtrace/ui` is **public**. It is intended for eventual publication to
+npm under a public scope. Everything here is visible to anyone who installs
+the package or browses the source.
+
+## What is allowed
+
+- Generic operational-interface vocabulary: dashboards, forms, tables,
+  workflows, status, layouts, feedback, navigation
+- Design tokens (spacing, typography, semantic colors, radii)
+- Thin wrappers around MUI primitives
+- Generic patterns (PageHeader, FormSection, EmptyState, DataTable,
+  KpiCard, SectionCard, FilterChips, SearchField, StatusBadge, etc.)
+- Accessibility considerations
+- React + MUI + emotion idioms
+
+## What is forbidden
+
+- Internal customer names
+- Private product names
+- Business-specific workflows (inspection runs, labelling pipelines,
+  dataset/model/camera-specific behavior, datalake terminology, …)
+- Private URLs (internal hosts, staging endpoints, customer portals)
+- Real environment names
+- Internal API routes
+- Private architectural details from any specific Mindtrace product
+- App-specific assumptions baked into component defaults
+
+## Generalising internal concepts
+
+When you have a component that looks generic but is named after an internal
+concept, rename it on the way in:
+
+- `DatasetSelector` → `ResourceSelector`
+- `InspectionRunTable` → `DataTable`
+- `ModelStatusBadge` → `StatusBadge`
+- `CameraCard` → `ResourceCard`
+- `LabellingWizard` → `Wizard`
+- `DatalakeBrowser` → never expose this term publicly; rename or keep
+  internal
+
+## Rule of thumb
+
+> The library contains **primitives and generic patterns only**. Domain
+> workflows, private business logic, and product-specific composition stay
+> in app code (or in a future private package).
+
+If you find yourself reaching for a noun that names a Mindtrace business
+concept, you are about to leak. Stop, generalise, and revisit. When in
+doubt, keep it in the app.
+
+## Pre-merge checklist
+
+Before merging a PR that touches this package, grep the diff for known leaky
+terms and confirm nothing slipped through:
+
+```bash
+grep -rin -E 'datalake|dataset|inspection|labelling|camera|recipe|defect|annotation' packages/ui/src packages/ui/docs
+```
+
+Result should be empty (or only obvious counter-examples like this very
+checklist).

--- a/packages/ui/docs/STORYBOOK_USAGE.md
+++ b/packages/ui/docs/STORYBOOK_USAGE.md
@@ -1,0 +1,44 @@
+# Storybook usage
+
+Storybook is the canonical visual catalogue for `@mindtrace/ui`. It is the
+source of truth for what each component looks like, what props it accepts,
+and how to compose it.
+
+## Workflow
+
+1. **Before designing or building UI**, browse Storybook to find an existing
+   component or pattern. Many things you might want to build already exist.
+2. **When you change a component**, add or update its story. A change without
+   a corresponding story update is a missed opportunity to verify the result.
+3. **When you build a new component**, ship a story alongside it. Stories
+   live next to the component file:
+   `src/components/<Name>/<Name>.stories.tsx`.
+4. **Use Storybook to compare app UI against the shared library.** If you
+   find yourself rebuilding something that exists, switch to the shared
+   version. If you find yourself extending a pattern in two apps, promote it
+   here.
+
+## Running Storybook
+
+```bash
+npm run storybook         # dev server on :6006
+npm run build:storybook   # static build into storybook-static/
+```
+
+## Story conventions
+
+- **Titles** use one of three top-level prefixes: `Foundations/…`,
+  `Components/…`, `Patterns/…`.
+- **Tags** include `'autodocs'` so Storybook generates a prop table.
+- **Examples are generic.** No private data, no internal customer names, no
+  business-specific workflows.
+- **Show common variants.** Default, disabled, loading, error — wherever
+  relevant. Stories are documentation; one happy-path story is rarely enough.
+
+## What stories shouldn't include
+
+- Screenshots of internal apps
+- Real customer or environment names
+- Internal URLs, API routes, or service hostnames
+- Domain-specific data (datasets, models, cameras, inspection workflows,
+  labelling pipelines, etc.) — substitute generic placeholders

--- a/packages/ui/docs/STORYBOOK_USAGE.md
+++ b/packages/ui/docs/STORYBOOK_USAGE.md
@@ -25,6 +25,18 @@ npm run storybook         # dev server on :6006
 npm run build:storybook   # static build into storybook-static/
 ```
 
+## Accessibility checks (on demand)
+
+The `@storybook/addon-a11y` (axe-core) addon is configured to run **manually**
+(`initialGlobals.a11y.manual` in `.storybook/preview.tsx`). Open the
+**Accessibility** panel and click **Run test** to audit the current story.
+
+It's manual on purpose: by default axe runs a full pass on every story render —
+once per story, again per preview on a Docs page, and again on every navigation
+and controls change — which made heavier pages (e.g. the composite
+`Patterns/PageLayout` docs page) janky and slowed navigation. Manual mode keeps
+the audit one click away without the per-render cost.
+
 ## Story conventions
 
 - **Titles** use one of three top-level prefixes: `Foundations/…`,

--- a/packages/ui/docs/UI_PHILOSOPHY.md
+++ b/packages/ui/docs/UI_PHILOSOPHY.md
@@ -1,0 +1,32 @@
+# UI philosophy
+
+`@mindtrace/ui` is built for **calm, data-heavy operational interfaces** —
+admin tools, dashboards, internal back-offices, control panels — used daily by
+expert users who care about throughput and predictability.
+
+## Principles
+
+- **Clarity over decoration.** Information density wins over visual flair.
+  Operators should be able to scan a screen, find what they need, and act.
+- **Predictable layouts.** Every page assembles from the same primitives
+  (`PageHeader`, `SectionCard`, `FormSection`, `DataTable`). Users should
+  never have to relearn navigation between screens.
+- **Strong hierarchy.** Use type scale, weight, and spacing — not color or
+  decoration — to communicate importance.
+- **Accessible by default.** Components inherit MUI's accessibility work;
+  stories ship with the a11y addon enabled.
+- **Boring, reliable patterns.** Prefer the obvious solution. Operators
+  remember interfaces by their consistency, not their cleverness.
+- **Explicit status and feedback.** Use `StatusBadge`, `Alert`, `StatusDot` to
+  surface state — never rely on color alone, never let users guess what's
+  happening.
+- **Avoid visual noise.** No decorative gradients, no flashy animations, no
+  marketing-style hero blocks. The visual budget is small; spend it on data.
+
+## What this is not
+
+It is not a marketing site kit. It is not a flashy AI-product showcase. It is
+not a place to experiment with novel interactions.
+
+If a screen needs to feel exciting, it probably shouldn't be built from these
+primitives — write something bespoke in the app and keep this library calm.

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,0 +1,9252 @@
+{
+  "name": "@mindtrace/ui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@mindtrace/ui",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^9.0.1",
+        "@mui/material": "^9.0.1",
+        "@storybook/addon-a11y": "^8.4.7",
+        "@storybook/addon-essentials": "^8.4.7",
+        "@storybook/addon-interactions": "^8.4.7",
+        "@storybook/addon-themes": "^8.4.7",
+        "@storybook/react": "^8.4.7",
+        "@storybook/react-vite": "^8.4.7",
+        "@storybook/test": "^8.4.7",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/react": "^18.3.8",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "@vitest/coverage-v8": "^4.1.6",
+        "jsdom": "^29.1.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "storybook": "^8.4.7",
+        "tsup": "^8.3.0",
+        "typescript": "^5.6.2",
+        "vite": "^5.4.6",
+        "vitest": "^4.1.6"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0",
+        "@emotion/styled": "^11.0.0",
+        "@mui/icons-material": "^9.0.0 || ^7.0.0 || ^6.0.0",
+        "@mui/material": "^9.0.0 || ^7.0.0 || ^6.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@mui/icons-material": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.5.0.tgz",
+      "integrity": "sha512-qYDdL7fPwLRI+bJNurVcis+tNgJmvWjH4YTBGXTA8xMuxFrnAz6E5o35iyzyKbq5J5Lr8mJGfrR5GXl+WGwhgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "magic-string": "^0.27.0",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.3.x",
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mdx-js/react": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdx": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.0.1.tgz",
+      "integrity": "sha512-GzamIIhZ1bH77dq7eKaeyRgJdkypsxin4jBFq2EMs4lBWRR0LFO1CSVMsoebn/VvjcNrnrOrjy48MkrkQUK2iw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.0.1.tgz",
+      "integrity": "sha512-5PRpQjVLTNLyV/2J9J53Yz4R0tVbodG0BQDN2zQI1QBG1OPYM25ar+4N20eyFOfJT6zKglLzsnU70+zdVLaTkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^9.0.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.1.tgz",
+      "integrity": "sha512-voyCpeUxcSWLN7KPZuq0pGCIt726T9K6kiVM3XUcywZDAlZSarLHaUxJVQpospbjjOzN53hwyjo8s6KoWl6utw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/core-downloads-tracker": "^9.0.1",
+        "@mui/system": "^9.0.1",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.0.1",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.4",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^9.0.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.0.1.tgz",
+      "integrity": "sha512-pSIGq4Yw749KHEwlkYZWVERgHgwJELP6ODtBNUfV8V4oIb5H+h7IQDFXuk/b2oQccODK1enJAtiEzlgLZmq+8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/utils": "^9.0.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.0.0.tgz",
+      "integrity": "sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.0.1.tgz",
+      "integrity": "sha512-WvlioaLxk6ewUIOfh0StxUvOPDS1mCfzaulcudsL1brZNXuh0N9FMk7RpH7ImJKjEz412SEy/V/yvqmtxbqxCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/private-theming": "^9.0.1",
+        "@mui/styled-engine": "^9.0.0",
+        "@mui/types": "^9.0.0",
+        "@mui/utils": "^9.0.1",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.1.tgz",
+      "integrity": "sha512-f3UO3jNN1pYg5zxqXC81Bvv8hx5ACcYc0387382ZI7M5ono1heIwHYLrKsz85myguWdeVKPRZGmDdynWUBjK2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.0.0",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.129.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+      "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+      "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+      "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+      "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+      "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-8.6.18.tgz",
+      "integrity": "sha512-LFvudttdIfDTNWprA8/N1vbiWbJRrNscyt2OP9Qwi85E1d3LKLy+e8AWiqY08gpy2OUYujK7AjxfpKtNeddrxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/addon-highlight": "8.6.18",
+        "@storybook/global": "^5.0.0",
+        "@storybook/test": "8.6.18",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.18"
+      }
+    },
+    "node_modules/@storybook/addon-actions": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.6.14.tgz",
+      "integrity": "sha512-mDQxylxGGCQSK7tJPkD144J8jWh9IU9ziJMHfB84PKpI/V5ZgqMDnpr2bssTrUaGDqU5e1/z8KcRF+Melhs9pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@types/uuid": "^9.0.1",
+        "dequal": "^2.0.2",
+        "polished": "^4.2.2",
+        "uuid": "^9.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-backgrounds": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.6.14.tgz",
+      "integrity": "sha512-l9xS8qWe5n4tvMwth09QxH2PmJbCctEvBAc1tjjRasAfrd69f7/uFK4WhwJAstzBTNgTc8VXI4w8ZR97i1sFbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "memoizerific": "^1.11.3",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-controls": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.6.14.tgz",
+      "integrity": "sha512-IiQpkNJdiRyA4Mq9mzjZlvQugL/aE7hNgVxBBGPiIZG6wb6Ht9hNnBYpap5ZXXFKV9p2qVI0FZK445ONmAa+Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "dequal": "^2.0.2",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-docs": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.6.14.tgz",
+      "integrity": "sha512-Obpd0OhAF99JyU5pp5ci17YmpcQtMNgqW2pTXV8jAiiipWpwO++hNDeQmLmlSXB399XjtRDOcDVkoc7rc6JzdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/react": "^3.0.0",
+        "@storybook/blocks": "8.6.14",
+        "@storybook/csf-plugin": "8.6.14",
+        "@storybook/react-dom-shim": "8.6.14",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-essentials": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.6.14.tgz",
+      "integrity": "sha512-5ZZSHNaW9mXMOFkoPyc3QkoNGdJHETZydI62/OASR0lmPlJ1065TNigEo5dJddmZNn0/3bkE8eKMAzLnO5eIdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/addon-actions": "8.6.14",
+        "@storybook/addon-backgrounds": "8.6.14",
+        "@storybook/addon-controls": "8.6.14",
+        "@storybook/addon-docs": "8.6.14",
+        "@storybook/addon-highlight": "8.6.14",
+        "@storybook/addon-measure": "8.6.14",
+        "@storybook/addon-outline": "8.6.14",
+        "@storybook/addon-toolbars": "8.6.14",
+        "@storybook/addon-viewport": "8.6.14",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-essentials/node_modules/@storybook/addon-highlight": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.6.14.tgz",
+      "integrity": "sha512-4H19OJlapkofiE9tM6K/vsepf4ir9jMm9T+zw5L85blJZxhKZIbJ6FO0TCG9PDc4iPt3L6+aq5B0X29s9zicNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-highlight": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.6.18.tgz",
+      "integrity": "sha512-wTFJ1DPM0C8gK6nGTJxH75byayQj7BPAz02fME4AOmT6clrBpVl1zSTFTkXaSr+k4xOfeMR/xNUfVskaXz6T9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.18"
+      }
+    },
+    "node_modules/@storybook/addon-interactions": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-8.6.14.tgz",
+      "integrity": "sha512-8VmElhm2XOjh22l/dO4UmXxNOolGhNiSpBcls2pqWSraVh4a670EyYBZsHpkXqfNHo2YgKyZN3C91+9zfH79qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/instrumenter": "8.6.14",
+        "@storybook/test": "8.6.14",
+        "polished": "^4.2.2",
+        "ts-dedent": "^2.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-interactions/node_modules/@storybook/test": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.6.14.tgz",
+      "integrity": "sha512-GkPNBbbZmz+XRdrhMtkxPotCLOQ1BaGNp/gFZYdGDk2KmUWBKmvc5JxxOhtoXM2703IzNFlQHSSNnhrDZYuLlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/instrumenter": "8.6.14",
+        "@testing-library/dom": "10.4.0",
+        "@testing-library/jest-dom": "6.5.0",
+        "@testing-library/user-event": "14.5.2",
+        "@vitest/expect": "2.0.5",
+        "@vitest/spy": "2.0.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-interactions/node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/addon-interactions/node_modules/@testing-library/jest-dom": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.5.0.tgz",
+      "integrity": "sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@storybook/addon-interactions/node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/addon-interactions/node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/addon-interactions/node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@storybook/addon-measure": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.6.14.tgz",
+      "integrity": "sha512-1Tlyb72NX8aAqm6I6OICsUuGOP6hgnXcuFlXucyhKomPa6j3Eu2vKu561t/f0oGtAK2nO93Z70kVaEh5X+vaGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-outline": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.6.14.tgz",
+      "integrity": "sha512-CW857JvN6OxGWElqjlzJO2S69DHf+xO3WsEfT5mT3ZtIjmsvRDukdWfDU9bIYUFyA2lFvYjncBGjbK+I91XR7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-themes": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-8.6.18.tgz",
+      "integrity": "sha512-v+Xcxo/XB2ayw9E/RygGOqUIaPOXp9XEFv6EF7DRt41/RQkQ846yJBARTC2cH8kCb+7FYcvDLD3GN/ms7i8wNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.18"
+      }
+    },
+    "node_modules/@storybook/addon-toolbars": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.6.14.tgz",
+      "integrity": "sha512-W/wEXT8h3VyZTVfWK/84BAcjAxTdtRiAkT2KAN0nbSHxxB5KEM1MjKpKu2upyzzMa3EywITqbfy4dP6lpkVTwQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/addon-viewport": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.6.14.tgz",
+      "integrity": "sha512-gNzVQbMqRC+/4uQTPI2ZrWuRHGquTMZpdgB9DrD88VTEjNudP+J6r8myLfr2VvGksBbUMHkGHMXHuIhrBEnXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "memoizerific": "^1.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/blocks": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.6.14.tgz",
+      "integrity": "sha512-rBMHAfA39AGHgkrDze4RmsnQTMw1ND5fGWobr9pDcJdnDKWQWNRD7Nrlxj0gFlN3n4D9lEZhWGdFrCbku7FVAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/icons": "^1.2.12",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^8.6.14"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/builder-vite": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-8.6.18.tgz",
+      "integrity": "sha512-XLqnOv4C36jlTd4uC8xpWBxv+7GV4/05zWJ0wAcU4qflorropUTirt4UQPGkwIzi+BVAhs9pJj+m4k0IWJtpHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "8.6.18",
+        "browser-assert": "^1.2.1",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.18",
+        "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@storybook/builder-vite/node_modules/@storybook/csf-plugin": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.18.tgz",
+      "integrity": "sha512-x1ioz/L0CwaelCkHci3P31YtvwayN3FBftvwQOPbvRh9qeb4Cpz5IdVDmyvSxxYwXN66uAORNoqgjTi7B4/y5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.18"
+      }
+    },
+    "node_modules/@storybook/components": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.6.18.tgz",
+      "integrity": "sha512-55yViiZzPS/cPBuOeW4QGxGqrusjXVyxuknmbYCIwDtFyyvI/CgbjXRHdxNBaIjz+IlftxvBmmSaOqFG5+/dkA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
+    "node_modules/@storybook/core": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.18.tgz",
+      "integrity": "sha512-dRBP2TnX6fGdS0T2mXBHjkS/3Nlu1ra1huovZVFuM67CYMzrhM/3hX/zru1vWSC5rqY93ZaAhjMciPW4pK5mMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/theming": "8.6.18",
+        "better-opn": "^3.0.2",
+        "browser-assert": "^1.2.1",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
+        "esbuild-register": "^3.5.0",
+        "jsdoc-type-pratt-parser": "^4.0.0",
+        "process": "^0.11.10",
+        "recast": "^0.23.5",
+        "semver": "^7.6.2",
+        "util": "^0.12.5",
+        "ws": "^8.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/core/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/csf-plugin": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.14.tgz",
+      "integrity": "sha512-dErtc9teAuN+eelN8FojzFE635xlq9cNGGGEu0WEmMUQ4iJ8pingvBO1N8X3scz4Ry7KnxX++NNf3J3gpxS8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/global": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
+      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/icons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.6.0.tgz",
+      "integrity": "sha512-hcFZIjW8yQz8O8//2WTIXylm5Xsgc+lW9ISLgUk1xGmptIJQRdlhVIXCpSyLrQaaRiyhQRaVg7l3BD9S216BHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
+      }
+    },
+    "node_modules/@storybook/instrumenter": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.6.14.tgz",
+      "integrity": "sha512-iG4MlWCcz1L7Yu8AwgsnfVAmMbvyRSk700Mfy2g4c8y5O+Cv1ejshE1LBBsCwHgkuqU0H4R0qu4g23+6UnUemQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@vitest/utils": "^2.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/manager-api": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.6.18.tgz",
+      "integrity": "sha512-BjIp12gEMgzFkEsgKpDIbZdnSWTZpm2dlws8WiPJCpgJtG+HWSxZ0/Ms30Au9yfwzQEKRSbV/5zpsKMGc2SIJw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
+    "node_modules/@storybook/preview-api": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.6.18.tgz",
+      "integrity": "sha512-joXRXh3GdVvzhbfIgmix1xs90p8Q/nja7AhEAC2egn5Pl7SKsIYZUCYI6UdrQANb2myg9P552LKXfPect8llKg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
+    "node_modules/@storybook/react": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-8.6.18.tgz",
+      "integrity": "sha512-BuLpzMkKtF+UCQCbi+lYVX9cdcAMG86Lu2dDn7UFkPi5HRNFq/zHPSvlz1XDgL0OYMtcqB1aoVzFzcyzUBhhjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/components": "8.6.18",
+        "@storybook/global": "^5.0.0",
+        "@storybook/manager-api": "8.6.18",
+        "@storybook/preview-api": "8.6.18",
+        "@storybook/react-dom-shim": "8.6.18",
+        "@storybook/theming": "8.6.18"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@storybook/test": "8.6.18",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "storybook": "^8.6.18",
+        "typescript": ">= 4.2.x"
+      },
+      "peerDependenciesMeta": {
+        "@storybook/test": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-dom-shim": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.14.tgz",
+      "integrity": "sha512-0hixr3dOy3f3M+HBofp3jtMQMS+sqzjKNgl7Arfuj3fvjmyXOks/yGjDImySR4imPtEllvPZfhiQNlejheaInw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "storybook": "^8.6.14"
+      }
+    },
+    "node_modules/@storybook/react-vite": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-8.6.18.tgz",
+      "integrity": "sha512-qpSYyH2IizlEsI95MJTdIL6xpLSgiNCMoJpHu+IEqLnyvmecRR/YEZvcHalgdtawuXlimH0bAYuwIu3l8Vo6FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "0.5.0",
+        "@rollup/pluginutils": "^5.0.2",
+        "@storybook/builder-vite": "8.6.18",
+        "@storybook/react": "8.6.18",
+        "find-up": "^5.0.0",
+        "magic-string": "^0.30.0",
+        "react-docgen": "^7.0.0",
+        "resolve": "^1.22.8",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@storybook/test": "8.6.18",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "storybook": "^8.6.18",
+        "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@storybook/test": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react/node_modules/@storybook/react-dom-shim": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.18.tgz",
+      "integrity": "sha512-N4xULcAWZQTUv4jy1/d346Tyb4gufuC3UaLCuU/iVSZ1brYF4OW3ANr+096btbMxY8pR/65lmtoqr5CTGwnBvA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "storybook": "^8.6.18"
+      }
+    },
+    "node_modules/@storybook/test": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.6.18.tgz",
+      "integrity": "sha512-u/RwfWMyHcH0N2hqfMTw2CoZ58IXdeED3b8NmcHc8bmERB3byI5vVAkwYbcD7+WeRHIiym38ZHi0SRn+IpkO3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/instrumenter": "8.6.18",
+        "@testing-library/dom": "10.4.0",
+        "@testing-library/jest-dom": "6.5.0",
+        "@testing-library/user-event": "14.5.2",
+        "@vitest/expect": "2.0.5",
+        "@vitest/spy": "2.0.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.18"
+      }
+    },
+    "node_modules/@storybook/test/node_modules/@storybook/instrumenter": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.6.18.tgz",
+      "integrity": "sha512-viEC1BGlYyjAzi1Tv3LZjByh7Y3Oh04u6QKsujxdeUbr5rUOH4pa/wCKmxXmY6yWrD4WjcNtojmUvQZN/66FXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@vitest/utils": "^2.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.18"
+      }
+    },
+    "node_modules/@storybook/test/node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/test/node_modules/@testing-library/jest-dom": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.5.0.tgz",
+      "integrity": "sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@storybook/test/node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/test/node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/test/node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@storybook/theming": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.18.tgz",
+      "integrity": "sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/doctrine": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
+      "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
+      "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+      "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
+      "integrity": "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.0.5",
+        "@vitest/utils": "2.0.5",
+        "chai": "^5.1.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/pretty-format": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.5.tgz",
+      "integrity": "sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.5.tgz",
+      "integrity": "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.0.5",
+        "estree-walker": "^3.0.3",
+        "loupe": "^3.1.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.5.tgz",
+      "integrity": "sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-opn": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-3.0.2.tgz",
+      "integrity": "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^8.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browser-assert": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
+      "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
+      "dev": true
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.353",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
+      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esbuild-register": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
+      "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.12 <1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.8.0.tgz",
+      "integrity": "sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/map-or-similar": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
+      "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/memoizerific": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
+      "integrity": "sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "map-or-similar": "^1.5.0"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/polished": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-docgen": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-7.1.1.tgz",
+      "integrity": "sha512-hlSJDQ2synMPKFZOsKo9Hi8WWZTC7POR8EmWvTSjow+VDgKzkmjQvFm2fk0tmRw+f0vTOIYKlarR0iL4996pdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.9",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9",
+        "@types/babel__core": "^7.18.0",
+        "@types/babel__traverse": "^7.18.0",
+        "@types/doctrine": "^0.0.9",
+        "@types/resolve": "^1.20.2",
+        "doctrine": "^3.0.0",
+        "resolve": "^1.22.1",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      }
+    },
+    "node_modules/react-docgen-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
+      "integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">= 4.3.x"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+      "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.129.0",
+        "@rolldown/pluginutils": "1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0",
+        "@rolldown/binding-darwin-arm64": "1.0.0",
+        "@rolldown/binding-darwin-x64": "1.0.0",
+        "@rolldown/binding-freebsd-x64": "1.0.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-musl": "1.0.0",
+        "@rolldown/binding-openharmony-arm64": "1.0.0",
+        "@rolldown/binding-wasm32-wasi": "1.0.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+      "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/storybook": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.18.tgz",
+      "integrity": "sha512-p8seiSI6FiVY6P3V0pG+5v7c8pDMehMAFRWEhG5XqIBSQszzOjDnW2rNvm3odoLKfo3V3P6Cs6Hv9ILzymULyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/core": "8.6.18"
+      },
+      "bin": {
+        "getstorybook": "bin/index.cjs",
+        "sb": "bin/index.cjs",
+        "storybook": "bin/index.cjs"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/tsup/node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsup/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/tsup/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unplugin": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.1.tgz",
+      "integrity": "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+      "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,94 @@
+{
+  "name": "@mindtrace/ui",
+  "version": "0.1.0",
+  "description": "React components and theme primitives for calm, data-heavy operational interfaces.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./theme": {
+      "types": "./dist/theme.d.ts",
+      "import": "./dist/theme.js",
+      "require": "./dist/theme.cjs"
+    },
+    "./tokens": {
+      "types": "./dist/tokens.d.ts",
+      "import": "./dist/tokens.js",
+      "require": "./dist/tokens.cjs"
+    },
+    "./provider": {
+      "types": "./dist/provider.d.ts",
+      "import": "./dist/provider.js",
+      "require": "./dist/provider.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "storybook": "storybook dev -p 6006 --no-open",
+    "build:storybook": "storybook build -o storybook-static",
+    "prepublishOnly": "npm run typecheck && npm run build"
+  },
+  "peerDependencies": {
+    "@emotion/react": "^11.0.0",
+    "@emotion/styled": "^11.0.0",
+    "@mui/icons-material": "^9.0.0 || ^7.0.0 || ^6.0.0",
+    "@mui/material": "^9.0.0 || ^7.0.0 || ^6.0.0",
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@mui/icons-material": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^9.0.1",
+    "@mui/material": "^9.0.1",
+    "@storybook/addon-a11y": "^8.4.7",
+    "@storybook/addon-essentials": "^8.4.7",
+    "@storybook/addon-interactions": "^8.4.7",
+    "@storybook/addon-themes": "^8.4.7",
+    "@storybook/react": "^8.4.7",
+    "@storybook/react-vite": "^8.4.7",
+    "@storybook/test": "^8.4.7",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "^18.3.8",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "@vitest/coverage-v8": "^4.1.6",
+    "jsdom": "^29.1.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "storybook": "^8.4.7",
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.6",
+    "vitest": "^4.1.6"
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,15 +52,10 @@
   "peerDependencies": {
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
-    "@mui/icons-material": "^9.0.0 || ^7.0.0 || ^6.0.0",
-    "@mui/material": "^9.0.0 || ^7.0.0 || ^6.0.0",
+    "@mui/icons-material": "^9.0.0",
+    "@mui/material": "^9.0.0",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@mui/icons-material": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@emotion/react": "^11.14.0",

--- a/packages/ui/scripts/run-tests.sh
+++ b/packages/ui/scripts/run-tests.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Vitest runner for @mindtrace/ui. Lives inside the package so the
+# package stays portable — works the same whether it's invoked via
+# `npm test`, from the monorepo via `ds test_ui`, or in a CI pipeline
+# that just clones this directory.
+#
+# Usage (from this directory or via wrappers):
+#   bash scripts/run-tests.sh                     # run once
+#   bash scripts/run-tests.sh --watch             # watch mode
+#   bash scripts/run-tests.sh --coverage          # coverage report
+#   bash scripts/run-tests.sh src/components/...  # specific path
+#
+# `--unit` / `--integration` / `--stress` are accepted for parity with
+# the Python suite (when launched via `ds test_ui`) but no-op here.
+
+set -e
+
+# Move to the package directory regardless of where this script is invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PACKAGE_DIR"
+
+if [ ! -d node_modules ]; then
+    echo "Installing @mindtrace/ui dependencies..."
+    npm install --silent
+fi
+
+ARGS=()
+WATCH=false
+COVERAGE=false
+for arg in "$@"; do
+    case "$arg" in
+        --unit | --integration | --stress | --utils) ;;  # Python-suite flags; no-op here.
+        --watch) WATCH=true ;;
+        --coverage) COVERAGE=true ;;
+        *) ARGS+=("$arg") ;;
+    esac
+done
+
+if [ "$WATCH" = true ]; then
+    exec npx vitest "${ARGS[@]}"
+elif [ "$COVERAGE" = true ]; then
+    exec npx vitest run --coverage "${ARGS[@]}"
+else
+    exec npx vitest run "${ARGS[@]}"
+fi

--- a/packages/ui/scripts/run-tests.sh
+++ b/packages/ui/scripts/run-tests.sh
@@ -23,7 +23,14 @@ cd "$PACKAGE_DIR"
 
 if [ ! -d node_modules ]; then
     echo "Installing @mindtrace/ui dependencies..."
-    npm install --silent
+    # Prefer `npm ci` for reproducible, lockfile-pinned installs (the right
+    # choice for CI). Fall back to `npm install` only when there's no lockfile
+    # to install from (e.g. a fresh local checkout that hasn't generated one).
+    if [ -f package-lock.json ]; then
+        npm ci --silent
+    else
+        npm install --silent
+    fi
 fi
 
 ARGS=()

--- a/packages/ui/src/components/Alert/Alert.stories.tsx
+++ b/packages/ui/src/components/Alert/Alert.stories.tsx
@@ -1,0 +1,59 @@
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+
+import { Alert, AlertTitle } from './Alert'
+
+const meta = {
+  title: 'Components/Alert',
+  component: Alert,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    severity: {
+      control: { type: 'inline-radio' },
+      options: ['info', 'success', 'warning', 'error'],
+    },
+    variant: {
+      control: { type: 'inline-radio' },
+      options: ['standard', 'filled', 'outlined'],
+    },
+    onClose: { action: 'closed' },
+  },
+  args: { severity: 'info', children: 'Inline feedback message.' },
+} satisfies Meta<typeof Alert>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Severities: Story = {
+  render: (args) => (
+    <Stack spacing={1.5} sx={{ width: 480 }}>
+      <Alert {...args} severity="info">Build queued — waiting for an available runner.</Alert>
+      <Alert {...args} severity="success">Changes saved.</Alert>
+      <Alert {...args} severity="warning">You have unsaved edits in two tabs.</Alert>
+      <Alert {...args} severity="error">Could not reach the API. Check your connection.</Alert>
+    </Stack>
+  ),
+}
+
+export const WithTitle: Story = {
+  args: { severity: 'warning' },
+  render: (args) => (
+    <Alert {...args} sx={{ width: 480 }}>
+      <AlertTitle>Heads up</AlertTitle>
+      Permissions for this resource have changed. Review before continuing.
+    </Alert>
+  ),
+}
+
+export const Dismissible: Story = {
+  args: { severity: 'info', onClose: fn(), children: 'Click the close icon to dismiss.' },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /close/i }))
+    await expect(args.onClose).toHaveBeenCalled()
+  },
+}

--- a/packages/ui/src/components/Alert/Alert.test.tsx
+++ b/packages/ui/src/components/Alert/Alert.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { Alert } from './Alert'
+
+describe('Alert', () => {
+  it('renders message', () => {
+    render(<Alert severity="info">All good</Alert>)
+    expect(screen.getByText('All good')).toBeInTheDocument()
+  })
+
+  it('fires onClose when dismiss is clicked', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <Alert severity="info" onClose={onClose}>
+        msg
+      </Alert>,
+    )
+    await user.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -1,0 +1,17 @@
+import MuiAlert, { type AlertProps as MuiAlertProps } from '@mui/material/Alert'
+import AlertTitle, { type AlertTitleProps } from '@mui/material/AlertTitle'
+import { forwardRef } from 'react'
+
+export type AlertProps = MuiAlertProps
+
+/**
+ * Inline feedback message. Thin wrapper around MUI Alert.
+ *
+ *   <Alert severity="warning">Connection unstable. Retrying…</Alert>
+ */
+export const Alert = forwardRef<HTMLDivElement, AlertProps>(function Alert(props, ref) {
+  return <MuiAlert ref={ref} {...props} />
+})
+
+export { AlertTitle }
+export type { AlertTitleProps }

--- a/packages/ui/src/components/Alert/index.ts
+++ b/packages/ui/src/components/Alert/index.ts
@@ -1,0 +1,1 @@
+export * from './Alert'

--- a/packages/ui/src/components/AppBar/AppBar.stories.tsx
+++ b/packages/ui/src/components/AppBar/AppBar.stories.tsx
@@ -1,0 +1,92 @@
+import DarkModeIcon from '@mui/icons-material/DarkMode'
+import HelpOutlineIcon from '@mui/icons-material/Help'
+import SearchIcon from '@mui/icons-material/Search'
+import Box from '@mui/material/Box'
+import IconButton from '@mui/material/IconButton'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Button } from '../Button'
+import { SearchField } from '../SearchField'
+import { UserMenu } from '../UserMenu'
+import { AppBar } from './AppBar'
+
+const Brand = (
+  <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.6 }}>
+    <Typography sx={{ fontSize: '1rem', fontWeight: 700, letterSpacing: '-0.01em' }}>
+      Mindtrace
+    </Typography>
+    <Typography sx={{ fontSize: '1rem', fontWeight: 500, color: 'primary.main' }}>
+      Workspace
+    </Typography>
+  </Box>
+)
+
+const meta = {
+  title: 'Layout/AppBar',
+  component: AppBar,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    height: { control: { type: 'number', min: 48, max: 96, step: 4 } },
+  },
+  args: { height: 60 },
+} satisfies Meta<typeof AppBar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { brand: Brand },
+}
+
+export const WithActions: Story = {
+  args: {
+    brand: Brand,
+    actions: (
+      <>
+        <IconButton size="small" aria-label="Help">
+          <HelpOutlineIcon fontSize="small" />
+        </IconButton>
+        <IconButton size="small" aria-label="Toggle theme">
+          <DarkModeIcon fontSize="small" />
+        </IconButton>
+        <UserMenu name="Avery Lin" email="avery@example.com" onSignOut={() => {}} />
+      </>
+    ),
+  },
+}
+
+export const WithCenterSearch: Story = {
+  args: {
+    brand: Brand,
+    center: (
+      <Box sx={{ width: 320 }}>
+        <SearchField value="" onChange={() => {}} placeholder="Search workspace…" />
+      </Box>
+    ),
+    actions: (
+      <>
+        <IconButton size="small" aria-label="Search">
+          <SearchIcon fontSize="small" />
+        </IconButton>
+        <Button variant="contained" size="small">Invite</Button>
+      </>
+    ),
+  },
+}
+
+export const WithBreadcrumb: Story = {
+  args: {
+    brand: Brand,
+    center: (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        <Typography variant="mono" sx={{ fontSize: '0.8125rem' }}>workspace</Typography>
+        <Typography variant="caption" color="text.secondary">/</Typography>
+        <Typography variant="mono" sx={{ fontSize: '0.8125rem' }}>projects</Typography>
+        <Typography variant="caption" color="text.secondary">/</Typography>
+        <Typography variant="mono" sx={{ fontSize: '0.8125rem' }}>p-42</Typography>
+      </Box>
+    ),
+  },
+}

--- a/packages/ui/src/components/AppBar/AppBar.test.tsx
+++ b/packages/ui/src/components/AppBar/AppBar.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { AppBar } from './AppBar'
+
+describe('AppBar', () => {
+  it('renders brand / center / actions slots', () => {
+    render(<AppBar brand={<div>brand</div>} center={<div>center</div>} actions={<div>actions</div>} />)
+    expect(screen.getByText('brand')).toBeInTheDocument()
+    expect(screen.getByText('center')).toBeInTheDocument()
+    expect(screen.getByText('actions')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/AppBar/AppBar.tsx
+++ b/packages/ui/src/components/AppBar/AppBar.tsx
@@ -1,0 +1,75 @@
+/**
+ * AppBar — page header strip.
+ *
+ * Three slots — `brand` on the left, `center` in the middle, `actions`
+ * on the right. Stateless and unopinionated: pass whatever components
+ * (wordmark, breadcrumbs, search box, icon buttons, user menu) you want
+ * in each slot.
+ *
+ * Renamed from MUI's AppBar to avoid colliding with the underlying
+ * `@mui/material/AppBar` re-export. Use the MUI AppBar directly if you
+ * need its position/elevation behaviors.
+ */
+
+import Box, { type BoxProps } from '@mui/material/Box'
+import type { ReactNode } from 'react'
+
+export type AppBarProps = {
+  /** Left slot — typically a wordmark or logo. */
+  brand?: ReactNode
+  /** Middle slot — breadcrumbs, search, scope path indicator, etc. */
+  center?: ReactNode
+  /** Right slot — icon buttons, user menu, etc. */
+  actions?: ReactNode
+  /** Strip height in pixels. Default `60`. */
+  height?: number
+  /** Extra sx forwarded to the root. */
+  sx?: BoxProps['sx']
+}
+
+export function AppBar({ brand, center, actions, height = 60, sx }: AppBarProps) {
+  return (
+    <Box
+      component="header"
+      sx={[
+        (theme) => ({
+          flex: '0 0 auto',
+          height,
+          px: 3,
+          gap: 1,
+          display: 'flex',
+          alignItems: 'center',
+          bgcolor:
+            theme.palette.mode === 'dark' ? theme.palette.surface.subtle : theme.palette.background.default,
+          borderBottom: 1,
+          borderColor: 'divider',
+        }),
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+    >
+      {brand && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6, flexShrink: 0 }}>{brand}</Box>
+      )}
+      {center && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            minWidth: 0,
+            pl: brand ? 2 : 0,
+            ml: brand ? 2 : 0,
+            borderLeft: brand ? 1 : 0,
+            borderColor: 'divider',
+          }}
+        >
+          {center}
+        </Box>
+      )}
+      <Box sx={{ flexGrow: 1 }} />
+      {actions && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }}>{actions}</Box>
+      )}
+    </Box>
+  )
+}

--- a/packages/ui/src/components/AppBar/index.ts
+++ b/packages/ui/src/components/AppBar/index.ts
@@ -1,0 +1,1 @@
+export * from './AppBar'

--- a/packages/ui/src/components/AppShell/AppShell.stories.tsx
+++ b/packages/ui/src/components/AppShell/AppShell.stories.tsx
@@ -1,0 +1,144 @@
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+
+import { AppBar } from '../AppBar'
+import { Button } from '../Button'
+import { PrimaryRail, type PrimaryRailSection } from '../PrimaryRail'
+import { UserMenu } from '../UserMenu'
+import { AppShell } from './AppShell'
+
+const sections: PrimaryRailSection[] = [
+  {
+    label: 'Workspace',
+    items: [
+      { href: '/', label: 'Dashboard' },
+      { href: '/projects', label: 'Projects' },
+      { href: '/members', label: 'Members' },
+    ],
+  },
+  {
+    label: 'Admin',
+    items: [
+      { href: '/settings', label: 'Settings' },
+      { href: '/billing', label: 'Billing' },
+    ],
+  },
+]
+
+function PlaceholderContent() {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="h4">Page title</Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ maxWidth: 640 }}>
+        The shell composes a sidebar, a top bar, and an optional right rail
+        around scrolling main content. Each region is a slot — the shell owns
+        layout, you own contents.
+      </Typography>
+      {Array.from({ length: 30 }).map((_, i) => (
+        <Box key={i} sx={{ p: 2, border: 1, borderColor: 'divider', borderRadius: 1 }}>
+          Body row {i + 1}
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+const meta = {
+  title: 'Layout/AppShell',
+  component: AppShell,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  argTypes: {
+    embedded: { control: 'boolean' },
+  },
+  args: { embedded: false, children: null },
+} satisfies Meta<typeof AppShell>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function StatefulRail() {
+  const [active, setActive] = useState('/projects')
+  return (
+    <PrimaryRail
+      brand={<Typography sx={{ fontWeight: 700 }}>Mindtrace</Typography>}
+      sections={sections}
+      activeHref={active}
+      renderLink={(item, content) => (
+        <Box
+          component="a"
+          href={item.href}
+          onClick={(e) => {
+            e.preventDefault()
+            setActive(item.href)
+          }}
+          sx={{ textDecoration: 'none', color: 'inherit' }}
+        >
+          {content}
+        </Box>
+      )}
+    />
+  )
+}
+
+export const Default: Story = {
+  render: (args) => (
+    <AppShell
+      {...args}
+      sidebar={<StatefulRail />}
+      topBar={
+        <AppBar
+          brand={<Typography sx={{ fontWeight: 700 }}>Mindtrace</Typography>}
+          actions={<UserMenu name="Avery Lin" email="avery@example.com" onSignOut={() => {}} />}
+        />
+      }
+    >
+      <PlaceholderContent />
+    </AppShell>
+  ),
+}
+
+export const WithRightRail: Story = {
+  render: (args) => (
+    <AppShell
+      {...args}
+      sidebar={<StatefulRail />}
+      topBar={<AppBar brand={<Typography sx={{ fontWeight: 700 }}>Mindtrace</Typography>} actions={<Button size="small">Action</Button>} />}
+      rightRail={
+        <Box
+          sx={(theme) => ({
+            flex: '0 0 320px',
+            borderLeft: 1,
+            borderColor: 'divider',
+            p: 2,
+            bgcolor: theme.palette.surface.subtle,
+          })}
+        >
+          <Typography variant="h6">Inspector</Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            Optional right rail for inspector / agent / detail panels.
+          </Typography>
+        </Box>
+      }
+    >
+      <PlaceholderContent />
+    </AppShell>
+  ),
+}
+
+export const Embedded: Story = {
+  args: { embedded: true },
+  render: (args) => (
+    <AppShell {...args}>
+      <Box sx={{ p: 3 }}>
+        <Typography variant="h5">Embedded mode</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          When `embedded`, the shell hides sidebar / top bar / right rail and
+          renders only `children`. Useful for iframe or micro-frontend hosts.
+        </Typography>
+      </Box>
+    </AppShell>
+  ),
+}

--- a/packages/ui/src/components/AppShell/AppShell.test.tsx
+++ b/packages/ui/src/components/AppShell/AppShell.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { AppShell } from './AppShell'
+
+describe('AppShell', () => {
+  it('renders sidebar / topBar / main slots', () => {
+    render(
+      <AppShell sidebar={<aside>nav</aside>} topBar={<header>bar</header>}>
+        <main>body</main>
+      </AppShell>,
+    )
+    expect(screen.getByText('nav')).toBeInTheDocument()
+    expect(screen.getByText('bar')).toBeInTheDocument()
+    expect(screen.getByText('body')).toBeInTheDocument()
+  })
+
+  it('hides slots when embedded', () => {
+    render(
+      <AppShell embedded sidebar={<aside>nav</aside>} topBar={<header>bar</header>}>
+        <main>body</main>
+      </AppShell>,
+    )
+    expect(screen.queryByText('nav')).not.toBeInTheDocument()
+    expect(screen.queryByText('bar')).not.toBeInTheDocument()
+    expect(screen.getByText('body')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/AppShell/AppShell.tsx
+++ b/packages/ui/src/components/AppShell/AppShell.tsx
@@ -1,0 +1,110 @@
+/**
+ * AppShell — generic operational-interface frame.
+ *
+ * Layout:
+ *   ┌─────┬───────────────────────────────────┐
+ *   │     │ topBar                            │
+ *   │ side├───────────────┬───────────────────┤
+ *   │ bar │ children      │ rightRail         │
+ *   │     │ (scrolls)     │ (optional)        │
+ *   └─────┴───────────────┴───────────────────┘
+ *
+ * Flex with height: 100vh so inner regions own their own scrolling.
+ * All regions are slots — pass whatever component fits. When `embedded`
+ * is true the shell renders only `children` (no sidebar, topBar, or
+ * rightRail), useful for iframe / micro-frontend embedding.
+ */
+
+import Box, { type BoxProps } from '@mui/material/Box'
+import type { ReactNode } from 'react'
+
+export type AppShellProps = {
+  /** Primary left rail (typically a `<PrimaryRail>`). */
+  sidebar?: ReactNode
+  /** Header rendered above the main content. */
+  topBar?: ReactNode
+  /** Main content. Scrolls independently. */
+  children: ReactNode
+  /** Optional secondary right-side rail (inspector, agent panel, etc.). */
+  rightRail?: ReactNode
+  /** When true, suppresses every slot except `children`. */
+  embedded?: boolean
+  /** Inline padding for the main content (theme spacing units). Default `3.5`. */
+  mainPx?: number | string
+  /** Block padding for the main content (theme spacing units). Default `3`. */
+  mainPy?: number | string
+  /** Override the main scroll container's sx for full control. */
+  mainSx?: BoxProps['sx']
+}
+
+export function AppShell({
+  sidebar,
+  topBar,
+  children,
+  rightRail,
+  embedded = false,
+  mainPx = 3.5,
+  mainPy = 3,
+  mainSx,
+}: AppShellProps) {
+  if (embedded) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          height: '100vh',
+          width: '100%',
+          overflow: 'hidden',
+          bgcolor: 'background.default',
+        }}
+      >
+        <Box component="main" sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+          {children}
+        </Box>
+      </Box>
+    )
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        height: '100vh',
+        width: '100%',
+        overflow: 'hidden',
+        bgcolor: 'background.default',
+      }}
+    >
+      {sidebar}
+      <Box
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {topBar}
+        <Box sx={{ display: 'flex', flex: 1, minHeight: 0 }}>
+          <Box
+            component="main"
+            sx={[
+              {
+                flex: 1,
+                minHeight: 0,
+                overflow: 'auto',
+                px: mainPx,
+                py: mainPy,
+              },
+              ...(Array.isArray(mainSx) ? mainSx : [mainSx]),
+            ]}
+          >
+            {children}
+          </Box>
+          {rightRail}
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/packages/ui/src/components/AppShell/index.ts
+++ b/packages/ui/src/components/AppShell/index.ts
@@ -1,0 +1,1 @@
+export * from './AppShell'

--- a/packages/ui/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/ui/src/components/Avatar/Avatar.stories.tsx
@@ -1,0 +1,53 @@
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Avatar } from './Avatar'
+
+const meta = {
+  title: 'Components/Avatar',
+  component: Avatar,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    name: { control: 'text' },
+    email: { control: 'text' },
+    initials: { control: 'text' },
+    src: { control: 'text' },
+    tint: { control: { type: 'inline-radio' }, options: ['subject', 'neutral'] },
+  },
+  args: { name: 'Avery Lin' },
+} satisfies Meta<typeof Avatar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const FromName: Story = {}
+
+export const FromEmail: Story = { args: { name: undefined, email: 'taylor.kim@example.com' } }
+
+export const WithImage: Story = {
+  args: { src: 'https://i.pravatar.cc/64?img=12' },
+}
+
+export const ManyPeople: Story = {
+  render: () => (
+    <Stack direction="row" spacing={1}>
+      {['Avery Lin', 'Taylor Kim', 'Jordan Patel', 'Sam Reed', 'Chris Wu', 'Robin Khan'].map((n) => (
+        <Avatar key={n} name={n} />
+      ))}
+    </Stack>
+  ),
+}
+
+export const Sizes: Story = {
+  render: () => (
+    <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+      <Avatar name="Avery Lin" sx={{ width: 24, height: 24, fontSize: '0.65rem' }} />
+      <Avatar name="Avery Lin" />
+      <Avatar name="Avery Lin" sx={{ width: 48, height: 48, fontSize: '1rem' }} />
+      <Avatar name="Avery Lin" sx={{ width: 64, height: 64, fontSize: '1.25rem' }} />
+    </Stack>
+  ),
+}
+
+export const NoSubject: Story = { args: { name: undefined, email: undefined } }

--- a/packages/ui/src/components/Avatar/Avatar.test.tsx
+++ b/packages/ui/src/components/Avatar/Avatar.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { Avatar } from './Avatar'
+
+describe('Avatar', () => {
+  it('derives initials from name', () => {
+    render(<Avatar name="Avery Lin" />)
+    expect(screen.getByText('AL')).toBeInTheDocument()
+  })
+
+  it('derives initials from email when name is missing', () => {
+    render(<Avatar email="taylor.kim@example.com" />)
+    expect(screen.getByText('TK')).toBeInTheDocument()
+  })
+
+  it('uses explicit initials override', () => {
+    render(<Avatar name="Avery Lin" initials="XY" />)
+    expect(screen.getByText('XY')).toBeInTheDocument()
+  })
+
+  it('shows "?" when no subject is given', () => {
+    render(<Avatar />)
+    expect(screen.getByText('?')).toBeInTheDocument()
+  })
+
+  it('renders the image when src is provided', () => {
+    render(<Avatar src="/me.png" alt="me" name="Avery Lin" />)
+    expect(screen.getByRole('img', { name: 'me' })).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/Avatar/Avatar.tsx
+++ b/packages/ui/src/components/Avatar/Avatar.tsx
@@ -1,0 +1,97 @@
+/**
+ * Avatar — wraps MUI Avatar with two ergonomic defaults:
+ *
+ *   - When no `src` or `children` is given, falls back to **initials**
+ *     derived from `name` or `email`.
+ *   - When no `bgcolor` is given, derives a stable color from the
+ *     subject string so the same person always gets the same tile color.
+ *
+ *   <Avatar name="Avery Lin" />              // → AL on a stable tile color
+ *   <Avatar email="taylor@example.com" />    // → TA on a stable color
+ *   <Avatar src="/me.png" />                 // image; no fallback
+ *   <Avatar>?</Avatar>                       // explicit children
+ */
+
+import MuiAvatar, { type AvatarProps as MuiAvatarProps } from '@mui/material/Avatar'
+import { forwardRef } from 'react'
+
+import { brand, neutral } from '../../theme/tokens'
+
+export type AvatarProps = Omit<MuiAvatarProps, 'children'> & {
+  /** Subject's display name. Used to derive initials and a stable color. */
+  name?: string
+  /** Subject's email. Used to derive initials/color when `name` is missing. */
+  email?: string
+  /** Override the auto-derived initials. */
+  initials?: string
+  /** Tint algorithm. `'subject'` picks from a fixed palette via hash;
+   *  `'neutral'` uses theme neutrals. Default `'subject'`. */
+  tint?: 'subject' | 'neutral'
+  /** Children — use when you want a custom glyph (e.g. an icon). */
+  children?: MuiAvatarProps['children']
+}
+
+const TILE_COLORS = [
+  brand.purple[500],
+  brand.teal[500],
+  brand.blue[500],
+  '#EC4899', // pink
+  '#F59E0B', // amber
+  '#10B981', // emerald
+  '#8B5CF6', // violet
+  '#06B6D4', // cyan
+  '#F97316', // orange
+  '#6366F1', // indigo
+] as const
+
+function deriveInitials(nameOrEmail: string): string {
+  const source = nameOrEmail.includes('@') ? nameOrEmail.split('@')[0] : nameOrEmail
+  const parts = source.split(/[\s._-]+/).filter(Boolean)
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase()
+  return source.slice(0, 2).toUpperCase()
+}
+
+function hashString(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0
+  return Math.abs(h)
+}
+
+function deriveColor(s: string): string {
+  return TILE_COLORS[hashString(s) % TILE_COLORS.length]
+}
+
+export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(function Avatar(
+  { name, email, initials, tint = 'subject', children, src, sx, ...rest },
+  ref,
+) {
+  const subject = (name || email || '').trim()
+  const text = children ?? (subject ? (initials ?? deriveInitials(subject)) : '?')
+  const isImage = !!src
+  const bg =
+    tint === 'neutral'
+      ? neutral[200]
+      : subject
+        ? deriveColor(subject)
+        : neutral[400]
+
+  return (
+    <MuiAvatar
+      ref={ref}
+      src={src}
+      sx={[
+        {
+          bgcolor: isImage ? undefined : bg,
+          color: '#FFFFFF',
+          fontSize: '0.78rem',
+          fontWeight: 700,
+          letterSpacing: '0.02em',
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+      {...rest}
+    >
+      {!isImage && text}
+    </MuiAvatar>
+  )
+})

--- a/packages/ui/src/components/Avatar/index.ts
+++ b/packages/ui/src/components/Avatar/index.ts
@@ -1,0 +1,1 @@
+export * from './Avatar'

--- a/packages/ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/ui/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,56 @@
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+
+import { Badge } from './Badge'
+
+const meta = {
+  title: 'Components/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    label: { control: 'text' },
+    color: {
+      control: { type: 'select' },
+      options: ['default', 'primary', 'secondary', 'success', 'warning', 'error', 'info'],
+    },
+    variant: { control: { type: 'inline-radio' }, options: ['filled', 'outlined'] },
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium'] },
+    clickable: { control: 'boolean' },
+    onClick: { action: 'clicked' },
+    onDelete: { action: 'deleted' },
+  },
+  args: { label: 'pending', onClick: fn() },
+} satisfies Meta<typeof Badge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Colors: Story = {
+  render: (args) => (
+    <Stack direction="row" spacing={1}>
+      <Badge {...args} label="default" color="default" />
+      <Badge {...args} label="primary" color="primary" />
+      <Badge {...args} label="success" color="success" />
+      <Badge {...args} label="warning" color="warning" />
+      <Badge {...args} label="error" color="error" />
+      <Badge {...args} label="info" color="info" />
+    </Stack>
+  ),
+}
+
+export const Variants: Story = {
+  render: (args) => (
+    <Stack direction="row" spacing={1}>
+      <Badge {...args} variant="filled" label="filled" color="primary" />
+      <Badge {...args} variant="outlined" label="outlined" color="primary" />
+    </Stack>
+  ),
+}
+
+export const Deletable: Story = {
+  args: { label: 'tag', onDelete: fn() },
+}

--- a/packages/ui/src/components/Badge/Badge.test.tsx
+++ b/packages/ui/src/components/Badge/Badge.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { Badge } from './Badge'
+
+describe('Badge', () => {
+  it('renders its label', () => {
+    render(<Badge label="active" />)
+    expect(screen.getByText('active')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -1,0 +1,15 @@
+import Chip, { type ChipProps } from '@mui/material/Chip'
+import { forwardRef } from 'react'
+
+export type BadgeProps = ChipProps
+
+/**
+ * Inline label/tag. Wraps MUI Chip rather than MUI Badge because the
+ * common product use-case here is "small labelled token", not "counter dot".
+ * For dot/counter overlay semantics, import MUI Badge directly.
+ *
+ *   <Badge label="active" color="primary" size="small" />
+ */
+export const Badge = forwardRef<HTMLDivElement, BadgeProps>(function Badge(props, ref) {
+  return <Chip ref={ref} size="small" variant="outlined" {...props} />
+})

--- a/packages/ui/src/components/Badge/index.ts
+++ b/packages/ui/src/components/Badge/index.ts
@@ -1,0 +1,1 @@
+export * from './Badge'

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -1,0 +1,57 @@
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+
+import { Button } from './Button'
+
+const meta = {
+  title: 'Components/Button',
+  component: Button,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    variant: { control: { type: 'inline-radio' }, options: ['contained', 'outlined', 'text'] },
+    color: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'success', 'warning', 'error', 'info', 'inherit'],
+    },
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+    disabled: { control: 'boolean' },
+    children: { control: 'text' },
+    onClick: { action: 'clicked' },
+  },
+  args: { children: 'Save changes', variant: 'contained', color: 'primary', onClick: fn() },
+} satisfies Meta<typeof Button>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /save changes/i }))
+    await expect(args.onClick).toHaveBeenCalledOnce()
+  },
+}
+
+export const Variants: Story = {
+  render: (args) => (
+    <Stack direction="row" spacing={1.5}>
+      <Button {...args} variant="contained">Contained</Button>
+      <Button {...args} variant="outlined">Outlined</Button>
+      <Button {...args} variant="text">Text</Button>
+    </Stack>
+  ),
+}
+
+export const Sizes: Story = {
+  render: (args) => (
+    <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+      <Button {...args} size="small">Small</Button>
+      <Button {...args} size="medium">Medium</Button>
+      <Button {...args} size="large">Large</Button>
+    </Stack>
+  ),
+}
+
+export const Disabled: Story = { args: { disabled: true } }

--- a/packages/ui/src/components/Button/Button.test.tsx
+++ b/packages/ui/src/components/Button/Button.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { Button } from './Button'
+
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button>Save</Button>)
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  })
+
+  it('fires onClick', async () => {
+    const onClick = vi.fn()
+    const user = userEvent.setup()
+    render(<Button onClick={onClick}>Save</Button>)
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it('is disabled when prop is set', () => {
+    render(
+      <Button onClick={() => {}} disabled>
+        Save
+      </Button>,
+    )
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+})

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,0 +1,13 @@
+import MuiButton, { type ButtonProps as MuiButtonProps } from '@mui/material/Button'
+import { forwardRef } from 'react'
+
+export type ButtonProps = MuiButtonProps
+
+/**
+ * Standard action button. Thin wrapper around MUI Button — accepts every MUI prop.
+ *
+ *   <Button variant="contained" color="primary">Save changes</Button>
+ */
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(props, ref) {
+  return <MuiButton ref={ref} {...props} />
+})

--- a/packages/ui/src/components/Button/index.ts
+++ b/packages/ui/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export * from './Button'

--- a/packages/ui/src/components/Card/Card.stories.tsx
+++ b/packages/ui/src/components/Card/Card.stories.tsx
@@ -1,0 +1,54 @@
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+
+import { Button } from '../Button'
+import { Card, CardActions, CardContent, CardHeader } from './Card'
+
+const meta = {
+  title: 'Components/Card',
+  component: Card,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    variant: { control: { type: 'inline-radio' }, options: ['elevation', 'outlined'] },
+    raised: { control: 'boolean' },
+    onClick: { action: 'clicked' },
+  },
+  args: { onClick: fn() },
+} satisfies Meta<typeof Card>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { sx: { width: 320 } },
+  render: (args) => (
+    <Card {...args}>
+      <CardContent>
+        <Typography variant="h6">Card title</Typography>
+        <Typography variant="body2" color="text.secondary">
+          A neutral surface for grouping related content.
+        </Typography>
+      </CardContent>
+    </Card>
+  ),
+}
+
+export const WithHeaderAndActions: Story = {
+  args: { sx: { width: 360 } },
+  render: (args) => (
+    <Card {...args}>
+      <CardHeader title="Summary" subheader="Updated just now" />
+      <CardContent>
+        <Typography variant="body2" color="text.secondary">
+          Compact card layout with a header, body copy, and footer actions.
+        </Typography>
+      </CardContent>
+      <CardActions sx={{ justifyContent: 'flex-end' }}>
+        <Button variant="text">Dismiss</Button>
+        <Button variant="contained">View details</Button>
+      </CardActions>
+    </Card>
+  ),
+}

--- a/packages/ui/src/components/Card/Card.test.tsx
+++ b/packages/ui/src/components/Card/Card.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { Card, CardContent } from './Card'
+
+describe('Card', () => {
+  it('renders children', () => {
+    render(
+      <Card>
+        <CardContent>body</CardContent>
+      </Card>,
+    )
+    expect(screen.getByText('body')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -1,0 +1,18 @@
+import MuiCard, { type CardProps as MuiCardProps } from '@mui/material/Card'
+import CardActions, { type CardActionsProps } from '@mui/material/CardActions'
+import CardContent, { type CardContentProps } from '@mui/material/CardContent'
+import CardHeader, { type CardHeaderProps } from '@mui/material/CardHeader'
+import { forwardRef } from 'react'
+
+export type CardProps = MuiCardProps
+
+/**
+ * Surface for grouped content. Thin wrapper around MUI Card; pair with
+ * `CardHeader`, `CardContent`, `CardActions` re-exports.
+ */
+export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(props, ref) {
+  return <MuiCard ref={ref} {...props} />
+})
+
+export { CardActions, CardContent, CardHeader }
+export type { CardActionsProps, CardContentProps, CardHeaderProps }

--- a/packages/ui/src/components/Card/index.ts
+++ b/packages/ui/src/components/Card/index.ts
@@ -1,0 +1,1 @@
+export * from './Card'

--- a/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,38 @@
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+
+import { Checkbox } from './Checkbox'
+
+const meta = {
+  title: 'Components/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    label: { control: 'text' },
+    helperText: { control: 'text' },
+    disabled: { control: 'boolean' },
+    indeterminate: { control: 'boolean' },
+    labelPlacement: { control: { type: 'inline-radio' }, options: ['start', 'end'] },
+    onChange: { action: 'changed' },
+  },
+  args: { label: 'Subscribe to updates', onChange: fn() },
+} satisfies Meta<typeof Checkbox>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+export const WithHelperText: Story = { args: { helperText: 'You can unsubscribe any time.' } }
+export const States: Story = {
+  render: (args) => (
+    <Stack spacing={1.5}>
+      <Checkbox {...args} label="Unchecked" />
+      <Checkbox {...args} label="Checked" defaultChecked />
+      <Checkbox {...args} label="Indeterminate" indeterminate />
+      <Checkbox {...args} label="Disabled" disabled />
+      <Checkbox {...args} label="Disabled + checked" disabled defaultChecked />
+    </Stack>
+  ),
+}

--- a/packages/ui/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { Checkbox } from './Checkbox'
+
+describe('Checkbox', () => {
+  it('renders with a label', () => {
+    render(<Checkbox label="Subscribe" />)
+    expect(screen.getByLabelText('Subscribe')).toBeInTheDocument()
+  })
+
+  it('toggles via click + fires onChange', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Checkbox label="Subscribe" onChange={onChange} />)
+    const cb = screen.getByLabelText('Subscribe')
+    await user.click(cb)
+    expect(onChange).toHaveBeenCalled()
+    expect(cb).toBeChecked()
+  })
+
+  it('renders helper text', () => {
+    render(<Checkbox label="x" helperText="Description" />)
+    expect(screen.getByText('Description')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,41 @@
+import FormControlLabel from '@mui/material/FormControlLabel'
+import FormHelperText from '@mui/material/FormHelperText'
+import MuiCheckbox, { type CheckboxProps as MuiCheckboxProps } from '@mui/material/Checkbox'
+import Stack from '@mui/material/Stack'
+import type { ReactNode } from 'react'
+
+export type CheckboxProps = MuiCheckboxProps & {
+  /** Inline label shown to the right of the box. */
+  label?: ReactNode
+  /** Description shown beneath the label. */
+  helperText?: ReactNode
+  /** Place the label on the left instead of the right. */
+  labelPlacement?: 'start' | 'end'
+}
+
+/**
+ * Boolean input with an optional inline label + helper text. Wraps MUI
+ * Checkbox + FormControlLabel so callers don't have to compose them.
+ *
+ *   <Checkbox label="Subscribe to updates" checked={v} onChange={(_, n) => setV(n)} />
+ */
+export function Checkbox({
+  label,
+  helperText,
+  labelPlacement = 'end',
+  sx,
+  ...rest
+}: CheckboxProps) {
+  const control = <MuiCheckbox {...rest} />
+  if (!label && !helperText) return control
+  return (
+    <Stack spacing={0.25} sx={{ display: 'inline-flex' }}>
+      <FormControlLabel control={control} label={label ?? ''} labelPlacement={labelPlacement} sx={sx} />
+      {helperText && (
+        <FormHelperText sx={{ ml: labelPlacement === 'start' ? 0 : 3.75 }}>
+          {helperText}
+        </FormHelperText>
+      )}
+    </Stack>
+  )
+}

--- a/packages/ui/src/components/Checkbox/index.ts
+++ b/packages/ui/src/components/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export * from './Checkbox'

--- a/packages/ui/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/packages/ui/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+import { useState } from 'react'
+
+import { Button } from '../Button'
+import { ConfirmDialog } from './ConfirmDialog'
+
+const meta = {
+  title: 'Components/ConfirmDialog',
+  component: ConfirmDialog,
+  tags: ['autodocs'],
+  argTypes: {
+    open: { control: 'boolean' },
+    destructive: { control: 'boolean' },
+    loading: { control: 'boolean' },
+    title: { control: 'text' },
+    description: { control: 'text' },
+    confirmLabel: { control: 'text' },
+    cancelLabel: { control: 'text' },
+    onConfirm: { action: 'confirmed' },
+    onCancel: { action: 'cancelled' },
+  },
+  args: {
+    open: false,
+    title: 'Delete project?',
+    description: 'This action is permanent.',
+    confirmLabel: 'Delete',
+    destructive: true,
+    onConfirm: fn(),
+    onCancel: fn(),
+  },
+} satisfies Meta<typeof ConfirmDialog>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Trigger: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(false)
+    return (
+      <>
+        <Button variant="contained" color="error" onClick={() => setOpen(true)}>
+          Delete…
+        </Button>
+        <ConfirmDialog
+          {...args}
+          open={open}
+          onConfirm={() => {
+            setOpen(false)
+            args.onConfirm()
+          }}
+          onCancel={() => {
+            setOpen(false)
+            args.onCancel()
+          }}
+        />
+      </>
+    )
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /delete…/i }))
+    const dialog = await within(document.body).findByRole('dialog')
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+    await expect(args.onConfirm).toHaveBeenCalledOnce()
+  },
+}
+
+export const Loading: Story = { args: { open: true, loading: true } }
+
+export const NonDestructive: Story = {
+  args: {
+    open: true,
+    title: 'Publish changes?',
+    description: 'Your team will see the updated content immediately.',
+    confirmLabel: 'Publish',
+    destructive: false,
+  },
+}
+
+export const ForcedAcknowledgement: Story = {
+  args: {
+    open: true,
+    title: 'Your session expired',
+    description: 'Please sign in again to continue.',
+    confirmLabel: 'OK',
+    hideCancel: true,
+    destructive: false,
+  },
+}

--- a/packages/ui/src/components/ConfirmDialog/ConfirmDialog.test.tsx
+++ b/packages/ui/src/components/ConfirmDialog/ConfirmDialog.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { ConfirmDialog } from './ConfirmDialog'
+
+describe('ConfirmDialog', () => {
+  it('renders title + description', () => {
+    render(
+      <ConfirmDialog
+        open
+        title="Delete?"
+        description="Permanent."
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    expect(screen.getByText('Delete?')).toBeInTheDocument()
+    expect(screen.getByText('Permanent.')).toBeInTheDocument()
+  })
+
+  it('fires onConfirm and onCancel', async () => {
+    const onConfirm = vi.fn()
+    const onCancel = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <ConfirmDialog
+        open
+        title="Delete?"
+        confirmLabel="Delete"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalled()
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('disables buttons when loading', () => {
+    render(
+      <ConfirmDialog open title="X" loading onConfirm={() => {}} onCancel={() => {}} />,
+    )
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled()
+  })
+
+  it('hides cancel when hideCancel is set', () => {
+    render(
+      <ConfirmDialog open title="X" hideCancel onConfirm={() => {}} onCancel={() => {}} />,
+    )
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/packages/ui/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -1,0 +1,95 @@
+/**
+ * ConfirmDialog — preset over Modal for the "are you sure?" pattern.
+ *
+ *   <ConfirmDialog
+ *     open={open}
+ *     title="Delete project?"
+ *     description="This action is permanent."
+ *     destructive
+ *     confirmLabel="Delete"
+ *     loading={deleting}
+ *     onConfirm={handleDelete}
+ *     onCancel={close}
+ *   />
+ *
+ * Renders a focused dialog with a description body, cancel button,
+ * and a primary confirm button (red when `destructive`). When `loading`
+ * is true the confirm button shows a spinner and disables both buttons.
+ */
+
+import CircularProgress from '@mui/material/CircularProgress'
+import { type ReactNode } from 'react'
+
+import { Button } from '../Button'
+import { Modal, ModalActions, ModalContent, ModalContentText, ModalTitle } from '../Modal'
+
+export type ConfirmDialogProps = {
+  open: boolean
+  title: ReactNode
+  description?: ReactNode
+  /** Extra body content rendered below the description. */
+  children?: ReactNode
+  confirmLabel?: string
+  cancelLabel?: string
+  /** Red confirm button + warning tone. */
+  destructive?: boolean
+  /** Show a spinner on confirm; disable both buttons. */
+  loading?: boolean
+  /** Confirm handler. May be async — pair with `loading` to drive UI. */
+  onConfirm: () => void | Promise<void>
+  /** Cancel handler. Also called when the backdrop is clicked. */
+  onCancel: () => void
+  /** Hide the cancel button (e.g. for forced acknowledgements). */
+  hideCancel?: boolean
+  /** Max width forwarded to the dialog. Default `'xs'`. */
+  maxWidth?: 'xs' | 'sm' | 'md'
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  children,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  destructive = false,
+  loading = false,
+  onConfirm,
+  onCancel,
+  hideCancel = false,
+  maxWidth = 'xs',
+}: ConfirmDialogProps) {
+  return (
+    <Modal
+      open={open}
+      onClose={loading ? undefined : onCancel}
+      maxWidth={maxWidth}
+      fullWidth
+      aria-labelledby="confirm-dialog-title"
+    >
+      <ModalTitle id="confirm-dialog-title">{title}</ModalTitle>
+      {(description || children) && (
+        <ModalContent>
+          {description && <ModalContentText>{description}</ModalContentText>}
+          {children}
+        </ModalContent>
+      )}
+      <ModalActions>
+        {!hideCancel && (
+          <Button variant="text" onClick={onCancel} disabled={loading}>
+            {cancelLabel}
+          </Button>
+        )}
+        <Button
+          variant="contained"
+          color={destructive ? 'error' : 'primary'}
+          onClick={onConfirm}
+          disabled={loading}
+          startIcon={loading ? <CircularProgress size={14} color="inherit" /> : undefined}
+        >
+          {confirmLabel}
+        </Button>
+      </ModalActions>
+    </Modal>
+  )
+}

--- a/packages/ui/src/components/ConfirmDialog/index.ts
+++ b/packages/ui/src/components/ConfirmDialog/index.ts
@@ -1,0 +1,1 @@
+export * from './ConfirmDialog'

--- a/packages/ui/src/components/CopyButton/CopyButton.stories.tsx
+++ b/packages/ui/src/components/CopyButton/CopyButton.stories.tsx
@@ -1,0 +1,35 @@
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+
+import { Mono } from '../Mono'
+import { CopyButton } from './CopyButton'
+
+const meta = {
+  title: 'Components/CopyButton',
+  component: CopyButton,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    value: { control: 'text' },
+    label: { control: 'text' },
+    copiedLabel: { control: 'text' },
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium', 'large'] },
+    onCopy: { action: 'copied' },
+  },
+  args: { value: 'a3b6e5bf6ff856d2509292e95c8f57f0df7017cf', onCopy: fn() },
+} satisfies Meta<typeof CopyButton>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithMono: Story = {
+  render: (args) => (
+    <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+      <Mono>{args.value}</Mono>
+      <CopyButton {...args} />
+    </Stack>
+  ),
+}

--- a/packages/ui/src/components/CopyButton/CopyButton.test.tsx
+++ b/packages/ui/src/components/CopyButton/CopyButton.test.tsx
@@ -1,0 +1,26 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent } from '@testing-library/react'
+
+import { render, screen, waitFor } from '../../test-utils'
+import { CopyButton } from './CopyButton'
+
+describe('CopyButton', () => {
+  let writeText: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('writes value on click + fires onCopy', async () => {
+    const onCopy = vi.fn()
+    render(<CopyButton value="abc" onCopy={onCopy} disableTooltip />)
+    fireEvent.click(screen.getByRole('button'))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('abc'))
+    await waitFor(() => expect(onCopy).toHaveBeenCalledWith(true))
+  })
+})

--- a/packages/ui/src/components/CopyButton/CopyButton.tsx
+++ b/packages/ui/src/components/CopyButton/CopyButton.tsx
@@ -1,0 +1,62 @@
+/**
+ * CopyButton — icon button that copies a string to the clipboard.
+ *
+ *   <Mono>{id}</Mono>
+ *   <CopyButton value={id} />
+ *
+ * Shows a check icon for ~1.5s after success. Wrapped in a tooltip
+ * unless `disableTooltip` is set.
+ */
+
+import CheckIcon from '@mui/icons-material/Check'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import IconButton, { type IconButtonProps } from '@mui/material/IconButton'
+import Tooltip from '@mui/material/Tooltip'
+import { forwardRef } from 'react'
+
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard'
+
+export type CopyButtonProps = Omit<IconButtonProps, 'onClick' | 'children'> & {
+  /** Text to copy when the button is clicked. */
+  value: string
+  /** Tooltip shown by default. */
+  label?: string
+  /** Tooltip shown right after a successful copy. */
+  copiedLabel?: string
+  /** Skip the tooltip entirely. */
+  disableTooltip?: boolean
+  /** Called after a copy attempt. Receives `true` on success. */
+  onCopy?: (success: boolean) => void
+}
+
+export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(function CopyButton(
+  {
+    value,
+    label = 'Copy',
+    copiedLabel = 'Copied',
+    disableTooltip = false,
+    onCopy,
+    size = 'small',
+    ...rest
+  },
+  ref,
+) {
+  const [copy, { copied }] = useCopyToClipboard()
+  const handle = async () => {
+    const ok = await copy(value)
+    onCopy?.(ok)
+  }
+  const button = (
+    <IconButton
+      ref={ref}
+      size={size}
+      onClick={handle}
+      aria-label={copied ? copiedLabel : label}
+      {...rest}
+    >
+      {copied ? <CheckIcon fontSize="inherit" /> : <ContentCopyIcon fontSize="inherit" />}
+    </IconButton>
+  )
+  if (disableTooltip) return button
+  return <Tooltip title={copied ? copiedLabel : label}>{button}</Tooltip>
+})

--- a/packages/ui/src/components/CopyButton/index.ts
+++ b/packages/ui/src/components/CopyButton/index.ts
@@ -1,0 +1,1 @@
+export * from './CopyButton'

--- a/packages/ui/src/components/DataTable/DataTable.stories.tsx
+++ b/packages/ui/src/components/DataTable/DataTable.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+
+import { Mono } from '../Mono'
+import { StatusBadge } from '../StatusBadge'
+import { DataTable } from './DataTable'
+
+type Job = {
+  id: string
+  name: string
+  status: 'success' | 'warning' | 'error'
+  duration_ms: number
+  ts: string
+}
+
+const rows: Job[] = [
+  { id: 'j-9241', name: 'nightly-report', status: 'success', duration_ms: 142, ts: '2026-05-08 14:03' },
+  { id: 'j-9240', name: 'nightly-report', status: 'success', duration_ms: 138, ts: '2026-05-08 14:02' },
+  { id: 'j-9239', name: 'image-resize', status: 'warning', duration_ms: 312, ts: '2026-05-08 14:01' },
+  { id: 'j-9238', name: 'image-resize', status: 'error', duration_ms: 0, ts: '2026-05-08 14:00' },
+  { id: 'j-9237', name: 'nightly-report', status: 'success', duration_ms: 134, ts: '2026-05-08 13:59' },
+]
+
+const columns = [
+  { id: 'id', label: 'ID', render: (r: Job) => <Mono>{r.id}</Mono> },
+  { id: 'name', label: 'Job' },
+  { id: 'status', label: 'Status', render: (r: Job) => <StatusBadge tone={r.status} label={r.status} /> },
+  {
+    id: 'duration_ms',
+    label: 'Duration',
+    align: 'right' as const,
+    render: (r: Job) => `${r.duration_ms} ms`,
+  },
+  { id: 'ts', label: 'When', render: (r: Job) => <Mono>{r.ts}</Mono> },
+]
+
+const meta = {
+  title: 'Patterns/DataTable',
+  component: DataTable<Job>,
+  tags: ['autodocs'],
+  argTypes: {
+    density: { control: { type: 'inline-radio' }, options: ['small', 'medium'] },
+    loading: { control: 'boolean' },
+    onRowClick: { action: 'rowClicked' },
+  },
+  args: {
+    rows,
+    columns,
+    getRowKey: (r: Job) => r.id,
+    density: 'small',
+  },
+} satisfies Meta<typeof DataTable<Job>>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Clickable: Story = {
+  args: { onRowClick: fn() },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    const firstId = await canvas.findByText('j-9241')
+    await userEvent.click(firstId)
+    await expect(args.onRowClick).toHaveBeenCalled()
+  },
+}
+
+export const Loading: Story = { args: { loading: true } }
+
+export const Empty: Story = {
+  args: {
+    rows: [],
+    empty: 'No jobs in the last 24h.',
+  },
+}

--- a/packages/ui/src/components/DataTable/DataTable.test.tsx
+++ b/packages/ui/src/components/DataTable/DataTable.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { DataTable } from './DataTable'
+
+type Row = { id: string; name: string }
+const rows: Row[] = [
+  { id: 'a', name: 'Alice' },
+  { id: 'b', name: 'Bob' },
+]
+const columns = [
+  { id: 'id', label: 'ID' },
+  { id: 'name', label: 'Name' },
+]
+
+describe('DataTable', () => {
+  it('renders rows + columns', () => {
+    render(<DataTable rows={rows} columns={columns} getRowKey={(r) => r.id} />)
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.getByText('Bob')).toBeInTheDocument()
+    expect(screen.getByText('ID')).toBeInTheDocument()
+  })
+
+  it('shows empty state', () => {
+    render(<DataTable rows={[]} columns={columns} getRowKey={(r: Row) => r.id} empty="None" />)
+    expect(screen.getByText('None')).toBeInTheDocument()
+  })
+
+  it('fires onRowClick', async () => {
+    const onRowClick = vi.fn()
+    const user = userEvent.setup()
+    render(<DataTable rows={rows} columns={columns} getRowKey={(r) => r.id} onRowClick={onRowClick} />)
+    await user.click(screen.getByText('Alice'))
+    expect(onRowClick).toHaveBeenCalledWith(rows[0])
+  })
+})

--- a/packages/ui/src/components/DataTable/DataTable.test.tsx
+++ b/packages/ui/src/components/DataTable/DataTable.test.tsx
@@ -33,4 +33,26 @@ describe('DataTable', () => {
     await user.click(screen.getByText('Alice'))
     expect(onRowClick).toHaveBeenCalledWith(rows[0])
   })
+
+  it('falls back to a dash for non-primitive cells (no crash on circular refs)', () => {
+    // A circular object would throw if the default renderer called JSON.stringify.
+    const circular: { self?: unknown } = {}
+    circular.self = circular
+    const objRows = [{ id: 'x', meta: circular }]
+    expect(() =>
+      render(
+        <DataTable
+          rows={objRows}
+          columns={[
+            { id: 'id', label: 'ID' },
+            { id: 'meta', label: 'Meta' },
+          ]}
+          getRowKey={(r) => r.id}
+        />,
+      ),
+    ).not.toThrow()
+    // The non-primitive cell renders the em-dash placeholder, not raw JSON.
+    expect(screen.getByText('x')).toBeInTheDocument()
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
 })

--- a/packages/ui/src/components/DataTable/DataTable.tsx
+++ b/packages/ui/src/components/DataTable/DataTable.tsx
@@ -1,0 +1,118 @@
+/**
+ * DataTable — a thin, typed wrapper around MUI Table for the common
+ * "render a list of objects as rows with named columns" case.
+ *
+ * For complex needs (sorting, filtering, virtualization, server-side
+ * paging) reach for `@mui/x-data-grid` directly. This is the cheap path.
+ *
+ *   <DataTable
+ *     rows={items}
+ *     columns={[
+ *       { id: 'name', label: 'Name' },
+ *       { id: 'status', label: 'Status', render: (r) => <StatusBadge ... /> },
+ *       { id: 'created_at', label: 'Created', align: 'right',
+ *         render: (r) => fmtDate(r.created_at) },
+ *     ]}
+ *     getRowKey={(r) => r.id}
+ *     onRowClick={(r) => navigate(`/x/${r.id}`)}
+ *     empty="No items yet."
+ *   />
+ */
+
+import Box from '@mui/material/Box'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableContainer from '@mui/material/TableContainer'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import Typography from '@mui/material/Typography'
+import type { ReactNode } from 'react'
+
+import { EmptyState } from '../EmptyState/EmptyState'
+
+export type Column<Row> = {
+  id: string
+  label: ReactNode
+  align?: 'left' | 'right' | 'center'
+  width?: number | string
+  render?: (row: Row) => ReactNode
+}
+
+export type DataTableProps<Row> = {
+  rows: Row[]
+  columns: Column<Row>[]
+  getRowKey: (row: Row) => string
+  onRowClick?: (row: Row) => void
+  empty?: ReactNode
+  loading?: boolean
+  /** Reduce row height (small) or use comfortable defaults (medium). */
+  density?: 'small' | 'medium'
+}
+
+export function DataTable<Row>({
+  rows,
+  columns,
+  getRowKey,
+  onRowClick,
+  empty,
+  loading,
+  density = 'small',
+}: DataTableProps<Row>) {
+  if (!loading && rows.length === 0) {
+    return (
+      <EmptyState
+        title="No results"
+        description={typeof empty === 'string' ? empty : 'Nothing to show here.'}
+      />
+    )
+  }
+  return (
+    <TableContainer>
+      <Table size={density} stickyHeader>
+        <TableHead>
+          <TableRow>
+            {columns.map((col) => (
+              <TableCell key={col.id} align={col.align} sx={{ width: col.width }}>
+                {col.label}
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow
+              key={getRowKey(row)}
+              hover={Boolean(onRowClick)}
+              onClick={onRowClick ? () => onRowClick(row) : undefined}
+              sx={{
+                cursor: onRowClick ? 'pointer' : 'default',
+                '&:last-child td': { borderBottom: 0 },
+              }}
+            >
+              {columns.map((col) => (
+                <TableCell key={col.id} align={col.align}>
+                  {col.render ? col.render(row) : renderDefault(row, col.id)}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {loading && (
+        <Box sx={{ textAlign: 'center', py: 2 }}>
+          <Typography variant="caption" color="text.secondary">
+            Loading…
+          </Typography>
+        </Box>
+      )}
+    </TableContainer>
+  )
+}
+
+function renderDefault<Row>(row: Row, id: string): ReactNode {
+  const v = (row as Record<string, unknown>)[id]
+  if (v == null) return '—'
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return String(v)
+  return JSON.stringify(v)
+}

--- a/packages/ui/src/components/DataTable/DataTable.tsx
+++ b/packages/ui/src/components/DataTable/DataTable.tsx
@@ -113,6 +113,12 @@ export function DataTable<Row>({
 function renderDefault<Row>(row: Row, id: string): ReactNode {
   const v = (row as Record<string, unknown>)[id]
   if (v == null) return '—'
-  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return String(v)
-  return JSON.stringify(v)
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean' || typeof v === 'bigint') {
+    return String(v)
+  }
+  // Non-primitive (object/array/function/symbol): the default renderer can't
+  // safely stringify these — JSON.stringify throws on circular references and
+  // dumps unreadable walls of text for large nested objects. Supply a custom
+  // `render` for the column when the value isn't a primitive.
+  return '—'
 }

--- a/packages/ui/src/components/DataTable/index.ts
+++ b/packages/ui/src/components/DataTable/index.ts
@@ -1,0 +1,2 @@
+export { DataTable } from './DataTable'
+export type { DataTableProps, Column } from './DataTable'

--- a/packages/ui/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.stories.tsx
@@ -1,0 +1,81 @@
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+import { useState } from 'react'
+
+import { Button } from '../Button'
+import { Drawer } from './Drawer'
+
+const meta = {
+  title: 'Components/Drawer',
+  component: Drawer,
+  tags: ['autodocs'],
+  argTypes: {
+    anchor: {
+      control: { type: 'inline-radio' },
+      options: ['left', 'right', 'top', 'bottom'],
+    },
+    variant: {
+      control: { type: 'inline-radio' },
+      options: ['temporary', 'persistent', 'permanent'],
+    },
+    open: { control: 'boolean' },
+    onClose: { action: 'closed' },
+  },
+  args: { anchor: 'right', open: false, onClose: fn() },
+} satisfies Meta<typeof Drawer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Trigger: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(false)
+    return (
+      <>
+        <Button variant="outlined" onClick={() => setOpen(true)}>Open drawer</Button>
+        <Drawer
+          {...args}
+          open={open}
+          onClose={(event, reason) => {
+            setOpen(false)
+            args.onClose?.(event, reason)
+          }}
+        >
+          <Box sx={{ width: 320, p: 3 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">Details</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Drawers are good for secondary context that needs to stay scoped
+                to the current page.
+              </Typography>
+              <Button variant="contained" onClick={() => setOpen(false)}>Close</Button>
+            </Stack>
+          </Box>
+        </Drawer>
+      </>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /open drawer/i }))
+    const drawer = await within(document.body).findByText('Details')
+    await expect(drawer).toBeVisible()
+  },
+}
+
+export const Open: Story = {
+  args: { open: true, anchor: 'right' },
+  render: (args) => (
+    <Drawer {...args}>
+      <Box sx={{ width: 320, p: 3 }}>
+        <Typography variant="h6">Details</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          A statically-open drawer for visual inspection.
+        </Typography>
+      </Box>
+    </Drawer>
+  ),
+}

--- a/packages/ui/src/components/Drawer/Drawer.test.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { Drawer } from './Drawer'
+
+describe('Drawer', () => {
+  it('renders contents when open', () => {
+    render(
+      <Drawer open onClose={() => {}}>
+        <div>panel</div>
+      </Drawer>,
+    )
+    expect(screen.getByText('panel')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/Drawer/Drawer.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.tsx
@@ -1,0 +1,13 @@
+import MuiDrawer, { type DrawerProps as MuiDrawerProps } from '@mui/material/Drawer'
+import { forwardRef } from 'react'
+
+export type DrawerProps = MuiDrawerProps
+
+/**
+ * Edge-anchored sliding panel. Thin wrapper around MUI Drawer.
+ *
+ *   <Drawer anchor="right" open={open} onClose={close}>…</Drawer>
+ */
+export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(function Drawer(props, ref) {
+  return <MuiDrawer ref={ref} {...props} />
+})

--- a/packages/ui/src/components/Drawer/index.ts
+++ b/packages/ui/src/components/Drawer/index.ts
@@ -1,0 +1,1 @@
+export * from './Drawer'

--- a/packages/ui/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/ui/src/components/EmptyState/EmptyState.stories.tsx
@@ -1,0 +1,33 @@
+import InboxIcon from '@mui/icons-material/Inbox'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Button } from '../Button'
+import { EmptyState } from './EmptyState'
+
+const meta = {
+  title: 'Patterns/EmptyState',
+  component: EmptyState,
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+  },
+  args: {
+    title: 'No items yet',
+    description: "When something happens here, it'll show up.",
+  },
+} satisfies Meta<typeof EmptyState>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithAction: Story = {
+  args: {
+    icon: <InboxIcon fontSize="inherit" />,
+    title: 'Inbox empty',
+    description: 'Nothing assigned to you. Browse the workspace to pick up new items.',
+    action: <Button variant="contained">Browse workspace</Button>,
+  },
+}

--- a/packages/ui/src/components/EmptyState/EmptyState.test.tsx
+++ b/packages/ui/src/components/EmptyState/EmptyState.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { EmptyState } from './EmptyState'
+
+describe('EmptyState', () => {
+  it('renders title + description', () => {
+    render(<EmptyState title="Empty" description="Nothing here yet." />)
+    expect(screen.getByText('Empty')).toBeInTheDocument()
+    expect(screen.getByText('Nothing here yet.')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/EmptyState/EmptyState.tsx
+++ b/packages/ui/src/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,42 @@
+/**
+ * Empty / zero-data state. Use for empty lists, "nothing here yet", and
+ * recoverable error views.
+ */
+
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { ReactNode } from 'react'
+
+export type EmptyStateProps = {
+  icon?: ReactNode
+  title: ReactNode
+  description?: ReactNode
+  action?: ReactNode
+}
+
+export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+  return (
+    <Stack
+      spacing={1.5}
+      sx={(theme) => ({
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        py: 6,
+        px: 3,
+        color: theme.palette.text.secondary,
+      })}
+    >
+      {icon && <Stack sx={{ fontSize: 32, color: 'text.disabled' }}>{icon}</Stack>}
+      <Typography variant="h5" component="p" color="text.primary">
+        {title}
+      </Typography>
+      {description && (
+        <Typography variant="body2" sx={{ maxWidth: 480 }}>
+          {description}
+        </Typography>
+      )}
+      {action && <Stack sx={{ pt: 1 }}>{action}</Stack>}
+    </Stack>
+  )
+}

--- a/packages/ui/src/components/EmptyState/index.ts
+++ b/packages/ui/src/components/EmptyState/index.ts
@@ -1,0 +1,2 @@
+export { EmptyState } from './EmptyState'
+export type { EmptyStateProps } from './EmptyState'

--- a/packages/ui/src/components/FilterChips/FilterChips.stories.tsx
+++ b/packages/ui/src/components/FilterChips/FilterChips.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+import { useState } from 'react'
+
+import { FilterChips, type FilterOption } from './FilterChips'
+
+const options: FilterOption[] = [
+  { id: 'pending', label: 'Pending', count: 12 },
+  { id: 'in-progress', label: 'In progress', count: 3 },
+  { id: 'completed', label: 'Completed', count: 41 },
+  { id: 'archived', label: 'Archived', count: 200 },
+]
+
+const meta = {
+  title: 'Patterns/FilterChips',
+  component: FilterChips,
+  tags: ['autodocs'],
+  argTypes: {
+    exclusive: { control: 'boolean' },
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium'] },
+    onChange: { action: 'changed' },
+  },
+  args: {
+    options,
+    selected: ['pending'],
+    onChange: fn(),
+  },
+} satisfies Meta<typeof FilterChips>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function Wrapper({ exclusive, size, onChange }: { exclusive?: boolean; size?: 'small' | 'medium'; onChange: (next: string[]) => void }) {
+  const [selected, setSelected] = useState<string[]>(['pending'])
+  return (
+    <FilterChips
+      options={options}
+      selected={selected}
+      onChange={(next) => { setSelected(next); onChange(next) }}
+      exclusive={exclusive}
+      size={size}
+    />
+  )
+}
+
+export const MultiSelect: Story = {
+  render: (args) => <Wrapper exclusive={args.exclusive} size={args.size} onChange={args.onChange} />,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByText(/Completed/))
+    await expect(args.onChange).toHaveBeenCalled()
+  },
+}
+
+export const Exclusive: Story = {
+  args: { exclusive: true },
+  render: (args) => <Wrapper exclusive={args.exclusive} size={args.size} onChange={args.onChange} />,
+}

--- a/packages/ui/src/components/FilterChips/FilterChips.test.tsx
+++ b/packages/ui/src/components/FilterChips/FilterChips.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { FilterChips } from './FilterChips'
+
+const options = [
+  { id: 'a', label: 'A' },
+  { id: 'b', label: 'B' },
+]
+
+describe('FilterChips', () => {
+  it('toggles selection', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<FilterChips options={options} selected={[]} onChange={onChange} />)
+    await user.click(screen.getByText('A'))
+    expect(onChange).toHaveBeenCalledWith(['a'])
+  })
+
+  it('replaces selection when exclusive', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<FilterChips options={options} selected={['a']} exclusive onChange={onChange} />)
+    await user.click(screen.getByText('B'))
+    expect(onChange).toHaveBeenCalledWith(['b'])
+  })
+})

--- a/packages/ui/src/components/FilterChips/FilterChips.tsx
+++ b/packages/ui/src/components/FilterChips/FilterChips.tsx
@@ -1,0 +1,62 @@
+/**
+ * FilterChips — a row of selectable chips, multi-select.
+ *
+ *   <FilterChips
+ *     options={[{ id: 'pending', label: 'Pending' }, ...]}
+ *     selected={['pending']}
+ *     onChange={setSelected}
+ *   />
+ */
+
+import Chip from '@mui/material/Chip'
+import Stack from '@mui/material/Stack'
+
+export type FilterOption<Id extends string = string> = {
+  id: Id
+  label: string
+  count?: number
+}
+
+export type FilterChipsProps<Id extends string = string> = {
+  options: FilterOption<Id>[]
+  selected: Id[]
+  onChange: (next: Id[]) => void
+  /** When true, only one chip can be selected at a time. */
+  exclusive?: boolean
+  size?: 'small' | 'medium'
+}
+
+export function FilterChips<Id extends string = string>({
+  options,
+  selected,
+  onChange,
+  exclusive,
+  size = 'small',
+}: FilterChipsProps<Id>) {
+  function toggle(id: Id) {
+    if (exclusive) {
+      onChange(selected.includes(id) ? [] : [id])
+      return
+    }
+    onChange(selected.includes(id) ? selected.filter((x) => x !== id) : [...selected, id])
+  }
+  return (
+    <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', gap: 1 }}>
+      {options.map((opt) => {
+        const active = selected.includes(opt.id)
+        return (
+          <Chip
+            key={opt.id}
+            size={size}
+            label={opt.count != null ? `${opt.label} · ${opt.count}` : opt.label}
+            clickable
+            onClick={() => toggle(opt.id)}
+            variant={active ? 'filled' : 'outlined'}
+            color={active ? 'primary' : 'default'}
+            sx={{ fontWeight: 500 }}
+          />
+        )
+      })}
+    </Stack>
+  )
+}

--- a/packages/ui/src/components/FilterChips/index.ts
+++ b/packages/ui/src/components/FilterChips/index.ts
@@ -1,0 +1,2 @@
+export { FilterChips } from './FilterChips'
+export type { FilterChipsProps, FilterOption } from './FilterChips'

--- a/packages/ui/src/components/FormSection/FormSection.stories.tsx
+++ b/packages/ui/src/components/FormSection/FormSection.stories.tsx
@@ -1,0 +1,54 @@
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Button } from '../Button'
+import { TextField } from '../TextField'
+import { FormSection } from './FormSection'
+
+const meta = {
+  title: 'Patterns/FormSection',
+  component: FormSection,
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+  },
+  args: {
+    title: 'Section title',
+    description: 'Supporting copy under the heading.',
+    children: null,
+  },
+} satisfies Meta<typeof FormSection>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    title: 'Profile',
+    description: 'How you appear to teammates.',
+  },
+  render: (args) => (
+    <Stack sx={{ maxWidth: 560 }}>
+      <FormSection {...args}>
+        <TextField label="Display name" defaultValue="Alex" />
+        <TextField label="Email" defaultValue="alex@example.com" />
+      </FormSection>
+    </Stack>
+  ),
+}
+
+export const WithActions: Story = {
+  args: {
+    title: 'API keys',
+    description: 'Rotate or revoke long-lived credentials.',
+    actions: <Button variant="outlined" size="small">Create key</Button>,
+  },
+  render: (args) => (
+    <Stack sx={{ maxWidth: 560 }}>
+      <FormSection {...args}>
+        <TextField label="Active key" value="••••••••••••mtui" disabled />
+      </FormSection>
+    </Stack>
+  ),
+}

--- a/packages/ui/src/components/FormSection/FormSection.test.tsx
+++ b/packages/ui/src/components/FormSection/FormSection.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { FormSection } from './FormSection'
+
+describe('FormSection', () => {
+  it('renders title, description, and children', () => {
+    render(
+      <FormSection title="Profile" description="How you appear to others">
+        <div>body</div>
+      </FormSection>,
+    )
+    expect(screen.getByText('Profile')).toBeInTheDocument()
+    expect(screen.getByText('How you appear to others')).toBeInTheDocument()
+    expect(screen.getByText('body')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/FormSection/FormSection.tsx
+++ b/packages/ui/src/components/FormSection/FormSection.tsx
@@ -1,0 +1,44 @@
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { ReactNode } from 'react'
+
+export type FormSectionProps = {
+  /** Section heading. */
+  title: ReactNode
+  /** Optional supporting copy under the heading. */
+  description?: ReactNode
+  /** Form fields and other content. */
+  children: ReactNode
+  /** Right-aligned slot for section-level actions. */
+  actions?: ReactNode
+}
+
+/**
+ * Generic form grouping: a titled section with optional description and
+ * action slot, sitting above a stack of form fields.
+ *
+ *   <FormSection title="Account" description="Where notifications get sent">
+ *     <TextField label="Email" />
+ *   </FormSection>
+ */
+export function FormSection({ title, description, children, actions }: FormSectionProps) {
+  return (
+    <Box component="section" sx={{ display: 'grid', gap: 2 }}>
+      <Stack direction="row" spacing={2} sx={{ alignItems: 'flex-start', justifyContent: 'space-between' }}>
+        <Box>
+          <Typography variant="h6" component="h3">
+            {title}
+          </Typography>
+          {description ? (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              {description}
+            </Typography>
+          ) : null}
+        </Box>
+        {actions ? <Box sx={{ flexShrink: 0 }}>{actions}</Box> : null}
+      </Stack>
+      <Stack spacing={2}>{children}</Stack>
+    </Box>
+  )
+}

--- a/packages/ui/src/components/FormSection/index.ts
+++ b/packages/ui/src/components/FormSection/index.ts
@@ -1,0 +1,1 @@
+export * from './FormSection'

--- a/packages/ui/src/components/HeroBackground/HeroBackground.stories.tsx
+++ b/packages/ui/src/components/HeroBackground/HeroBackground.stories.tsx
@@ -1,0 +1,66 @@
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Button } from '../Button'
+import { Card, CardActions, CardContent } from '../Card'
+import { TextField } from '../TextField'
+import { HeroBackground } from './HeroBackground'
+
+const meta = {
+  title: 'Patterns/HeroBackground',
+  component: HeroBackground,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    professional: { control: 'boolean' },
+  },
+  args: { professional: false, children: null },
+} satisfies Meta<typeof HeroBackground>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => (
+    <HeroBackground {...args}>
+      <Stack
+        spacing={1}
+        sx={{ alignItems: 'center', textAlign: 'center', py: { xs: 6, md: 10 } }}
+      >
+        <Typography variant="h2">Welcome back.</Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ maxWidth: 480 }}>
+          A calm, full-bleed decorative surface for landing, login, and welcome screens.
+        </Typography>
+      </Stack>
+    </HeroBackground>
+  ),
+}
+
+export const Professional: Story = {
+  args: { professional: true },
+  render: Default.render,
+}
+
+export const Login: Story = {
+  render: (args) => (
+    <HeroBackground {...args}>
+      <Stack spacing={3} sx={{ alignItems: 'center', py: { xs: 6, md: 10 } }}>
+        <Typography variant="h3">Sign in</Typography>
+        <Card sx={{ width: 360 }}>
+          <CardContent>
+            <Stack spacing={2}>
+              <TextField label="Email" placeholder="you@example.com" fullWidth />
+              <TextField label="Password" type="password" fullWidth />
+            </Stack>
+          </CardContent>
+          <CardActions sx={{ justifyContent: 'flex-end', px: 2, pb: 2 }}>
+            <Button variant="contained" fullWidth>
+              Continue
+            </Button>
+          </CardActions>
+        </Card>
+      </Stack>
+    </HeroBackground>
+  ),
+}

--- a/packages/ui/src/components/HeroBackground/HeroBackground.test.tsx
+++ b/packages/ui/src/components/HeroBackground/HeroBackground.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { HeroBackground } from './HeroBackground'
+
+describe('HeroBackground', () => {
+  it('renders children', () => {
+    render(
+      <HeroBackground>
+        <h1>Sign in</h1>
+      </HeroBackground>,
+    )
+    expect(screen.getByRole('heading', { name: 'Sign in' })).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/HeroBackground/HeroBackground.tsx
+++ b/packages/ui/src/components/HeroBackground/HeroBackground.tsx
@@ -1,0 +1,71 @@
+/**
+ * HeroBackground — full-bleed decorative section for landing / login screens.
+ *
+ * Renders a tinted gradient surface with a subtle noise overlay. The
+ * `professional` variant tones the gradient down for marketing-vs-tool
+ * contexts. Stateless and brand-agnostic — drop any content inside it.
+ *
+ *   <HeroBackground>
+ *     <LoginForm />
+ *   </HeroBackground>
+ */
+
+import Box, { type BoxProps } from '@mui/material/Box'
+import type { ReactNode } from 'react'
+
+const NOISE_DATA_URI =
+  "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.4 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>\")"
+
+export type HeroBackgroundProps = {
+  children: ReactNode
+  /** Use the tamer, content-forward palette. Default `false`. */
+  professional?: boolean
+  /** Extra sx forwarded to the section. */
+  sx?: BoxProps['sx']
+}
+
+export function HeroBackground({ children, professional = false, sx }: HeroBackgroundProps) {
+  return (
+    <Box
+      component="section"
+      sx={[
+        (theme) => {
+          const isDark = theme.palette.mode === 'dark'
+          const gradient = professional
+            ? isDark
+              ? 'radial-gradient(120% 80% at 50% -10%, rgba(124,58,237,0.18), transparent 60%), linear-gradient(180deg, #0B0B0F 0%, #111118 100%)'
+              : 'radial-gradient(120% 80% at 50% -10%, rgba(124,58,237,0.10), transparent 60%), linear-gradient(180deg, #FAFAFC 0%, #FFFFFF 100%)'
+            : isDark
+              ? 'radial-gradient(140% 90% at 50% -10%, rgba(124,58,237,0.35), transparent 60%), linear-gradient(180deg, #0B0B0F 0%, #15101F 100%)'
+              : 'radial-gradient(140% 90% at 50% -10%, rgba(124,58,237,0.18), transparent 60%), linear-gradient(180deg, #FFFFFF 0%, #F6F2FF 100%)'
+          return {
+            position: 'relative',
+            minHeight: '100vh',
+            width: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            overflow: 'hidden',
+            color: theme.palette.text.primary,
+            backgroundImage: gradient,
+          }
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+    >
+      <Box
+        aria-hidden
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+          opacity: 0.18,
+          mixBlendMode: 'overlay',
+          backgroundImage: NOISE_DATA_URI,
+          backgroundSize: '200px 200px',
+        }}
+      />
+      <Box sx={{ position: 'relative', zIndex: 1, width: '100%' }}>{children}</Box>
+    </Box>
+  )
+}

--- a/packages/ui/src/components/HeroBackground/index.ts
+++ b/packages/ui/src/components/HeroBackground/index.ts
@@ -1,0 +1,1 @@
+export * from './HeroBackground'

--- a/packages/ui/src/components/KpiCard/KpiCard.stories.tsx
+++ b/packages/ui/src/components/KpiCard/KpiCard.stories.tsx
@@ -1,0 +1,50 @@
+import Box from '@mui/material/Box'
+import GroupIcon from '@mui/icons-material/Group'
+import TrendingUpIcon from '@mui/icons-material/TrendingUp'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { KpiCard } from './KpiCard'
+
+const meta = {
+  title: 'Patterns/KpiCard',
+  component: KpiCard,
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' },
+    value: { control: 'text' },
+    hint: { control: 'text' },
+    loading: { control: 'boolean' },
+  },
+  args: {
+    label: 'Active users',
+    value: '12,840',
+    delta: { value: '+4.2%', tone: 'success' },
+    icon: <TrendingUpIcon />,
+  },
+} satisfies Meta<typeof KpiCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Negative: Story = {
+  args: {
+    label: 'Error rate',
+    value: '1.8%',
+    delta: { value: '+0.3%', tone: 'error' },
+  },
+}
+
+export const Loading: Story = { args: { loading: true } }
+
+export const Grid: Story = {
+  render: () => (
+    <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+      <KpiCard label="Active users" value="12,840" icon={<GroupIcon />} />
+      <KpiCard label="Projects" value="42" delta={{ value: '+3 this week', tone: 'success' }} />
+      <KpiCard label="Open tickets" value={7} hint="across 3 teams" />
+      <KpiCard label="Alerts" value={0} delta={{ value: 'all clear', tone: 'success' }} />
+    </Box>
+  ),
+}

--- a/packages/ui/src/components/KpiCard/KpiCard.test.tsx
+++ b/packages/ui/src/components/KpiCard/KpiCard.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { KpiCard } from './KpiCard'
+
+describe('KpiCard', () => {
+  it('renders label + value', () => {
+    render(<KpiCard label="Active users" value="12,840" />)
+    expect(screen.getByText('Active users')).toBeInTheDocument()
+    expect(screen.getByText('12,840')).toBeInTheDocument()
+  })
+
+  it('shows "—" when loading', () => {
+    render(<KpiCard label="x" value="1" loading />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/KpiCard/KpiCard.tsx
+++ b/packages/ui/src/components/KpiCard/KpiCard.tsx
@@ -1,0 +1,117 @@
+/**
+ * KpiCard — a single metric tile.
+ *
+ * Use for dashboards / overview pages where you want a row of high-level
+ * numbers. Pairs with a trend delta and optional icon.
+ *
+ *   <KpiCard
+ *     label="Active users"
+ *     value="12,840"
+ *     delta={{ value: '+4.2%', tone: 'success' }}
+ *     icon={<TrendingUp />}
+ *   />
+ */
+
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+import type { ReactNode } from 'react'
+
+import type { StatusTone } from '../StatusDot/StatusDot'
+
+export type KpiDelta = {
+  value: string
+  tone: StatusTone
+}
+
+export type KpiCardProps = {
+  label: string
+  value: ReactNode
+  delta?: KpiDelta
+  icon?: ReactNode
+  hint?: string
+  loading?: boolean
+}
+
+export function KpiCard({ label, value, delta, icon, hint, loading }: KpiCardProps) {
+  const theme = useTheme()
+  const deltaTone = delta?.tone ?? 'neutral'
+  const deltaColor =
+    deltaTone === 'neutral'
+      ? theme.palette.text.secondary
+      : deltaTone === 'success'
+        ? theme.palette.success.main
+        : deltaTone === 'warning'
+          ? theme.palette.warning.main
+          : deltaTone === 'error'
+            ? theme.palette.error.main
+            : theme.palette.info.main
+
+  return (
+    <Box
+      sx={(t) => ({
+        position: 'relative',
+        p: 2.5,
+        borderRadius: 2,
+        border: `1px solid ${t.palette.border.subtle}`,
+        bgcolor: t.palette.background.paper,
+        transition: 'border-color 120ms, box-shadow 120ms',
+        '&:hover': {
+          borderColor: t.palette.border.default,
+          boxShadow: t.shadows[1],
+        },
+      })}
+    >
+      <Stack direction="row" spacing={1.5} sx={{ alignItems: 'flex-start', justifyContent: 'space-between' }}>
+        <Stack spacing={1} sx={{ minWidth: 0 }}>
+          <Typography variant="label" component="div" color="text.secondary">
+            {label}
+          </Typography>
+          <Typography
+            variant="h2"
+            component="div"
+            sx={{
+              fontVariantNumeric: 'tabular-nums',
+              opacity: loading ? 0.4 : 1,
+              fontSize: '1.875rem',
+              lineHeight: 1.1,
+            }}
+          >
+            {loading ? '—' : value}
+          </Typography>
+          {delta && (
+            <Typography
+              variant="body2"
+              sx={{ color: deltaColor, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}
+            >
+              {delta.value}
+            </Typography>
+          )}
+          {hint && (
+            <Typography variant="caption" color="text.secondary">
+              {hint}
+            </Typography>
+          )}
+        </Stack>
+        {icon && (
+          <Box
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 40,
+              height: 40,
+              borderRadius: 1.5,
+              bgcolor: alpha(theme.palette.primary.main, 0.12),
+              color: theme.palette.primary.main,
+              flexShrink: 0,
+            }}
+          >
+            {icon}
+          </Box>
+        )}
+      </Stack>
+    </Box>
+  )
+}

--- a/packages/ui/src/components/KpiCard/KpiCard.tsx
+++ b/packages/ui/src/components/KpiCard/KpiCard.tsx
@@ -65,7 +65,7 @@ export function KpiCard({ label, value, delta, icon, hint, loading }: KpiCardPro
     >
       <Stack direction="row" spacing={1.5} sx={{ alignItems: 'flex-start', justifyContent: 'space-between' }}>
         <Stack spacing={1} sx={{ minWidth: 0 }}>
-          <Typography variant="label" component="div" color="text.secondary">
+          <Typography variant="metricLabel" component="div" color="text.secondary">
             {label}
           </Typography>
           <Typography

--- a/packages/ui/src/components/KpiCard/index.ts
+++ b/packages/ui/src/components/KpiCard/index.ts
@@ -1,0 +1,2 @@
+export { KpiCard } from './KpiCard'
+export type { KpiCardProps, KpiDelta } from './KpiCard'

--- a/packages/ui/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui/src/components/Modal/Modal.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+import { useState } from 'react'
+
+import { Button } from '../Button'
+import { Modal, ModalActions, ModalContent, ModalContentText, ModalTitle } from './Modal'
+
+const meta = {
+  title: 'Components/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+  argTypes: {
+    open: { control: 'boolean' },
+    fullScreen: { control: 'boolean' },
+    maxWidth: {
+      control: { type: 'select' },
+      options: [false, 'xs', 'sm', 'md', 'lg', 'xl'],
+    },
+    onClose: { action: 'closed' },
+  },
+  args: { open: false, onClose: fn() },
+} satisfies Meta<typeof Modal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Trigger: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(false)
+    return (
+      <>
+        <Button variant="contained" onClick={() => setOpen(true)}>
+          Open modal
+        </Button>
+        <Modal
+          {...args}
+          open={open}
+          onClose={(event, reason) => {
+            setOpen(false)
+            args.onClose?.(event, reason)
+          }}
+        >
+          <ModalTitle>Discard changes?</ModalTitle>
+          <ModalContent>
+            <ModalContentText>
+              You have unsaved edits. Discarding will lose them permanently.
+            </ModalContentText>
+          </ModalContent>
+          <ModalActions>
+            <Button variant="text" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button variant="contained" color="error" onClick={() => setOpen(false)}>
+              Discard
+            </Button>
+          </ModalActions>
+        </Modal>
+      </>
+    )
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /open modal/i }))
+    const dialog = await within(document.body).findByRole('dialog')
+    const cancel = await within(dialog).findByRole('button', { name: /cancel/i })
+    await userEvent.click(cancel)
+    await expect(args.onClose).not.toHaveBeenCalled()
+  },
+}
+
+export const Open: Story = {
+  args: { open: true },
+  render: (args) => (
+    <Modal {...args}>
+      <ModalTitle>Notice</ModalTitle>
+      <ModalContent>
+        <ModalContentText>A statically-open modal for visual inspection.</ModalContentText>
+      </ModalContent>
+      <ModalActions>
+        <Button variant="contained">OK</Button>
+      </ModalActions>
+    </Modal>
+  ),
+}

--- a/packages/ui/src/components/Modal/Modal.test.tsx
+++ b/packages/ui/src/components/Modal/Modal.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { Modal, ModalActions, ModalContent, ModalTitle } from './Modal'
+import { Button } from '../Button'
+
+describe('Modal', () => {
+  it('renders when open', () => {
+    render(
+      <Modal open onClose={() => {}}>
+        <ModalTitle>Title</ModalTitle>
+        <ModalContent>Body</ModalContent>
+      </Modal>,
+    )
+    expect(screen.getByText('Title')).toBeInTheDocument()
+    expect(screen.getByText('Body')).toBeInTheDocument()
+  })
+
+  it('does not render when closed', () => {
+    render(
+      <Modal open={false} onClose={() => {}}>
+        <ModalTitle>Hidden</ModalTitle>
+      </Modal>,
+    )
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument()
+  })
+
+  it('fires onClose when escape is pressed', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <Modal open onClose={onClose}>
+        <ModalTitle>X</ModalTitle>
+        <ModalActions>
+          <Button>Cancel</Button>
+        </ModalActions>
+      </Modal>,
+    )
+    await user.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -1,0 +1,32 @@
+import Dialog, { type DialogProps } from '@mui/material/Dialog'
+import DialogActions, { type DialogActionsProps } from '@mui/material/DialogActions'
+import DialogContent, { type DialogContentProps } from '@mui/material/DialogContent'
+import DialogContentText, { type DialogContentTextProps } from '@mui/material/DialogContentText'
+import DialogTitle, { type DialogTitleProps } from '@mui/material/DialogTitle'
+import { forwardRef } from 'react'
+
+export type ModalProps = DialogProps
+
+/**
+ * Centered modal dialog. Thin wrapper around MUI Dialog — re-exports
+ * `ModalTitle`, `ModalContent`, `ModalContentText`, `ModalActions` for
+ * structured layouts.
+ *
+ *   <Modal open={open} onClose={close}>
+ *     <ModalTitle>Confirm</ModalTitle>
+ *     <ModalContent>Are you sure?</ModalContent>
+ *     <ModalActions>…</ModalActions>
+ *   </Modal>
+ */
+export const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(props, ref) {
+  return <Dialog ref={ref} {...props} />
+})
+
+export const ModalTitle = DialogTitle
+export const ModalContent = DialogContent
+export const ModalContentText = DialogContentText
+export const ModalActions = DialogActions
+export type ModalTitleProps = DialogTitleProps
+export type ModalContentProps = DialogContentProps
+export type ModalContentTextProps = DialogContentTextProps
+export type ModalActionsProps = DialogActionsProps

--- a/packages/ui/src/components/Modal/index.ts
+++ b/packages/ui/src/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export * from './Modal'

--- a/packages/ui/src/components/Mono/Mono.stories.tsx
+++ b/packages/ui/src/components/Mono/Mono.stories.tsx
@@ -1,0 +1,33 @@
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Mono } from './Mono'
+
+const meta = {
+  title: 'Components/Mono',
+  component: Mono,
+  tags: ['autodocs'],
+  argTypes: {
+    children: { control: 'text' },
+  },
+  args: { children: 'a3b6e5bf6ff856d2509292e95c8f57f0df7017cf' },
+} satisfies Meta<typeof Mono>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Inline: Story = {
+  render: () => (
+    <Stack spacing={1.5}>
+      <Typography>
+        Last commit: <Mono>2b3a6e8b</Mono> at 14:03 UTC.
+      </Typography>
+      <Typography>
+        File path: <Mono>src/components/Button/Button.tsx</Mono>
+      </Typography>
+    </Stack>
+  ),
+}

--- a/packages/ui/src/components/Mono/Mono.test.tsx
+++ b/packages/ui/src/components/Mono/Mono.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { Mono } from './Mono'
+
+describe('Mono', () => {
+  it('renders its content', () => {
+    render(<Mono>abc123</Mono>)
+    expect(screen.getByText('abc123')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/Mono/Mono.tsx
+++ b/packages/ui/src/components/Mono/Mono.tsx
@@ -1,0 +1,28 @@
+/**
+ * Monospaced inline text — for IDs, hashes, file paths, codes.
+ *
+ * Use instead of raw <code>; this picks up the theme's mono variant and
+ * tabular-figures styling so columns of IDs line up.
+ */
+
+import Typography from '@mui/material/Typography'
+import type { TypographyProps } from '@mui/material/Typography'
+import type { ReactNode } from 'react'
+
+export type MonoProps = Omit<TypographyProps, 'variant'> & { children: ReactNode }
+
+export function Mono({ children, sx, ...rest }: MonoProps) {
+  return (
+    <Typography
+      component="span"
+      variant="mono"
+      sx={[
+        { fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+      {...rest}
+    >
+      {children}
+    </Typography>
+  )
+}

--- a/packages/ui/src/components/Mono/index.ts
+++ b/packages/ui/src/components/Mono/index.ts
@@ -1,0 +1,2 @@
+export { Mono } from './Mono'
+export type { MonoProps } from './Mono'

--- a/packages/ui/src/components/NumberBadge/NumberBadge.stories.tsx
+++ b/packages/ui/src/components/NumberBadge/NumberBadge.stories.tsx
@@ -1,0 +1,48 @@
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { NumberBadge } from './NumberBadge'
+
+const meta = {
+  title: 'Components/NumberBadge',
+  component: NumberBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    tone: {
+      control: { type: 'inline-radio' },
+      options: ['neutral', 'success', 'warning', 'error', 'info'],
+    },
+    variant: { control: { type: 'inline-radio' }, options: ['subtle', 'solid'] },
+    children: { control: 'text' },
+  },
+  args: { children: 3, tone: 'neutral', variant: 'subtle' },
+} satisfies Meta<typeof NumberBadge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const AllTones: Story = {
+  render: () => (
+    <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+      <NumberBadge>0</NumberBadge>
+      <NumberBadge tone="info">5</NumberBadge>
+      <NumberBadge tone="success">12</NumberBadge>
+      <NumberBadge tone="warning">3</NumberBadge>
+      <NumberBadge tone="error">99+</NumberBadge>
+    </Stack>
+  ),
+}
+
+export const Solid: Story = {
+  render: () => (
+    <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+      <Typography variant="body2">Pending alerts</Typography>
+      <NumberBadge tone="error" variant="solid">
+        7
+      </NumberBadge>
+    </Stack>
+  ),
+}

--- a/packages/ui/src/components/NumberBadge/NumberBadge.test.tsx
+++ b/packages/ui/src/components/NumberBadge/NumberBadge.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { NumberBadge } from './NumberBadge'
+
+describe('NumberBadge', () => {
+  it('renders its content', () => {
+    render(<NumberBadge tone="error">99+</NumberBadge>)
+    expect(screen.getByText('99+')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/NumberBadge/NumberBadge.tsx
+++ b/packages/ui/src/components/NumberBadge/NumberBadge.tsx
@@ -1,0 +1,65 @@
+/**
+ * NumberBadge — tiny pill for inline counts.
+ *
+ * Two variants:
+ *   - `'subtle'` (default) — high-contrast `text.primary` on a tinted
+ *     background. Tone is carried by the bg hue; text stays legible.
+ *   - `'solid'` — `contrastText` on a solid tone background. Use when
+ *     the count is the visual focus (e.g. error counters on tab titles).
+ *
+ * Distinct from MUI's `Badge`, which is for absolute-positioned overlays
+ * on icons.
+ */
+
+import Box from '@mui/material/Box'
+import { alpha, useTheme } from '@mui/material/styles'
+import type { ReactNode } from 'react'
+
+import type { StatusTone } from '../StatusDot/StatusDot'
+
+export type NumberBadgeProps = {
+  children: ReactNode
+  tone?: StatusTone
+  variant?: 'subtle' | 'solid'
+}
+
+export function NumberBadge({ children, tone = 'neutral', variant = 'subtle' }: NumberBadgeProps) {
+  const theme = useTheme()
+
+  const accent =
+    tone === 'neutral'
+      ? theme.palette.text.secondary
+      : theme.palette[tone].main
+  const contrastText =
+    tone === 'neutral'
+      ? theme.palette.background.paper
+      : theme.palette[tone].contrastText ?? '#fff'
+
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minWidth: 18,
+        height: 18,
+        px: 0.75,
+        borderRadius: 9999,
+        fontSize: '0.6875rem',
+        fontWeight: 600,
+        lineHeight: 1,
+        fontVariantNumeric: 'tabular-nums',
+        ...(variant === 'subtle'
+          ? {
+              color: 'text.primary',
+              bgcolor: alpha(accent, 0.16),
+              border: `1px solid ${alpha(accent, 0.28)}`,
+            }
+          : { color: contrastText, bgcolor: accent }),
+      }}
+    >
+      {children}
+    </Box>
+  )
+}

--- a/packages/ui/src/components/NumberBadge/index.ts
+++ b/packages/ui/src/components/NumberBadge/index.ts
@@ -1,0 +1,2 @@
+export { NumberBadge } from './NumberBadge'
+export type { NumberBadgeProps } from './NumberBadge'

--- a/packages/ui/src/components/PageContainer/PageContainer.stories.tsx
+++ b/packages/ui/src/components/PageContainer/PageContainer.stories.tsx
@@ -1,0 +1,73 @@
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { PageContainer } from './PageContainer'
+
+const meta = {
+  title: 'Layout/PageContainer',
+  component: PageContainer,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    fullBleed: { control: 'boolean' },
+    embedded: { control: 'boolean' },
+  },
+  args: { fullBleed: false, embedded: false, children: null },
+} satisfies Meta<typeof PageContainer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => (
+    <Box sx={{ height: 480, display: 'flex' }}>
+      <PageContainer {...args}>
+        <Typography variant="h4">Standard page</Typography>
+        <Typography variant="body1" color="text.secondary">
+          Default padding + gap apply.
+        </Typography>
+        {Array.from({ length: 10 }).map((_, i) => (
+          <Box key={i} sx={{ p: 2, border: 1, borderColor: 'divider', borderRadius: 1 }}>
+            Section {i + 1}
+          </Box>
+        ))}
+      </PageContainer>
+    </Box>
+  ),
+}
+
+export const FullBleed: Story = {
+  args: { fullBleed: true },
+  render: (args) => (
+    <Box sx={{ height: 480, display: 'flex' }}>
+      <PageContainer {...args}>
+        <Box
+          sx={{
+            flex: 1,
+            display: 'grid',
+            placeItems: 'center',
+            bgcolor: 'surface.muted',
+            color: 'text.secondary',
+          }}
+        >
+          <Typography>Edge-to-edge canvas (no padding, no gap)</Typography>
+        </Box>
+      </PageContainer>
+    </Box>
+  ),
+}
+
+export const Embedded: Story = {
+  args: { embedded: true },
+  render: (args) => (
+    <Box sx={{ height: 480, display: 'flex' }}>
+      <PageContainer {...args}>
+        <Typography variant="h5">Embedded mode</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No padding when hosted inside another framed shell.
+        </Typography>
+      </PageContainer>
+    </Box>
+  ),
+}

--- a/packages/ui/src/components/PageContainer/PageContainer.test.tsx
+++ b/packages/ui/src/components/PageContainer/PageContainer.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { PageContainer } from './PageContainer'
+
+describe('PageContainer', () => {
+  it('renders children', () => {
+    render(
+      <PageContainer>
+        <div>body</div>
+      </PageContainer>,
+    )
+    expect(screen.getByText('body')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/PageContainer/PageContainer.tsx
+++ b/packages/ui/src/components/PageContainer/PageContainer.tsx
@@ -1,0 +1,48 @@
+/**
+ * PageContainer — the scrollable region that hosts a route's content.
+ *
+ * Applies standard page padding by default. Use `fullBleed` for
+ * canvas-style pages (editors, maps, full-screen workspaces) that own
+ * their own padding. Use `embedded` to drop padding entirely when the
+ * shell is hosted inside another frame.
+ *
+ * Stateless. No router awareness — callers decide when to set the flags.
+ */
+
+import Box, { type BoxProps } from '@mui/material/Box'
+import type { ReactNode } from 'react'
+
+export type PageContainerProps = {
+  children: ReactNode
+  /** Skip default padding/gap — the page owns its own layout. */
+  fullBleed?: boolean
+  /** Drop all padding (use inside an embedded shell). */
+  embedded?: boolean
+  /** Forward extra sx to the container. */
+  sx?: BoxProps['sx']
+}
+
+export function PageContainer({ children, fullBleed = false, embedded = false, sx }: PageContainerProps) {
+  return (
+    <Box
+      sx={[
+        {
+          position: 'relative',
+          zIndex: 0,
+          display: 'flex',
+          flex: 1,
+          minHeight: 0,
+          flexDirection: 'column',
+          ...(fullBleed
+            ? { p: 0, gap: 0 }
+            : embedded
+              ? { p: 0 }
+              : { p: { xs: 2, md: 3 }, gap: 2 }),
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+    >
+      {children}
+    </Box>
+  )
+}

--- a/packages/ui/src/components/PageContainer/index.ts
+++ b/packages/ui/src/components/PageContainer/index.ts
@@ -1,0 +1,1 @@
+export * from './PageContainer'

--- a/packages/ui/src/components/PageHeader/PageHeader.stories.tsx
+++ b/packages/ui/src/components/PageHeader/PageHeader.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Button } from '../Button'
+import { PageHeader } from './PageHeader'
+
+const meta = {
+  title: 'Patterns/PageHeader',
+  component: PageHeader,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Standard top-of-page block. Every full page mounts one — never style page titles ad-hoc.',
+      },
+    },
+  },
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+  },
+  args: {
+    title: 'Members',
+    description: 'People with access to this workspace.',
+  },
+} satisfies Meta<typeof PageHeader>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithActions: Story = {
+  args: {
+    actions: (
+      <>
+        <Button variant="outlined">Export</Button>
+        <Button variant="contained">Invite</Button>
+      </>
+    ),
+  },
+}
+
+export const WithBreadcrumbs: Story = {
+  args: {
+    breadcrumbs: [{ label: 'Settings', href: '/settings' }, { label: 'Members' }],
+  },
+}
+
+export const Full: Story = {
+  args: {
+    title: 'API tokens',
+    description: 'Long-lived credentials used by scripts and services.',
+    breadcrumbs: [{ label: 'Settings' }, { label: 'Security' }, { label: 'API tokens' }],
+    actions: <Button variant="contained">Save changes</Button>,
+  },
+}

--- a/packages/ui/src/components/PageHeader/PageHeader.test.tsx
+++ b/packages/ui/src/components/PageHeader/PageHeader.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { PageHeader } from './PageHeader'
+
+describe('PageHeader', () => {
+  it('renders title, description, breadcrumbs', () => {
+    render(
+      <PageHeader
+        title="Members"
+        description="People with access"
+        breadcrumbs={[{ label: 'Settings' }, { label: 'Members' }]}
+      />,
+    )
+    expect(screen.getByRole('heading', { name: 'Members' })).toBeInTheDocument()
+    expect(screen.getByText('People with access')).toBeInTheDocument()
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/PageHeader/PageHeader.tsx
+++ b/packages/ui/src/components/PageHeader/PageHeader.tsx
@@ -1,0 +1,71 @@
+/**
+ * Page header — the standard top-of-page block for every full page.
+ *
+ *   <PageHeader
+ *     title="Members"
+ *     description="People with access to this workspace."
+ *     actions={<Button variant="contained">Invite</Button>}
+ *     breadcrumbs={[{ label: 'Settings' }, { label: 'Members' }]}
+ *   />
+ *
+ * Typography sizes are theme-driven; do not pass overrides — the design
+ * system owns the visual weight.
+ */
+
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import Breadcrumbs from '@mui/material/Breadcrumbs'
+import Link from '@mui/material/Link'
+import type { ReactNode } from 'react'
+
+export type Crumb = { label: string; href?: string }
+
+export type PageHeaderProps = {
+  title: ReactNode
+  description?: ReactNode
+  actions?: ReactNode
+  breadcrumbs?: Crumb[]
+}
+
+export function PageHeader({ title, description, actions, breadcrumbs }: PageHeaderProps) {
+  return (
+    <Stack spacing={1.5} sx={{ pb: 3 }}>
+      {breadcrumbs && breadcrumbs.length > 0 && (
+        <Breadcrumbs separator="/" sx={{ fontSize: '0.8125rem' }}>
+          {breadcrumbs.map((c, i) =>
+            c.href ? (
+              <Link key={i} href={c.href} color="text.secondary" underline="hover">
+                {c.label}
+              </Link>
+            ) : (
+              <Typography key={i} variant="body2" color="text.secondary">
+                {c.label}
+              </Typography>
+            ),
+          )}
+        </Breadcrumbs>
+      )}
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        spacing={2}
+        sx={{ alignItems: { md: 'center' }, justifyContent: 'space-between' }}
+      >
+        <Stack spacing={0.5} sx={{ minWidth: 0 }}>
+          <Typography variant="h2" component="h1">
+            {title}
+          </Typography>
+          {description && (
+            <Typography variant="body1" color="text.secondary">
+              {description}
+            </Typography>
+          )}
+        </Stack>
+        {actions && (
+          <Stack direction="row" spacing={1} sx={{ flexShrink: 0 }}>
+            {actions}
+          </Stack>
+        )}
+      </Stack>
+    </Stack>
+  )
+}

--- a/packages/ui/src/components/PageHeader/index.ts
+++ b/packages/ui/src/components/PageHeader/index.ts
@@ -1,0 +1,2 @@
+export { PageHeader } from './PageHeader'
+export type { PageHeaderProps, Crumb } from './PageHeader'

--- a/packages/ui/src/components/PageLayout/PageLayout.stories.tsx
+++ b/packages/ui/src/components/PageLayout/PageLayout.stories.tsx
@@ -1,0 +1,52 @@
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Button } from '../Button'
+import { EmptyState } from '../EmptyState'
+import { PageLayout } from './PageLayout'
+
+const meta = {
+  title: 'Patterns/PageLayout',
+  component: PageLayout,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+    fullBleed: { control: 'boolean' },
+    embedded: { control: 'boolean' },
+  },
+  args: {
+    title: 'Members',
+    description: 'People with access to this workspace.',
+    breadcrumbs: [{ label: 'Settings' }, { label: 'Members' }],
+    actions: <Button variant="contained">Invite</Button>,
+  },
+} satisfies Meta<typeof PageLayout>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => (
+    <PageLayout {...args}>
+      <EmptyState title="No members yet" description="Invite someone to get started." />
+    </PageLayout>
+  ),
+}
+
+export const WithTabs: Story = {
+  render: (args) => (
+    <PageLayout
+      {...args}
+      tabs={{
+        defaultValue: 'active',
+        tabs: [
+          { value: 'active', label: 'Active', content: <Typography>Active members</Typography> },
+          { value: 'invited', label: 'Invited', content: <Typography>Invited members</Typography> },
+          { value: 'archived', label: 'Archived', content: <Typography>Archived members</Typography> },
+        ],
+      }}
+    />
+  ),
+}

--- a/packages/ui/src/components/PageLayout/PageLayout.test.tsx
+++ b/packages/ui/src/components/PageLayout/PageLayout.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { PageLayout } from './PageLayout'
+
+describe('PageLayout', () => {
+  it('composes PageHeader + body', () => {
+    render(
+      <PageLayout title="Members" description="People">
+        <div>body</div>
+      </PageLayout>,
+    )
+    expect(screen.getByRole('heading', { name: 'Members' })).toBeInTheDocument()
+    expect(screen.getByText('body')).toBeInTheDocument()
+  })
+
+  it('renders tabs when provided', () => {
+    render(
+      <PageLayout
+        title="X"
+        tabs={{
+          defaultValue: 'a',
+          tabs: [
+            { value: 'a', label: 'A', content: <div>A body</div> },
+            { value: 'b', label: 'B', content: <div>B body</div> },
+          ],
+        }}
+      />,
+    )
+    expect(screen.getByText('A body')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/PageLayout/PageLayout.tsx
+++ b/packages/ui/src/components/PageLayout/PageLayout.tsx
@@ -1,0 +1,80 @@
+/**
+ * PageLayout — composite of PageHeader + PageContainer (+ optional tabs).
+ *
+ * The most common page shell: a heading block at the top, an optional
+ * tab strip, and the page body in a scrollable container. Use this
+ * instead of assembling PageHeader / PageContainer by hand on every
+ * route.
+ *
+ *   <PageLayout
+ *     title="Members"
+ *     description="People with access to this workspace."
+ *     breadcrumbs={[{ label: 'Settings' }, { label: 'Members' }]}
+ *     actions={<Button variant="contained">Invite</Button>}
+ *     tabs={{
+ *       value: tab,
+ *       onChange: setTab,
+ *       tabs: [
+ *         { value: 'active', label: 'Active', content: <Active/> },
+ *         { value: 'invited', label: 'Invited', content: <Invited/> },
+ *       ],
+ *     }}
+ *   />
+ *
+ * When `tabs` is provided, the active tab's `content` renders inside
+ * the container; `children` is rendered above the tabs if present.
+ */
+
+import { type ReactNode } from 'react'
+
+import { PageContainer } from '../PageContainer'
+import { PageHeader, type Crumb } from '../PageHeader'
+import { Tabs, type TabsItem, type TabsProps } from '../Tabs'
+
+export type PageLayoutTabsConfig<T extends string = string> = Omit<
+  TabsProps<T>,
+  'tabs' | 'value' | 'onChange' | 'defaultValue'
+> & {
+  tabs: TabsItem<T>[]
+  value?: T
+  defaultValue?: T
+  onChange?: (next: T) => void
+}
+
+export type PageLayoutProps<T extends string = string> = {
+  /** Page heading. */
+  title: ReactNode
+  /** Supporting copy beneath the title. */
+  description?: ReactNode
+  /** Breadcrumbs displayed above the title. */
+  breadcrumbs?: Crumb[]
+  /** Right-aligned heading actions. */
+  actions?: ReactNode
+  /** Optional tab navigation just below the heading. */
+  tabs?: PageLayoutTabsConfig<T>
+  /** Page body. When `tabs` is set, this renders above the tabs. */
+  children?: ReactNode
+  /** Skip default padding/gap. */
+  fullBleed?: boolean
+  /** No padding when hosted inside an embedded shell. */
+  embedded?: boolean
+}
+
+export function PageLayout<T extends string = string>({
+  title,
+  description,
+  breadcrumbs,
+  actions,
+  tabs,
+  children,
+  fullBleed,
+  embedded,
+}: PageLayoutProps<T>) {
+  return (
+    <PageContainer fullBleed={fullBleed} embedded={embedded}>
+      <PageHeader title={title} description={description} breadcrumbs={breadcrumbs} actions={actions} />
+      {children}
+      {tabs && <Tabs<T> {...tabs} />}
+    </PageContainer>
+  )
+}

--- a/packages/ui/src/components/PageLayout/index.ts
+++ b/packages/ui/src/components/PageLayout/index.ts
@@ -1,0 +1,1 @@
+export * from './PageLayout'

--- a/packages/ui/src/components/PathBreadcrumb/PathBreadcrumb.stories.tsx
+++ b/packages/ui/src/components/PathBreadcrumb/PathBreadcrumb.stories.tsx
@@ -1,0 +1,109 @@
+import BusinessIcon from '@mui/icons-material/Business'
+import FactoryIcon from '@mui/icons-material/Factory'
+import GroupIcon from '@mui/icons-material/Group'
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+
+import { Badge } from '../Badge'
+import { StatusDot } from '../StatusDot'
+import { PathBreadcrumb, type PathSegment } from './PathBreadcrumb'
+
+const orgs = [
+  { id: 'acme', label: 'Acme Corp', secondary: 'admin', leading: <StatusDot tone="error" size={6} /> },
+  { id: 'globex', label: 'Globex Industries', secondary: 'engineer', leading: <StatusDot tone="warning" size={6} /> },
+  { id: 'initech', label: 'Initech', secondary: 'viewer', leading: <StatusDot tone="neutral" size={6} /> },
+]
+
+const teams = [
+  { id: 'eng', label: 'Engineering', secondary: 'admin' },
+  { id: 'ops', label: 'Operations', secondary: 'engineer' },
+  { id: 'design', label: 'Design', secondary: 'viewer' },
+]
+
+const meta = {
+  title: 'Patterns/PathBreadcrumb',
+  component: PathBreadcrumb,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof PathBreadcrumb>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const ReadOnly: Story = {
+  args: {
+    segments: [
+      { id: 'org', label: 'Acme Corp', icon: <BusinessIcon /> },
+      { id: 'team', label: 'Engineering', icon: <GroupIcon /> },
+      { id: 'project', label: 'Onboarding', icon: <FactoryIcon /> },
+    ],
+  },
+}
+
+export const WithTrailingBadge: Story = {
+  args: {
+    segments: [
+      { id: 'org', label: 'Acme Corp', icon: <BusinessIcon /> },
+      { id: 'team', label: 'Engineering', icon: <GroupIcon /> },
+    ],
+    trailing: <Badge label="admin" color="primary" size="small" />,
+  },
+}
+
+export const Interactive: Story = {
+  args: {
+    segments: [
+      {
+        id: 'org',
+        label: 'Acme Corp',
+        icon: <BusinessIcon />,
+        items: orgs,
+        currentId: 'acme',
+        onSelect: fn() as PathSegment['onSelect'],
+        searchPlaceholder: 'Search organization…',
+      },
+      {
+        id: 'team',
+        label: 'Engineering',
+        icon: <GroupIcon />,
+        items: teams,
+        currentId: 'eng',
+        onSelect: fn() as PathSegment['onSelect'],
+        searchPlaceholder: 'Search team…',
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /acme corp/i }))
+    const list = await within(document.body).findByRole('button', { name: /globex industries/i })
+    await expect(list).toBeVisible()
+    await userEvent.click(list)
+  },
+}
+
+export const MixedReadOnlyAndInteractive: Story = {
+  args: {
+    segments: [
+      { id: 'org', label: 'Acme Corp', icon: <BusinessIcon /> },
+      {
+        id: 'team',
+        label: 'Engineering',
+        icon: <GroupIcon />,
+        items: teams,
+        currentId: 'eng',
+        onSelect: fn() as PathSegment['onSelect'],
+      },
+      { id: 'project', label: 'Onboarding', icon: <FactoryIcon /> },
+    ],
+    trailing: <Badge label="admin" color="primary" size="small" />,
+  },
+}
+
+export const Empty: Story = {
+  args: {
+    segments: [
+      { id: 'org', label: null, icon: <BusinessIcon />, placeholder: 'Select organization' },
+    ],
+  },
+}

--- a/packages/ui/src/components/PathBreadcrumb/PathBreadcrumb.test.tsx
+++ b/packages/ui/src/components/PathBreadcrumb/PathBreadcrumb.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { PathBreadcrumb } from './PathBreadcrumb'
+
+describe('PathBreadcrumb', () => {
+  it('renders read-only segments', () => {
+    render(
+      <PathBreadcrumb
+        segments={[
+          { id: 'a', label: 'Acme' },
+          { id: 'b', label: 'Engineering' },
+        ]}
+      />,
+    )
+    expect(screen.getByText('Acme')).toBeInTheDocument()
+    expect(screen.getByText('Engineering')).toBeInTheDocument()
+  })
+
+  it('pops the dropdown and picks an item', async () => {
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <PathBreadcrumb
+        segments={[
+          {
+            id: 'org',
+            label: 'Acme',
+            items: [
+              { id: 'a', label: 'Acme' },
+              { id: 'b', label: 'Globex' },
+            ],
+            currentId: 'a',
+            onSelect,
+          },
+        ]}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: /Acme/i }))
+    const option = await screen.findByRole('button', { name: /Globex/i })
+    await user.click(option)
+    expect(onSelect).toHaveBeenCalledWith('b')
+  })
+})

--- a/packages/ui/src/components/PathBreadcrumb/PathBreadcrumb.tsx
+++ b/packages/ui/src/components/PathBreadcrumb/PathBreadcrumb.tsx
@@ -1,0 +1,270 @@
+/**
+ * PathBreadcrumb — segmented path display.
+ *
+ * Each segment renders as `[icon] label` and is separated by a `/`.
+ * If a segment has an `items` array it becomes a popover-trigger that
+ * shows a searchable list of siblings; otherwise it is read-only.
+ * A `trailing` slot to the right of the path is useful for a role/scope
+ * badge.
+ *
+ *   <PathBreadcrumb
+ *     segments={[
+ *       { id: 'org', label: 'Acme', icon: <Business />, items: orgs, currentId: org.id, onSelect: pickOrg },
+ *       { id: 'team', label: 'Engineering', icon: <Group />, items: teams, currentId: team.id, onSelect: pickTeam },
+ *     ]}
+ *     trailing={<Badge label="admin" color="primary" />}
+ *   />
+ */
+
+import CheckIcon from '@mui/icons-material/Check'
+import ChevronDownIcon from '@mui/icons-material/KeyboardArrowDown'
+import SearchIcon from '@mui/icons-material/Search'
+import Box from '@mui/material/Box'
+import Divider from '@mui/material/Divider'
+import InputAdornment from '@mui/material/InputAdornment'
+import Popover from '@mui/material/Popover'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import { alpha, useTheme } from '@mui/material/styles'
+import { useMemo, useState, type ReactNode } from 'react'
+
+import { Button } from '../Button'
+
+export type PathSegmentItem = {
+  /** Stable identifier — compared to `currentId` for active styling. */
+  id: string
+  /** Display label. */
+  label: string
+  /** Secondary value shown right-aligned (e.g. role tag, kind). */
+  secondary?: ReactNode
+  /** Leading marker (e.g. a `<StatusDot>`). */
+  leading?: ReactNode
+}
+
+export type PathSegment = {
+  /** Stable identifier for React key + active comparison. */
+  id: string
+  /** Display label. `null` renders the `placeholder`. */
+  label: string | null
+  /** Leading icon. */
+  icon?: ReactNode
+  /** Items to show in the popover. Omit for read-only segments. */
+  items?: PathSegmentItem[]
+  /** Id of the currently-selected item; used for active styling. */
+  currentId?: string | null
+  /** Called when the user picks a popover item. */
+  onSelect?: (id: string) => void
+  /** Shown in the segment trigger when `label` is null. */
+  placeholder?: string
+  /** Override the popover search-field placeholder. */
+  searchPlaceholder?: string
+  /** Hidden when the segment has no items. Default `false`. */
+  hideWhenEmpty?: boolean
+}
+
+export type PathBreadcrumbProps = {
+  segments: PathSegment[]
+  /** Separator rendered between segments. Default `/`. */
+  separator?: ReactNode
+  /** Trailing slot to the right of the path. */
+  trailing?: ReactNode
+}
+
+const DEFAULT_SEPARATOR = (
+  <Typography component="span" sx={{ px: 0.5, color: 'text.disabled', userSelect: 'none' }} variant="body2">
+    /
+  </Typography>
+)
+
+export function PathBreadcrumb({
+  segments,
+  separator = DEFAULT_SEPARATOR,
+  trailing,
+}: PathBreadcrumbProps) {
+  const visible = segments.filter((s) => !(s.hideWhenEmpty && (!s.items || s.items.length === 0)))
+  return (
+    <Stack direction="row" spacing={0} sx={{ alignItems: 'center', minWidth: 0 }}>
+      {visible.map((segment, idx) => (
+        <Stack key={segment.id} direction="row" sx={{ alignItems: 'center', minWidth: 0 }}>
+          {idx > 0 && separator}
+          {segment.items && segment.items.length > 0 && segment.onSelect ? (
+            <InteractiveSegment segment={segment} />
+          ) : (
+            <ReadOnlySegment segment={segment} />
+          )}
+        </Stack>
+      ))}
+      {trailing && <Box sx={{ ml: 1 }}>{trailing}</Box>}
+    </Stack>
+  )
+}
+
+function ReadOnlySegment({ segment }: { segment: PathSegment }) {
+  return (
+    <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', minWidth: 0, px: 1 }}>
+      {segment.icon && (
+        <Box sx={{ display: 'inline-flex', color: 'text.secondary', '& .MuiSvgIcon-root': { fontSize: 14 } }}>
+          {segment.icon}
+        </Box>
+      )}
+      <Typography
+        variant="body2"
+        sx={{
+          fontWeight: 500,
+          color: segment.label ? 'text.primary' : 'text.secondary',
+          maxWidth: '14rem',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {segment.label ?? segment.placeholder ?? '—'}
+      </Typography>
+    </Stack>
+  )
+}
+
+function InteractiveSegment({ segment }: { segment: PathSegment }) {
+  const theme = useTheme()
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const [query, setQuery] = useState('')
+  const open = Boolean(anchorEl)
+
+  const filtered = useMemo(() => {
+    if (!segment.items) return []
+    const q = query.trim().toLowerCase()
+    if (!q) return segment.items
+    return segment.items.filter((it) => it.label.toLowerCase().includes(q) || it.id.toLowerCase().includes(q))
+  }, [segment.items, query])
+
+  function close() {
+    setAnchorEl(null)
+    setQuery('')
+  }
+
+  return (
+    <>
+      <Button
+        size="small"
+        variant="text"
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+        startIcon={segment.icon ? <Box sx={{ display: 'inline-flex', opacity: 0.7 }}>{segment.icon}</Box> : undefined}
+        endIcon={
+          <ChevronDownIcon
+            sx={{
+              fontSize: 14,
+              opacity: 0.5,
+              transition: 'transform 120ms',
+              transform: open ? 'rotate(180deg)' : 'none',
+            }}
+          />
+        }
+        sx={{
+          textTransform: 'none',
+          fontWeight: 500,
+          color: segment.label ? 'text.primary' : 'text.secondary',
+          minWidth: 0,
+          maxWidth: '14rem',
+          '& .MuiButton-startIcon': { mr: 0.75 },
+          '& .MuiButton-endIcon': { ml: 0.25 },
+        }}
+      >
+        <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {segment.label ?? segment.placeholder ?? '—'}
+        </Box>
+      </Button>
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={close}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        slotProps={{ paper: { sx: { width: 288, mt: 0.5 } } }}
+      >
+        <Box sx={{ p: 1 }}>
+          <TextField
+            autoFocus
+            size="small"
+            fullWidth
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={segment.searchPlaceholder ?? 'Search…'}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+        </Box>
+        <Divider />
+        <Box sx={{ maxHeight: 288, overflowY: 'auto', p: 0.5 }}>
+          {filtered.length === 0 ? (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: 'block', textAlign: 'center', py: 3 }}
+            >
+              {segment.items && segment.items.length === 0 ? 'Nothing here.' : 'No matches.'}
+            </Typography>
+          ) : (
+            filtered.map((it) => {
+              const active = it.id === segment.currentId
+              return (
+                <Box
+                  key={it.id}
+                  component="button"
+                  type="button"
+                  onClick={() => {
+                    segment.onSelect?.(it.id)
+                    close()
+                  }}
+                  sx={{
+                    width: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    py: 0.75,
+                    px: 1,
+                    border: 0,
+                    borderRadius: 1,
+                    bgcolor: active ? alpha(theme.palette.primary.main, 0.1) : 'transparent',
+                    color: 'text.primary',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    fontFamily: theme.typography.fontFamily,
+                    fontSize: '0.875rem',
+                    fontWeight: active ? 600 : 400,
+                    '&:hover': { bgcolor: alpha(theme.palette.primary.main, 0.06) },
+                  }}
+                >
+                  {it.leading}
+                  <Box
+                    component="span"
+                    sx={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                  >
+                    {it.label}
+                  </Box>
+                  {it.secondary && (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ textTransform: 'uppercase', letterSpacing: '0.04em' }}
+                    >
+                      {it.secondary}
+                    </Typography>
+                  )}
+                  {active && <CheckIcon sx={{ fontSize: 16, color: 'primary.main' }} />}
+                </Box>
+              )
+            })
+          )}
+        </Box>
+      </Popover>
+    </>
+  )
+}

--- a/packages/ui/src/components/PathBreadcrumb/index.ts
+++ b/packages/ui/src/components/PathBreadcrumb/index.ts
@@ -1,0 +1,1 @@
+export * from './PathBreadcrumb'

--- a/packages/ui/src/components/PrimaryRail/PrimaryRail.stories.tsx
+++ b/packages/ui/src/components/PrimaryRail/PrimaryRail.stories.tsx
@@ -1,0 +1,152 @@
+import BarChartIcon from '@mui/icons-material/BarChart'
+import DashboardIcon from '@mui/icons-material/Dashboard'
+import FolderIcon from '@mui/icons-material/Folder'
+import GroupIcon from '@mui/icons-material/Group'
+import NotificationsIcon from '@mui/icons-material/Notifications'
+import ReceiptIcon from '@mui/icons-material/Receipt'
+import SettingsIcon from '@mui/icons-material/Settings'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, userEvent, within } from '@storybook/test'
+import { useState } from 'react'
+
+import { NumberBadge } from '../NumberBadge'
+import { PrimaryRail, type PrimaryRailSection } from './PrimaryRail'
+
+const sections: PrimaryRailSection[] = [
+  {
+    label: 'Workspace',
+    items: [
+      { href: '/', label: 'Dashboard', icon: <DashboardIcon /> },
+      { href: '/projects', label: 'Projects', icon: <FolderIcon /> },
+      { href: '/members', label: 'Members', icon: <GroupIcon /> },
+      {
+        href: '/alerts',
+        label: 'Alerts',
+        icon: <NotificationsIcon />,
+        badge: <NumberBadge tone="error">3</NumberBadge>,
+      },
+      { href: '/reports', label: 'Reports', icon: <BarChartIcon /> },
+    ],
+  },
+  {
+    label: 'Admin',
+    items: [
+      { href: '/settings', label: 'Settings', icon: <SettingsIcon /> },
+      { href: '/billing', label: 'Billing', icon: <ReceiptIcon /> },
+    ],
+  },
+]
+
+const meta = {
+  title: 'Layout/PrimaryRail',
+  component: PrimaryRail,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    activeHref: { control: 'text' },
+    collapsed: { control: 'boolean' },
+    collapsedWidth: { control: { type: 'number', min: 48, max: 120 } },
+    expandedWidth: { control: { type: 'number', min: 160, max: 320 } },
+    showCollapseToggle: { control: 'boolean' },
+    onCollapsedChange: { action: 'collapsedChanged' },
+  },
+  args: {
+    sections,
+    activeHref: '/projects',
+    showCollapseToggle: true,
+    collapsedWidth: 64,
+    expandedWidth: 220,
+  },
+} satisfies Meta<typeof PrimaryRail>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const Brand = (
+  <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+    <Typography sx={{ fontSize: '0.9rem', fontWeight: 700, lineHeight: 1.1 }}>Mindtrace</Typography>
+    <Typography sx={{ fontSize: '0.78rem', color: 'primary.main', fontWeight: 500, lineHeight: 1.2 }}>
+      Workspace
+    </Typography>
+  </Box>
+)
+
+/**
+ * Stories use `renderLink` to handle clicks via React state instead of
+ * triggering real browser navigation — otherwise clicks would break the
+ * user out of Storybook's iframe. In a real app, `renderLink` is where
+ * you'd return a `<Link>` from your router instead.
+ */
+function StoryShell(args: React.ComponentProps<typeof PrimaryRail>) {
+  const [active, setActive] = useState(args.activeHref ?? '/projects')
+  return (
+    <Box sx={{ display: 'flex', height: 600, bgcolor: 'background.default' }}>
+      <PrimaryRail
+        {...args}
+        activeHref={active}
+        renderLink={(item, content) => (
+          <Box
+            component="a"
+            href={item.href}
+            onClick={(e) => {
+              e.preventDefault()
+              setActive(item.href)
+            }}
+            sx={{ textDecoration: 'none', color: 'inherit' }}
+          >
+            {content}
+          </Box>
+        )}
+      />
+      <Box sx={{ flex: 1, p: 3 }}>
+        <Typography variant="caption" color="text.secondary">
+          Active route
+        </Typography>
+        <Typography variant="h4">{active}</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          Click any item in the rail to see the active state move.
+        </Typography>
+      </Box>
+    </Box>
+  )
+}
+
+export const Expanded: Story = {
+  args: { brand: Brand, collapsed: false },
+  render: (args) => <StoryShell {...args} />,
+}
+
+export const Collapsed: Story = {
+  args: { brand: Brand, collapsed: true },
+  render: (args) => <StoryShell {...args} />,
+}
+
+export const Toggle: Story = {
+  args: { brand: Brand },
+  render: (args) => <StoryShell {...args} />,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    const toggle = canvas.getByRole('button', { name: /collapse navigation|expand navigation/i })
+    await userEvent.click(toggle)
+    await expect(args.onCollapsedChange).toHaveBeenCalled()
+  },
+}
+
+export const Navigate: Story = {
+  args: { brand: Brand, collapsed: false },
+  render: (args) => <StoryShell {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByText('Members'))
+    await expect(canvas.getByRole('heading', { name: '/members' })).toBeVisible()
+    await userEvent.click(canvas.getByText('Settings'))
+    await expect(canvas.getByRole('heading', { name: '/settings' })).toBeVisible()
+  },
+}
+
+export const WithoutBrand: Story = {
+  args: { collapsed: false },
+  render: (args) => <StoryShell {...args} />,
+}

--- a/packages/ui/src/components/PrimaryRail/PrimaryRail.test.tsx
+++ b/packages/ui/src/components/PrimaryRail/PrimaryRail.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { PrimaryRail } from './PrimaryRail'
+
+const sections = [
+  {
+    label: 'Workspace',
+    items: [
+      { href: '/', label: 'Dashboard' },
+      { href: '/projects', label: 'Projects' },
+    ],
+  },
+]
+
+describe('PrimaryRail', () => {
+  it('renders nav items', () => {
+    render(<PrimaryRail sections={sections} />)
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Projects')).toBeInTheDocument()
+  })
+
+  it('toggles collapsed state via the toggle button', async () => {
+    const onCollapsedChange = vi.fn()
+    const user = userEvent.setup()
+    render(<PrimaryRail sections={sections} onCollapsedChange={onCollapsedChange} />)
+    await user.click(screen.getByRole('button', { name: /collapse navigation/i }))
+    expect(onCollapsedChange).toHaveBeenCalledWith(true)
+  })
+
+  it('uses renderLink when provided', () => {
+    const renderLink = vi.fn((_item, content) => <span data-testid="custom">{content}</span>)
+    render(<PrimaryRail sections={sections} renderLink={renderLink} />)
+    expect(renderLink).toHaveBeenCalled()
+    expect(screen.getAllByTestId('custom').length).toBeGreaterThan(0)
+  })
+})

--- a/packages/ui/src/components/PrimaryRail/PrimaryRail.tsx
+++ b/packages/ui/src/components/PrimaryRail/PrimaryRail.tsx
@@ -1,0 +1,327 @@
+/**
+ * PrimaryRail — collapsible left navigation rail.
+ *
+ * Structure:
+ *   - `brand` slot at top
+ *   - Collapse toggle hanging off the right edge
+ *   - Scrollable list of sections
+ *
+ * Each section has an optional label (uppercase tiny label when expanded,
+ * a thin divider when collapsed) and a list of items: icon + label
+ * + optional badge.
+ *
+ * Active state is driven by `activeHref` (string match) or a custom
+ * `isItemActive` function. Use `renderLink` to integrate with a router
+ * (e.g. React Router's `<Link>`); by default items render as plain `<a>`.
+ *
+ * Collapse can be controlled (`collapsed` + `onCollapsedChange`) or
+ * uncontrolled with optional `persistKey` for `localStorage` persistence.
+ */
+
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import Box from '@mui/material/Box'
+import Divider from '@mui/material/Divider'
+import IconButton from '@mui/material/IconButton'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { useEffect, useState, type ReactNode } from 'react'
+
+export type PrimaryRailItem = {
+  /** Stable identifier used for the active comparison + key. */
+  href: string
+  label: string
+  icon?: ReactNode
+  /** Optional badge rendered to the right when expanded. */
+  badge?: ReactNode
+}
+
+export type PrimaryRailSection = {
+  /** Section heading (shown only when expanded). */
+  label?: string
+  items: PrimaryRailItem[]
+}
+
+export type PrimaryRailProps = {
+  /** Top-of-rail brand slot. */
+  brand?: ReactNode
+  /** Sections of nav items, rendered in order. */
+  sections: PrimaryRailSection[]
+  /** Currently-active route. Compared with each item's `href`. */
+  activeHref?: string
+  /** Override active-match logic if your routing pattern needs it. */
+  isItemActive?: (item: PrimaryRailItem) => boolean
+  /** Render an item's link — override to integrate with a router. */
+  renderLink?: (item: PrimaryRailItem, content: ReactNode) => ReactNode
+  /** Controlled collapsed state. */
+  collapsed?: boolean
+  /** Uncontrolled starting state. */
+  defaultCollapsed?: boolean
+  /** Called whenever the collapsed state changes. */
+  onCollapsedChange?: (collapsed: boolean) => void
+  /** Persist collapsed state in `localStorage` under this key. */
+  persistKey?: string
+  /** Collapsed rail width. Default `64`. */
+  collapsedWidth?: number
+  /** Expanded rail width. Default `220`. */
+  expandedWidth?: number
+  /** Show the collapse toggle button. Default `true`. */
+  showCollapseToggle?: boolean
+}
+
+function defaultIsActive(activeHref: string | undefined, item: PrimaryRailItem): boolean {
+  if (!activeHref) return false
+  if (item.href === '/') return activeHref === '/'
+  return activeHref === item.href || activeHref.startsWith(`${item.href}/`)
+}
+
+export function PrimaryRail({
+  brand,
+  sections,
+  activeHref,
+  isItemActive,
+  renderLink,
+  collapsed,
+  defaultCollapsed = false,
+  onCollapsedChange,
+  persistKey,
+  collapsedWidth = 64,
+  expandedWidth = 220,
+  showCollapseToggle = true,
+}: PrimaryRailProps) {
+  const isControlled = collapsed !== undefined
+  const [uncontrolled, setUncontrolled] = useState<boolean>(() => {
+    if (persistKey) {
+      try {
+        const stored = window.localStorage.getItem(persistKey)
+        if (stored !== null) return stored === 'true'
+      } catch {
+        /* ignore */
+      }
+    }
+    return defaultCollapsed
+  })
+  const isCollapsed = isControlled ? collapsed : uncontrolled
+
+  useEffect(() => {
+    if (!isControlled && persistKey) {
+      try {
+        window.localStorage.setItem(persistKey, String(uncontrolled))
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [isControlled, persistKey, uncontrolled])
+
+  function toggle() {
+    const next = !isCollapsed
+    if (!isControlled) setUncontrolled(next)
+    onCollapsedChange?.(next)
+  }
+
+  const width = isCollapsed ? collapsedWidth : expandedWidth
+  const expanded = !isCollapsed
+
+  return (
+    <Box
+      component="nav"
+      aria-label="Primary navigation"
+      sx={(theme) => ({
+        flex: `0 0 ${width}px`,
+        width,
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'stretch',
+        pt: 2,
+        pb: 1,
+        bgcolor: theme.palette.mode === 'dark' ? theme.palette.surface.subtle : theme.palette.background.paper,
+        borderRight: 1,
+        borderColor: 'divider',
+        transition: 'width 160ms ease, flex-basis 160ms ease, padding 160ms ease',
+        overflow: 'visible',
+        position: 'relative',
+      })}
+    >
+      {brand && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: expanded ? 'flex-start' : 'center',
+            mb: 1.5,
+            mx: expanded ? 1.5 : 0,
+            minHeight: 36,
+          }}
+        >
+          {brand}
+        </Box>
+      )}
+
+      {showCollapseToggle && (
+        <Tooltip title={expanded ? 'Collapse navigation' : 'Expand navigation'} placement="right" arrow>
+          <IconButton
+            onClick={toggle}
+            aria-label={expanded ? 'Collapse navigation' : 'Expand navigation'}
+            size="small"
+            sx={(theme) => ({
+              position: 'absolute',
+              top: 28,
+              right: -12,
+              zIndex: theme.zIndex.appBar + 1,
+              width: 24,
+              height: 24,
+              borderRadius: '50%',
+              bgcolor: theme.palette.background.paper,
+              border: 1,
+              borderColor: 'divider',
+              color: 'text.secondary',
+              boxShadow: 1,
+              '&:hover': {
+                bgcolor: theme.palette.background.paper,
+                color: 'primary.main',
+                borderColor: 'primary.main',
+              },
+            })}
+          >
+            {expanded ? <ChevronLeftIcon sx={{ fontSize: 16 }} /> : <ChevronRightIcon sx={{ fontSize: 16 }} />}
+          </IconButton>
+        </Tooltip>
+      )}
+
+      <Box sx={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', minHeight: 0, pt: 0.5 }}>
+        {sections.map((section, idx) => (
+          <NavSection
+            key={section.label ?? idx}
+            section={section}
+            expanded={expanded}
+            showSeparator={idx > 0}
+            isActive={(item) => isItemActive?.(item) ?? defaultIsActive(activeHref, item)}
+            renderLink={renderLink}
+          />
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
+function NavSection({
+  section,
+  expanded,
+  showSeparator,
+  isActive,
+  renderLink,
+}: {
+  section: PrimaryRailSection
+  expanded: boolean
+  showSeparator: boolean
+  isActive: (item: PrimaryRailItem) => boolean
+  renderLink?: PrimaryRailProps['renderLink']
+}) {
+  return (
+    <Box sx={{ pb: 0.5 }}>
+      {showSeparator && !expanded && (
+        <Box sx={{ px: 1.25, py: 0.5 }}>
+          <Divider sx={{ my: 0.25 }} />
+        </Box>
+      )}
+      {expanded && section.label && (
+        <Typography
+          variant="tinyLabel"
+          sx={{
+            color: 'text.secondary',
+            display: 'block',
+            px: 1.5,
+            pt: showSeparator ? 1.25 : 0.5,
+            pb: 0.5,
+          }}
+        >
+          {section.label}
+        </Typography>
+      )}
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 0.25,
+          px: expanded ? 1 : 0,
+          alignItems: expanded ? 'stretch' : 'center',
+        }}
+      >
+        {section.items.map((item) => (
+          <NavRow key={item.href} item={item} expanded={expanded} active={isActive(item)} renderLink={renderLink} />
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
+function NavRow({
+  item,
+  expanded,
+  active,
+  renderLink,
+}: {
+  item: PrimaryRailItem
+  expanded: boolean
+  active: boolean
+  renderLink?: PrimaryRailProps['renderLink']
+}) {
+  const content = (
+    <>
+      <Box sx={{ display: 'inline-flex', '& .MuiSvgIcon-root': { fontSize: 20 } }}>{item.icon}</Box>
+      {expanded && (
+        <Typography
+          sx={{
+            fontSize: '0.83rem',
+            fontWeight: active ? 600 : 500,
+            color: 'inherit',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            flex: 1,
+          }}
+        >
+          {item.label}
+        </Typography>
+      )}
+      {expanded && item.badge != null && <Box sx={{ display: 'inline-flex' }}>{item.badge}</Box>}
+    </>
+  )
+
+  const innerSx = {
+    width: expanded ? '100%' : 40,
+    height: 36,
+    borderRadius: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: expanded ? 'flex-start' : 'center',
+    gap: expanded ? 1.5 : 0,
+    px: expanded ? 1.25 : 0,
+    cursor: 'pointer',
+    textDecoration: 'none',
+    color: active ? 'primary.main' : 'text.secondary',
+    bgcolor: active ? 'action.selected' : 'transparent',
+    transition: 'background-color 120ms, color 120ms',
+    '&:hover': {
+      bgcolor: active ? 'action.selected' : 'action.hover',
+      color: active ? 'primary.main' : 'text.primary',
+    },
+    flexShrink: 0,
+  } as const
+
+  const inner = renderLink ? (
+    renderLink(item, <Box sx={innerSx}>{content}</Box>)
+  ) : (
+    <Box component="a" href={item.href} sx={innerSx}>
+      {content}
+    </Box>
+  )
+
+  if (expanded) return inner
+  return (
+    <Tooltip title={item.label} placement="right" arrow>
+      <Box sx={{ display: 'inline-flex' }}>{inner}</Box>
+    </Tooltip>
+  )
+}

--- a/packages/ui/src/components/PrimaryRail/PrimaryRail.tsx
+++ b/packages/ui/src/components/PrimaryRail/PrimaryRail.tsx
@@ -23,6 +23,7 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import Box from '@mui/material/Box'
 import Divider from '@mui/material/Divider'
 import IconButton from '@mui/material/IconButton'
+import { alpha, type Theme } from '@mui/material/styles'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { useEffect, useState, type ReactNode } from 'react'
@@ -91,7 +92,10 @@ export function PrimaryRail({
 }: PrimaryRailProps) {
   const isControlled = collapsed !== undefined
   const [uncontrolled, setUncontrolled] = useState<boolean>(() => {
-    if (persistKey) {
+    // Guard `window` so this initializer is safe during SSR, where `window`
+    // is undefined. On the server we fall back to `defaultCollapsed`; on the
+    // client the stored value is read synchronously (no collapse flash).
+    if (persistKey && typeof window !== 'undefined') {
       try {
         const stored = window.localStorage.getItem(persistKey)
         if (stored !== null) return stored === 'true'
@@ -289,26 +293,31 @@ function NavRow({
     </>
   )
 
-  const innerSx = {
-    width: expanded ? '100%' : 40,
-    height: 36,
-    borderRadius: 1,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: expanded ? 'flex-start' : 'center',
-    gap: expanded ? 1.5 : 0,
-    px: expanded ? 1.25 : 0,
-    cursor: 'pointer',
-    textDecoration: 'none',
-    color: active ? 'primary.main' : 'text.secondary',
-    bgcolor: active ? 'action.selected' : 'transparent',
-    transition: 'background-color 120ms, color 120ms',
-    '&:hover': {
-      bgcolor: active ? 'action.selected' : 'action.hover',
-      color: active ? 'primary.main' : 'text.primary',
-    },
-    flexShrink: 0,
-  } as const
+  const innerSx = (theme: Theme) => {
+    // Active tint derives from `palette.primary` so it tracks a custom primary.
+    const selected = alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.16 : 0.08)
+    const selectedHover = alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.24 : 0.14)
+    return {
+      width: expanded ? '100%' : 40,
+      height: 36,
+      borderRadius: 1,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: expanded ? 'flex-start' : 'center',
+      gap: expanded ? 1.5 : 0,
+      px: expanded ? 1.25 : 0,
+      cursor: 'pointer',
+      textDecoration: 'none',
+      color: active ? 'primary.main' : 'text.secondary',
+      bgcolor: active ? selected : 'transparent',
+      transition: 'background-color 120ms, color 120ms',
+      '&:hover': {
+        bgcolor: active ? selectedHover : theme.palette.action.hover,
+        color: active ? 'primary.main' : 'text.primary',
+      },
+      flexShrink: 0,
+    } as const
+  }
 
   const inner = renderLink ? (
     renderLink(item, <Box sx={innerSx}>{content}</Box>)

--- a/packages/ui/src/components/PrimaryRail/index.ts
+++ b/packages/ui/src/components/PrimaryRail/index.ts
@@ -1,0 +1,1 @@
+export * from './PrimaryRail'

--- a/packages/ui/src/components/Radio/Radio.stories.tsx
+++ b/packages/ui/src/components/Radio/Radio.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import { useState } from 'react'
+
+import { RadioGroup, type RadioOption } from './Radio'
+
+const options: RadioOption[] = [
+  { value: 'free', label: 'Free' },
+  { value: 'pro', label: 'Pro' },
+  { value: 'enterprise', label: 'Enterprise', disabled: true },
+]
+
+const meta = {
+  title: 'Components/Radio',
+  component: RadioGroup,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    label: { control: 'text' },
+    helperText: { control: 'text' },
+    error: { control: 'boolean' },
+    onChange: { action: 'changed' },
+  },
+  args: { label: 'Plan', options, onChange: fn() },
+} satisfies Meta<typeof RadioGroup>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = { args: { defaultValue: 'pro' } }
+
+export const Interactive: Story = {
+  render: (args) => {
+    const [v, setV] = useState('free')
+    return (
+      <RadioGroup
+        {...args}
+        value={v}
+        onChange={(next) => {
+          setV(next)
+          args.onChange?.(next)
+        }}
+      />
+    )
+  },
+}
+
+export const WithHelperText: Story = {
+  args: { helperText: 'You can change this later in billing.' },
+}
+
+export const Error: Story = {
+  args: { error: true, helperText: 'Please pick a plan.' },
+}

--- a/packages/ui/src/components/Radio/Radio.test.tsx
+++ b/packages/ui/src/components/Radio/Radio.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { RadioGroup } from './Radio'
+
+describe('RadioGroup', () => {
+  it('renders options + picks one', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <RadioGroup
+        label="Plan"
+        defaultValue="free"
+        onChange={onChange}
+        options={[
+          { value: 'free', label: 'Free' },
+          { value: 'pro', label: 'Pro' },
+        ]}
+      />,
+    )
+    await user.click(screen.getByLabelText('Pro'))
+    expect(onChange).toHaveBeenCalledWith('pro')
+  })
+
+  it('renders helper text', () => {
+    render(
+      <RadioGroup label="Plan" helperText="Pick one" options={[{ value: 'a', label: 'A' }]} />,
+    )
+    expect(screen.getByText('Pick one')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/Radio/Radio.tsx
+++ b/packages/ui/src/components/Radio/Radio.tsx
@@ -1,0 +1,78 @@
+import FormControl from '@mui/material/FormControl'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import FormHelperText from '@mui/material/FormHelperText'
+import FormLabel from '@mui/material/FormLabel'
+import MuiRadio, { type RadioProps as MuiRadioProps } from '@mui/material/Radio'
+import MuiRadioGroup, { type RadioGroupProps as MuiRadioGroupProps } from '@mui/material/RadioGroup'
+import type { ReactNode } from 'react'
+
+export type RadioProps = MuiRadioProps & { label?: ReactNode }
+
+/**
+ * Single radio input. Typically used inside a `RadioGroup`. Use the
+ * `label` prop to avoid composing FormControlLabel manually.
+ */
+export function Radio({ label, ...rest }: RadioProps) {
+  const control = <MuiRadio {...rest} />
+  if (label === undefined) return control
+  return <FormControlLabel control={control} label={label} />
+}
+
+export type RadioOption<T extends string = string> = {
+  value: T
+  label: ReactNode
+  disabled?: boolean
+}
+
+export type RadioGroupProps<T extends string = string> = Omit<MuiRadioGroupProps, 'onChange'> & {
+  /** Group heading. */
+  label?: ReactNode
+  /** Helper text under the group. */
+  helperText?: ReactNode
+  /** Show validation error styling. */
+  error?: boolean
+  /** Convenience for a flat list of radios. Use children for custom rendering. */
+  options?: RadioOption<T>[]
+  onChange?: (value: T) => void
+}
+
+/**
+ * Group of radio inputs sharing a name. Renders an optional heading +
+ * helper text and supports a flat `options` array.
+ *
+ *   <RadioGroup
+ *     label="Plan"
+ *     value={plan}
+ *     onChange={setPlan}
+ *     options={[{ value: 'free', label: 'Free' }, { value: 'pro', label: 'Pro' }]}
+ *   />
+ */
+export function RadioGroup<T extends string = string>({
+  label,
+  helperText,
+  error,
+  options,
+  onChange,
+  children,
+  ...rest
+}: RadioGroupProps<T>) {
+  return (
+    <FormControl error={error} component="fieldset">
+      {label && <FormLabel component="legend">{label}</FormLabel>}
+      <MuiRadioGroup {...rest} onChange={(_, v) => onChange?.(v as T)}>
+        {options
+          ? options.map((o) => (
+              <FormControlLabel
+                key={String(o.value)}
+                value={o.value}
+                control={<MuiRadio />}
+                label={o.label}
+                disabled={o.disabled}
+              />
+            ))
+          : children}
+      </MuiRadioGroup>
+      {helperText && <FormHelperText>{helperText}</FormHelperText>}
+    </FormControl>
+  )
+}

--- a/packages/ui/src/components/Radio/index.ts
+++ b/packages/ui/src/components/Radio/index.ts
@@ -1,0 +1,1 @@
+export * from './Radio'

--- a/packages/ui/src/components/SearchField/SearchField.stories.tsx
+++ b/packages/ui/src/components/SearchField/SearchField.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+import { useState } from 'react'
+
+import { SearchField } from './SearchField'
+
+const meta = {
+  title: 'Patterns/SearchField',
+  component: SearchField,
+  tags: ['autodocs'],
+  argTypes: {
+    placeholder: { control: 'text' },
+    autoFocus: { control: 'boolean' },
+    fullWidth: { control: 'boolean' },
+    disableClear: { control: 'boolean' },
+    onChange: { action: 'changed' },
+  },
+  args: {
+    value: '',
+    placeholder: 'Search…',
+    maxWidth: 420,
+    onChange: fn(),
+  },
+} satisfies Meta<typeof SearchField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function Wrapper({ onChange, ...rest }: React.ComponentProps<typeof SearchField>) {
+  const [v, setV] = useState(rest.value ?? '')
+  return (
+    <SearchField
+      {...rest}
+      value={v}
+      onChange={(next) => { setV(next); onChange(next) }}
+    />
+  )
+}
+
+export const Default: Story = {
+  render: (args) => <Wrapper {...args} />,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByPlaceholderText('Search…')
+    await userEvent.type(input, 'engineering')
+    await expect(args.onChange).toHaveBeenCalled()
+    await expect(input).toHaveValue('engineering')
+  },
+}
+
+export const Filled: Story = {
+  args: { value: 'engineering' },
+  render: (args) => <Wrapper {...args} />,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /clear/i }))
+    await expect(args.onChange).toHaveBeenLastCalledWith('')
+  },
+}

--- a/packages/ui/src/components/SearchField/SearchField.test.tsx
+++ b/packages/ui/src/components/SearchField/SearchField.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { SearchField } from './SearchField'
+
+describe('SearchField', () => {
+  it('fires onChange with the typed value', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<SearchField value="" onChange={onChange} />)
+    await user.type(screen.getByPlaceholderText('Search…'), 'abc')
+    expect(onChange).toHaveBeenCalled()
+  })
+
+  it('clears via the clear button', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<SearchField value="abc" onChange={onChange} />)
+    await user.click(screen.getByRole('button', { name: /clear/i }))
+    expect(onChange).toHaveBeenLastCalledWith('')
+  })
+})

--- a/packages/ui/src/components/SearchField/SearchField.tsx
+++ b/packages/ui/src/components/SearchField/SearchField.tsx
@@ -1,0 +1,66 @@
+/**
+ * SearchField — a `TextField` preconfigured for search use.
+ *
+ *   <SearchField value={q} onChange={setQ} placeholder="Search runs…" />
+ *
+ * Includes a leading search icon and a clear-button when value is set.
+ * Use for any list/table filter input; consistent affordance across the
+ * app means users never have to learn it twice.
+ */
+
+import ClearIcon from '@mui/icons-material/Close'
+import SearchIcon from '@mui/icons-material/Search'
+import IconButton from '@mui/material/IconButton'
+import InputAdornment from '@mui/material/InputAdornment'
+import TextField from '@mui/material/TextField'
+import type { ChangeEvent } from 'react'
+
+export type SearchFieldProps = {
+  value: string
+  onChange: (next: string) => void
+  placeholder?: string
+  autoFocus?: boolean
+  fullWidth?: boolean
+  /** Visual width override; default is `fullWidth`. */
+  maxWidth?: number | string
+  /** Disable the clear button. */
+  disableClear?: boolean
+}
+
+export function SearchField({
+  value,
+  onChange,
+  placeholder = 'Search…',
+  autoFocus,
+  fullWidth = true,
+  maxWidth,
+  disableClear,
+}: SearchFieldProps) {
+  return (
+    <TextField
+      placeholder={placeholder}
+      value={value}
+      autoFocus={autoFocus}
+      fullWidth={fullWidth}
+      onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+      sx={{ maxWidth }}
+      slotProps={{
+        input: {
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+            </InputAdornment>
+          ),
+          endAdornment:
+            value && !disableClear ? (
+              <InputAdornment position="end">
+                <IconButton size="small" onClick={() => onChange('')} aria-label="Clear search">
+                  <ClearIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
+        },
+      }}
+    />
+  )
+}

--- a/packages/ui/src/components/SearchField/index.ts
+++ b/packages/ui/src/components/SearchField/index.ts
@@ -1,0 +1,2 @@
+export { SearchField } from './SearchField'
+export type { SearchFieldProps } from './SearchField'

--- a/packages/ui/src/components/SectionCard/SectionCard.stories.tsx
+++ b/packages/ui/src/components/SectionCard/SectionCard.stories.tsx
@@ -1,0 +1,62 @@
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Button } from '../Button'
+import { SectionCard } from './SectionCard'
+
+const meta = {
+  title: 'Patterns/SectionCard',
+  component: SectionCard,
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: 'text' },
+    subtitle: { control: 'text' },
+    disablePadding: { control: 'boolean' },
+  },
+  args: { title: 'Section', children: null },
+} satisfies Meta<typeof SectionCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    title: 'Settings',
+    children: <Typography color="text.secondary">Card body content.</Typography>,
+  },
+}
+
+export const WithSubtitle: Story = {
+  args: {
+    title: 'Webhooks',
+    subtitle: 'HTTP endpoints we call when events fire in this workspace.',
+    children: <Typography color="text.secondary">Card body content.</Typography>,
+  },
+}
+
+export const WithActions: Story = {
+  args: {
+    title: 'Active notifications',
+    actions: <Button size="small">View all</Button>,
+    children: <Typography color="text.secondary">Card body content.</Typography>,
+  },
+}
+
+export const DisablePadding: Story = {
+  args: {
+    title: 'Recent activity',
+    disablePadding: true,
+    children: (
+      <Stack
+        sx={(theme) => ({
+          borderTop: `1px solid ${theme.palette.border.subtle}`,
+          py: 4,
+          textAlign: 'center',
+        })}
+      >
+        <Typography color="text.secondary">Table body would sit edge-to-edge here.</Typography>
+      </Stack>
+    ),
+  },
+}

--- a/packages/ui/src/components/SectionCard/SectionCard.test.tsx
+++ b/packages/ui/src/components/SectionCard/SectionCard.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { SectionCard } from './SectionCard'
+
+describe('SectionCard', () => {
+  it('renders title, subtitle, and body', () => {
+    render(
+      <SectionCard title="Webhooks" subtitle="HTTP endpoints">
+        <div>body</div>
+      </SectionCard>,
+    )
+    expect(screen.getByText('Webhooks')).toBeInTheDocument()
+    expect(screen.getByText('HTTP endpoints')).toBeInTheDocument()
+    expect(screen.getByText('body')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/SectionCard/SectionCard.tsx
+++ b/packages/ui/src/components/SectionCard/SectionCard.tsx
@@ -1,0 +1,75 @@
+/**
+ * Section card — the standard "panel of content under a heading".
+ *
+ * Combines Card + an internal header row into one element so consumers
+ * don't have to assemble CardHeader / CardContent every time. Pairs well
+ * with table bodies, grouped settings, and dashboard tiles.
+ */
+
+import Card, { type CardProps } from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { ReactNode, ElementType } from 'react'
+
+export type SectionCardProps = {
+  title?: ReactNode
+  subtitle?: ReactNode
+  actions?: ReactNode
+  children: ReactNode
+  /** Render-as element, defaults to `<section>`. */
+  component?: ElementType
+  /** Drop the inner padding when the body owns its own layout (e.g. tables). */
+  disablePadding?: boolean
+  /** Forwarded to the underlying Card. */
+  sx?: CardProps['sx']
+}
+
+export function SectionCard({
+  title,
+  subtitle,
+  actions,
+  children,
+  component = 'section',
+  disablePadding = false,
+  sx,
+}: SectionCardProps) {
+  return (
+    <Card component={component} sx={sx}>
+      {(title || subtitle || actions) && (
+        <Stack
+          direction="row"
+          spacing={2}
+          sx={{
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            px: 3,
+            pt: 2.5,
+            pb: title ? 1.5 : 2,
+          }}
+        >
+          <Stack spacing={0.25} sx={{ minWidth: 0 }}>
+            {title && (
+              <Typography variant="h5" component="h2">
+                {title}
+              </Typography>
+            )}
+            {subtitle && (
+              <Typography variant="body2" color="text.secondary">
+                {subtitle}
+              </Typography>
+            )}
+          </Stack>
+          {actions && (
+            <Stack direction="row" spacing={1}>
+              {actions}
+            </Stack>
+          )}
+        </Stack>
+      )}
+      <CardContent sx={{ p: disablePadding ? 0 : 3, pt: title ? 0 : 3, '&:last-child': { pb: disablePadding ? 0 : 3 } }}>
+        {children}
+      </CardContent>
+    </Card>
+  )
+}

--- a/packages/ui/src/components/SectionCard/index.ts
+++ b/packages/ui/src/components/SectionCard/index.ts
@@ -1,0 +1,2 @@
+export { SectionCard } from './SectionCard'
+export type { SectionCardProps } from './SectionCard'

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+import { useState } from 'react'
+
+import { Select, type SelectOption } from './Select'
+
+const options: SelectOption[] = [
+  { value: 'sm', label: 'Small' },
+  { value: 'md', label: 'Medium' },
+  { value: 'lg', label: 'Large' },
+  { value: 'xl', label: 'Extra large', disabled: true },
+]
+
+const meta = {
+  title: 'Components/Select',
+  component: Select,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    label: { control: 'text' },
+    helperText: { control: 'text' },
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium'] },
+    fullWidth: { control: 'boolean' },
+    error: { control: 'boolean' },
+    onChange: { action: 'changed' },
+  },
+  args: { label: 'Size', onChange: fn() },
+} satisfies Meta<typeof Select>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { options, defaultValue: 'md', sx: { minWidth: 220 } },
+}
+
+export const Interactive: Story = {
+  args: { options, sx: { minWidth: 220 } },
+  render: (args) => {
+    const [value, setValue] = useState<string>('md')
+    return (
+      <Select
+        {...args}
+        value={value}
+        onChange={(e, child) => {
+          const next = e.target.value as string
+          setValue(next)
+          args.onChange?.(e, child)
+        }}
+      />
+    )
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('combobox'))
+    const option = await within(document.body).findByRole('option', { name: 'Large' })
+    await userEvent.click(option)
+    await expect(args.onChange).toHaveBeenCalled()
+  },
+}
+
+export const WithHelperText: Story = {
+  args: {
+    label: 'Tier',
+    helperText: 'Affects pricing and quotas.',
+    options: [
+      { value: 'free', label: 'Free' },
+      { value: 'pro', label: 'Pro' },
+      { value: 'enterprise', label: 'Enterprise' },
+    ],
+    defaultValue: '',
+    sx: { minWidth: 220 },
+  },
+}
+
+export const Error: Story = {
+  args: {
+    label: 'Region',
+    error: true,
+    helperText: 'Please select a region.',
+    options: [
+      { value: 'us', label: 'United States' },
+      { value: 'eu', label: 'Europe' },
+    ],
+    defaultValue: '',
+    sx: { minWidth: 220 },
+  },
+}

--- a/packages/ui/src/components/Select/Select.test.tsx
+++ b/packages/ui/src/components/Select/Select.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { Select, type SelectOption } from './Select'
+
+const options: SelectOption[] = [
+  { value: 'sm', label: 'Small' },
+  { value: 'md', label: 'Medium' },
+  { value: 'lg', label: 'Large' },
+]
+
+describe('Select', () => {
+  it('renders the default value', () => {
+    render(<Select label="Size" options={options} defaultValue="md" />)
+    expect(screen.getByText('Medium')).toBeInTheDocument()
+  })
+
+  it('opens and picks an option', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Select label="Size" options={options} defaultValue="md" onChange={onChange} />)
+    await user.click(screen.getByRole('combobox'))
+    const option = await screen.findByRole('option', { name: 'Large' })
+    await user.click(option)
+    expect(onChange).toHaveBeenCalled()
+  })
+
+  it('renders helper text', () => {
+    render(<Select label="Tier" options={options} helperText="Affects pricing" />)
+    expect(screen.getByText('Affects pricing')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -1,0 +1,52 @@
+import FormControl from '@mui/material/FormControl'
+import FormHelperText from '@mui/material/FormHelperText'
+import InputLabel from '@mui/material/InputLabel'
+import MenuItem from '@mui/material/MenuItem'
+import MuiSelect, { type SelectProps as MuiSelectProps } from '@mui/material/Select'
+import { useId } from 'react'
+
+export type SelectOption<T extends string | number = string> = {
+  value: T
+  label: string
+  disabled?: boolean
+}
+
+export type SelectProps<T extends string | number = string> = Omit<MuiSelectProps<T>, 'children'> & {
+  /** Convenience for a flat list of options. Use MUI Select's `children` for grouped/custom rendering. */
+  options?: SelectOption<T>[]
+  /** Helper text below the select. */
+  helperText?: string
+}
+
+/**
+ * Single-value select. Wraps MUI Select with an `options` shortcut + label/helper wiring.
+ *
+ *   <Select label="Environment" options={[{ value: 'a', label: 'A' }]} value={env} onChange={…} />
+ */
+export function Select<T extends string | number = string>({
+  options,
+  helperText,
+  label,
+  id,
+  fullWidth,
+  size,
+  error,
+  ...rest
+}: SelectProps<T>) {
+  const autoId = useId()
+  const fieldId = id ?? `mt-select-${autoId}`
+  const labelId = `${fieldId}-label`
+  return (
+    <FormControl fullWidth={fullWidth} size={size} error={error}>
+      {label ? <InputLabel id={labelId}>{label}</InputLabel> : null}
+      <MuiSelect<T> labelId={label ? labelId : undefined} id={fieldId} label={label} {...rest}>
+        {options?.map((o) => (
+          <MenuItem key={String(o.value)} value={o.value} disabled={o.disabled}>
+            {o.label}
+          </MenuItem>
+        ))}
+      </MuiSelect>
+      {helperText ? <FormHelperText>{helperText}</FormHelperText> : null}
+    </FormControl>
+  )
+}

--- a/packages/ui/src/components/Select/index.ts
+++ b/packages/ui/src/components/Select/index.ts
@@ -1,0 +1,1 @@
+export * from './Select'

--- a/packages/ui/src/components/SeverityBadge/SeverityBadge.stories.tsx
+++ b/packages/ui/src/components/SeverityBadge/SeverityBadge.stories.tsx
@@ -1,0 +1,35 @@
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { SeverityBadge } from './SeverityBadge'
+
+const meta = {
+  title: 'Components/SeverityBadge',
+  component: SeverityBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    severity: {
+      control: { type: 'inline-radio' },
+      options: ['critical', 'major', 'minor', 'info'],
+    },
+    labelOverride: { control: 'text' },
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium'] },
+  },
+  args: { severity: 'major' },
+} satisfies Meta<typeof SeverityBadge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const All: Story = {
+  render: () => (
+    <Stack direction="row" spacing={1}>
+      <SeverityBadge severity="critical" />
+      <SeverityBadge severity="major" />
+      <SeverityBadge severity="minor" />
+      <SeverityBadge severity="info" />
+    </Stack>
+  ),
+}

--- a/packages/ui/src/components/SeverityBadge/SeverityBadge.test.tsx
+++ b/packages/ui/src/components/SeverityBadge/SeverityBadge.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { SeverityBadge } from './SeverityBadge'
+
+describe('SeverityBadge', () => {
+  it('renders Critical', () => {
+    render(<SeverityBadge severity="critical" />)
+    expect(screen.getByText('Critical')).toBeInTheDocument()
+  })
+
+  it('respects labelOverride', () => {
+    render(<SeverityBadge severity="major" labelOverride="HIGH" />)
+    expect(screen.getByText('HIGH')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/SeverityBadge/SeverityBadge.tsx
+++ b/packages/ui/src/components/SeverityBadge/SeverityBadge.tsx
@@ -1,0 +1,88 @@
+/**
+ * SeverityBadge — labelled severity tag for events, alerts, incidents.
+ *
+ * Severity ladder: `critical > major > minor > info`. Two visual variants:
+ *
+ *   - `'solid'` (default) — white text on a solid tone background. The
+ *     strongest, most accessible treatment; matches the classic severity
+ *     convention (red Critical, amber Major, …). Use here.
+ *   - `'tinted'` — tinted background + high-contrast `text.primary` with
+ *     a colored left marker. Useful when severity badges sit alongside
+ *     softer status chips and you don't want them to dominate.
+ *
+ * In both variants the tone-carrying surface is independent from the
+ * text color, so contrast stays WCAG AA at the small size we use here.
+ */
+
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import { alpha, useTheme } from '@mui/material/styles'
+
+export type Severity = 'critical' | 'major' | 'minor' | 'info'
+
+const severityToken: Record<Severity, { label: string; palette: 'error' | 'warning' | 'info' | 'success' }> = {
+  critical: { label: 'Critical', palette: 'error' },
+  major: { label: 'Major', palette: 'warning' },
+  minor: { label: 'Minor', palette: 'info' },
+  info: { label: 'Info', palette: 'success' },
+}
+
+export type SeverityBadgeProps = {
+  severity: Severity
+  labelOverride?: string
+  size?: 'small' | 'medium'
+  variant?: 'solid' | 'tinted'
+}
+
+export function SeverityBadge({
+  severity,
+  labelOverride,
+  size = 'small',
+  variant = 'solid',
+}: SeverityBadgeProps) {
+  const theme = useTheme()
+  const token = severityToken[severity]
+  const color = theme.palette[token.palette].main
+  const contrastText = theme.palette[token.palette].contrastText ?? '#fff'
+
+  if (variant === 'solid') {
+    return (
+      <Chip
+        size={size}
+        label={labelOverride ?? token.label}
+        sx={{
+          color: contrastText,
+          bgcolor: color,
+          border: `1px solid ${color}`,
+          fontWeight: 600,
+          letterSpacing: '0.02em',
+          textTransform: 'uppercase',
+          fontSize: '0.6875rem',
+        }}
+      />
+    )
+  }
+
+  return (
+    <Chip
+      size={size}
+      label={labelOverride ?? token.label}
+      icon={
+        <Box
+          component="span"
+          sx={{ display: 'inline-block', width: 8, height: 8, bgcolor: color, borderRadius: '50%', ml: 1.25 }}
+        />
+      }
+      sx={{
+        color: 'text.primary',
+        bgcolor: alpha(color, 0.12),
+        border: `1px solid ${alpha(color, 0.32)}`,
+        fontWeight: 600,
+        letterSpacing: '0.02em',
+        textTransform: 'uppercase',
+        fontSize: '0.6875rem',
+        '& .MuiChip-icon': { mr: -0.5 },
+      }}
+    />
+  )
+}

--- a/packages/ui/src/components/SeverityBadge/index.ts
+++ b/packages/ui/src/components/SeverityBadge/index.ts
@@ -1,0 +1,2 @@
+export { SeverityBadge } from './SeverityBadge'
+export type { SeverityBadgeProps, Severity } from './SeverityBadge'

--- a/packages/ui/src/components/StatusBadge/StatusBadge.stories.tsx
+++ b/packages/ui/src/components/StatusBadge/StatusBadge.stories.tsx
@@ -1,0 +1,37 @@
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { StatusBadge } from './StatusBadge'
+
+const meta = {
+  title: 'Components/StatusBadge',
+  component: StatusBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    tone: {
+      control: { type: 'inline-radio' },
+      options: ['neutral', 'success', 'warning', 'error', 'info'],
+    },
+    label: { control: 'text' },
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium'] },
+    pulse: { control: 'boolean' },
+  },
+  args: { tone: 'success', label: 'Healthy' },
+} satisfies Meta<typeof StatusBadge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const AllTones: Story = {
+  render: () => (
+    <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', gap: 1 }}>
+      <StatusBadge tone="success" label="Healthy" />
+      <StatusBadge tone="warning" label="Degraded" pulse />
+      <StatusBadge tone="error" label="Down" />
+      <StatusBadge tone="info" label="Pending" />
+      <StatusBadge tone="neutral" label="Idle" />
+    </Stack>
+  ),
+}

--- a/packages/ui/src/components/StatusBadge/StatusBadge.test.tsx
+++ b/packages/ui/src/components/StatusBadge/StatusBadge.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen } from '../../test-utils'
+import { StatusBadge } from './StatusBadge'
+
+describe('StatusBadge', () => {
+  it('renders the label', () => {
+    render(<StatusBadge tone="success" label="Healthy" />)
+    expect(screen.getByText('Healthy')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/StatusBadge/StatusBadge.tsx
+++ b/packages/ui/src/components/StatusBadge/StatusBadge.tsx
@@ -1,0 +1,48 @@
+/**
+ * StatusBadge — labelled status chip with a semantic dot indicator.
+ *
+ * Tone is carried by the **dot**, not the text. Text uses
+ * `text.primary` so it stays high-contrast against the tinted surface,
+ * meeting WCAG AA at typical body sizes. The dot + the tinted bg
+ * communicate the tone at a glance; the label stays readable.
+ *
+ *   <StatusBadge tone="success" label="Healthy" />
+ *   <StatusBadge tone="warning" label="Degraded" pulse />
+ *   <StatusBadge tone="error" label="Down" />
+ */
+
+import Chip from '@mui/material/Chip'
+import { alpha, useTheme, type Theme } from '@mui/material/styles'
+
+import { StatusDot, type StatusTone } from '../StatusDot/StatusDot'
+
+export type StatusBadgeProps = {
+  tone: StatusTone
+  label: string
+  pulse?: boolean
+  size?: 'small' | 'medium'
+}
+
+function toneColor(theme: Theme, tone: StatusTone): string {
+  if (tone === 'neutral') return theme.palette.text.secondary
+  return theme.palette[tone].main
+}
+
+export function StatusBadge({ tone, label, pulse, size = 'small' }: StatusBadgeProps) {
+  const theme = useTheme()
+  const accent = toneColor(theme, tone)
+  return (
+    <Chip
+      size={size}
+      label={label}
+      icon={<StatusDot tone={tone} pulse={pulse} size={8} sx={{ ml: 1.25 }} />}
+      sx={{
+        color: 'text.primary',
+        bgcolor: alpha(accent, 0.12),
+        border: `1px solid ${alpha(accent, 0.32)}`,
+        fontWeight: 500,
+        '& .MuiChip-icon': { color: accent, mr: -0.5 },
+      }}
+    />
+  )
+}

--- a/packages/ui/src/components/StatusBadge/index.ts
+++ b/packages/ui/src/components/StatusBadge/index.ts
@@ -1,0 +1,2 @@
+export { StatusBadge } from './StatusBadge'
+export type { StatusBadgeProps } from './StatusBadge'

--- a/packages/ui/src/components/StatusDot/StatusDot.stories.tsx
+++ b/packages/ui/src/components/StatusDot/StatusDot.stories.tsx
@@ -1,0 +1,42 @@
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { StatusDot } from './StatusDot'
+
+const meta = {
+  title: 'Components/StatusDot',
+  component: StatusDot,
+  tags: ['autodocs'],
+  argTypes: {
+    tone: {
+      control: { type: 'inline-radio' },
+      options: ['neutral', 'success', 'warning', 'error', 'info'],
+    },
+    size: { control: { type: 'range', min: 4, max: 20, step: 1 } },
+    pulse: { control: 'boolean' },
+  },
+  args: { tone: 'success', size: 8, pulse: false },
+} satisfies Meta<typeof StatusDot>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const AllTones: Story = {
+  render: () => (
+    <Stack spacing={1.5}>
+      {(['neutral', 'success', 'warning', 'error', 'info'] as const).map((tone) => (
+        <Stack direction="row" spacing={1.5} key={tone} sx={{ alignItems: 'center' }}>
+          <StatusDot tone={tone} />
+          <Typography variant="body2">{tone}</Typography>
+        </Stack>
+      ))}
+    </Stack>
+  ),
+}
+
+export const Pulse: Story = {
+  args: { pulse: true, tone: 'warning', size: 10 },
+}

--- a/packages/ui/src/components/StatusDot/StatusDot.test.tsx
+++ b/packages/ui/src/components/StatusDot/StatusDot.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { render } from '../../test-utils'
+import { StatusDot } from './StatusDot'
+
+describe('StatusDot', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<StatusDot tone="success" />)
+    expect(container.querySelector('span')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/StatusDot/StatusDot.tsx
+++ b/packages/ui/src/components/StatusDot/StatusDot.tsx
@@ -1,0 +1,54 @@
+/**
+ * Tiny status indicator dot. Pairs with a label for inline status display.
+ *
+ *   <StatusDot tone="success" /> Healthy
+ *   <StatusDot tone="warning" /> Degraded
+ *   <StatusDot tone="error" />   Down
+ */
+
+import Box from '@mui/material/Box'
+import type { SxProps, Theme } from '@mui/material/styles'
+
+export type StatusTone = 'neutral' | 'success' | 'warning' | 'error' | 'info'
+
+const toneToColor = {
+  neutral: 'text.disabled',
+  success: 'success.main',
+  warning: 'warning.main',
+  error: 'error.main',
+  info: 'info.main',
+} as const
+
+export type StatusDotProps = {
+  tone?: StatusTone
+  size?: number
+  pulse?: boolean
+  sx?: SxProps<Theme>
+}
+
+export function StatusDot({ tone = 'neutral', size = 8, pulse = false, sx }: StatusDotProps) {
+  return (
+    <Box
+      component="span"
+      role="presentation"
+      sx={[
+        {
+          display: 'inline-block',
+          width: size,
+          height: size,
+          borderRadius: '50%',
+          bgcolor: toneToColor[tone],
+          flexShrink: 0,
+          ...(pulse && {
+            animation: 'mindtrace-pulse 1.6s ease-in-out infinite',
+            '@keyframes mindtrace-pulse': {
+              '0%, 100%': { opacity: 1 },
+              '50%': { opacity: 0.45 },
+            },
+          }),
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+    />
+  )
+}

--- a/packages/ui/src/components/StatusDot/index.ts
+++ b/packages/ui/src/components/StatusDot/index.ts
@@ -1,0 +1,2 @@
+export { StatusDot } from './StatusDot'
+export type { StatusDotProps, StatusTone } from './StatusDot'

--- a/packages/ui/src/components/Switch/Switch.stories.tsx
+++ b/packages/ui/src/components/Switch/Switch.stories.tsx
@@ -1,0 +1,38 @@
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+
+import { Switch } from './Switch'
+
+const meta = {
+  title: 'Components/Switch',
+  component: Switch,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    label: { control: 'text' },
+    helperText: { control: 'text' },
+    disabled: { control: 'boolean' },
+    labelPlacement: { control: { type: 'inline-radio' }, options: ['start', 'end'] },
+    onChange: { action: 'changed' },
+  },
+  args: { label: 'Email me on failures', onChange: fn() },
+} satisfies Meta<typeof Switch>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+export const WithHelperText: Story = {
+  args: { helperText: 'Sends one email per incident.' },
+}
+export const States: Story = {
+  render: (args) => (
+    <Stack spacing={1.5}>
+      <Switch {...args} label="Off" />
+      <Switch {...args} label="On" defaultChecked />
+      <Switch {...args} label="Disabled off" disabled />
+      <Switch {...args} label="Disabled on" disabled defaultChecked />
+    </Stack>
+  ),
+}

--- a/packages/ui/src/components/Switch/Switch.test.tsx
+++ b/packages/ui/src/components/Switch/Switch.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { Switch } from './Switch'
+
+describe('Switch', () => {
+  it('toggles on click', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Switch label="Email me" onChange={onChange} />)
+    const sw = screen.getByLabelText('Email me')
+    await user.click(sw)
+    expect(onChange).toHaveBeenCalled()
+    expect(sw).toBeChecked()
+  })
+})

--- a/packages/ui/src/components/Switch/Switch.tsx
+++ b/packages/ui/src/components/Switch/Switch.tsx
@@ -1,0 +1,29 @@
+import FormControlLabel from '@mui/material/FormControlLabel'
+import FormHelperText from '@mui/material/FormHelperText'
+import Stack from '@mui/material/Stack'
+import MuiSwitch, { type SwitchProps as MuiSwitchProps } from '@mui/material/Switch'
+import type { ReactNode } from 'react'
+
+export type SwitchProps = MuiSwitchProps & {
+  label?: ReactNode
+  helperText?: ReactNode
+  labelPlacement?: 'start' | 'end'
+}
+
+/**
+ * Toggle. Wraps MUI Switch with an optional inline label + helper text.
+ *
+ *   <Switch label="Email me on failures" checked={v} onChange={(_, n) => setV(n)} />
+ */
+export function Switch({ label, helperText, labelPlacement = 'end', sx, ...rest }: SwitchProps) {
+  const control = <MuiSwitch {...rest} />
+  if (!label && !helperText) return control
+  return (
+    <Stack spacing={0.25} sx={{ display: 'inline-flex' }}>
+      <FormControlLabel control={control} label={label ?? ''} labelPlacement={labelPlacement} sx={sx} />
+      {helperText && (
+        <FormHelperText sx={{ ml: labelPlacement === 'start' ? 0 : 6.25 }}>{helperText}</FormHelperText>
+      )}
+    </Stack>
+  )
+}

--- a/packages/ui/src/components/Switch/index.ts
+++ b/packages/ui/src/components/Switch/index.ts
@@ -1,0 +1,1 @@
+export * from './Switch'

--- a/packages/ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,72 @@
+import GroupIcon from '@mui/icons-material/Group'
+import HomeIcon from '@mui/icons-material/Home'
+import SettingsIcon from '@mui/icons-material/Settings'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+
+import { NumberBadge } from '../NumberBadge'
+import { Tabs } from './Tabs'
+
+const meta = {
+  title: 'Components/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: { type: 'inline-radio' }, options: ['standard', 'fullWidth', 'scrollable'] },
+    onChange: { action: 'changed' },
+  },
+  args: {
+    tabs: [
+      { value: 'overview', label: 'Overview', content: <Typography>Overview body</Typography> },
+      {
+        value: 'members',
+        label: 'Members',
+        badge: <NumberBadge tone="info">3</NumberBadge>,
+        content: <Typography>Members body</Typography>,
+      },
+      {
+        value: 'settings',
+        label: 'Settings',
+        content: <Typography>Settings body</Typography>,
+      },
+    ],
+    defaultValue: 'overview',
+    onChange: fn(),
+  },
+} satisfies Meta<typeof Tabs>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('tab', { name: /members/i }))
+    await expect(args.onChange).toHaveBeenLastCalledWith('members')
+    await expect(canvas.getByText('Members body')).toBeVisible()
+  },
+}
+
+export const WithIcons: Story = {
+  args: {
+    tabs: [
+      { value: 'home', label: 'Home', icon: <HomeIcon />, content: <Typography>Home</Typography> },
+      {
+        value: 'people',
+        label: 'People',
+        icon: <GroupIcon />,
+        content: <Typography>People</Typography>,
+      },
+      {
+        value: 'settings',
+        label: 'Settings',
+        icon: <SettingsIcon />,
+        content: <Typography>Settings</Typography>,
+      },
+    ],
+    defaultValue: 'home',
+  },
+}
+
+export const FullWidth: Story = { args: { variant: 'fullWidth' } }

--- a/packages/ui/src/components/Tabs/Tabs.test.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { Tabs } from './Tabs'
+
+const tabs = [
+  { value: 'overview', label: 'Overview', content: <div>Overview body</div> },
+  { value: 'members', label: 'Members', content: <div>Members body</div> },
+]
+
+describe('Tabs', () => {
+  it('renders the active panel and switches', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Tabs tabs={tabs} defaultValue="overview" onChange={onChange} />)
+    expect(screen.getByText('Overview body')).toBeInTheDocument()
+    await user.click(screen.getByRole('tab', { name: 'Members' }))
+    expect(onChange).toHaveBeenLastCalledWith('members')
+    expect(screen.getByText('Members body')).toBeInTheDocument()
+  })
+
+  it('renders a disabled tab as disabled', () => {
+    render(
+      <Tabs
+        tabs={[
+          { value: 'a', label: 'A', content: <div>A</div> },
+          { value: 'b', label: 'B', content: <div>B</div>, disabled: true },
+        ]}
+        defaultValue="a"
+      />,
+    )
+    expect(screen.getByRole('tab', { name: 'B' })).toBeDisabled()
+  })
+})

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tabs — tabbed view with a flat `tabs` array and built-in panel rendering.
+ *
+ *   <Tabs
+ *     value={tab}
+ *     onChange={setTab}
+ *     tabs={[
+ *       { value: 'overview', label: 'Overview', content: <Overview/> },
+ *       { value: 'members', label: 'Members', content: <Members/>, badge: <NumberBadge>3</NumberBadge> },
+ *     ]}
+ *   />
+ *
+ * Pass `value` + `onChange` to control externally, or omit them for
+ * uncontrolled (use `defaultValue`). Each tab's `content` is rendered
+ * inside an accessible `role="tabpanel"` region.
+ */
+
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import MuiTab, { type TabProps as MuiTabProps } from '@mui/material/Tab'
+import MuiTabs, { type TabsProps as MuiTabsProps } from '@mui/material/Tabs'
+import { useState, type ReactNode, type SyntheticEvent } from 'react'
+
+export type TabsItem<T extends string = string> = {
+  value: T
+  label: ReactNode
+  /** Body rendered when this tab is active. */
+  content?: ReactNode
+  /** Right-side adornment (e.g. a NumberBadge). */
+  badge?: ReactNode
+  /** Optional leading icon. */
+  icon?: ReactNode
+  disabled?: boolean
+}
+
+export type TabsProps<T extends string = string> = Omit<MuiTabsProps, 'onChange' | 'value' | 'children'> & {
+  tabs: TabsItem<T>[]
+  /** Controlled active tab value. */
+  value?: T
+  /** Uncontrolled starting value. */
+  defaultValue?: T
+  /** Notified when the active tab changes. */
+  onChange?: (next: T) => void
+  /** Render `content` for the active tab. Default `true`. */
+  renderContent?: boolean
+  /** Extra props for each individual MUI Tab. */
+  tabProps?: Partial<MuiTabProps>
+}
+
+export function Tabs<T extends string = string>({
+  tabs,
+  value,
+  defaultValue,
+  onChange,
+  renderContent = true,
+  tabProps,
+  ...muiProps
+}: TabsProps<T>) {
+  const isControlled = value !== undefined
+  const [internal, setInternal] = useState<T>((defaultValue ?? tabs[0]?.value) as T)
+  const active = isControlled ? value : internal
+
+  function handle(_: SyntheticEvent, next: T) {
+    if (!isControlled) setInternal(next)
+    onChange?.(next)
+  }
+
+  return (
+    <Box>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <MuiTabs {...muiProps} value={active} onChange={handle}>
+          {tabs.map((t) => (
+            <MuiTab
+              key={t.value}
+              value={t.value}
+              disabled={t.disabled}
+              icon={t.icon as MuiTabProps['icon']}
+              iconPosition={t.icon ? 'start' : undefined}
+              label={
+                t.badge ? (
+                  <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                    <span>{t.label}</span>
+                    {t.badge}
+                  </Stack>
+                ) : (
+                  t.label
+                )
+              }
+              {...tabProps}
+            />
+          ))}
+        </MuiTabs>
+      </Box>
+      {renderContent &&
+        tabs.map((t) => (
+          <Box
+            key={t.value}
+            role="tabpanel"
+            id={`tabpanel-${t.value}`}
+            aria-labelledby={`tab-${t.value}`}
+            hidden={t.value !== active}
+            sx={{ pt: 2 }}
+          >
+            {t.value === active ? t.content : null}
+          </Box>
+        ))}
+    </Box>
+  )
+}

--- a/packages/ui/src/components/Tabs/index.ts
+++ b/packages/ui/src/components/Tabs/index.ts
@@ -1,0 +1,1 @@
+export * from './Tabs'

--- a/packages/ui/src/components/TextField/TextField.stories.tsx
+++ b/packages/ui/src/components/TextField/TextField.stories.tsx
@@ -1,0 +1,55 @@
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+
+import { TextField } from './TextField'
+
+const meta = {
+  title: 'Components/TextField',
+  component: TextField,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    helperText: { control: 'text' },
+    variant: { control: { type: 'inline-radio' }, options: ['outlined', 'filled', 'standard'] },
+    size: { control: { type: 'inline-radio' }, options: ['small', 'medium'] },
+    error: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    multiline: { control: 'boolean' },
+    fullWidth: { control: 'boolean' },
+    onChange: { action: 'changed' },
+  },
+  args: { label: 'Label', placeholder: 'Type here…', onChange: fn() },
+} satisfies Meta<typeof TextField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByLabelText('Label')
+    await userEvent.type(input, 'hello')
+    await expect(args.onChange).toHaveBeenCalled()
+    await expect(input).toHaveValue('hello')
+  },
+}
+
+export const WithHelperText: Story = { args: { helperText: 'Optional helper text' } }
+
+export const Error: Story = {
+  args: { error: true, helperText: 'This value is required', value: '' },
+}
+
+export const Disabled: Story = { args: { disabled: true, value: 'Read-only value' } }
+
+export const Multiline: Story = {
+  args: { multiline: true, minRows: 3, placeholder: 'Describe…' },
+  render: (args) => (
+    <Stack sx={{ width: 360 }}>
+      <TextField {...args} />
+    </Stack>
+  ),
+}

--- a/packages/ui/src/components/TextField/TextField.test.tsx
+++ b/packages/ui/src/components/TextField/TextField.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { TextField } from './TextField'
+
+describe('TextField', () => {
+  it('renders label + accepts typed input', async () => {
+    const user = userEvent.setup()
+    render(<TextField label="Name" />)
+    const input = screen.getByLabelText('Name')
+    await user.type(input, 'Avery')
+    expect(input).toHaveValue('Avery')
+  })
+
+  it('fires onChange', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<TextField label="Name" onChange={onChange} />)
+    await user.type(screen.getByLabelText('Name'), 'a')
+    expect(onChange).toHaveBeenCalled()
+  })
+
+  it('shows helper text + error state', () => {
+    render(<TextField label="Email" error helperText="Required" />)
+    expect(screen.getByText('Required')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/TextField/TextField.tsx
+++ b/packages/ui/src/components/TextField/TextField.tsx
@@ -1,0 +1,13 @@
+import MuiTextField, { type TextFieldProps as MuiTextFieldProps } from '@mui/material/TextField'
+import { forwardRef } from 'react'
+
+export type TextFieldProps = MuiTextFieldProps
+
+/**
+ * Single- or multi-line text input. Thin wrapper around MUI TextField.
+ *
+ *   <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+ */
+export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function TextField(props, ref) {
+  return <MuiTextField ref={ref} {...props} />
+})

--- a/packages/ui/src/components/TextField/index.ts
+++ b/packages/ui/src/components/TextField/index.ts
@@ -1,0 +1,1 @@
+export * from './TextField'

--- a/packages/ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/ui/src/components/Toast/Toast.stories.tsx
@@ -1,0 +1,85 @@
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, userEvent, within } from '@storybook/test'
+
+import { Button } from '../Button'
+import { ToastProvider, useToast, type ToastAnchor } from './ToastProvider'
+
+const meta = {
+  title: 'Components/Toast',
+  component: ToastProvider,
+  tags: ['autodocs'],
+  argTypes: {
+    anchorOrigin: { control: false },
+    defaultDurationMs: { control: { type: 'number' } },
+    max: { control: { type: 'number', min: 1, max: 10 } },
+  },
+  args: { defaultDurationMs: 5000, max: 5, children: null },
+} satisfies Meta<typeof ToastProvider>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function Demo({ anchorOrigin }: { anchorOrigin?: ToastAnchor }) {
+  return (
+    <ToastProvider anchorOrigin={anchorOrigin}>
+      <DemoContent />
+    </ToastProvider>
+  )
+}
+
+function DemoContent() {
+  const toast = useToast()
+  return (
+    <Stack spacing={1.5} sx={{ alignItems: 'flex-start' }}>
+      <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
+        <Button variant="contained" color="success" onClick={() => toast.success('Saved.')}>
+          Success
+        </Button>
+        <Button variant="contained" color="error" onClick={() => toast.error('Could not reach the API.')}>
+          Error
+        </Button>
+        <Button variant="contained" color="warning" onClick={() => toast.warning('Your session expires in 2 min.')}>
+          Warning
+        </Button>
+        <Button variant="contained" color="info" onClick={() => toast.info('Connection established.')}>
+          Info
+        </Button>
+        <Button variant="text" onClick={() => toast.clear()}>
+          Clear all
+        </Button>
+      </Stack>
+      <Button
+        variant="outlined"
+        onClick={() =>
+          toast.show({
+            severity: 'info',
+            title: 'Long-running job',
+            message: 'Will not auto-dismiss.',
+            durationMs: null,
+          })
+        }
+      >
+        Persistent (no auto-dismiss)
+      </Button>
+    </Stack>
+  )
+}
+
+export const Default: Story = {
+  render: () => <Demo />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: 'Success' }))
+    const toast = await within(document.body).findByText('Saved.')
+    await expect(toast).toBeVisible()
+  },
+}
+
+export const TopRight: Story = {
+  render: () => <Demo anchorOrigin={{ vertical: 'top', horizontal: 'right' }} />,
+}
+
+export const BottomCenter: Story = {
+  render: () => <Demo anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }} />,
+}

--- a/packages/ui/src/components/Toast/Toast.test.tsx
+++ b/packages/ui/src/components/Toast/Toast.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, screen, userEvent, waitFor, within } from '../../test-utils'
+import { Button } from '../Button'
+import { ToastProvider, useToast } from './ToastProvider'
+
+function App() {
+  const t = useToast()
+  return (
+    <div>
+      <Button onClick={() => t.success('Saved')}>Save</Button>
+      <Button onClick={() => t.error('Could not reach the API')}>Fail</Button>
+      <Button onClick={() => t.clear()}>Clear</Button>
+    </div>
+  )
+}
+
+describe('Toast', () => {
+  it('shows a success toast on demand', async () => {
+    const user = userEvent.setup()
+    render(
+      <ToastProvider>
+        <App />
+      </ToastProvider>,
+    )
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    expect(await screen.findByText('Saved')).toBeInTheDocument()
+  })
+
+  it('auto-dismisses after the duration', async () => {
+    const user = userEvent.setup()
+    render(
+      <ToastProvider defaultDurationMs={150}>
+        <App />
+      </ToastProvider>,
+    )
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    expect(await screen.findByText('Saved')).toBeInTheDocument()
+    await waitFor(
+      () => {
+        expect(screen.queryByText('Saved')).not.toBeInTheDocument()
+      },
+      { timeout: 1000 },
+    )
+  })
+
+  it('clear() drops all queued toasts', async () => {
+    const user = userEvent.setup()
+    render(
+      <ToastProvider>
+        <App />
+      </ToastProvider>,
+    )
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await user.click(screen.getByRole('button', { name: 'Fail' }))
+    const region = await screen.findByRole('region', { name: 'Notifications' })
+    expect(within(region).getByText('Saved')).toBeInTheDocument()
+    expect(within(region).getByText('Could not reach the API')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Clear' }))
+    expect(within(region).queryByText('Saved')).not.toBeInTheDocument()
+    expect(within(region).queryByText('Could not reach the API')).not.toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/components/Toast/Toast.test.tsx
+++ b/packages/ui/src/components/Toast/Toast.test.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { describe, expect, it } from 'vitest'
 
 import { render, screen, userEvent, waitFor, within } from '../../test-utils'
@@ -11,6 +12,20 @@ function App() {
       <Button onClick={() => t.success('Saved')}>Save</Button>
       <Button onClick={() => t.error('Could not reach the API')}>Fail</Button>
       <Button onClick={() => t.clear()}>Clear</Button>
+    </div>
+  )
+}
+
+function StickyApp() {
+  const t = useToast()
+  const n = useRef(0)
+  return (
+    <div>
+      {/* A sticky toast never auto-dismisses (durationMs: null). */}
+      <Button onClick={() => t.info('Sticky note', { durationMs: null })}>Sticky</Button>
+      {/* Non-sticky filler toasts (long duration so they don't fire mid-test),
+          each with a distinct label. These are the ones trimming may drop. */}
+      <Button onClick={() => t.success(`Filler ${(n.current += 1)}`, { durationMs: 100000 })}>Filler</Button>
     </div>
   )
 }
@@ -59,5 +74,29 @@ describe('Toast', () => {
     await user.click(screen.getByRole('button', { name: 'Clear' }))
     expect(within(region).queryByText('Saved')).not.toBeInTheDocument()
     expect(within(region).queryByText('Could not reach the API')).not.toBeInTheDocument()
+  })
+
+  it('keeps sticky toasts when trimming to max, dropping oldest non-sticky first', async () => {
+    const user = userEvent.setup()
+    render(
+      <ToastProvider max={2}>
+        <StickyApp />
+      </ToastProvider>,
+    )
+    const sticky = screen.getByRole('button', { name: 'Sticky' })
+    const filler = screen.getByRole('button', { name: 'Filler' })
+
+    await user.click(sticky) // [Sticky]
+    await user.click(filler) // [Sticky, Filler 1]
+    await user.click(filler) // over max → drop Filler 1 → [Sticky, Filler 2]
+    await user.click(filler) // over max → drop Filler 2 → [Sticky, Filler 3]
+
+    const region = await screen.findByRole('region', { name: 'Notifications' })
+    // The sticky toast is the oldest, yet it must survive the trimming.
+    expect(within(region).getByText('Sticky note')).toBeInTheDocument()
+    // Only the newest non-sticky filler remains; older ones were dropped.
+    expect(within(region).getByText('Filler 3')).toBeInTheDocument()
+    expect(within(region).queryByText('Filler 1')).not.toBeInTheDocument()
+    expect(within(region).queryByText('Filler 2')).not.toBeInTheDocument()
   })
 })

--- a/packages/ui/src/components/Toast/ToastProvider.tsx
+++ b/packages/ui/src/components/Toast/ToastProvider.tsx
@@ -1,0 +1,206 @@
+/**
+ * Toast system — global notification queue.
+ *
+ * Mount `<ToastProvider>` once at the app root. Children call
+ * `useToast()` to push notifications:
+ *
+ *   const toast = useToast()
+ *   toast.success('Saved')
+ *   toast.error('Could not connect', { durationMs: 6000 })
+ *   const id = toast.show({ severity: 'info', message: 'Working…', durationMs: null })
+ *   toast.dismiss(id)
+ */
+
+import Alert, { type AlertColor } from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Portal from '@mui/material/Portal'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+
+export type ToastSeverity = AlertColor // 'success' | 'error' | 'warning' | 'info'
+
+export type Toast = {
+  id: string
+  severity: ToastSeverity
+  message: ReactNode
+  /** Auto-dismiss after this many ms. `null` means "keep until dismissed." */
+  durationMs: number | null
+  /** Optional title rendered above the message. */
+  title?: ReactNode
+}
+
+export type ToastInput = Omit<Toast, 'id' | 'durationMs'> & { durationMs?: number | null }
+
+export type ToastApi = {
+  show: (input: ToastInput) => string
+  success: (message: ReactNode, opts?: Partial<ToastInput>) => string
+  error: (message: ReactNode, opts?: Partial<ToastInput>) => string
+  warning: (message: ReactNode, opts?: Partial<ToastInput>) => string
+  info: (message: ReactNode, opts?: Partial<ToastInput>) => string
+  dismiss: (id: string) => void
+  clear: () => void
+}
+
+const ToastContext = createContext<ToastApi | null>(null)
+
+export type ToastAnchor = {
+  vertical: 'top' | 'bottom'
+  horizontal: 'left' | 'center' | 'right'
+}
+
+export type ToastProviderProps = {
+  children: ReactNode
+  /** Stack anchor. Default `{ vertical: 'bottom', horizontal: 'right' }`. */
+  anchorOrigin?: ToastAnchor
+  /** Default auto-dismiss in ms. Default `5000`. */
+  defaultDurationMs?: number
+  /** Max simultaneous toasts before the oldest auto-drops. Default `5`. */
+  max?: number
+  /** Edge offset for the viewport in pixels. Default `24`. */
+  offset?: number
+}
+
+let counter = 0
+function genId() {
+  counter += 1
+  return `t-${Date.now().toString(36)}-${counter}`
+}
+
+export function ToastProvider({
+  children,
+  anchorOrigin = { vertical: 'bottom', horizontal: 'right' },
+  defaultDurationMs = 5000,
+  max = 5,
+  offset = 24,
+}: ToastProviderProps) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  const clear = useCallback(() => setToasts([]), [])
+
+  const show = useCallback(
+    (input: ToastInput): string => {
+      const id = genId()
+      const next: Toast = {
+        id,
+        severity: input.severity,
+        message: input.message,
+        title: input.title,
+        durationMs: input.durationMs === undefined ? defaultDurationMs : input.durationMs,
+      }
+      setToasts((prev) => {
+        const trimmed = prev.length >= max ? prev.slice(prev.length - max + 1) : prev
+        return [...trimmed, next]
+      })
+      return id
+    },
+    [defaultDurationMs, max],
+  )
+
+  const api = useMemo<ToastApi>(
+    () => ({
+      show,
+      success: (message, opts) => show({ severity: 'success', message, ...opts }),
+      error: (message, opts) => show({ severity: 'error', message, ...opts }),
+      warning: (message, opts) => show({ severity: 'warning', message, ...opts }),
+      info: (message, opts) => show({ severity: 'info', message, ...opts }),
+      dismiss,
+      clear,
+    }),
+    [show, dismiss, clear],
+  )
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      {toasts.length > 0 && (
+        <Portal>
+          <ToastViewport toasts={toasts} anchorOrigin={anchorOrigin} offset={offset} onDismiss={dismiss} />
+        </Portal>
+      )}
+    </ToastContext.Provider>
+  )
+}
+
+function ToastViewport({
+  toasts,
+  anchorOrigin,
+  offset,
+  onDismiss,
+}: {
+  toasts: Toast[]
+  anchorOrigin: ToastAnchor
+  offset: number
+  onDismiss: (id: string) => void
+}) {
+  const isTop = anchorOrigin.vertical === 'top'
+  const horizontal =
+    anchorOrigin.horizontal === 'center'
+      ? ({ left: '50%', transform: 'translateX(-50%)' } as const)
+      : anchorOrigin.horizontal === 'left'
+        ? ({ left: offset } as const)
+        : ({ right: offset } as const)
+
+  return (
+    <Box
+      role="region"
+      aria-label="Notifications"
+      sx={{
+        position: 'fixed',
+        zIndex: (theme) => theme.zIndex.snackbar,
+        display: 'flex',
+        flexDirection: isTop ? 'column' : 'column-reverse',
+        gap: 1,
+        pointerEvents: 'none',
+        ...(isTop ? { top: offset } : { bottom: offset }),
+        ...horizontal,
+      }}
+    >
+      {toasts.map((t) => (
+        <ToastRow key={t.id} toast={t} onDismiss={() => onDismiss(t.id)} />
+      ))}
+    </Box>
+  )
+}
+
+function ToastRow({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }) {
+  useEffect(() => {
+    if (toast.durationMs == null) return
+    const handle = setTimeout(onDismiss, toast.durationMs)
+    return () => clearTimeout(handle)
+  }, [toast.durationMs, onDismiss])
+
+  return (
+    <Alert
+      severity={toast.severity}
+      variant="filled"
+      onClose={onDismiss}
+      sx={{ minWidth: 280, maxWidth: 480, pointerEvents: 'auto' }}
+    >
+      {toast.title && (
+        <Box component="strong" sx={{ display: 'block', mb: 0.25 }}>
+          {toast.title}
+        </Box>
+      )}
+      {toast.message}
+    </Alert>
+  )
+}
+
+export function useToast(): ToastApi {
+  const ctx = useContext(ToastContext)
+  if (!ctx) {
+    throw new Error('useToast must be used inside <ToastProvider>')
+  }
+  return ctx
+}

--- a/packages/ui/src/components/Toast/ToastProvider.tsx
+++ b/packages/ui/src/components/Toast/ToastProvider.tsx
@@ -99,8 +99,22 @@ export function ToastProvider({
         durationMs: input.durationMs === undefined ? defaultDurationMs : input.durationMs,
       }
       setToasts((prev) => {
-        const trimmed = prev.length >= max ? prev.slice(prev.length - max + 1) : prev
-        return [...trimmed, next]
+        const queue = [...prev, next]
+        if (queue.length <= max) return queue
+        // Over capacity: drop the oldest *auto-dismissing* toasts first so
+        // "sticky" toasts (durationMs === null, i.e. kept until dismissed)
+        // are never silently discarded. If every toast is sticky we keep them
+        // all and let the stack grow rather than throw a sticky one away.
+        const overflow = queue.length - max
+        let toDrop = overflow
+        const trimmed = queue.filter((t) => {
+          if (toDrop > 0 && t.durationMs !== null && t.id !== id) {
+            toDrop -= 1
+            return false
+          }
+          return true
+        })
+        return trimmed
       })
       return id
     },

--- a/packages/ui/src/components/Toast/index.ts
+++ b/packages/ui/src/components/Toast/index.ts
@@ -1,0 +1,1 @@
+export * from './ToastProvider'

--- a/packages/ui/src/components/UserMenu/UserMenu.stories.tsx
+++ b/packages/ui/src/components/UserMenu/UserMenu.stories.tsx
@@ -1,0 +1,116 @@
+import KeyIcon from '@mui/icons-material/VpnKey'
+import PersonIcon from '@mui/icons-material/Person'
+import SettingsIcon from '@mui/icons-material/Settings'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
+import MenuItem from '@mui/material/MenuItem'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+
+import { Badge } from '../Badge'
+import { UserMenu } from './UserMenu'
+
+const meta = {
+  title: 'Layout/UserMenu',
+  component: UserMenu,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    name: { control: 'text' },
+    email: { control: 'text' },
+    initials: { control: 'text' },
+    signOutLabel: { control: 'text' },
+    menuWidth: { control: { type: 'number', min: 200, max: 400 } },
+    onSignOut: { action: 'signedOut' },
+  },
+  args: {
+    name: 'Avery Lin',
+    email: 'avery@example.com',
+    onSignOut: fn(),
+  },
+} satisfies Meta<typeof UserMenu>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /account menu/i }))
+    const menu = await within(document.body).findByRole('menu')
+    await expect(menu).toBeVisible()
+  },
+}
+
+export const WithContext: Story = {
+  args: {
+    context: (
+      <Stack spacing={0.5}>
+        <Typography variant="label" color="text.secondary">
+          Current workspace
+        </Typography>
+        <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+          <Typography variant="mono">acme</Typography>
+          <Badge label="admin" color="primary" size="small" />
+        </Stack>
+      </Stack>
+    ),
+  },
+}
+
+export const WithItems: Story = {
+  args: {
+    items: (
+      <>
+        <MenuItem>
+          <ListItemIcon>
+            <PersonIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Profile</ListItemText>
+        </MenuItem>
+        <MenuItem>
+          <ListItemIcon>
+            <KeyIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>API tokens</ListItemText>
+        </MenuItem>
+        <MenuItem>
+          <ListItemIcon>
+            <SettingsIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Settings</ListItemText>
+        </MenuItem>
+      </>
+    ),
+  },
+}
+
+export const SignOutFlow: Story = {
+  args: {
+    items: (
+      <MenuItem>
+        <ListItemIcon>
+          <PersonIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>Profile</ListItemText>
+      </MenuItem>
+    ),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /account menu/i }))
+    const signOut = await within(document.body).findByText(/sign out/i)
+    await userEvent.click(signOut)
+    await expect(args.onSignOut).toHaveBeenCalledOnce()
+  },
+}
+
+export const SignedOut: Story = {
+  args: {
+    name: undefined,
+    email: undefined,
+    onSignOut: undefined,
+  },
+}

--- a/packages/ui/src/components/UserMenu/UserMenu.stories.tsx
+++ b/packages/ui/src/components/UserMenu/UserMenu.stories.tsx
@@ -48,7 +48,7 @@ export const WithContext: Story = {
   args: {
     context: (
       <Stack spacing={0.5}>
-        <Typography variant="label" color="text.secondary">
+        <Typography variant="metricLabel" color="text.secondary">
           Current workspace
         </Typography>
         <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>

--- a/packages/ui/src/components/UserMenu/UserMenu.test.tsx
+++ b/packages/ui/src/components/UserMenu/UserMenu.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { UserMenu } from './UserMenu'
+
+describe('UserMenu', () => {
+  it('shows the identity in the dropdown', async () => {
+    const user = userEvent.setup()
+    render(<UserMenu name="Avery Lin" email="avery@example.com" onSignOut={() => {}} />)
+    await user.click(screen.getByRole('button', { name: /account menu/i }))
+    expect(await screen.findByText('Avery Lin')).toBeInTheDocument()
+    expect(screen.getByText('avery@example.com')).toBeInTheDocument()
+  })
+
+  it('fires onSignOut', async () => {
+    const onSignOut = vi.fn()
+    const user = userEvent.setup()
+    render(<UserMenu name="Avery" onSignOut={onSignOut} />)
+    await user.click(screen.getByRole('button', { name: /account menu/i }))
+    await user.click(await screen.findByText(/sign out/i))
+    expect(onSignOut).toHaveBeenCalled()
+  })
+})

--- a/packages/ui/src/components/UserMenu/UserMenu.tsx
+++ b/packages/ui/src/components/UserMenu/UserMenu.tsx
@@ -1,0 +1,170 @@
+/**
+ * UserMenu — avatar trigger + dropdown for identity & account actions.
+ *
+ * Pure presentation: pass an identity (name/email/avatar), an optional
+ * context slot (e.g. current workspace), an optional items slot (the
+ * middle of the menu where account/admin links go), and a `onSignOut`
+ * handler. No auth, scope, or role logic baked in.
+ *
+ *   <UserMenu
+ *     name="Avery"
+ *     email="avery@example.com"
+ *     context={<Typography variant="caption">acme · production</Typography>}
+ *     items={<>
+ *       <MenuItem onClick={…}>Profile</MenuItem>
+ *       <MenuItem onClick={…}>Settings</MenuItem>
+ *     </>}
+ *     onSignOut={handleSignOut}
+ *   />
+ */
+
+import LogoutIcon from '@mui/icons-material/Logout'
+import Avatar from '@mui/material/Avatar'
+import Box from '@mui/material/Box'
+import Divider from '@mui/material/Divider'
+import IconButton from '@mui/material/IconButton'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { useState, type ReactNode } from 'react'
+
+export type UserMenuProps = {
+  /** Display name. */
+  name?: string
+  /** Email or secondary identifier. */
+  email?: string
+  /** Image src for the avatar; if omitted, falls back to `initials`. */
+  avatarSrc?: string
+  /** Explicit avatar text. If omitted, derived from `name` or `email`. */
+  initials?: string
+  /** Optional context block rendered below identity (workspace, role, …). */
+  context?: ReactNode
+  /** Optional menu items rendered between identity and the sign-out row. */
+  items?: ReactNode
+  /** Sign-out handler. If omitted, no sign-out row is rendered. */
+  onSignOut?: () => void
+  /** Label for the sign-out menu item. Default `'Sign out'`. */
+  signOutLabel?: string
+  /** Width of the dropdown. Default `280`. */
+  menuWidth?: number
+}
+
+function deriveInitials(nameOrEmail: string): string {
+  const source = nameOrEmail.includes('@') ? nameOrEmail.split('@')[0] : nameOrEmail
+  const parts = source.split(/[\s._-]+/).filter(Boolean)
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase()
+  return source.slice(0, 2).toUpperCase()
+}
+
+export function UserMenu({
+  name,
+  email,
+  avatarSrc,
+  initials,
+  context,
+  items,
+  onSignOut,
+  signOutLabel = 'Sign out',
+  menuWidth = 280,
+}: UserMenuProps) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const open = Boolean(anchorEl)
+
+  const display = name?.trim() || email || 'Signed out'
+  const computedInitials = initials ?? (name || email ? deriveInitials(name || email!) : '?')
+
+  return (
+    <>
+      <IconButton onClick={(e) => setAnchorEl(e.currentTarget)} aria-label="Account menu" size="small">
+        <Avatar
+          src={avatarSrc}
+          sx={(theme) => ({
+            width: 30,
+            height: 30,
+            fontSize: '0.75rem',
+            fontWeight: 600,
+            bgcolor: theme.palette.surface.muted,
+            color: theme.palette.text.primary,
+            border: `1px solid ${theme.palette.border.subtle}`,
+          })}
+        >
+          {computedInitials}
+        </Avatar>
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={() => setAnchorEl(null)}
+        slotProps={{ paper: { sx: { width: menuWidth } } }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        <Box sx={{ px: 2, py: 1.5 }}>
+          <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+            <Avatar
+              src={avatarSrc}
+              sx={(theme) => ({
+                width: 38,
+                height: 38,
+                fontSize: '0.8125rem',
+                fontWeight: 600,
+                bgcolor: theme.palette.surface.muted,
+                color: theme.palette.text.primary,
+              })}
+            >
+              {computedInitials}
+            </Avatar>
+            <Stack spacing={0.25} sx={{ minWidth: 0 }}>
+              <Typography variant="body2" sx={{ fontWeight: 600 }} noWrap>
+                {display}
+              </Typography>
+              {email && name && (
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  {email}
+                </Typography>
+              )}
+            </Stack>
+          </Stack>
+        </Box>
+
+        {context && (
+          <>
+            <Divider />
+            <Box sx={{ px: 2, py: 1.25 }}>{context}</Box>
+          </>
+        )}
+
+        {items && (
+          <>
+            <Divider />
+            {items}
+          </>
+        )}
+
+        {onSignOut && (
+          <>
+            <Divider />
+            <MenuItem
+              onClick={() => {
+                setAnchorEl(null)
+                onSignOut()
+              }}
+              sx={(theme) => ({
+                color: theme.palette.error.main,
+                '&:hover': { bgcolor: theme.palette.error.main + '14' },
+              })}
+            >
+              <ListItemIcon>
+                <LogoutIcon fontSize="small" sx={{ color: 'inherit' }} />
+              </ListItemIcon>
+              <ListItemText>{signOutLabel}</ListItemText>
+            </MenuItem>
+          </>
+        )}
+      </Menu>
+    </>
+  )
+}

--- a/packages/ui/src/components/UserMenu/index.ts
+++ b/packages/ui/src/components/UserMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './UserMenu'

--- a/packages/ui/src/components/Wizard/Wizard.stories.tsx
+++ b/packages/ui/src/components/Wizard/Wizard.stories.tsx
@@ -1,0 +1,74 @@
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+import { expect, fn, userEvent, within } from '@storybook/test'
+import { useEffect } from 'react'
+
+import { TextField } from '../TextField'
+import { Wizard, type WizardHelpers, type WizardStep } from './Wizard'
+
+const steps: WizardStep[] = [
+  { key: 'identity', title: 'Identity', description: 'Who is this user?' },
+  { key: 'access', title: 'Access', description: 'What can they do?' },
+  { key: 'review', title: 'Review', description: 'Confirm and submit' },
+]
+
+function StepBody({ keyName, helpers }: { keyName: string; helpers: WizardHelpers }) {
+  // Auto-mark every step valid after a tick so the demo is navigable.
+  useEffect(() => {
+    helpers.setValid(true)
+  }, [helpers])
+  return (
+    <Stack spacing={2} sx={{ maxWidth: 480 }}>
+      <Typography variant="body2" color="text.secondary">
+        Body for the <strong>{keyName}</strong> step. Replace with your form fields.
+      </Typography>
+      <TextField label="Example field" placeholder="…" />
+    </Stack>
+  )
+}
+
+const meta = {
+  title: 'Patterns/Wizard',
+  component: Wizard,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    layout: { control: { type: 'inline-radio' }, options: ['sidebar', 'top'] },
+    onCancel: { action: 'cancelled' },
+    onFinish: { action: 'finished' },
+    onStepChange: { action: 'stepChanged' },
+  },
+  args: {
+    steps,
+    layout: 'sidebar',
+    title: 'New user',
+    onCancel: fn(),
+    onFinish: fn(),
+    onStepChange: fn(),
+    renderStep: (key, helpers) => <StepBody keyName={key} helpers={helpers} />,
+  },
+} satisfies Meta<typeof Wizard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Sidebar: Story = {}
+
+export const Top: Story = { args: { layout: 'top' } }
+
+export const FlowToFinish: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    // Step 1 → 2
+    let next = await canvas.findByRole('button', { name: /next/i })
+    await userEvent.click(next)
+    // Step 2 → 3
+    next = await canvas.findByRole('button', { name: /next/i })
+    await userEvent.click(next)
+    // Finish
+    const finish = await canvas.findByRole('button', { name: /finish/i })
+    await userEvent.click(finish)
+    await expect(args.onFinish).toHaveBeenCalledOnce()
+  },
+}

--- a/packages/ui/src/components/Wizard/Wizard.test.tsx
+++ b/packages/ui/src/components/Wizard/Wizard.test.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { render, screen, userEvent } from '../../test-utils'
+import { Wizard, type WizardHelpers } from './Wizard'
+
+const steps = [
+  { key: 'one', title: 'Step one' },
+  { key: 'two', title: 'Step two' },
+  { key: 'three', title: 'Step three' },
+]
+
+function AutoValid({ helpers }: { helpers: WizardHelpers }) {
+  useEffect(() => {
+    helpers.setValid(true)
+  }, [helpers])
+  return <div>step body</div>
+}
+
+describe('Wizard', () => {
+  it('advances through steps and fires onFinish', async () => {
+    const onFinish = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <Wizard
+        steps={steps}
+        renderStep={(_, helpers) => <AutoValid helpers={helpers} />}
+        onFinish={onFinish}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: /next/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+    await user.click(screen.getByRole('button', { name: /finish/i }))
+    expect(onFinish).toHaveBeenCalled()
+  })
+
+  it('disables Next when step is invalid', () => {
+    render(<Wizard steps={steps} renderStep={() => <div>x</div>} />)
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
+  })
+})

--- a/packages/ui/src/components/Wizard/Wizard.tsx
+++ b/packages/ui/src/components/Wizard/Wizard.tsx
@@ -1,0 +1,496 @@
+/**
+ * Wizard — multi-step flow orchestrator.
+ *
+ * The shell owns the active step index plus a per-step "valid" boolean
+ * (the gate for the Next button). Step components render via the
+ * `renderStep` prop and signal validity through the `helpers.setValid`
+ * callback. Users can jump back to any reached step but cannot skip
+ * forward past their high-water mark.
+ *
+ *   <Wizard
+ *     steps={[
+ *       { key: 'identity', title: 'Identity', description: 'Who is this?' },
+ *       { key: 'access',   title: 'Access',   description: 'What can they do?' },
+ *       { key: 'review',   title: 'Review',   description: 'Confirm and submit' },
+ *     ]}
+ *     persistKey="mt:setup"
+ *     onCancel={cancel}
+ *     onFinish={finish}
+ *     renderStep={(key, h) => {
+ *       if (key === 'identity') return <IdentityStep onValid={h.setValid} />
+ *       ...
+ *     }}
+ *   />
+ *
+ * Layouts:
+ *   - `layout="sidebar"` (default) — left rail with numbered steps + body
+ *   - `layout="top"` — horizontal stepper above the body
+ */
+
+import CheckIcon from '@mui/icons-material/Check'
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import CloseIcon from '@mui/icons-material/Close'
+import Box from '@mui/material/Box'
+import Card from '@mui/material/Card'
+import Divider from '@mui/material/Divider'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+
+import { Button } from '../Button'
+
+export type WizardStep = {
+  /** Stable identifier passed to `renderStep` and used as React key. */
+  key: string
+  title: string
+  /** Short subtitle/blurb shown under the title in the rail or header. */
+  description?: string
+}
+
+export type WizardHelpers = {
+  /** Mark the current step as valid/invalid (gates the Next button). */
+  setValid: (valid: boolean) => void
+  /** Advance to the next step if validity allows. */
+  goNext: () => void
+  /** Step backward. */
+  goPrev: () => void
+  /** Jump to a specific step (only if it's at or below the high-water mark). */
+  goToStep: (idx: number) => void
+}
+
+export type WizardProps = {
+  steps: WizardStep[]
+  renderStep: (key: string, helpers: WizardHelpers) => ReactNode
+  /** Layout variant. Default `'sidebar'`. */
+  layout?: 'sidebar' | 'top'
+  /** Persist step state in `localStorage` under this key. */
+  persistKey?: string
+  /** Controlled current step index. */
+  currentStep?: number
+  /** Uncontrolled starting index. */
+  defaultStep?: number
+  /** Notified whenever the current step changes. */
+  onStepChange?: (idx: number) => void
+  /** Cancel/exit handler. Adds a "Cancel" affordance when provided. */
+  onCancel?: () => void
+  /** Final-step submit handler. */
+  onFinish?: () => void
+  /** Label for the back button. Default `'Back'`. */
+  backLabel?: string
+  /** Label for the next button. Default `'Next'`. */
+  nextLabel?: string
+  /** Label for the finish button. Default `'Finish'`. */
+  finishLabel?: string
+  /** Label for the cancel button. Default `'Cancel'`. */
+  cancelLabel?: string
+  /** Title for the sidebar / step heading. Default none. */
+  title?: ReactNode
+}
+
+type PersistedState = { step: number; max: number; valid: Record<string, boolean> }
+
+function loadPersisted(key: string | undefined, stepCount: number): PersistedState | null {
+  if (!key) return null
+  try {
+    const raw = window.localStorage.getItem(key)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<PersistedState>
+    const step =
+      typeof parsed.step === 'number' && parsed.step >= 0 && parsed.step < stepCount ? parsed.step : 0
+    const max =
+      typeof parsed.max === 'number' && parsed.max >= 0 && parsed.max < stepCount ? parsed.max : step
+    const valid = typeof parsed.valid === 'object' && parsed.valid ? parsed.valid : {}
+    return { step, max, valid: valid as Record<string, boolean> }
+  } catch {
+    return null
+  }
+}
+
+export function Wizard({
+  steps,
+  renderStep,
+  layout = 'sidebar',
+  persistKey,
+  currentStep,
+  defaultStep,
+  onStepChange,
+  onCancel,
+  onFinish,
+  backLabel = 'Back',
+  nextLabel = 'Next',
+  finishLabel = 'Finish',
+  cancelLabel = 'Cancel',
+  title,
+}: WizardProps) {
+  const lastIdx = steps.length - 1
+  const persisted = useMemo(() => loadPersisted(persistKey, steps.length), [persistKey, steps.length])
+
+  const isControlled = currentStep !== undefined
+  const [uncontrolledStep, setUncontrolledStep] = useState<number>(
+    persisted?.step ?? defaultStep ?? 0,
+  )
+  const stepIdx = isControlled ? currentStep! : uncontrolledStep
+
+  const [valid, setValid] = useState<Record<string, boolean>>(persisted?.valid ?? {})
+  const [maxReached, setMaxReached] = useState<number>(persisted?.max ?? stepIdx)
+
+  useEffect(() => {
+    if (!persistKey) return
+    try {
+      window.localStorage.setItem(persistKey, JSON.stringify({ step: stepIdx, max: maxReached, valid }))
+    } catch {
+      /* ignore quota errors */
+    }
+  }, [persistKey, stepIdx, maxReached, valid])
+
+  function setStep(next: number) {
+    if (next < 0 || next > lastIdx) return
+    if (!isControlled) setUncontrolledStep(next)
+    if (next > maxReached) setMaxReached(next)
+    onStepChange?.(next)
+  }
+
+  const current = steps[stepIdx]
+  const isFirst = stepIdx === 0
+  const isLast = stepIdx === lastIdx
+  const canAdvance = !!valid[current?.key ?? '']
+
+  const goNext = useCallback(() => setStep(Math.min(lastIdx, stepIdx + 1)), [stepIdx, lastIdx])
+  const goPrev = useCallback(() => setStep(Math.max(0, stepIdx - 1)), [stepIdx])
+  const goToStep = useCallback(
+    (idx: number) => {
+      if (idx <= maxReached) setStep(idx)
+    },
+    [maxReached],
+  )
+  const setStepValid = useCallback(
+    (next: boolean) => {
+      const key = steps[stepIdx]?.key
+      if (!key) return
+      setValid((prev) => (prev[key] === next ? prev : { ...prev, [key]: next }))
+    },
+    [stepIdx, steps],
+  )
+
+  const helpers = useMemo<WizardHelpers>(
+    () => ({ setValid: setStepValid, goNext, goPrev, goToStep }),
+    [setStepValid, goNext, goPrev, goToStep],
+  )
+
+  const body = (
+    <Card sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 480 }}>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider', px: 3, py: 2 }}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'baseline' }}>
+          <Typography variant="mono" color="text.secondary" sx={{ fontSize: '0.75rem' }}>
+            Step {stepIdx + 1} / {steps.length}
+          </Typography>
+          <Typography variant="h6" component="h2">
+            {current?.title}
+          </Typography>
+        </Stack>
+        {current?.description && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
+            {current.description}
+          </Typography>
+        )}
+      </Box>
+      <Box sx={{ flex: 1, overflowY: 'auto', p: 3 }}>{renderStep(current.key, helpers)}</Box>
+      <Box
+        sx={{
+          borderTop: 1,
+          borderColor: 'divider',
+          px: 3,
+          py: 2,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 2,
+        }}
+      >
+        <Button variant="outlined" size="small" onClick={goPrev} disabled={isFirst} startIcon={<ChevronLeftIcon />}>
+          {backLabel}
+        </Button>
+        {isLast ? (
+          <Button
+            variant="contained"
+            size="small"
+            onClick={() => onFinish?.()}
+            disabled={!canAdvance}
+            startIcon={<CheckIcon />}
+          >
+            {finishLabel}
+          </Button>
+        ) : (
+          <Button
+            variant="contained"
+            size="small"
+            onClick={goNext}
+            disabled={!canAdvance}
+            endIcon={<ChevronRightIcon />}
+          >
+            {nextLabel}
+          </Button>
+        )}
+      </Box>
+    </Card>
+  )
+
+  if (layout === 'top') {
+    return (
+      <Stack spacing={2}>
+        <TopStepIndicator
+          steps={steps}
+          stepIdx={stepIdx}
+          maxReached={maxReached}
+          valid={valid}
+          onStepClick={goToStep}
+          title={title}
+          onCancel={onCancel}
+          cancelLabel={cancelLabel}
+        />
+        {body}
+      </Stack>
+    )
+  }
+
+  return (
+    <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '240px 1fr' }, gap: 2 }}>
+      <SidebarStepList
+        steps={steps}
+        stepIdx={stepIdx}
+        maxReached={maxReached}
+        valid={valid}
+        onStepClick={goToStep}
+        title={title}
+        onCancel={onCancel}
+        cancelLabel={cancelLabel}
+      />
+      {body}
+    </Box>
+  )
+}
+
+function SidebarStepList({
+  steps,
+  stepIdx,
+  maxReached,
+  valid,
+  onStepClick,
+  title,
+  onCancel,
+  cancelLabel,
+}: {
+  steps: WizardStep[]
+  stepIdx: number
+  maxReached: number
+  valid: Record<string, boolean>
+  onStepClick: (idx: number) => void
+  title?: ReactNode
+  onCancel?: () => void
+  cancelLabel: string
+}) {
+  return (
+    <Card sx={{ alignSelf: 'start', p: 1.5 }}>
+      {title && (
+        <Typography variant="tinyLabel" color="text.secondary" sx={{ display: 'block', mb: 1, px: 0.5 }}>
+          {title}
+        </Typography>
+      )}
+      <Stack component="ol" spacing={0.5} sx={{ m: 0, p: 0, listStyle: 'none' }}>
+        {steps.map((s, i) => (
+          <li key={s.key}>
+            <StepRow
+              idx={i}
+              step={s}
+              current={i === stepIdx}
+              completed={!!valid[s.key] && i < stepIdx}
+              locked={i > maxReached}
+              onClick={() => onStepClick(i)}
+            />
+          </li>
+        ))}
+      </Stack>
+      {onCancel && (
+        <>
+          <Divider sx={{ my: 1.5 }} />
+          <Button variant="text" size="small" fullWidth onClick={onCancel} startIcon={<CloseIcon />}>
+            {cancelLabel}
+          </Button>
+        </>
+      )}
+    </Card>
+  )
+}
+
+function StepRow({
+  idx,
+  step,
+  current,
+  completed,
+  locked,
+  onClick,
+}: {
+  idx: number
+  step: WizardStep
+  current: boolean
+  completed: boolean
+  locked: boolean
+  onClick: () => void
+}) {
+  return (
+    <Box
+      component="button"
+      type="button"
+      onClick={onClick}
+      disabled={locked}
+      sx={(theme) => ({
+        width: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        py: 0.75,
+        px: 1,
+        borderRadius: 1,
+        border: 0,
+        textAlign: 'left',
+        cursor: locked ? 'not-allowed' : 'pointer',
+        bgcolor: current ? theme.palette.action.selected : 'transparent',
+        color: current ? 'primary.main' : locked ? 'text.disabled' : 'text.primary',
+        fontFamily: 'inherit',
+        '&:hover': locked ? undefined : { bgcolor: current ? theme.palette.action.selected : theme.palette.action.hover },
+      })}
+    >
+      <Box
+        sx={(theme) => ({
+          flexShrink: 0,
+          width: 22,
+          height: 22,
+          borderRadius: '50%',
+          border: 1,
+          borderColor: completed
+            ? theme.palette.success.main
+            : current
+              ? 'primary.main'
+              : 'divider',
+          bgcolor: completed
+            ? theme.palette.success.main + '22'
+            : 'transparent',
+          color: completed ? 'success.main' : current ? 'primary.main' : 'text.secondary',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: '0.7rem',
+          fontVariantNumeric: 'tabular-nums',
+          fontWeight: 600,
+        })}
+      >
+        {completed ? <CheckIcon sx={{ fontSize: 14 }} /> : <span>{idx + 1}</span>}
+      </Box>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography sx={{ fontSize: '0.825rem', fontWeight: current ? 600 : 500, lineHeight: 1.2 }} noWrap>
+          {step.title}
+        </Typography>
+        {step.description && (
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', lineHeight: 1.2 }} noWrap>
+            {step.description}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+function TopStepIndicator({
+  steps,
+  stepIdx,
+  maxReached,
+  valid,
+  onStepClick,
+  title,
+  onCancel,
+  cancelLabel,
+}: {
+  steps: WizardStep[]
+  stepIdx: number
+  maxReached: number
+  valid: Record<string, boolean>
+  onStepClick: (idx: number) => void
+  title?: ReactNode
+  onCancel?: () => void
+  cancelLabel: string
+}) {
+  return (
+    <Card sx={{ p: 2 }}>
+      <Stack direction="row" spacing={2} sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        {title && (
+          <Typography variant="tinyLabel" color="text.secondary">
+            {title}
+          </Typography>
+        )}
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', flex: 1, overflowX: 'auto' }}>
+          {steps.map((s, i) => {
+            const completed = !!valid[s.key] && i < stepIdx
+            const current = i === stepIdx
+            const locked = i > maxReached
+            return (
+              <Stack
+                key={s.key}
+                direction="row"
+                spacing={1}
+                sx={{ alignItems: 'center', flexShrink: 0 }}
+                component="button"
+                type="button"
+                onClick={() => onStepClick(i)}
+                disabled={locked}
+                style={{
+                  background: 'none',
+                  border: 0,
+                  padding: 0,
+                  cursor: locked ? 'not-allowed' : 'pointer',
+                }}
+              >
+                <Box
+                  sx={(theme) => ({
+                    width: 22,
+                    height: 22,
+                    borderRadius: '50%',
+                    border: 1,
+                    borderColor: completed
+                      ? theme.palette.success.main
+                      : current
+                        ? 'primary.main'
+                        : 'divider',
+                    bgcolor: completed ? theme.palette.success.main + '22' : 'transparent',
+                    color: completed ? 'success.main' : current ? 'primary.main' : 'text.secondary',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: '0.7rem',
+                    fontWeight: 600,
+                  })}
+                >
+                  {completed ? <CheckIcon sx={{ fontSize: 14 }} /> : <span>{i + 1}</span>}
+                </Box>
+                <Typography
+                  sx={{
+                    fontSize: '0.825rem',
+                    fontWeight: current ? 600 : 500,
+                    color: locked ? 'text.disabled' : current ? 'primary.main' : 'text.primary',
+                  }}
+                >
+                  {s.title}
+                </Typography>
+              </Stack>
+            )
+          })}
+        </Stack>
+        {onCancel && (
+          <Button variant="text" size="small" onClick={onCancel} startIcon={<CloseIcon />}>
+            {cancelLabel}
+          </Button>
+        )}
+      </Stack>
+    </Card>
+  )
+}

--- a/packages/ui/src/components/Wizard/Wizard.tsx
+++ b/packages/ui/src/components/Wizard/Wizard.tsx
@@ -35,6 +35,7 @@ import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import Divider from '@mui/material/Divider'
 import Stack from '@mui/material/Stack'
+import { alpha } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 
@@ -92,6 +93,10 @@ type PersistedState = { step: number; max: number; valid: Record<string, boolean
 
 function loadPersisted(key: string | undefined, stepCount: number): PersistedState | null {
   if (!key) return null
+  // `useMemo` runs this during render, including on the server where `window`
+  // is undefined — guard so SSR doesn't crash. The state simply starts unpersisted
+  // on the server and the write effect re-syncs once mounted on the client.
+  if (typeof window === 'undefined') return null
   try {
     const raw = window.localStorage.getItem(key)
     if (!raw) return null
@@ -355,10 +360,16 @@ function StepRow({
         border: 0,
         textAlign: 'left',
         cursor: locked ? 'not-allowed' : 'pointer',
-        bgcolor: current ? theme.palette.action.selected : 'transparent',
+        bgcolor: current ? alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.16 : 0.08) : 'transparent',
         color: current ? 'primary.main' : locked ? 'text.disabled' : 'text.primary',
         fontFamily: 'inherit',
-        '&:hover': locked ? undefined : { bgcolor: current ? theme.palette.action.selected : theme.palette.action.hover },
+        '&:hover': locked
+          ? undefined
+          : {
+              bgcolor: current
+                ? alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.24 : 0.14)
+                : theme.palette.action.hover,
+            },
       })}
     >
       <Box

--- a/packages/ui/src/components/Wizard/index.ts
+++ b/packages/ui/src/components/Wizard/index.ts
@@ -1,0 +1,1 @@
+export * from './Wizard'

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,0 +1,140 @@
+/**
+ * Public component surface for `@mindtrace/ui`.
+ *
+ * Three groups:
+ *   1. Thin wrappers around MUI: `Button`, `TextField`, `Select`, `Checkbox`,
+ *      `Switch`, `Radio`, `Card`, `Badge`, `Alert`, `Modal`, `Drawer`,
+ *      `Tabs`, `Avatar`. Use these in app code instead of reaching for MUI
+ *      directly so theme/behavior overrides stay centralized.
+ *   2. Bespoke patterns: `PageHeader`, `FormSection`, `EmptyState`, `DataTable`,
+ *      `KpiCard`, `SectionCard`, `FilterChips`, `SearchField`, `StatusDot`,
+ *      `StatusBadge`, `SeverityBadge`, `NumberBadge`, `Mono`, `Wizard`,
+ *      `PathBreadcrumb`, `PageLayout`, `ConfirmDialog`, `Toast`, `CopyButton`.
+ *   3. Raw MUI re-exports for layout/utility primitives that don't warrant
+ *      a wrapper: `Box`, `Stack`, `Container`, `Grid`, `Divider`, `Typography`,
+ *      `Link`, `IconButton`, `Tooltip`, `Chip`, etc.
+ *
+ * Brand-specific elements (logos, layout shells) live in consuming apps —
+ * this library stays brand-agnostic.
+ */
+
+// ── Wrappers ─────────────────────────────────────────────────────────────
+export * from './Alert'
+export * from './Avatar'
+export * from './Badge'
+export * from './Button'
+export * from './Card'
+export * from './Checkbox'
+export * from './ConfirmDialog'
+export * from './CopyButton'
+export * from './Drawer'
+export * from './FormSection'
+export * from './Modal'
+export * from './Radio'
+export * from './Select'
+export * from './Switch'
+export * from './Tabs'
+export * from './TextField'
+export * from './Toast'
+
+// ── Layout primitives ────────────────────────────────────────────────────
+export * from './AppBar'
+export * from './AppShell'
+export * from './HeroBackground'
+export * from './PageContainer'
+export * from './PageLayout'
+export * from './PrimaryRail'
+export * from './UserMenu'
+
+// ── Bespoke patterns ────────────────────────────────────────────────────
+export * from './DataTable'
+export * from './EmptyState'
+export * from './FilterChips'
+export * from './KpiCard'
+export * from './Mono'
+export * from './NumberBadge'
+export * from './PageHeader'
+export * from './PathBreadcrumb'
+export * from './SearchField'
+export * from './SectionCard'
+export * from './SeverityBadge'
+export * from './StatusBadge'
+export * from './StatusDot'
+export * from './Wizard'
+
+// ── Layout primitives (MUI re-exports) ──────────────────────────────────
+export { default as Box } from '@mui/material/Box'
+export { default as Container } from '@mui/material/Container'
+export { default as Grid } from '@mui/material/Grid'
+export { default as Stack } from '@mui/material/Stack'
+export { default as Divider } from '@mui/material/Divider'
+
+// ── Surfaces ────────────────────────────────────────────────────────────
+export { default as Paper } from '@mui/material/Paper'
+
+// ── Typography primitives ───────────────────────────────────────────────
+export { default as Typography } from '@mui/material/Typography'
+export { default as Link } from '@mui/material/Link'
+
+// ── Input primitives (building blocks not already covered by wrappers) ──
+export { default as ButtonGroup } from '@mui/material/ButtonGroup'
+export { default as IconButton } from '@mui/material/IconButton'
+export { default as InputAdornment } from '@mui/material/InputAdornment'
+export { default as InputLabel } from '@mui/material/InputLabel'
+export { default as OutlinedInput } from '@mui/material/OutlinedInput'
+export { default as FormControl } from '@mui/material/FormControl'
+export { default as FormControlLabel } from '@mui/material/FormControlLabel'
+export { default as FormHelperText } from '@mui/material/FormHelperText'
+export { default as FormGroup } from '@mui/material/FormGroup'
+export { default as MenuItem } from '@mui/material/MenuItem'
+export { default as Slider } from '@mui/material/Slider'
+export { default as Autocomplete } from '@mui/material/Autocomplete'
+export { default as ToggleButton } from '@mui/material/ToggleButton'
+export { default as ToggleButtonGroup } from '@mui/material/ToggleButtonGroup'
+
+// ── Data display ────────────────────────────────────────────────────────
+export { default as Chip } from '@mui/material/Chip'
+export { default as AvatarGroup } from '@mui/material/AvatarGroup'
+export { default as Tooltip } from '@mui/material/Tooltip'
+export { default as List } from '@mui/material/List'
+export { default as ListItem } from '@mui/material/ListItem'
+export { default as ListItemButton } from '@mui/material/ListItemButton'
+export { default as ListItemIcon } from '@mui/material/ListItemIcon'
+export { default as ListItemText } from '@mui/material/ListItemText'
+export { default as ListSubheader } from '@mui/material/ListSubheader'
+export { default as Table } from '@mui/material/Table'
+export { default as TableBody } from '@mui/material/TableBody'
+export { default as TableCell } from '@mui/material/TableCell'
+export { default as TableContainer } from '@mui/material/TableContainer'
+export { default as TableFooter } from '@mui/material/TableFooter'
+export { default as TableHead } from '@mui/material/TableHead'
+export { default as TablePagination } from '@mui/material/TablePagination'
+export { default as TableRow } from '@mui/material/TableRow'
+export { default as TableSortLabel } from '@mui/material/TableSortLabel'
+
+// ── Feedback ────────────────────────────────────────────────────────────
+export { default as CircularProgress } from '@mui/material/CircularProgress'
+export { default as LinearProgress } from '@mui/material/LinearProgress'
+export { default as Skeleton } from '@mui/material/Skeleton'
+export { default as Snackbar } from '@mui/material/Snackbar'
+
+// ── Overlay / navigation ────────────────────────────────────────────────
+export { default as Menu } from '@mui/material/Menu'
+export { default as Popover } from '@mui/material/Popover'
+export { default as Popper } from '@mui/material/Popper'
+export { default as Toolbar } from '@mui/material/Toolbar'
+export { default as Breadcrumbs } from '@mui/material/Breadcrumbs'
+export { default as Pagination } from '@mui/material/Pagination'
+export { default as Stepper } from '@mui/material/Stepper'
+export { default as Step } from '@mui/material/Step'
+export { default as StepLabel } from '@mui/material/StepLabel'
+export { default as StepContent } from '@mui/material/StepContent'
+export { default as Accordion } from '@mui/material/Accordion'
+export { default as AccordionSummary } from '@mui/material/AccordionSummary'
+export { default as AccordionDetails } from '@mui/material/AccordionDetails'
+export { default as Collapse } from '@mui/material/Collapse'
+export { default as Fade } from '@mui/material/Fade'
+
+// ── Style utilities ─────────────────────────────────────────────────────
+export { styled, useTheme as useMuiTheme, alpha } from '@mui/material/styles'
+export type { Theme, SxProps } from '@mui/material/styles'

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useCopyToClipboard'

--- a/packages/ui/src/hooks/useCopyToClipboard.test.ts
+++ b/packages/ui/src/hooks/useCopyToClipboard.test.ts
@@ -1,0 +1,49 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useCopyToClipboard } from './useCopyToClipboard'
+
+describe('useCopyToClipboard', () => {
+  let writeText: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('writes to the clipboard + flips copied true', async () => {
+    const { result } = renderHook(() => useCopyToClipboard({ resetMs: 1000 }))
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current[0]('hello')
+    })
+    expect(ok).toBe(true)
+    expect(writeText).toHaveBeenCalledWith('hello')
+    expect(result.current[1].copied).toBe(true)
+  })
+
+  it('resets copied after resetMs', async () => {
+    const { result } = renderHook(() => useCopyToClipboard({ resetMs: 100 }))
+    await act(async () => {
+      await result.current[0]('x')
+    })
+    expect(result.current[1].copied).toBe(true)
+    await waitFor(() => expect(result.current[1].copied).toBe(false), { timeout: 500 })
+  })
+
+  it('captures errors when clipboard write fails', async () => {
+    writeText.mockRejectedValueOnce(new Error('denied'))
+    const { result } = renderHook(() => useCopyToClipboard())
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current[0]('x')
+    })
+    expect(ok).toBe(false)
+    expect(result.current[1].copied).toBe(false)
+    expect(result.current[1].error?.message).toBe('denied')
+  })
+})

--- a/packages/ui/src/hooks/useCopyToClipboard.ts
+++ b/packages/ui/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export type CopyState = {
+  /** True for `resetMs` after a successful copy, then resets. */
+  copied: boolean
+  /** Last clipboard error (browser API rejection or absent API). */
+  error: Error | null
+}
+
+export type UseCopyToClipboardOptions = {
+  /** How long the `copied` flag stays true. Default `1500` ms. */
+  resetMs?: number
+}
+
+/**
+ * Copy-to-clipboard hook with a self-clearing `copied` flag.
+ *
+ *   const [copy, { copied }] = useCopyToClipboard()
+ *   <Button onClick={() => copy('abc')}>{copied ? 'Copied' : 'Copy'}</Button>
+ *
+ * Returns a tuple of (`copy(text) => Promise<boolean>`, state). The
+ * promise resolves to `true` when the write succeeds.
+ */
+export function useCopyToClipboard(
+  options: UseCopyToClipboardOptions = {},
+): [copy: (text: string) => Promise<boolean>, state: CopyState] {
+  const { resetMs = 1500 } = options
+  const [copied, setCopied] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  }, [])
+
+  const copy = useCallback(
+    async (text: string) => {
+      try {
+        if (!navigator?.clipboard?.writeText) {
+          throw new Error('Clipboard API unavailable')
+        }
+        await navigator.clipboard.writeText(text)
+        setCopied(true)
+        setError(null)
+        if (timeoutRef.current) clearTimeout(timeoutRef.current)
+        timeoutRef.current = setTimeout(() => setCopied(false), resetMs)
+        return true
+      } catch (e) {
+        setCopied(false)
+        setError(e instanceof Error ? e : new Error(String(e)))
+        return false
+      }
+    },
+    [resetMs],
+  )
+
+  return [copy, { copied, error }]
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * `@mindtrace/ui` — public API surface.
+ *
+ *   import { MindtraceProvider, Button, TextField } from '@mindtrace/ui'
+ *
+ * Layout:
+ *   ./theme      — MUI themes + design tokens
+ *   ./providers  — MindtraceProvider
+ *   ./components — thin MUI wrappers + bespoke primitives + MUI layout re-exports
+ */
+
+export * from './theme'
+export * from './providers'
+export * from './components'
+export * from './hooks'

--- a/packages/ui/src/providers/MindtraceProvider.test.tsx
+++ b/packages/ui/src/providers/MindtraceProvider.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { MindtraceProvider } from './MindtraceProvider'
+
+describe('MindtraceProvider', () => {
+  it('renders children', () => {
+    render(
+      <MindtraceProvider>
+        <span>hello</span>
+      </MindtraceProvider>,
+    )
+    expect(screen.getByText('hello')).toBeInTheDocument()
+  })
+
+  it('omits CssBaseline when disabled', () => {
+    render(
+      <MindtraceProvider disableCssBaseline>
+        <span>x</span>
+      </MindtraceProvider>,
+    )
+    expect(screen.getByText('x')).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/providers/MindtraceProvider.tsx
+++ b/packages/ui/src/providers/MindtraceProvider.tsx
@@ -1,0 +1,47 @@
+/**
+ * MindtraceProvider — drop-in MUI theme stack.
+ *
+ *   <MindtraceProvider mode="light">
+ *     <App />
+ *   </MindtraceProvider>
+ *
+ * Wraps:
+ *   1. `StyledEngineProvider injectFirst` — emotion's <style> tags ship
+ *      *before* any user CSS so utility class libraries keep working
+ *      during a migration window.
+ *   2. `ThemeProvider` with this library's theme (or a caller-supplied one).
+ *   3. `CssBaseline enableColorScheme` (opt-out via `disableCssBaseline`).
+ */
+
+import CssBaseline from '@mui/material/CssBaseline'
+import { StyledEngineProvider, ThemeProvider, type Theme } from '@mui/material/styles'
+import type { ReactNode } from 'react'
+
+import { getTheme, type ThemeMode } from '../theme'
+
+export type MindtraceProviderProps = {
+  children: ReactNode
+  /** Theme variant. Defaults to `'light'`. Ignored when `theme` is supplied. */
+  mode?: ThemeMode
+  /** Caller-supplied MUI theme. Skip if you just want the built-in theme. */
+  theme?: Theme
+  /** Skip `<CssBaseline>` if the host app already resets styles. */
+  disableCssBaseline?: boolean
+}
+
+export function MindtraceProvider({
+  children,
+  mode = 'light',
+  theme,
+  disableCssBaseline = false,
+}: MindtraceProviderProps) {
+  const resolvedTheme = theme ?? getTheme(mode)
+  return (
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider theme={resolvedTheme}>
+        {disableCssBaseline ? null : <CssBaseline enableColorScheme />}
+        {children}
+      </ThemeProvider>
+    </StyledEngineProvider>
+  )
+}

--- a/packages/ui/src/providers/index.ts
+++ b/packages/ui/src/providers/index.ts
@@ -1,0 +1,1 @@
+export * from './MindtraceProvider'

--- a/packages/ui/src/stories/Introduction.mdx
+++ b/packages/ui/src/stories/Introduction.mdx
@@ -1,0 +1,171 @@
+import { Meta } from '@storybook/blocks'
+
+<Meta title="Introduction" />
+
+# @mindtrace/ui
+
+A React component library for **calm, data-heavy operational interfaces** —
+admin tools, dashboards, internal back-offices, control panels — used daily
+by expert users who care about throughput and predictability over flash.
+
+Built on **MUI**, themed and pre-wrapped so the same components look and
+behave the same way across every surface that consumes the library.
+
+---
+
+## What you can do here
+
+Storybook is the source-of-truth catalogue. Every component ships with a
+story so you can:
+
+- **Try multiple themes** — the toolbar (top-right) exposes seven theme
+  presets including light/dark Mindtrace plus four custom palettes. See how
+  each component absorbs a brand color change.
+- **Drive props live** — open the **Controls** panel and tweak strings,
+  enums, booleans, colors, ranges. Every component has typed `argTypes`.
+- **Watch events fire** — the **Actions** panel logs every `onClick`,
+  `onChange`, `onClose`, etc.
+- **Step through interactions** — the **Interactions** panel replays the
+  `play()` function for stories that have one (Wizard navigation, Toast
+  show/dismiss, Modal confirm/cancel, …).
+- **Check accessibility** — the **a11y** panel runs axe-core against the
+  rendered story.
+
+---
+
+## Where things live
+
+### Foundations — start here
+
+- [`Theme Builder`](?path=/docs/foundations-theme-builder--docs) — author a
+  theme inline with color pickers + a kitchen-sink showcase. Validates the
+  library against any brand palette.
+- `Palette`, `Typography`, `Shape`, `Shadows`, `Stack & Grid` — design
+  tokens and primitive scales.
+
+### Components — thin MUI wrappers
+
+The day-to-day building blocks. Each wraps a single MUI primitive and adds
+sensible defaults + a generic API.
+
+**Inputs.** `Button`, `TextField`, `Select`, `Checkbox`, `Switch`, `Radio`,
+`Tabs`, `CopyButton`.
+
+**Surfaces.** `Card`, `Modal`, `Drawer`, `ConfirmDialog`, `Toast`.
+
+**Status & feedback.** `Alert`, `Badge`, `StatusDot`, `StatusBadge`,
+`SeverityBadge`, `NumberBadge`, `Avatar`, `Mono`.
+
+**Plus raw MUI re-exports** for layout primitives (`Box`, `Stack`, `Grid`,
+`Container`), data display (`Table`, `Tooltip`, `Chip`), navigation (`Menu`,
+`Popover`, `Breadcrumbs`, `Pagination`, `Stepper`, `Accordion`), and
+feedback (`Snackbar`, `CircularProgress`, `LinearProgress`, `Skeleton`).
+
+### Layout — app frame primitives
+
+Composable shells, slot-based, no auth/business logic baked in:
+`AppShell`, `AppBar`, `PrimaryRail`, `PageContainer`, `UserMenu`,
+`HeroBackground`.
+
+### Patterns — bespoke higher-order composites
+
+Generic shapes lifted from real operational UIs:
+`PageLayout`, `PageHeader`, `FormSection`, `EmptyState`, `DataTable`,
+`KpiCard`, `SectionCard`, `FilterChips`, `SearchField`,
+`PathBreadcrumb`, `Wizard`.
+
+---
+
+## Quick start (in your app)
+
+```tsx
+import { MindtraceProvider, Button } from '@mindtrace/ui'
+
+export function App() {
+  return (
+    <MindtraceProvider mode="light">
+      <Button variant="contained">Save changes</Button>
+    </MindtraceProvider>
+  )
+}
+```
+
+One `MindtraceProvider` at the root — every descendant reads from its
+theme automatically. Pass `mode="dark"`, a custom `theme`, or
+`disableCssBaseline` for advanced setups.
+
+---
+
+## How Storybook is wired
+
+- Components live under `src/components/<Name>/` co-located with their
+  stories (`<Name>.stories.tsx`).
+- Theme is the real `lightTheme` / `darkTheme` from `src/theme/`, mounted
+  via the `addon-themes` decorator in `.storybook/preview.tsx`. The
+  toolbar picker swaps between this and the custom presets in
+  `.storybook/themes.ts`.
+- The `MindtraceProvider` (`src/providers/MindtraceProvider.tsx`) is what
+  consuming apps mount once at root; Storybook applies the same MUI
+  constituents directly so addon controls still resolve.
+
+---
+
+## Adding a new story
+
+Co-locate with the component:
+
+```tsx
+// src/components/MyComponent/MyComponent.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+
+import { MyComponent } from './MyComponent'
+
+const meta = {
+  title: 'Components/MyComponent',
+  component: MyComponent,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: { type: 'inline-radio' }, options: ['a', 'b'] },
+    disabled: { control: 'boolean' },
+    onClick: { action: 'clicked' },
+  },
+  args: { variant: 'a', onClick: fn() },
+} satisfies Meta<typeof MyComponent>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+```
+
+The `src/**/*.stories.@(ts|tsx)` glob in `.storybook/main.ts` picks new
+files up automatically.
+
+**Rules of thumb:**
+
+- Use `title: 'Components/…'` / `'Layout/…'` / `'Patterns/…'` /
+  `'Foundations/…'` so the story sorts into the right group.
+- Always include `tags: ['autodocs']` for the prop table.
+- Declare `argTypes` for any enum-like prop so the control becomes a
+  picker instead of a free-form input.
+- Wire `onClick`-style callbacks via `fn()` from `@storybook/test` so
+  the Actions panel shows them.
+- Keep example values generic. No private data, no customer or domain
+  terminology, no real URLs. See
+  [`docs/PUBLIC_PACKAGE_BOUNDARIES.md`](https://github.com/Mindtrace/mindtrace/blob/dev/packages/ui/docs/PUBLIC_PACKAGE_BOUNDARIES.md)
+  for the boundary rules.
+
+---
+
+## Further reading
+
+The [`docs/`](https://github.com/Mindtrace/mindtrace/tree/dev/packages/ui/docs)
+folder ships alongside the source:
+
+- `AI_USAGE_GUIDE.md` — rules for AI coding tools using this library
+- `UI_PHILOSOPHY.md` — what this UI is and isn't
+- `COMPONENT_GUIDELINES.md` — when to use which component
+- `STORYBOOK_USAGE.md` — Storybook as source of truth
+- `DESIGN_TOKENS.md` — tokens and how to use them
+- `PUBLIC_PACKAGE_BOUNDARIES.md` — what's allowed in the public package

--- a/packages/ui/src/stories/Layout.stories.tsx
+++ b/packages/ui/src/stories/Layout.stories.tsx
@@ -1,0 +1,80 @@
+import Box from '@mui/material/Box'
+import Grid from '@mui/material/Grid'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta: Meta = {
+  title: 'Foundations/Stack & Grid',
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj
+
+function Cell({ n }: { n: number }) {
+  return (
+    <Paper sx={{ p: 2, textAlign: 'center', bgcolor: 'surface.subtle' }}>
+      <Typography variant="body2">{n}</Typography>
+    </Paper>
+  )
+}
+
+export const StackRow: Story = {
+  render: () => (
+    <Stack direction="row" spacing={2}>
+      {[1, 2, 3, 4].map((n) => (
+        <Cell key={n} n={n} />
+      ))}
+    </Stack>
+  ),
+}
+
+export const StackColumn: Story = {
+  render: () => (
+    <Stack spacing={2}>
+      {[1, 2, 3].map((n) => (
+        <Cell key={n} n={n} />
+      ))}
+    </Stack>
+  ),
+}
+
+export const GridSplit: Story = {
+  render: () => (
+    <Grid container spacing={2}>
+      <Grid size={{ xs: 12, md: 8 }}>
+        <Cell n={1} />
+      </Grid>
+      <Grid size={{ xs: 12, md: 4 }}>
+        <Cell n={2} />
+      </Grid>
+      <Grid size={{ xs: 6, md: 4 }}>
+        <Cell n={3} />
+      </Grid>
+      <Grid size={{ xs: 6, md: 4 }}>
+        <Cell n={4} />
+      </Grid>
+      <Grid size={{ xs: 12, md: 4 }}>
+        <Cell n={5} />
+      </Grid>
+    </Grid>
+  ),
+}
+
+export const ResponsiveBox: Story = {
+  render: () => (
+    <Box
+      sx={{
+        display: 'grid',
+        gap: 2,
+        gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(4, 1fr)' },
+      }}
+    >
+      {[1, 2, 3, 4, 5, 6, 7, 8].map((n) => (
+        <Cell key={n} n={n} />
+      ))}
+    </Box>
+  ),
+}

--- a/packages/ui/src/stories/Menu.stories.tsx
+++ b/packages/ui/src/stories/Menu.stories.tsx
@@ -1,0 +1,55 @@
+import Button from '@mui/material/Button'
+import Divider from '@mui/material/Divider'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import LogoutIcon from '@mui/icons-material/Logout'
+import PersonIcon from '@mui/icons-material/Person'
+import SettingsIcon from '@mui/icons-material/Settings'
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+
+const meta = {
+  title: 'Components/Menu',
+  component: Menu,
+  tags: ['autodocs'],
+  args: { open: false },
+} satisfies Meta<typeof Menu>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function Demo() {
+  const [el, setEl] = useState<HTMLElement | null>(null)
+  return (
+    <>
+      <Button variant="outlined" onClick={(e) => setEl(e.currentTarget)}>
+        Open menu
+      </Button>
+      <Menu anchorEl={el} open={Boolean(el)} onClose={() => setEl(null)}>
+        <MenuItem onClick={() => setEl(null)}>
+          <ListItemIcon>
+            <PersonIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Profile</ListItemText>
+        </MenuItem>
+        <MenuItem onClick={() => setEl(null)}>
+          <ListItemIcon>
+            <SettingsIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Settings</ListItemText>
+        </MenuItem>
+        <Divider />
+        <MenuItem onClick={() => setEl(null)}>
+          <ListItemIcon>
+            <LogoutIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Sign out</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  )
+}
+
+export const Default: Story = { render: () => <Demo /> }

--- a/packages/ui/src/stories/Palette.stories.tsx
+++ b/packages/ui/src/stories/Palette.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { useTheme } from '@mui/material/styles'
+
+function Swatch({ label, color, foreground }: { label: string; color: string; foreground?: string }) {
+  return (
+    <Stack
+      sx={{
+        borderRadius: 1,
+        overflow: 'hidden',
+        border: '1px solid',
+        borderColor: 'border.subtle',
+        minWidth: 140,
+      }}
+    >
+      <Box sx={{ bgcolor: color, height: 72, display: 'flex', alignItems: 'flex-end', p: 1 }}>
+        {foreground && (
+          <Typography variant="caption" sx={{ color: foreground, fontWeight: 600 }}>
+            Aa
+          </Typography>
+        )}
+      </Box>
+      <Stack sx={{ p: 1, bgcolor: 'background.paper' }}>
+        <Typography variant="caption" sx={{ fontWeight: 600 }}>
+          {label}
+        </Typography>
+        <Typography variant="mono" sx={{ fontSize: '0.6875rem', color: 'text.secondary' }}>
+          {color}
+        </Typography>
+      </Stack>
+    </Stack>
+  )
+}
+
+function PaletteShowcase() {
+  const theme = useTheme()
+  const p = theme.palette
+  const groups = [
+    {
+      title: 'Brand & status',
+      items: [
+        { label: 'primary.main', color: p.primary.main, foreground: p.primary.contrastText },
+        { label: 'primary.dark', color: p.primary.dark, foreground: p.primary.contrastText },
+        { label: 'primary.light', color: p.primary.light, foreground: p.primary.contrastText },
+        { label: 'secondary.main', color: p.secondary.main, foreground: p.secondary.contrastText },
+        { label: 'success.main', color: p.success.main, foreground: p.success.contrastText },
+        { label: 'warning.main', color: p.warning.main, foreground: p.warning.contrastText },
+        { label: 'error.main', color: p.error.main, foreground: p.error.contrastText },
+        { label: 'info.main', color: p.info.main, foreground: p.info.contrastText },
+      ],
+    },
+    {
+      title: 'Backgrounds & surfaces',
+      items: [
+        { label: 'background.default', color: p.background.default, foreground: p.text.primary },
+        { label: 'background.paper', color: p.background.paper, foreground: p.text.primary },
+        { label: 'surface.subtle', color: p.surface.subtle, foreground: p.text.primary },
+        { label: 'surface.muted', color: p.surface.muted, foreground: p.text.primary },
+        { label: 'surface.strong', color: p.surface.strong, foreground: p.text.primary },
+      ],
+    },
+    {
+      title: 'Text & borders',
+      items: [
+        { label: 'text.primary', color: p.text.primary, foreground: p.background.paper },
+        { label: 'text.secondary', color: p.text.secondary, foreground: p.background.paper },
+        { label: 'text.disabled', color: p.text.disabled, foreground: p.background.paper },
+        { label: 'divider', color: typeof p.divider === 'string' ? p.divider : '#e2e8f0' },
+        { label: 'border.subtle', color: p.border.subtle as string },
+        { label: 'border.default', color: p.border.default as string },
+        { label: 'border.strong', color: p.border.strong as string },
+      ],
+    },
+    {
+      title: 'Grey ramp',
+      items: ([50, 100, 200, 300, 400, 500, 600, 700, 800, 900] as const).map((shade) => ({
+        label: `grey.${shade}`,
+        color: p.grey[shade],
+        foreground: shade >= 500 ? '#fff' : p.text.primary,
+      })),
+    },
+  ]
+  return (
+    <Stack spacing={4}>
+      {groups.map((g) => (
+        <Stack key={g.title} spacing={1.5}>
+          <Typography variant="overline" color="text.secondary">
+            {g.title}
+          </Typography>
+          <Box sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))' }}>
+            {g.items.map((it) => (
+              <Swatch key={it.label} label={it.label} color={it.color} foreground={it.foreground} />
+            ))}
+          </Box>
+        </Stack>
+      ))}
+    </Stack>
+  )
+}
+
+const meta: Meta = {
+  title: 'Foundations/Palette',
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj
+
+export const Default: Story = {
+  render: () => <PaletteShowcase />,
+}

--- a/packages/ui/src/stories/Progress.stories.tsx
+++ b/packages/ui/src/stories/Progress.stories.tsx
@@ -1,0 +1,33 @@
+import CircularProgress from '@mui/material/CircularProgress'
+import LinearProgress from '@mui/material/LinearProgress'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta: Meta = {
+  title: 'Components/Progress',
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj
+
+export const Linear: Story = {
+  render: () => (
+    <Stack spacing={2} sx={{ maxWidth: 360 }}>
+      <LinearProgress />
+      <LinearProgress variant="determinate" value={42} />
+      <Typography variant="caption">42% — determinate</Typography>
+    </Stack>
+  ),
+}
+
+export const Circular: Story = {
+  render: () => (
+    <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+      <CircularProgress size={16} />
+      <CircularProgress size={24} />
+      <CircularProgress size={36} />
+    </Stack>
+  ),
+}

--- a/packages/ui/src/stories/Shadows.stories.tsx
+++ b/packages/ui/src/stories/Shadows.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { useTheme } from '@mui/material/styles'
+
+function ShadowsShowcase() {
+  const theme = useTheme()
+  // Sample every distinct elevation step
+  const elevations = [0, 1, 2, 4, 7, 16] as const
+  return (
+    <Stack spacing={3}>
+      <Typography variant="overline" color="text.secondary">
+        Elevation ramp
+      </Typography>
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: 4 }}>
+        {elevations.map((n) => (
+          <Stack key={n} spacing={1} sx={{ alignItems: 'center' }}>
+            <Box
+              sx={{
+                width: 120,
+                height: 120,
+                bgcolor: 'background.paper',
+                borderRadius: 2,
+                boxShadow: theme.shadows[n],
+                border: '1px solid',
+                borderColor: 'border.subtle',
+              }}
+            />
+            <Typography variant="caption" sx={{ fontWeight: 600 }}>
+              shadows[{n}]
+            </Typography>
+          </Stack>
+        ))}
+      </Box>
+    </Stack>
+  )
+}
+
+const meta: Meta = {
+  title: 'Foundations/Shadows',
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj
+
+export const Default: Story = {
+  render: () => <ShadowsShowcase />,
+}

--- a/packages/ui/src/stories/Shape.stories.tsx
+++ b/packages/ui/src/stories/Shape.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+
+import { radius, spacing } from '../theme/shape'
+
+function ShapeShowcase() {
+  return (
+    <Stack spacing={5}>
+      <Stack spacing={2}>
+        <Typography variant="overline" color="text.secondary">
+          Radius scale
+        </Typography>
+        <Stack direction="row" spacing={3} sx={{ flexWrap: 'wrap', gap: 3 }}>
+          {Object.entries(radius).map(([name, value]) => (
+            <Stack key={name} spacing={1} sx={{ alignItems: 'center' }}>
+              <Box
+                sx={{
+                  width: 80,
+                  height: 80,
+                  bgcolor: 'primary.main',
+                  borderRadius: `${value}px`,
+                }}
+              />
+              <Typography variant="caption" sx={{ fontWeight: 600 }}>
+                {name}
+              </Typography>
+              <Typography variant="mono" sx={{ fontSize: '0.6875rem', color: 'text.secondary' }}>
+                {value}px
+              </Typography>
+            </Stack>
+          ))}
+        </Stack>
+      </Stack>
+
+      <Stack spacing={2}>
+        <Typography variant="overline" color="text.secondary">
+          Spacing (theme.spacing = {spacing}px)
+        </Typography>
+        <Stack spacing={1.5}>
+          {[1, 1.5, 2, 3, 4, 6, 8].map((n) => (
+            <Stack key={n} direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+              <Typography variant="mono" sx={{ width: 60, fontSize: '0.75rem' }}>
+                spacing({n})
+              </Typography>
+              <Box sx={{ height: 12, bgcolor: 'primary.main', borderRadius: 0.5, width: n * spacing * 1 }} />
+              <Typography variant="caption" color="text.secondary">
+                {n * spacing}px
+              </Typography>
+            </Stack>
+          ))}
+        </Stack>
+      </Stack>
+    </Stack>
+  )
+}
+
+const meta: Meta = {
+  title: 'Foundations/Shape',
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj
+
+export const Default: Story = {
+  render: () => <ShapeShowcase />,
+}

--- a/packages/ui/src/stories/Skeleton.stories.tsx
+++ b/packages/ui/src/stories/Skeleton.stories.tsx
@@ -1,0 +1,25 @@
+import Box from '@mui/material/Box'
+import Skeleton from '@mui/material/Skeleton'
+import Stack from '@mui/material/Stack'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Components/Skeleton',
+  component: Skeleton,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Skeleton>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => (
+    <Box sx={{ maxWidth: 380 }}>
+      <Stack spacing={1}>
+        <Skeleton variant="rectangular" height={120} />
+        <Skeleton width="60%" />
+        <Skeleton width="40%" />
+      </Stack>
+    </Box>
+  ),
+}

--- a/packages/ui/src/stories/Table.stories.tsx
+++ b/packages/ui/src/stories/Table.stories.tsx
@@ -1,0 +1,53 @@
+import Paper from '@mui/material/Paper'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableContainer from '@mui/material/TableContainer'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Components/Table',
+  component: Table,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Table>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const rows = [
+  { id: 'r-9241', pipeline: 'weld-detect-v3', latency: 142, status: 'success' },
+  { id: 'r-9240', pipeline: 'weld-detect-v3', latency: 138, status: 'success' },
+  { id: 'r-9239', pipeline: 'spatter-classify-v2', latency: 312, status: 'warning' },
+  { id: 'r-9238', pipeline: 'spatter-classify-v2', latency: 0, status: 'error' },
+]
+
+export const Default: Story = {
+  render: () => (
+    <Paper>
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Pipeline</TableCell>
+              <TableCell align="right">Latency</TableCell>
+              <TableCell>Status</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((r) => (
+              <TableRow key={r.id} hover>
+                <TableCell>{r.id}</TableCell>
+                <TableCell>{r.pipeline}</TableCell>
+                <TableCell align="right">{r.latency} ms</TableCell>
+                <TableCell>{r.status}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Paper>
+  ),
+}

--- a/packages/ui/src/stories/ThemeBuilder.stories.tsx
+++ b/packages/ui/src/stories/ThemeBuilder.stories.tsx
@@ -1,0 +1,356 @@
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { createTheme } from '@mui/material/styles'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Alert } from '../components/Alert'
+import { Badge } from '../components/Badge'
+import { Button } from '../components/Button'
+import { Card, CardActions, CardContent, CardHeader } from '../components/Card'
+import { DataTable } from '../components/DataTable'
+import { EmptyState } from '../components/EmptyState'
+import { FilterChips } from '../components/FilterChips'
+import { FormSection } from '../components/FormSection'
+import { KpiCard } from '../components/KpiCard'
+import { Mono } from '../components/Mono'
+import { NumberBadge } from '../components/NumberBadge'
+import { PageHeader } from '../components/PageHeader'
+import { SectionCard } from '../components/SectionCard'
+import { Select } from '../components/Select'
+import { SeverityBadge } from '../components/SeverityBadge'
+import { StatusBadge } from '../components/StatusBadge'
+import { TextField } from '../components/TextField'
+import { MindtraceProvider } from '../providers'
+import { darkTheme as builtinDark, lightTheme as builtinLight, getTheme } from '../theme'
+
+type Args = {
+  /** Which built-in theme to start from. Custom colors apply on top. */
+  base: 'mindtrace-light' | 'mindtrace-dark' | 'custom'
+  mode: 'light' | 'dark'
+  primary: string
+  secondary: string
+  success: string
+  warning: string
+  error: string
+  info: string
+  backgroundDefault: string
+  backgroundPaper: string
+  textPrimary: string
+  fontFamily: string
+  borderRadius: number
+}
+
+function buildTheme(a: Args) {
+  if (a.base === 'mindtrace-light') return builtinLight
+  if (a.base === 'mindtrace-dark') return builtinDark
+  // Custom — overlay user colors onto a sane base for the chosen mode.
+  const root = getTheme(a.mode)
+  return createTheme({
+    ...root,
+    palette: {
+      ...root.palette,
+      mode: a.mode,
+      primary: { main: a.primary },
+      secondary: { main: a.secondary },
+      success: { main: a.success },
+      warning: { main: a.warning },
+      error: { main: a.error },
+      info: { main: a.info },
+      background: {
+        default: a.backgroundDefault,
+        paper: a.backgroundPaper,
+      },
+      text: {
+        ...root.palette.text,
+        primary: a.textPrimary,
+      },
+    },
+    typography: {
+      ...root.typography,
+      ...(a.fontFamily ? { fontFamily: a.fontFamily } : {}),
+    },
+    shape: { borderRadius: a.borderRadius },
+  })
+}
+
+function Showcase(_args: Args) {
+  return (
+    <Stack spacing={4}>
+      <Section title="Buttons">
+        <Stack direction="row" spacing={1.5} sx={{ flexWrap: 'wrap', gap: 1 }}>
+          <Button variant="contained">Primary</Button>
+          <Button variant="outlined">Outlined</Button>
+          <Button variant="text">Text</Button>
+          <Button variant="contained" color="secondary">Secondary</Button>
+          <Button variant="contained" color="success">Success</Button>
+          <Button variant="contained" color="warning">Warning</Button>
+          <Button variant="contained" color="error">Error</Button>
+          <Button variant="contained" color="info">Info</Button>
+          <Button variant="contained" disabled>Disabled</Button>
+        </Stack>
+      </Section>
+
+      <Section title="Inputs">
+        <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap' }}>
+          <TextField label="Name" placeholder="Type here…" sx={{ minWidth: 220 }} />
+          <TextField label="Email" defaultValue="me@example.com" sx={{ minWidth: 220 }} />
+          <TextField label="Error" error helperText="This field is required" sx={{ minWidth: 220 }} />
+          <Select
+            label="Tier"
+            defaultValue="pro"
+            options={[
+              { value: 'free', label: 'Free' },
+              { value: 'pro', label: 'Pro' },
+              { value: 'enterprise', label: 'Enterprise' },
+            ]}
+            sx={{ minWidth: 220 }}
+          />
+        </Stack>
+      </Section>
+
+      <Section title="Status & feedback">
+        <Stack spacing={1.5}>
+          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
+            <StatusBadge tone="success" label="Healthy" />
+            <StatusBadge tone="warning" label="Degraded" pulse />
+            <StatusBadge tone="error" label="Down" />
+            <StatusBadge tone="info" label="Pending" />
+            <StatusBadge tone="neutral" label="Idle" />
+          </Stack>
+          <Stack direction="row" spacing={1}>
+            <SeverityBadge severity="critical" />
+            <SeverityBadge severity="major" />
+            <SeverityBadge severity="minor" />
+            <SeverityBadge severity="info" />
+          </Stack>
+          <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+            <Badge label="default" />
+            <Badge label="primary" color="primary" />
+            <Badge label="success" color="success" />
+            <Badge label="warning" color="warning" />
+            <Badge label="error" color="error" />
+            <NumberBadge tone="info">5</NumberBadge>
+            <NumberBadge tone="error" variant="solid">99+</NumberBadge>
+          </Stack>
+          <Alert severity="info">Info — connection established.</Alert>
+          <Alert severity="success">Success — changes saved.</Alert>
+          <Alert severity="warning">Warning — unsaved edits.</Alert>
+          <Alert severity="error">Error — could not reach the API.</Alert>
+        </Stack>
+      </Section>
+
+      <Section title="Cards & layout">
+        <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap' }}>
+          <Card sx={{ width: 280 }}>
+            <CardHeader title="Plain card" subheader="Updated just now" />
+            <CardContent>
+              <Typography variant="body2" color="text.secondary">
+                Wraps MUI Card. Picks up theme palette and radius.
+              </Typography>
+            </CardContent>
+            <CardActions sx={{ justifyContent: 'flex-end' }}>
+              <Button variant="text" size="small">Cancel</Button>
+              <Button variant="contained" size="small">Save</Button>
+            </CardActions>
+          </Card>
+          <SectionCard title="Webhooks" subtitle="HTTP endpoints" sx={{ width: 320 }}>
+            <Typography variant="body2" color="text.secondary">
+              SectionCard composes Card + header in one element.
+            </Typography>
+          </SectionCard>
+          <KpiCard label="Active users" value="12,840" delta={{ value: '+4.2%', tone: 'success' }} />
+        </Stack>
+      </Section>
+
+      <Section title="Page header + form">
+        <Stack spacing={2}>
+          <PageHeader
+            title="Members"
+            description="People with access to this workspace."
+            breadcrumbs={[{ label: 'Settings' }, { label: 'Members' }]}
+            actions={<Button variant="contained">Invite</Button>}
+          />
+          <FormSection title="Profile" description="How you appear to teammates.">
+            <TextField label="Display name" defaultValue="Alex" />
+            <TextField label="Email" defaultValue="alex@example.com" />
+          </FormSection>
+        </Stack>
+      </Section>
+
+      <Section title="Data + filters + IDs">
+        <Stack spacing={2}>
+          <FilterChips
+            options={[
+              { id: 'all', label: 'All', count: 256 },
+              { id: 'pending', label: 'Pending', count: 12 },
+              { id: 'in-progress', label: 'In progress', count: 3 },
+              { id: 'completed', label: 'Completed', count: 41 },
+            ]}
+            selected={['pending']}
+            onChange={() => {}}
+          />
+          <DataTable
+            rows={[
+              { id: 'j-9241', name: 'nightly-report', status: 'success' as const, duration: '142 ms' },
+              { id: 'j-9240', name: 'image-resize', status: 'warning' as const, duration: '312 ms' },
+              { id: 'j-9239', name: 'image-resize', status: 'error' as const, duration: '0 ms' },
+            ]}
+            getRowKey={(r) => r.id}
+            columns={[
+              { id: 'id', label: 'ID', render: (r) => <Mono>{r.id}</Mono> },
+              { id: 'name', label: 'Job' },
+              { id: 'status', label: 'Status', render: (r) => <StatusBadge tone={r.status} label={r.status} /> },
+              { id: 'duration', label: 'Duration', align: 'right' },
+            ]}
+          />
+        </Stack>
+      </Section>
+
+      <Section title="Empty state">
+        <EmptyState
+          title="Nothing here yet"
+          description="When data shows up, it'll appear in this surface."
+          action={<Button variant="contained">Get started</Button>}
+        />
+      </Section>
+    </Stack>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Stack spacing={1.5}>
+      <Typography variant="tinyLabel" color="text.secondary">
+        {title}
+      </Typography>
+      {children}
+    </Stack>
+  )
+}
+
+/**
+ * Demonstrates the real consumer pattern: wrap the app once in
+ * `MindtraceProvider` at the root, passing the constructed `theme`.
+ * Every descendant — including all `@mindtrace/ui` components — reads
+ * from that theme via MUI's context.
+ */
+function ThemeBuilderShell(args: Args) {
+  const theme = buildTheme(args)
+  return (
+    <MindtraceProvider theme={theme}>
+      <Box sx={{ bgcolor: 'background.default', color: 'text.primary', p: 3, borderRadius: 1 }}>
+        <Showcase {...args} />
+      </Box>
+    </MindtraceProvider>
+  )
+}
+
+const meta = {
+  title: 'Foundations/Theme Builder',
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Author a theme inline and see every component re-render against it. Pick a built-in theme to start, or switch `base` to `custom` to override individual colors, font, and radius. Useful for validating the library against non-Mindtrace brand palettes before adopting it.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    base: {
+      control: { type: 'inline-radio' },
+      options: ['mindtrace-light', 'mindtrace-dark', 'custom'],
+      description: 'Start from a built-in theme or build a custom one.',
+    },
+    mode: { control: { type: 'inline-radio' }, options: ['light', 'dark'], if: { arg: 'base', eq: 'custom' } },
+    primary: { control: 'color', if: { arg: 'base', eq: 'custom' } },
+    secondary: { control: 'color', if: { arg: 'base', eq: 'custom' } },
+    success: { control: 'color', if: { arg: 'base', eq: 'custom' } },
+    warning: { control: 'color', if: { arg: 'base', eq: 'custom' } },
+    error: { control: 'color', if: { arg: 'base', eq: 'custom' } },
+    info: { control: 'color', if: { arg: 'base', eq: 'custom' } },
+    backgroundDefault: { control: 'color', if: { arg: 'base', eq: 'custom' } },
+    backgroundPaper: { control: 'color', if: { arg: 'base', eq: 'custom' } },
+    textPrimary: { control: 'color', if: { arg: 'base', eq: 'custom' } },
+    fontFamily: { control: 'text', if: { arg: 'base', eq: 'custom' } },
+    borderRadius: {
+      control: { type: 'range', min: 0, max: 24, step: 1 },
+      if: { arg: 'base', eq: 'custom' },
+    },
+  },
+  args: {
+    base: 'custom',
+    mode: 'light',
+    primary: '#7C3AED',
+    secondary: '#52525B',
+    success: '#16A34A',
+    warning: '#D97706',
+    error: '#DC2626',
+    info: '#0891B2',
+    backgroundDefault: '#FAFAFA',
+    backgroundPaper: '#FFFFFF',
+    textPrimary: '#18181B',
+    fontFamily: '',
+    borderRadius: 10,
+  } satisfies Args,
+  render: (args) => <ThemeBuilderShell {...(args as Args)} />,
+} satisfies Meta<Args>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const MindtraceLight: Story = { args: { base: 'mindtrace-light' } }
+export const MindtraceDark: Story = { args: { base: 'mindtrace-dark' } }
+
+export const CustomBlue: Story = {
+  args: {
+    base: 'custom',
+    primary: '#2563EB',
+    secondary: '#475569',
+    success: '#059669',
+    warning: '#D97706',
+    error: '#DC2626',
+    info: '#0EA5E9',
+    backgroundDefault: '#F8FAFC',
+    backgroundPaper: '#FFFFFF',
+    textPrimary: '#0F172A',
+    borderRadius: 6,
+  },
+}
+
+export const CustomGreen: Story = {
+  args: {
+    base: 'custom',
+    primary: '#15803D',
+    secondary: '#3F3F46',
+    success: '#16A34A',
+    warning: '#CA8A04',
+    error: '#B91C1C',
+    info: '#0E7490',
+    backgroundDefault: '#FAFAF9',
+    backgroundPaper: '#FFFFFF',
+    textPrimary: '#0C0A09',
+    borderRadius: 14,
+  },
+}
+
+export const CustomDark: Story = {
+  args: {
+    base: 'custom',
+    mode: 'dark',
+    primary: '#22D3EE',
+    secondary: '#A1A1AA',
+    success: '#4ADE80',
+    warning: '#FBBF24',
+    error: '#F87171',
+    info: '#67E8F9',
+    backgroundDefault: '#0A0A0A',
+    backgroundPaper: '#171717',
+    textPrimary: '#FAFAFA',
+    borderRadius: 12,
+  },
+}
+
+export const Playground: Story = {}

--- a/packages/ui/src/stories/Tooltip.stories.tsx
+++ b/packages/ui/src/stories/Tooltip.stories.tsx
@@ -1,0 +1,33 @@
+import Button from '@mui/material/Button'
+import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  args: { title: '', children: <span /> },
+} satisfies Meta<typeof Tooltip>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Placements: Story = {
+  render: () => (
+    <Stack direction="row" spacing={3} sx={{ p: 5 }}>
+      <Tooltip title="Top" placement="top">
+        <Button variant="outlined">Top</Button>
+      </Tooltip>
+      <Tooltip title="Right" placement="right">
+        <Button variant="outlined">Right</Button>
+      </Tooltip>
+      <Tooltip title="Bottom" placement="bottom">
+        <Button variant="outlined">Bottom</Button>
+      </Tooltip>
+      <Tooltip title="Left" placement="left">
+        <Button variant="outlined">Left</Button>
+      </Tooltip>
+    </Stack>
+  ),
+}

--- a/packages/ui/src/stories/Typography.stories.tsx
+++ b/packages/ui/src/stories/Typography.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import Box from '@mui/material/Box'
+
+const VARIANTS = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'subtitle1',
+  'subtitle2',
+  'body1',
+  'body2',
+  'caption',
+  'overline',
+  'button',
+  'mono',
+  'label',
+] as const
+
+function TypographyShowcase() {
+  return (
+    <Stack spacing={2.5} divider={<Box sx={{ borderTop: 1, borderColor: 'divider' }} />}>
+      {VARIANTS.map((v) => (
+        <Stack key={v} direction="row" spacing={3} sx={{ alignItems: 'baseline' }}>
+          <Box sx={{ width: 90, flexShrink: 0 }}>
+            <Typography variant="mono" sx={{ color: 'text.secondary', fontSize: '0.75rem' }}>
+              {v}
+            </Typography>
+          </Box>
+          <Typography variant={v}>The quick brown fox jumps over the lazy dog — 0123456789</Typography>
+        </Stack>
+      ))}
+    </Stack>
+  )
+}
+
+const meta: Meta = {
+  title: 'Foundations/Typography',
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj
+
+export const AllVariants: Story = {
+  render: () => <TypographyShowcase />,
+}

--- a/packages/ui/src/stories/Typography.stories.tsx
+++ b/packages/ui/src/stories/Typography.stories.tsx
@@ -17,8 +17,12 @@ const VARIANTS = [
   'caption',
   'overline',
   'button',
+  'subheading',
+  'sectionLabel',
+  'metricLabel',
+  'tinyLabel',
+  'microCaption',
   'mono',
-  'label',
 ] as const
 
 function TypographyShowcase() {

--- a/packages/ui/src/test-utils.tsx
+++ b/packages/ui/src/test-utils.tsx
@@ -1,0 +1,20 @@
+/**
+ * Test helpers — wrap renders in `MindtraceProvider` so theme tokens are
+ * available, and re-export `render` + `screen` + `userEvent` for tests.
+ */
+
+import { render as rtlRender, type RenderOptions } from '@testing-library/react'
+import { type ReactElement, type ReactNode } from 'react'
+
+import { MindtraceProvider } from './providers'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <MindtraceProvider>{children}</MindtraceProvider>
+}
+
+export function render(ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) {
+  return rtlRender(ui, { wrapper: Wrapper, ...options })
+}
+
+export * from '@testing-library/react'
+export { default as userEvent } from '@testing-library/user-event'

--- a/packages/ui/src/theme/components.ts
+++ b/packages/ui/src/theme/components.ts
@@ -1,0 +1,219 @@
+/**
+ * Component-level overrides — tighter, denser defaults than MUI's base.
+ */
+
+import type { Components, Theme } from '@mui/material/styles'
+import { fontWeight, radii } from './tokens'
+
+export function buildComponents(mode: 'light' | 'dark'): Components<Theme> {
+  const isDark = mode === 'dark'
+  const surfaceElevated = isDark ? '#111116' : '#FFFFFF'
+  const surfaceBorder = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.08)'
+
+  return {
+    MuiCssBaseline: {
+      styleOverrides: {
+        body: {
+          scrollbarWidth: 'thin',
+          scrollbarColor: isDark ? 'rgba(255,255,255,0.10) transparent' : 'rgba(0,0,0,0.10) transparent',
+          fontFeatureSettings: "'cv11', 'ss01'",
+        },
+        '*::-webkit-scrollbar': { width: 8, height: 8 },
+        '*::-webkit-scrollbar-thumb': {
+          backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
+          borderRadius: radii.pill,
+          border: '2px solid transparent',
+          backgroundClip: 'content-box',
+        },
+        '*::-webkit-scrollbar-thumb:hover': {
+          backgroundColor: isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.18)',
+        },
+      },
+    },
+    MuiButton: {
+      defaultProps: { disableElevation: true },
+      styleOverrides: {
+        root: {
+          borderRadius: radii.sm,
+          paddingLeft: 14,
+          paddingRight: 14,
+          fontWeight: fontWeight.semibold,
+        },
+        sizeSmall: { paddingLeft: 10, paddingRight: 10 },
+        contained: ({ ownerState }) => {
+          if (!isDark || ownerState.color !== 'primary') return {}
+          return {
+            backgroundColor: '#7F23CF',
+            color: '#FFFFFF',
+            '&:hover': { backgroundColor: '#6D1DB5' },
+          }
+        },
+      },
+    },
+    MuiIconButton: { styleOverrides: { root: { borderRadius: radii.sm } } },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          borderRadius: radii.sm,
+          fontWeight: fontWeight.medium,
+          minHeight: 20,
+          fontSize: '0.72rem',
+        },
+        sizeSmall: { height: 22, minHeight: 20, fontSize: '0.72rem' },
+        outlined: isDark ? { borderColor: 'rgba(255,255,255,0.12)', color: 'rgba(255,255,255,0.7)' } : {},
+        filled: isDark ? { backgroundColor: 'rgba(255,255,255,0.08)', color: 'rgba(255,255,255,0.8)' } : {},
+      },
+    },
+    MuiCard: {
+      defaultProps: { elevation: 0 },
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          borderRadius: radii.md,
+          border: `1px solid ${surfaceBorder}`,
+          backgroundColor: surfaceElevated,
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: { backgroundImage: 'none' },
+        outlined: { borderColor: surfaceBorder, backgroundColor: surfaceElevated },
+      },
+    },
+    MuiTextField: { defaultProps: { size: 'small', variant: 'outlined' } },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          borderRadius: radii.sm,
+          ...(isDark
+            ? {
+                color: '#FAFAFA',
+                '& .MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.10)' },
+                '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.20)' },
+                '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#7F23CF' },
+              }
+            : {}),
+        },
+        input: isDark
+          ? {
+              '&::placeholder': { color: 'rgba(255,255,255,0.3)' },
+              '&::-webkit-calendar-picker-indicator': { filter: 'invert(1)' },
+            }
+          : {},
+      },
+    },
+    MuiInputLabel: {
+      styleOverrides: {
+        root: isDark ? { color: 'rgba(255,255,255,0.5)', '&.Mui-focused': { color: '#A78BFA' } } : {},
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        select: { cursor: 'pointer' },
+        icon: isDark ? { color: 'rgba(255,255,255,0.4)' } : {},
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: isDark
+          ? {
+              '&.Mui-selected': {
+                backgroundColor: 'rgba(167,139,250,0.12)',
+                '&:hover': { backgroundColor: 'rgba(167,139,250,0.18)' },
+              },
+            }
+          : {},
+      },
+    },
+    MuiSwitch: {
+      styleOverrides: { root: isDark ? { '& .MuiSwitch-track': { backgroundColor: 'rgba(255,255,255,0.15)' } } : {} },
+    },
+    MuiCheckbox: {
+      styleOverrides: {
+        root: isDark ? { color: 'rgba(255,255,255,0.3)', '&.Mui-checked': { color: '#A78BFA' } } : {},
+      },
+    },
+    MuiToggleButton: {
+      styleOverrides: {
+        root: {
+          borderColor: surfaceBorder,
+          ...(isDark
+            ? {
+                color: 'rgba(255,255,255,0.5)',
+                '&.Mui-selected': {
+                  backgroundColor: 'rgba(167,139,250,0.12)',
+                  color: '#A78BFA',
+                  borderColor: 'rgba(167,139,250,0.30)',
+                  '&:hover': { backgroundColor: 'rgba(167,139,250,0.18)' },
+                },
+              }
+            : {}),
+        },
+      },
+    },
+    MuiAlert: {
+      styleOverrides: {
+        root: isDark ? { backgroundColor: 'rgba(255,255,255,0.04)', border: `1px solid ${surfaceBorder}` } : {},
+      },
+    },
+    MuiListItemButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: radii.sm,
+          '&.Mui-selected': {
+            backgroundColor: isDark ? 'rgba(167, 139, 250, 0.12)' : 'rgba(124, 58, 237, 0.08)',
+            '&:hover': {
+              backgroundColor: isDark ? 'rgba(167, 139, 250, 0.18)' : 'rgba(124, 58, 237, 0.14)',
+            },
+          },
+        },
+      },
+    },
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          borderRadius: radii.sm,
+          fontSize: '0.75rem',
+          fontWeight: fontWeight.medium,
+          padding: '6px 10px',
+          ...(isDark ? { backgroundColor: '#1A1A20', border: `1px solid ${surfaceBorder}` } : {}),
+        },
+      },
+    },
+    MuiAppBar: {
+      defaultProps: { elevation: 0 },
+      styleOverrides: { root: { backgroundImage: 'none' } },
+    },
+    MuiDialog: {
+      styleOverrides: {
+        paper: {
+          borderRadius: radii.lg,
+          ...(isDark ? { backgroundColor: '#141418', border: `1px solid ${surfaceBorder}` } : {}),
+        },
+      },
+    },
+    MuiMenu: {
+      styleOverrides: {
+        paper: {
+          borderRadius: radii.md,
+          ...(isDark ? { backgroundColor: '#141418', border: `1px solid ${surfaceBorder}` } : {}),
+        },
+      },
+    },
+    MuiDivider: { styleOverrides: { root: { borderColor: surfaceBorder } } },
+    MuiTypography: {
+      defaultProps: {
+        variantMapping: {
+          subheading: 'h3',
+          sectionLabel: 'div',
+          metricLabel: 'div',
+          tinyLabel: 'div',
+          microCaption: 'span',
+          mono: 'span',
+          label: 'div',
+        },
+      },
+    },
+  }
+}

--- a/packages/ui/src/theme/components.ts
+++ b/packages/ui/src/theme/components.ts
@@ -2,6 +2,7 @@
  * Component-level overrides — tighter, denser defaults than MUI's base.
  */
 
+import { alpha } from '@mui/material/styles'
 import type { Components, Theme } from '@mui/material/styles'
 import { fontWeight, radii } from './tokens'
 
@@ -10,13 +11,18 @@ export function buildComponents(mode: 'light' | 'dark'): Components<Theme> {
   const surfaceElevated = isDark ? '#111116' : '#FFFFFF'
   const surfaceBorder = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.08)'
 
+  // Selection/focus tints are derived from `palette.primary` at render time so
+  // the whole UI tracks a single primary knob — including consumer overrides
+  // passed to `createTheme`. Opacities differ per mode for legibility.
+  const selectedAlpha = isDark ? 0.16 : 0.08
+  const selectedHoverAlpha = isDark ? 0.24 : 0.14
+
   return {
     MuiCssBaseline: {
       styleOverrides: {
         body: {
           scrollbarWidth: 'thin',
           scrollbarColor: isDark ? 'rgba(255,255,255,0.10) transparent' : 'rgba(0,0,0,0.10) transparent',
-          fontFeatureSettings: "'cv11', 'ss01'",
         },
         '*::-webkit-scrollbar': { width: 8, height: 8 },
         '*::-webkit-scrollbar-thumb': {
@@ -40,14 +46,6 @@ export function buildComponents(mode: 'light' | 'dark'): Components<Theme> {
           fontWeight: fontWeight.semibold,
         },
         sizeSmall: { paddingLeft: 10, paddingRight: 10 },
-        contained: ({ ownerState }) => {
-          if (!isDark || ownerState.color !== 'primary') return {}
-          return {
-            backgroundColor: '#7F23CF',
-            color: '#FFFFFF',
-            '&:hover': { backgroundColor: '#6D1DB5' },
-          }
-        },
       },
     },
     MuiIconButton: { styleOverrides: { root: { borderRadius: radii.sm } } },
@@ -84,17 +82,17 @@ export function buildComponents(mode: 'light' | 'dark'): Components<Theme> {
     MuiTextField: { defaultProps: { size: 'small', variant: 'outlined' } },
     MuiOutlinedInput: {
       styleOverrides: {
-        root: {
+        root: ({ theme }) => ({
           borderRadius: radii.sm,
           ...(isDark
             ? {
                 color: '#FAFAFA',
                 '& .MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.10)' },
                 '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.20)' },
-                '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#7F23CF' },
+                '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: theme.palette.primary.main },
               }
             : {}),
-        },
+        }),
         input: isDark
           ? {
               '&::placeholder': { color: 'rgba(255,255,255,0.3)' },
@@ -105,7 +103,8 @@ export function buildComponents(mode: 'light' | 'dark'): Components<Theme> {
     },
     MuiInputLabel: {
       styleOverrides: {
-        root: isDark ? { color: 'rgba(255,255,255,0.5)', '&.Mui-focused': { color: '#A78BFA' } } : {},
+        root: ({ theme }) =>
+          isDark ? { color: 'rgba(255,255,255,0.5)', '&.Mui-focused': { color: theme.palette.primary.main } } : {},
       },
     },
     MuiSelect: {
@@ -116,14 +115,12 @@ export function buildComponents(mode: 'light' | 'dark'): Components<Theme> {
     },
     MuiMenuItem: {
       styleOverrides: {
-        root: isDark
-          ? {
-              '&.Mui-selected': {
-                backgroundColor: 'rgba(167,139,250,0.12)',
-                '&:hover': { backgroundColor: 'rgba(167,139,250,0.18)' },
-              },
-            }
-          : {},
+        root: ({ theme }) => ({
+          '&.Mui-selected': {
+            backgroundColor: alpha(theme.palette.primary.main, selectedAlpha),
+            '&:hover': { backgroundColor: alpha(theme.palette.primary.main, selectedHoverAlpha) },
+          },
+        }),
       },
     },
     MuiSwitch: {
@@ -131,25 +128,22 @@ export function buildComponents(mode: 'light' | 'dark'): Components<Theme> {
     },
     MuiCheckbox: {
       styleOverrides: {
-        root: isDark ? { color: 'rgba(255,255,255,0.3)', '&.Mui-checked': { color: '#A78BFA' } } : {},
+        root: ({ theme }) =>
+          isDark ? { color: 'rgba(255,255,255,0.3)', '&.Mui-checked': { color: theme.palette.primary.main } } : {},
       },
     },
     MuiToggleButton: {
       styleOverrides: {
-        root: {
+        root: ({ theme }) => ({
           borderColor: surfaceBorder,
-          ...(isDark
-            ? {
-                color: 'rgba(255,255,255,0.5)',
-                '&.Mui-selected': {
-                  backgroundColor: 'rgba(167,139,250,0.12)',
-                  color: '#A78BFA',
-                  borderColor: 'rgba(167,139,250,0.30)',
-                  '&:hover': { backgroundColor: 'rgba(167,139,250,0.18)' },
-                },
-              }
-            : {}),
-        },
+          ...(isDark ? { color: 'rgba(255,255,255,0.5)' } : {}),
+          '&.Mui-selected': {
+            backgroundColor: alpha(theme.palette.primary.main, selectedAlpha),
+            color: theme.palette.primary.main,
+            borderColor: alpha(theme.palette.primary.main, 0.3),
+            '&:hover': { backgroundColor: alpha(theme.palette.primary.main, selectedHoverAlpha) },
+          },
+        }),
       },
     },
     MuiAlert: {
@@ -159,15 +153,15 @@ export function buildComponents(mode: 'light' | 'dark'): Components<Theme> {
     },
     MuiListItemButton: {
       styleOverrides: {
-        root: {
+        root: ({ theme }) => ({
           borderRadius: radii.sm,
           '&.Mui-selected': {
-            backgroundColor: isDark ? 'rgba(167, 139, 250, 0.12)' : 'rgba(124, 58, 237, 0.08)',
+            backgroundColor: alpha(theme.palette.primary.main, selectedAlpha),
             '&:hover': {
-              backgroundColor: isDark ? 'rgba(167, 139, 250, 0.18)' : 'rgba(124, 58, 237, 0.14)',
+              backgroundColor: alpha(theme.palette.primary.main, selectedHoverAlpha),
             },
           },
-        },
+        }),
       },
     },
     MuiTooltip: {
@@ -211,7 +205,6 @@ export function buildComponents(mode: 'light' | 'dark'): Components<Theme> {
           tinyLabel: 'div',
           microCaption: 'span',
           mono: 'span',
-          label: 'div',
         },
       },
     },

--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Theme entrypoint — light + dark MUI themes built from the design tokens.
+ */
+
+import { createTheme, type Theme } from '@mui/material/styles'
+
+import { buildComponents } from './components'
+import { darkPalette, lightPalette } from './palette'
+import { buildShadows } from './shadows'
+import { shape, spacing } from './shape'
+import { typography } from './typography'
+
+export type ThemeMode = 'light' | 'dark'
+
+export function getTheme(mode: ThemeMode): Theme {
+  return mode === 'dark' ? darkTheme : lightTheme
+}
+
+export const lightTheme: Theme = createTheme({
+  palette: lightPalette,
+  shape,
+  spacing,
+  typography,
+  shadows: buildShadows('light'),
+  components: buildComponents('light'),
+  transitions: { duration: { shortest: 120, shorter: 120, short: 200, standard: 200, complex: 320 } },
+})
+
+export const darkTheme: Theme = createTheme({
+  palette: darkPalette,
+  shape,
+  spacing,
+  typography,
+  shadows: buildShadows('dark'),
+  components: buildComponents('dark'),
+  transitions: { duration: { shortest: 120, shorter: 120, short: 200, standard: 200, complex: 320 } },
+})
+
+export { lightPalette, darkPalette, typography, shape, spacing, buildComponents }
+export * from './tokens'

--- a/packages/ui/src/theme/palette.ts
+++ b/packages/ui/src/theme/palette.ts
@@ -1,0 +1,108 @@
+/**
+ * MUI palette options for light + dark modes.
+ *
+ * Purple brand accent with zinc-toned neutrals. Hierarchy maintained
+ * through deliberate contrast steps.
+ */
+
+import type { PaletteOptions } from '@mui/material/styles'
+import { brand, neutral, semantic } from './tokens'
+
+declare module '@mui/material/styles' {
+  interface Palette {
+    surface: { subtle: string; muted: string; strong: string }
+    border: { subtle: string; default: string; strong: string }
+  }
+  interface PaletteOptions {
+    surface?: { subtle: string; muted: string; strong: string }
+    border?: { subtle: string; default: string; strong: string }
+  }
+}
+
+export const lightPalette: PaletteOptions = {
+  mode: 'light',
+  primary: {
+    main: brand.purple[600],
+    light: brand.purple[500],
+    dark: brand.purple[700],
+    contrastText: '#FFFFFF',
+  },
+  secondary: {
+    main: neutral[700],
+    light: neutral[600],
+    dark: neutral[800],
+    contrastText: '#FFFFFF',
+  },
+  background: {
+    default: neutral[50],
+    paper: '#FFFFFF',
+  },
+  divider: neutral[200],
+  text: {
+    primary: neutral[900],
+    secondary: neutral[500],
+    disabled: neutral[400],
+  },
+  action: {
+    hover: 'rgba(24, 24, 27, 0.04)',
+    selected: 'rgba(124, 58, 237, 0.08)',
+    disabled: neutral[300],
+    disabledBackground: neutral[100],
+    focus: 'rgba(124, 58, 237, 0.14)',
+  },
+  error: semantic.error,
+  warning: semantic.warning,
+  success: semantic.success,
+  info: semantic.info,
+  grey: neutral as unknown as PaletteOptions['grey'],
+  surface: { subtle: neutral[50], muted: neutral[100], strong: neutral[200] },
+  border: {
+    subtle: 'rgba(0,0,0,0.06)',
+    default: 'rgba(0,0,0,0.10)',
+    strong: 'rgba(0,0,0,0.18)',
+  },
+}
+
+export const darkPalette: PaletteOptions = {
+  mode: 'dark',
+  primary: {
+    main: brand.purple[400],
+    light: brand.purple[300],
+    dark: brand.purple[500],
+    contrastText: '#FFFFFF',
+  },
+  secondary: {
+    main: neutral[300],
+    light: neutral[200],
+    dark: neutral[400],
+    contrastText: neutral[950],
+  },
+  background: {
+    default: neutral[950],
+    paper: neutral[900],
+  },
+  divider: 'rgba(255, 255, 255, 0.08)',
+  text: {
+    primary: neutral[50],
+    secondary: neutral[400],
+    disabled: neutral[600],
+  },
+  action: {
+    hover: 'rgba(255, 255, 255, 0.04)',
+    selected: 'rgba(167, 139, 250, 0.12)',
+    disabled: neutral[700],
+    disabledBackground: neutral[800],
+    focus: 'rgba(167, 139, 250, 0.20)',
+  },
+  error: { main: '#F87171', light: '#FCA5A5', dark: '#EF4444' },
+  warning: { main: '#FBBF24', light: '#FCD34D', dark: '#F59E0B' },
+  success: { main: '#4ADE80', light: '#86EFAC', dark: '#22C55E' },
+  info: { main: '#22D3EE', light: '#67E8F9', dark: '#06B6D4' },
+  grey: neutral as unknown as PaletteOptions['grey'],
+  surface: { subtle: '#111116', muted: neutral[800], strong: neutral[700] },
+  border: {
+    subtle: 'rgba(255,255,255,0.06)',
+    default: 'rgba(255,255,255,0.12)',
+    strong: 'rgba(255,255,255,0.20)',
+  },
+}

--- a/packages/ui/src/theme/palette.ts
+++ b/packages/ui/src/theme/palette.ts
@@ -5,8 +5,18 @@
  * through deliberate contrast steps.
  */
 
+import { alpha } from '@mui/material/styles'
 import type { PaletteOptions } from '@mui/material/styles'
 import { brand, neutral, semantic } from './tokens'
+
+// Default primary accent per mode. `action.selected`/`focus` are derived from
+// these so the built-in theme's selection/focus tints track the primary.
+// Components additionally derive these states from `theme.palette.primary` at
+// render time (see theme/components.ts), so a consumer overriding `primary`
+// recolors selection/focus everywhere — not just where the default literal
+// would have applied.
+const primaryLight = brand.purple[600]
+const primaryDark = brand.purple[400]
 
 declare module '@mui/material/styles' {
   interface Palette {
@@ -45,10 +55,10 @@ export const lightPalette: PaletteOptions = {
   },
   action: {
     hover: 'rgba(24, 24, 27, 0.04)',
-    selected: 'rgba(124, 58, 237, 0.08)',
+    selected: alpha(primaryLight, 0.08),
     disabled: neutral[300],
     disabledBackground: neutral[100],
-    focus: 'rgba(124, 58, 237, 0.14)',
+    focus: alpha(primaryLight, 0.14),
   },
   error: semantic.error,
   warning: semantic.warning,
@@ -89,10 +99,10 @@ export const darkPalette: PaletteOptions = {
   },
   action: {
     hover: 'rgba(255, 255, 255, 0.04)',
-    selected: 'rgba(167, 139, 250, 0.12)',
+    selected: alpha(primaryDark, 0.16),
     disabled: neutral[700],
     disabledBackground: neutral[800],
-    focus: 'rgba(167, 139, 250, 0.20)',
+    focus: alpha(primaryDark, 0.24),
   },
   error: { main: '#F87171', light: '#FCA5A5', dark: '#EF4444' },
   warning: { main: '#FBBF24', light: '#FCD34D', dark: '#F59E0B' },

--- a/packages/ui/src/theme/shadows.ts
+++ b/packages/ui/src/theme/shadows.ts
@@ -1,0 +1,26 @@
+/**
+ * Custom shadow ramp. MUI's default 25-step ramp is heavy for this UI;
+ * we use 5 distinct elevations and zero everything else so over-shadowing
+ * is impossible.
+ */
+
+import type { Shadows } from '@mui/material/styles'
+
+const NONE = 'none'
+
+export function buildShadows(mode: 'light' | 'dark'): Shadows {
+  if (mode === 'dark') {
+    const e1 = '0 1px 2px 0 rgba(0,0,0,0.4)'
+    const e2 = '0 2px 6px -1px rgba(0,0,0,0.5), 0 1px 2px 0 rgba(0,0,0,0.4)'
+    const e3 = '0 6px 14px -4px rgba(0,0,0,0.55), 0 2px 4px -1px rgba(0,0,0,0.4)'
+    const e4 = '0 12px 28px -8px rgba(0,0,0,0.6), 0 6px 12px -6px rgba(0,0,0,0.45)'
+    const e5 = '0 24px 48px -12px rgba(0,0,0,0.7), 0 12px 24px -8px rgba(0,0,0,0.5)'
+    return [NONE, e1, e2, e2, e3, e3, e3, e4, e4, e4, e4, e4, e4, e4, e4, e4, e5, e5, e5, e5, e5, e5, e5, e5, e5] as unknown as Shadows
+  }
+  const e1 = '0 1px 2px 0 rgba(15,23,42,0.06)'
+  const e2 = '0 2px 6px -1px rgba(15,23,42,0.08), 0 1px 2px 0 rgba(15,23,42,0.05)'
+  const e3 = '0 6px 14px -4px rgba(15,23,42,0.1), 0 2px 4px -1px rgba(15,23,42,0.06)'
+  const e4 = '0 12px 28px -8px rgba(15,23,42,0.14), 0 6px 12px -6px rgba(15,23,42,0.08)'
+  const e5 = '0 24px 48px -12px rgba(15,23,42,0.18), 0 12px 24px -8px rgba(15,23,42,0.1)'
+  return [NONE, e1, e2, e2, e3, e3, e3, e4, e4, e4, e4, e4, e4, e4, e4, e4, e5, e5, e5, e5, e5, e5, e5, e5, e5] as unknown as Shadows
+}

--- a/packages/ui/src/theme/shape.ts
+++ b/packages/ui/src/theme/shape.ts
@@ -1,0 +1,5 @@
+import { radii, spacingUnit } from './tokens'
+
+export const shape = { borderRadius: radii.md } as const
+export const radius = radii
+export const spacing = spacingUnit

--- a/packages/ui/src/theme/theme.test.ts
+++ b/packages/ui/src/theme/theme.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { darkTheme, getTheme, lightTheme } from './index'
+
+describe('theme', () => {
+  it('exposes light + dark', () => {
+    expect(lightTheme.palette.mode).toBe('light')
+    expect(darkTheme.palette.mode).toBe('dark')
+  })
+
+  it('getTheme returns the right one', () => {
+    expect(getTheme('light').palette.mode).toBe('light')
+    expect(getTheme('dark').palette.mode).toBe('dark')
+  })
+
+  it('extends the palette with surface + border', () => {
+    expect(lightTheme.palette.surface.subtle).toBeTruthy()
+    expect(lightTheme.palette.border.subtle).toBeTruthy()
+  })
+})

--- a/packages/ui/src/theme/tokens.ts
+++ b/packages/ui/src/theme/tokens.ts
@@ -1,0 +1,140 @@
+/**
+ * Design tokens — the source of truth for color, spacing, radius, type.
+ *
+ * Three-layer color system:
+ *   Layer 1: Brand identity (purple, teal, blue) — sparingly, for emphasis
+ *   Layer 2: Product foundation (neutrals, surfaces) — 90% of daily UI
+ *   Layer 3: Semantic + data viz — restrained, mature
+ *
+ * Usage rules:
+ *   Purple → primary action, active selection, product identity, focus
+ *   Teal   → data signals, analysis accents, intelligence layer
+ *   Blue   → secondary emphasis, links, informational
+ *   Neutrals → surfaces, text, borders, panels, dense operational areas
+ */
+
+// ─── Layer 1: Brand Identity ─────────────────────────────────────────────
+
+export const brand = {
+  purple: {
+    50: '#F5F3FF',
+    100: '#EDE9FE',
+    200: '#DDD6FE',
+    300: '#C4B5FD',
+    400: '#A78BFA',
+    500: '#8B5CF6',
+    600: '#7C3AED',
+    700: '#6D28D9',
+    800: '#5B21B6',
+    900: '#4C1D95',
+  },
+  teal: {
+    50: '#F0FDFA',
+    100: '#CCFBF1',
+    200: '#99F6E4',
+    300: '#5EEAD4',
+    400: '#2DD4BF',
+    500: '#14B8A6',
+    600: '#0D9488',
+    700: '#0F766E',
+  },
+  blue: {
+    50: '#EFF6FF',
+    100: '#DBEAFE',
+    200: '#BFDBFE',
+    300: '#93C5FD',
+    400: '#60A5FA',
+    500: '#3B82F6',
+    600: '#2563EB',
+    700: '#1D4ED8',
+  },
+  gradient: { start: '#14B8A6', mid: '#3B82F6', end: '#7C3AED' },
+} as const
+
+// ─── Layer 2: Product Foundation ─────────────────────────────────────────
+
+export const neutral = {
+  50: '#FAFAFA',
+  100: '#F4F4F5',
+  200: '#E4E4E7',
+  300: '#D4D4D8',
+  400: '#A1A1AA',
+  500: '#71717A',
+  600: '#52525B',
+  700: '#3F3F46',
+  800: '#27272A',
+  900: '#18181B',
+  950: '#09090B',
+} as const
+
+// ─── Layer 3: Semantic ───────────────────────────────────────────────────
+
+export const semantic = {
+  success: { main: '#16A34A', light: '#22C55E', dark: '#15803D', muted: '#166534' },
+  warning: { main: '#D97706', light: '#F59E0B', dark: '#B45309', muted: '#92400E' },
+  error: { main: '#DC2626', light: '#EF4444', dark: '#B91C1C', muted: '#991B1B' },
+  info: { main: '#0891B2', light: '#06B6D4', dark: '#0E7490', muted: '#155E75' },
+} as const
+
+// ─── Data Visualization ──────────────────────────────────────────────────
+
+export const dataViz = {
+  series: ['#7C3AED', '#14B8A6', '#3B82F6', '#F59E0B', '#EC4899', '#8B5CF6', '#06B6D4', '#F97316'],
+  ranking: { first: '#F59E0B', second: '#A1A1AA', third: '#CD7F32', rest: '#52525B' },
+  matrix: { correct: '#7C3AED', incorrect: '#DC2626' },
+} as const
+
+// ─── Status Tones ────────────────────────────────────────────────────────
+
+export const statusTones = {
+  pending: { fg: '#71717A', bg: 'rgba(113,113,122,0.12)', border: 'rgba(113,113,122,0.24)' },
+  active: { fg: '#7C3AED', bg: 'rgba(124,58,237,0.10)', border: 'rgba(124,58,237,0.24)' },
+  running: { fg: '#0891B2', bg: 'rgba(8,145,178,0.10)', border: 'rgba(8,145,178,0.24)' },
+  submitted: { fg: '#D97706', bg: 'rgba(217,119,6,0.10)', border: 'rgba(217,119,6,0.24)' },
+  in_review: { fg: '#D97706', bg: 'rgba(217,119,6,0.10)', border: 'rgba(217,119,6,0.24)' },
+  approved: { fg: '#16A34A', bg: 'rgba(22,163,74,0.10)', border: 'rgba(22,163,74,0.24)' },
+  completed: { fg: '#16A34A', bg: 'rgba(22,163,74,0.10)', border: 'rgba(22,163,74,0.24)' },
+  rejected: { fg: '#DC2626', bg: 'rgba(220,38,38,0.10)', border: 'rgba(220,38,38,0.24)' },
+  failed: { fg: '#DC2626', bg: 'rgba(220,38,38,0.10)', border: 'rgba(220,38,38,0.24)' },
+  needs_changes: { fg: '#D97706', bg: 'rgba(217,119,6,0.10)', border: 'rgba(217,119,6,0.24)' },
+  draft: { fg: '#71717A', bg: 'rgba(113,113,122,0.08)', border: 'rgba(113,113,122,0.16)' },
+  archived: { fg: '#A1A1AA', bg: 'rgba(161,161,170,0.06)', border: 'rgba(161,161,170,0.12)' },
+} as const
+
+// ─── Primitives ──────────────────────────────────────────────────────────
+
+export const radii = { xs: 4, sm: 6, md: 10, lg: 14, xl: 20, pill: 999 } as const
+export const spacingUnit = 8
+
+export const zIndex = {
+  contentBelow: 0,
+  content: 1,
+  rail: 1000,
+  topBar: 1200,
+  drawer: 1300,
+  modal: 1400,
+  snackbar: 1500,
+  tooltip: 1600,
+} as const
+
+export const layout = {
+  topBarHeight: 60,
+  topBarHeightWithBorder: 61,
+  railWidth: 64,
+  railWidthExpanded: 180,
+  contentPadding: 28,
+} as const
+
+export const fontFamily = {
+  sans: "'Inter', 'Roboto', 'Helvetica Neue', system-ui, -apple-system, sans-serif",
+  mono: "'JetBrains Mono', 'Fira Code', 'SF Mono', Menlo, monospace",
+} as const
+
+export const fontWeight = {
+  regular: 400,
+  medium: 500,
+  semibold: 600,
+  bold: 700,
+} as const
+
+export const duration = { fast: 120, standard: 200, slow: 320 } as const

--- a/packages/ui/src/theme/tokens.ts
+++ b/packages/ui/src/theme/tokens.ts
@@ -2,18 +2,26 @@
  * Design tokens — the source of truth for color, spacing, radius, type.
  *
  * Three-layer color system:
- *   Layer 1: Brand identity (purple, teal, blue) — sparingly, for emphasis
+ *   Layer 1: Accent ramps (purple, teal, blue) — the *default* palette
  *   Layer 2: Product foundation (neutrals, surfaces) — 90% of daily UI
- *   Layer 3: Semantic + data viz — restrained, mature
+ *   Layer 3: Semantic — success/warning/error/info
  *
- * Usage rules:
- *   Purple → primary action, active selection, product identity, focus
- *   Teal   → data signals, analysis accents, intelligence layer
+ * These are defaults, not a fixed identity. The purple accent is wired in
+ * as `palette.primary` only so the library has a sensible out-of-the-box
+ * look; consumers re-theme by passing their own `primary` (and friends) to
+ * `createTheme` / `MindtraceProvider`. Everything that signals "active /
+ * selected / focused" derives from `palette.primary` at render time, so
+ * turning the primary knob recolors the whole UI — see `theme/components.ts`
+ * and `theme/palette.ts`.
+ *
+ * Usage rules (for the defaults):
+ *   Accent (primary) → primary action, active selection, focus
+ *   Teal   → data signals, analysis accents
  *   Blue   → secondary emphasis, links, informational
  *   Neutrals → surfaces, text, borders, panels, dense operational areas
  */
 
-// ─── Layer 1: Brand Identity ─────────────────────────────────────────────
+// ─── Layer 1: Accent ramps (default palette) ─────────────────────────────
 
 export const brand = {
   purple: {
@@ -48,7 +56,6 @@ export const brand = {
     600: '#2563EB',
     700: '#1D4ED8',
   },
-  gradient: { start: '#14B8A6', mid: '#3B82F6', end: '#7C3AED' },
 } as const
 
 // ─── Layer 2: Product Foundation ─────────────────────────────────────────
@@ -81,24 +88,6 @@ export const semantic = {
 export const dataViz = {
   series: ['#7C3AED', '#14B8A6', '#3B82F6', '#F59E0B', '#EC4899', '#8B5CF6', '#06B6D4', '#F97316'],
   ranking: { first: '#F59E0B', second: '#A1A1AA', third: '#CD7F32', rest: '#52525B' },
-  matrix: { correct: '#7C3AED', incorrect: '#DC2626' },
-} as const
-
-// ─── Status Tones ────────────────────────────────────────────────────────
-
-export const statusTones = {
-  pending: { fg: '#71717A', bg: 'rgba(113,113,122,0.12)', border: 'rgba(113,113,122,0.24)' },
-  active: { fg: '#7C3AED', bg: 'rgba(124,58,237,0.10)', border: 'rgba(124,58,237,0.24)' },
-  running: { fg: '#0891B2', bg: 'rgba(8,145,178,0.10)', border: 'rgba(8,145,178,0.24)' },
-  submitted: { fg: '#D97706', bg: 'rgba(217,119,6,0.10)', border: 'rgba(217,119,6,0.24)' },
-  in_review: { fg: '#D97706', bg: 'rgba(217,119,6,0.10)', border: 'rgba(217,119,6,0.24)' },
-  approved: { fg: '#16A34A', bg: 'rgba(22,163,74,0.10)', border: 'rgba(22,163,74,0.24)' },
-  completed: { fg: '#16A34A', bg: 'rgba(22,163,74,0.10)', border: 'rgba(22,163,74,0.24)' },
-  rejected: { fg: '#DC2626', bg: 'rgba(220,38,38,0.10)', border: 'rgba(220,38,38,0.24)' },
-  failed: { fg: '#DC2626', bg: 'rgba(220,38,38,0.10)', border: 'rgba(220,38,38,0.24)' },
-  needs_changes: { fg: '#D97706', bg: 'rgba(217,119,6,0.10)', border: 'rgba(217,119,6,0.24)' },
-  draft: { fg: '#71717A', bg: 'rgba(113,113,122,0.08)', border: 'rgba(113,113,122,0.16)' },
-  archived: { fg: '#A1A1AA', bg: 'rgba(161,161,170,0.06)', border: 'rgba(161,161,170,0.12)' },
 } as const
 
 // ─── Primitives ──────────────────────────────────────────────────────────
@@ -125,6 +114,12 @@ export const layout = {
   contentPadding: 28,
 } as const
 
+// `Inter` / `JetBrains Mono` lead the stacks as a *progressive enhancement*:
+// the package does not ship or load them, so a consumer only gets that face if
+// they install + load it themselves (the design reference uses Inter — see the
+// README "Fonts" note). Without it the stack falls back to Roboto / system-ui,
+// which is the guaranteed-available look. No font-specific OpenType features
+// are forced in CssBaseline, so the fallback renders cleanly.
 export const fontFamily = {
   sans: "'Inter', 'Roboto', 'Helvetica Neue', system-ui, -apple-system, sans-serif",
   mono: "'JetBrains Mono', 'Fira Code', 'SF Mono', Menlo, monospace",

--- a/packages/ui/src/theme/typography.ts
+++ b/packages/ui/src/theme/typography.ts
@@ -1,0 +1,130 @@
+/**
+ * Typography scale.
+ *
+ * Standard MUI variants plus six custom variants for dense operational
+ * surfaces:
+ *   - `subheading`    — h3-equivalent inline heading
+ *   - `sectionLabel`  — small uppercase section label
+ *   - `metricLabel`   — KPI tile label
+ *   - `tinyLabel`     — micro uppercase label
+ *   - `microCaption`  — smaller caption
+ *   - `mono`          — IDs, hashes, code
+ *   - `label`         — small uppercase label (alias of metricLabel kept for back-compat)
+ */
+
+import type { TypographyVariantsOptions, TypographyStyle } from '@mui/material/styles'
+import { fontFamily, fontWeight } from './tokens'
+
+declare module '@mui/material/styles' {
+  interface TypographyVariants {
+    subheading: TypographyStyle
+    sectionLabel: TypographyStyle
+    metricLabel: TypographyStyle
+    tinyLabel: TypographyStyle
+    microCaption: TypographyStyle
+    mono: TypographyStyle
+    label: TypographyStyle
+  }
+  interface TypographyVariantsOptions {
+    subheading?: TypographyStyle
+    sectionLabel?: TypographyStyle
+    metricLabel?: TypographyStyle
+    tinyLabel?: TypographyStyle
+    microCaption?: TypographyStyle
+    mono?: TypographyStyle
+    label?: TypographyStyle
+  }
+}
+
+declare module '@mui/material/Typography' {
+  interface TypographyPropsVariantOverrides {
+    subheading: true
+    sectionLabel: true
+    metricLabel: true
+    tinyLabel: true
+    microCaption: true
+    mono: true
+    label: true
+  }
+}
+
+export const typography: TypographyVariantsOptions = {
+  fontFamily: fontFamily.sans,
+  fontWeightRegular: fontWeight.regular,
+  fontWeightMedium: fontWeight.medium,
+  fontWeightBold: fontWeight.semibold,
+
+  h1: { fontWeight: fontWeight.semibold, fontSize: '2rem', letterSpacing: '-0.02em' },
+  h2: { fontWeight: fontWeight.semibold, fontSize: '1.75rem', letterSpacing: '-0.02em' },
+  h3: { fontWeight: fontWeight.semibold, fontSize: '1.5rem', letterSpacing: '-0.01em' },
+  h4: { fontWeight: fontWeight.semibold, fontSize: '1.375rem', letterSpacing: '-0.01em' },
+  h5: { fontWeight: fontWeight.semibold, fontSize: '1.125rem' },
+  h6: { fontWeight: fontWeight.semibold, fontSize: '1rem' },
+  subtitle1: { fontWeight: fontWeight.medium, fontSize: '0.9375rem' },
+  subtitle2: {
+    fontWeight: fontWeight.semibold,
+    fontSize: '0.78rem',
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+  },
+  body1: { fontSize: '0.9375rem', lineHeight: 1.55 },
+  body2: { fontSize: '0.8125rem', lineHeight: 1.5 },
+  caption: { fontSize: '0.78rem', lineHeight: 1.4 },
+  button: { textTransform: 'none', fontWeight: fontWeight.medium },
+
+  subheading: {
+    fontFamily: fontFamily.sans,
+    fontWeight: fontWeight.semibold,
+    fontSize: '0.95rem',
+    letterSpacing: '-0.005em',
+    lineHeight: 1.3,
+  },
+  sectionLabel: {
+    fontFamily: fontFamily.sans,
+    fontWeight: fontWeight.bold,
+    fontSize: '0.75rem',
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    lineHeight: 1.3,
+  },
+  metricLabel: {
+    fontFamily: fontFamily.sans,
+    fontWeight: fontWeight.semibold,
+    fontSize: '0.78rem',
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    lineHeight: 1.3,
+  },
+  tinyLabel: {
+    fontFamily: fontFamily.sans,
+    fontWeight: fontWeight.bold,
+    fontSize: '0.72rem',
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    lineHeight: 1.3,
+  },
+  microCaption: {
+    fontFamily: fontFamily.sans,
+    fontWeight: fontWeight.regular,
+    fontSize: '0.78rem',
+    lineHeight: 1.4,
+  },
+  mono: {
+    fontFamily: fontFamily.mono,
+    fontSize: '0.72rem',
+    fontWeight: fontWeight.medium,
+    lineHeight: 1.4,
+  },
+  // Back-compat alias for our existing `label` variant — same shape as metricLabel.
+  label: {
+    fontFamily: fontFamily.sans,
+    fontWeight: fontWeight.semibold,
+    fontSize: '0.78rem',
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    lineHeight: 1.3,
+  },
+}
+
+export const FONT_FAMILY_SANS = fontFamily.sans
+export const FONT_FAMILY_MONO = fontFamily.mono

--- a/packages/ui/src/theme/typography.ts
+++ b/packages/ui/src/theme/typography.ts
@@ -9,7 +9,6 @@
  *   - `tinyLabel`     — micro uppercase label
  *   - `microCaption`  — smaller caption
  *   - `mono`          — IDs, hashes, code
- *   - `label`         — small uppercase label (alias of metricLabel kept for back-compat)
  */
 
 import type { TypographyVariantsOptions, TypographyStyle } from '@mui/material/styles'
@@ -23,7 +22,6 @@ declare module '@mui/material/styles' {
     tinyLabel: TypographyStyle
     microCaption: TypographyStyle
     mono: TypographyStyle
-    label: TypographyStyle
   }
   interface TypographyVariantsOptions {
     subheading?: TypographyStyle
@@ -32,7 +30,6 @@ declare module '@mui/material/styles' {
     tinyLabel?: TypographyStyle
     microCaption?: TypographyStyle
     mono?: TypographyStyle
-    label?: TypographyStyle
   }
 }
 
@@ -44,7 +41,6 @@ declare module '@mui/material/Typography' {
     tinyLabel: true
     microCaption: true
     mono: true
-    label: true
   }
 }
 
@@ -114,15 +110,6 @@ export const typography: TypographyVariantsOptions = {
     fontSize: '0.72rem',
     fontWeight: fontWeight.medium,
     lineHeight: 1.4,
-  },
-  // Back-compat alias for our existing `label` variant — same shape as metricLabel.
-  label: {
-    fontFamily: fontFamily.sans,
-    fontWeight: fontWeight.semibold,
-    fontSize: '0.78rem',
-    textTransform: 'uppercase',
-    letterSpacing: '0.06em',
-    lineHeight: 1.3,
   },
 }
 

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "vitest.setup.ts", "vitest.config.ts"]
+}

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from 'tsup'
+
+/**
+ * Build config — emits ESM + CJS + .d.ts for the package entrypoints.
+ *
+ * Externalized: all peer dependencies. The consumer brings React, MUI,
+ * and emotion; we don't bundle them.
+ */
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    theme: 'src/theme/index.ts',
+    tokens: 'src/theme/tokens.ts',
+    provider: 'src/providers/MindtraceProvider.tsx',
+  },
+  format: ['esm', 'cjs'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  external: [
+    'react',
+    'react-dom',
+    'react/jsx-runtime',
+    '@mui/material',
+    '@mui/material/styles',
+    '@mui/icons-material',
+    '@emotion/react',
+    '@emotion/styled',
+  ],
+  esbuildOptions(opts) {
+    opts.jsx = 'automatic'
+  },
+})

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,28 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./vitest.setup.ts'],
+    css: false,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      exclude: [
+        'node_modules/**',
+        'dist/**',
+        'storybook-static/**',
+        '.storybook/**',
+        '**/*.stories.tsx',
+        '**/*.stories.ts',
+        'vitest.*',
+        'tsup.config.ts',
+        'src/index.ts',
+        'src/**/index.ts',
+      ],
+    },
+  },
+})

--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -1,0 +1,10 @@
+import '@testing-library/jest-dom/vitest'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+})
+
+// JSDOM doesn't ship a working clipboard API; tests that exercise
+// `useCopyToClipboard` stub it via `Object.defineProperty(navigator, …)`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,20 @@ test = """
     bash scripts/run_tests.sh ${@:-}
 """
 
+test_ui = """
+    # Run the @mindtrace/ui (vitest) test suite. The package is a
+    # standalone JS/TS library at packages/ui — this is just a `ds`-
+    # flavored shortcut to its own test runner so the team has the same
+    # UX as the Python suite.
+    #
+    # ds test_ui                          # run once
+    # ds test_ui --watch                  # watch mode
+    # ds test_ui --coverage               # with coverage
+    # ds test_ui: src/components/Button   # specific path/pattern
+
+    bash packages/ui/scripts/run-tests.sh ${@:-}
+"""
+
 publish_to_pypi = """
     # Push all packages to PyPI
     # First build all packages: uv build --all-packages


### PR DESCRIPTION
# Add `@mindtrace/ui` — operational-UI component library

## Summary

Introduces `@mindtrace/ui`, a public, brand-agnostic React component library
at `packages/ui/`. It packages a calm, MUI-based theme system plus
~40 components and patterns aimed at **data-heavy operational interfaces**
(admin tools, dashboards, internal back-offices, control panels).

The library is self-contained at `packages/ui/`. The only monorepo touchpoint
is one optional `ds test_ui` shortcut in the root `pyproject.toml` so the team
has the same `ds`-flavored UX as the Python suite — everything else lives
inside the package and would travel with it if/when it's extracted to its own
repo.

## What's in the package

### Theme system

- `MindtraceProvider` — single root provider (StyledEngineProvider →
  ThemeProvider → CssBaseline), accepts `mode`, `theme`, or
  `disableCssBaseline`
- `lightTheme` / `darkTheme` / `getTheme(mode)`
- Full design-token system: palette (with extended `surface.*` /
  `border.*`), typography (with operational variants like `mono`,
  `tinyLabel`, `metricLabel`), shape, shadows, components, z-index, layout
- Three subpath exports: `@mindtrace/ui`, `@mindtrace/ui/theme`,
  `@mindtrace/ui/tokens`

### Thin MUI wrappers (consistent API + sensible defaults)

`Button`, `TextField`, `Select`, `Card`, `Badge`, `Alert`, `Modal`,
`Drawer`, `Checkbox`, `Switch`, `Radio` / `RadioGroup`, `Tabs`,
`CopyButton`, `Avatar`, `ConfirmDialog`, `Toast` /
`ToastProvider` / `useToast`

### Layout primitives (slot-based, no business logic)

`AppShell`, `AppBar`, `PrimaryRail`, `PageContainer`, `PageLayout`,
`UserMenu`, `HeroBackground`

### Bespoke generic patterns

`PageHeader`, `FormSection`, `EmptyState`, `DataTable`, `KpiCard`,
`SectionCard`, `FilterChips`, `SearchField`, `StatusDot`, `StatusBadge`,
`SeverityBadge`, `NumberBadge`, `Mono`, `PathBreadcrumb`, `Wizard`

### Hooks

`useCopyToClipboard`

### MUI re-exports for layout / nav / data display

`Box`, `Stack`, `Grid`, `Container`, `Typography`, `Tooltip`, `Chip`,
`Menu`, `Popover`, `Pagination`, `Stepper`, `Accordion`, `Snackbar`,
table primitives, list primitives, etc. — so app code rarely needs to
reach for `@mui/material` directly.

## What's interesting

### 1. Theme Builder (Foundations / Theme Builder)

A live-controls Storybook story that:

- Lets you author a theme in the browser by tweaking primary / secondary /
  success / warning / error / info / background / text + radius + font
- Renders a kitchen-sink showcase of every component against the
  constructed theme
- Uses the same `MindtraceProvider` consumers use, so what you see is what
  ships
- Includes ready-made presets (`Mindtrace Light/Dark`, `Custom Blue/Green/
  Dark`)

### 2. Seven-theme Storybook toolbar picker

The theme switcher in the Storybook toolbar (top-right) now exposes seven
real `Theme` objects, not just light/dark — `Mindtrace · Light/Dark`,
`Slate · Light`, `Emerald · Light`, `Amber · Light`, `Indigo · Dark`,
`Cyan · Dark`. Lets reviewers validate the library against multiple brand
palettes without touching code. Presets live in `.storybook/themes.ts`
(Storybook-only, not exported from the public package — the library stays
brand-agnostic).

### 3. Tests

- **vitest** + **@testing-library/react** + **jsdom**, fully wired
- 41 test files, **81 tests passing**
- Smoke tests for every component + interaction tests for the behavioral
  ones (Button, TextField, Select, Modal, Drawer, FilterChips, Wizard,
  Tabs, ConfirmDialog, Toast, PathBreadcrumb, PrimaryRail, UserMenu,
  DataTable, SearchField, Checkbox/Switch/Radio, CopyButton + hook,
  theme exports, provider)
- Custom `src/test-utils.tsx` wraps every render in `MindtraceProvider`
  so theme tokens resolve

### 4. Storybook polish

- Every component has typed `argTypes` so the **Controls** panel shows
  pickers (inline-radio for enums, color pickers for colors, range
  sliders for numbers, text for strings) — not the raw 300-prop MUI
  inherited list
- Auto-detected props are filtered to skip anything inherited from
  `node_modules` (`reactDocgenTypescriptOptions.propFilter`) — keeps
  the panel curated
- Every callback wired with `fn()` from `@storybook/test` so the
  **Actions** panel logs them
- Behavioral stories include `play()` functions exercised in the
  **Interactions** panel (Modal open + cancel, Wizard navigate to
  finish, Toast show + dismiss, Tab switch, etc.)
- a11y addon enabled

### 5. Accessibility

`StatusBadge`, `SeverityBadge`, `NumberBadge` separate the tone-carrying
surface (colored dot / colored background) from the **text**, which uses
`text.primary` for WCAG AA contrast. Severity badges default to the
classic filled style (white text on solid tone) for the strongest
accessible read.

### 6. Docs

Six markdown guides in `packages/ui/docs/` aimed at both humans and AI
coding tools:

- `AI_USAGE_GUIDE.md` — rules for AI coding tools using this library
- `UI_PHILOSOPHY.md` — what this UI is for (and isn't)
- `COMPONENT_GUIDELINES.md` — when to use which component
- `STORYBOOK_USAGE.md` — Storybook as source of truth
- `DESIGN_TOKENS.md` — tokens and how to use them
- `PUBLIC_PACKAGE_BOUNDARIES.md` — what's allowed in the public package
  + concrete examples of generalizing internal concepts

## Layout

```
packages/ui/
├── docs/                       — AI / human guides
├── scripts/run-tests.sh        — self-contained vitest runner
├── src/
│   ├── index.ts                — top-level barrel
│   ├── providers/              — MindtraceProvider
│   ├── theme/                  — tokens, palette, typography, shape,
│   │                            shadows, components, theme assembly
│   ├── components/             — wrappers, layout, patterns; each
│   │   │                        component in its own folder with
│   │   │                        Component.tsx + .stories.tsx +
│   │   │                        .test.tsx + index.ts
│   │   ├── Button/
│   │   ├── …
│   │   └── index.ts            — component barrel
│   ├── hooks/                  — useCopyToClipboard + barrel
│   ├── stories/                — Foundations + Introduction
│   └── test-utils.tsx          — render() wrapped in MindtraceProvider
├── .storybook/                 — preview, manager, themes, main
├── package.json
├── tsconfig.json
├── tsup.config.ts
├── vitest.config.ts
├── vitest.setup.ts
└── README.md
```

## How to run

### Storybook (interactive review)

```bash
cd packages/ui
npm install                     # one-time
npm run storybook               # → http://localhost:6006
```

### Tests

```bash
# From the package
npm test                        # full suite, one shot
npm run test:watch              # watch mode
npm run test:coverage           # coverage report → coverage/

# Or from the monorepo root (optional `ds` shortcut)
ds test_ui
ds test_ui --watch
ds test_ui --coverage
ds test_ui: src/components/Button
```

### Build

```bash
cd packages/ui
npm run build                   # tsup → ESM + CJS + .d.ts in dist/
npm run typecheck               # tsc --noEmit
```

## Public-package boundary

The package is intended for public publication as `@mindtrace/ui`. It
contains primitives and generic patterns only — no customer names, no
domain terminology (datasets, inspections, cameras, defects, labelling,
plants, lines, PLCs, DAGs), no business workflows. Examples in stories
use generic placeholders (Members / Projects / Active users / nightly
jobs / image resize / etc.).

See `packages/ui/docs/PUBLIC_PACKAGE_BOUNDARIES.md` for the boundary
rules + the rename list applied during this PR (e.g. `DatasetSelector` →
`ResourceSelector`, `InspectionRunTable` → `DataTable`, etc.).

## Monorepo footprint

This PR's monorepo footprint is a single block in `pyproject.toml`
(14 lines under `[tool.ds.scripts.test_ui]`) that shells into
`packages/ui/scripts/run-tests.sh`. No other root-level files are touched.

If/when the package gets extracted to its own repo:
1. `git mv packages/ui ~/some-repo/`
2. Remove the `test_ui` block from monorepo `pyproject.toml`
3. Done — the package is fully self-contained.

## Future work (not in this PR)

Captured in a follow-up audit; nothing is blocking the merge:

- Form integration helpers (react-hook-form bindings)
- `DateField` / `TimeField` (optional `@mui/x-date-pickers` peer)
- `Banner`, `DefinitionList`, `Truncate`, `Tag` / `TagInput`,
  `CommandPalette`, `Sparkline`
- `useDebounce`, `useLocalStorage`, `useColorMode`, `useShortcut`
- Sorting / row-selection on `DataTable`
- Responsive `AppBar` (mobile hamburger collapse for `PrimaryRail`)
- `changesets` + GitHub Actions release workflow
- npm-publication cleanup pass (repo/homepage/bugs/keywords metadata,
  absolute GitHub URLs for `docs/*` links so they render on npmjs.com)

## Test plan

- [ ] `cd packages/ui && npm install && npm test` → 81/81 pass
- [ ] `npm run typecheck` clean
- [ ] `npm run build` produces `dist/index.{cjs,js,d.ts}` + the three
      subpath entries (`theme`, `tokens`, `provider`)
- [ ] `npm run storybook` boots; sidebar shows Introduction, Foundations
      (Theme Builder, Palette, Typography, Shape, Shadows, Stack & Grid),
      Components (~24 entries), Layout (6 entries), Patterns (~12
      entries)
- [ ] Toolbar theme picker (top-right) cycles through all 7 presets;
      every story re-renders
- [ ] Foundations / Theme Builder → Playground: tweak `primary` to
      `#15803D`, confirm every component in the showcase recolours
- [ ] Open any behavioral story (Wizard / Modal / Toast / Tabs /
      ConfirmDialog) and the Interactions panel replays the `play()`
- [ ] a11y panel on Components / Button reports zero violations

### Hero

1. **Sidebar + Introduction page** — full Storybook chrome
   
<img width="3008" height="1569" alt="Screenshot 2026-05-13 at 13 35 48" src="https://github.com/user-attachments/assets/90563dc7-fadc-4938-97c4-33d1e227c824" />

### Theming

**Theme Builder**

<img width="3002" height="1562" alt="Screenshot 2026-05-13 at 13 36 56" src="https://github.com/user-attachments/assets/7c50e3d7-90b3-4e61-a054-0e7e72a0c397" />

**Palette swatches**


<img width="2999" height="1567" alt="Screenshot 2026-05-13 at 13 38 16" src="https://github.com/user-attachments/assets/edc4d9c4-9b39-4808-a364-35068c2a4707" />

**Typography scale**

<img width="2995" height="1565" alt="Screenshot 2026-05-13 at 13 39 42" src="https://github.com/user-attachments/assets/6a5ddfde-d303-40a7-9f4d-c55a73ba06b2" />

### Storybook UX itself

1. **Controls panel** on any story — pick something like `Components / Button`
    and screenshot the right-hand panel showing typed argTypes
2. **Actions panel** — click a button in Storybook and screenshot the
    logged action
3. **Interactions panel** — open `Patterns / Wizard / Flow to finish`,
    re-run the play function, screenshot the step-by-step replay
