### PR TITLE
registry: add base materializers and Protocol

### DIFF
--- a/mindtrace/datalake/mindtrace/datalake/data_vault.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault.py
@@ -1,7 +1,7 @@
 """High-level alias-based access to datalake assets and payloads.
 
 Serialization uses the same registry/store stack as :class:`~mindtrace.datalake.AsyncDatalake`
-(``put_object`` / ``get_object``), so ZenML materializers registered on ``Registry`` apply.
+(``put_object`` / ``get_object``), so registry materializers registered on ``Registry`` apply.
 
 Facades:
 
@@ -60,7 +60,6 @@ from uuid import uuid4
 
 from PIL import Image
 from pydantic import BaseModel, Field
-from zenml.materializers.base_materializer import BaseMaterializer
 
 from mindtrace.database.core.exceptions import DocumentNotFoundError
 from mindtrace.datalake.annotations import AnnotationVariants, annotation_from_record
@@ -103,7 +102,7 @@ from mindtrace.datalake.vault_serialization import (
     extract_serialization_block,
     materialize_payload_with_hints,
 )
-from mindtrace.registry import Registry
+from mindtrace.registry import Materializer, Registry
 
 _SYNC_VAULT_METHODS = _SYNC_VAULT_METHOD_NAMES
 _DATA_VAULT_METADATA_QUERY_PREFIX = "metadata.mindtrace.data_vault"
@@ -1419,7 +1418,7 @@ class AsyncDataVault:
         To load by ``asset_id`` from :meth:`list_assets`, use :meth:`load_by_asset_id`.
 
         When ``materialize`` is True and a :class:`~mindtrace.registry.Registry` is provided (via
-        ``registry=`` or the vault constructor), byte payloads are passed through ZenML materializers
+        ``registry=`` or the vault constructor), byte payloads are passed through registry materializers
         using hints stored under ``Asset.metadata["mindtrace.serialization"]`` (see
         :mod:`mindtrace.datalake.vault_serialization`). In-process datalake backends may already
         return materialized objects; in that case this step is skipped for non-bytes results.
@@ -1465,7 +1464,7 @@ class AsyncDataVault:
         asset_metadata: dict[str, Any] | None = None,
         object_metadata: dict[str, Any] | None = None,
         on_conflict: str | None = None,
-        materializer: type[BaseMaterializer] | None = None,
+        materializer: type[Materializer] | None = None,
     ) -> Asset:
         """Store ``obj`` and register ``alias`` (unless it equals the new ``asset_id``)."""
         resolved_kind, resolved_media = _infer_kind_media(obj, kind, media_type)
@@ -2500,7 +2499,7 @@ class DataVault:
         To load by ``asset_id`` from :meth:`list_assets`, use :meth:`load_by_asset_id`.
 
         When ``materialize`` is True and a :class:`~mindtrace.registry.Registry` is provided (via
-        ``registry=`` or the vault constructor), byte payloads are passed through ZenML materializers
+        ``registry=`` or the vault constructor), byte payloads are passed through registry materializers
         using hints stored under ``Asset.metadata["mindtrace.serialization"]`` (see
         :mod:`mindtrace.datalake.vault_serialization`). In-process datalake backends may already
         return materialized objects; in that case this step is skipped for non-bytes results.
@@ -2546,7 +2545,7 @@ class DataVault:
         asset_metadata: dict[str, Any] | None = None,
         object_metadata: dict[str, Any] | None = None,
         on_conflict: str | None = None,
-        materializer: type[BaseMaterializer] | None = None,
+        materializer: type[Materializer] | None = None,
     ) -> Asset:
         """Store ``obj`` and register ``alias`` (unless it equals the new ``asset_id``)."""
         resolved_kind, resolved_media = _infer_kind_media(obj, kind, media_type)

--- a/mindtrace/datalake/mindtrace/datalake/vault_serialization.py
+++ b/mindtrace/datalake/mindtrace/datalake/vault_serialization.py
@@ -1,7 +1,7 @@
 """Conventions for registry ``class`` / ``materializer`` hints on :class:`~mindtrace.datalake.types.Asset`.
 
 These hints let a :class:`~mindtrace.datalake.DataVault` client that only receives **bytes** from a
-remote ``objects.get``-style API reconstruct a Python value using the same ZenML materializers as
+remote ``objects.get``-style API reconstruct a Python value using the same materializers as
 :class:`~mindtrace.registry.Registry`, provided the payload matches a **single-file** staged layout
 (see :meth:`~mindtrace.registry.Registry.materialize_from_bytes`).
 """
@@ -11,14 +11,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Type
 
-from zenml.materializers.base_materializer import BaseMaterializer
-
 from mindtrace.datalake.types import Asset
-from mindtrace.registry import Registry
+from mindtrace.registry import Materializer, Registry
 
 SERIALIZATION_METADATA_KEY = "mindtrace.serialization"
 
-BYTES_MATERIALIZER = "zenml.materializers.BytesMaterializer"
+BYTES_MATERIALIZER = "mindtrace.registry.archivers.builtin_materializers.BytesMaterializer"
 BYTES_CLASS = "builtins.bytes"
 DEFAULT_BYTES_FILES = ("data.txt",)
 
@@ -41,7 +39,7 @@ def serialization_block_for_save(
     obj: Any,
     *,
     registry: Registry | None,
-    materializer: Type[BaseMaterializer] | None = None,
+    materializer: Type[Materializer] | None = None,
 ) -> dict[str, Any]:
     """Build the ``mindtrace.serialization`` payload for an object about to be stored."""
     if isinstance(obj, (bytes, bytearray, Path)):
@@ -60,7 +58,7 @@ def augment_asset_metadata_for_vault_save(
     asset_metadata: dict[str, Any] | None,
     *,
     registry: Registry | None,
-    materializer: Type[BaseMaterializer] | None = None,
+    materializer: Type[Materializer] | None = None,
 ) -> dict[str, Any]:
     """Merge auto serialization hints into ``asset_metadata`` unless the user already set the key."""
     merged = dict(asset_metadata or {})
@@ -92,8 +90,8 @@ def materialize_payload_with_hints(
 ) -> Any:
     """Decode *raw* using *serialization* hints and :meth:`~mindtrace.registry.Registry.materialize_from_bytes`.
 
-    Only **single-file** ZenML layouts are supported here; multi-file artifacts require an in-process
-    :meth:`~mindtrace.registry.Registry.load` against the backing registry.
+    Only **single-file** materializer layouts are supported here; multi-file artifacts require an
+    in-process :meth:`~mindtrace.registry.Registry.load` against the backing registry.
     """
     files = serialization.get("_files")
     if isinstance(files, list) and files and all(isinstance(x, str) for x in files):
@@ -102,9 +100,7 @@ def materialize_payload_with_hints(
         rel_paths = list(DEFAULT_BYTES_FILES)
 
     if len(rel_paths) > 1:
-        raise NotImplementedError(
-            "Materializing multi-file ZenML artifacts from a single byte payload is not implemented."
-        )
+        raise NotImplementedError("Materializing multi-file artifacts from a single byte payload is not implemented.")
 
     init_params = serialization.get("init_params") or {}
     if not isinstance(init_params, dict):

--- a/mindtrace/jobs/mindtrace/jobs/local/fifo_queue.py
+++ b/mindtrace/jobs/mindtrace/jobs/local/fifo_queue.py
@@ -1,9 +1,7 @@
 import json
 import queue
 from pathlib import Path
-from typing import Any, ClassVar, Tuple, Type
-
-from zenml.enums import ArtifactType
+from typing import Any, Type
 
 from mindtrace.registry import Archiver, Registry
 
@@ -60,9 +58,6 @@ class LocalQueue:
 
 class LocalQueueArchiver(Archiver):
     """Archiver for LocalQueue objects using JSON serialization."""
-
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (LocalQueue,)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.DATA
 
     def __init__(self, uri: str, **kwargs):
         super().__init__(uri=uri, **kwargs)

--- a/mindtrace/jobs/mindtrace/jobs/local/priority_queue.py
+++ b/mindtrace/jobs/mindtrace/jobs/local/priority_queue.py
@@ -1,9 +1,7 @@
 import json
 import queue
 from pathlib import Path
-from typing import Any, ClassVar, Tuple, Type
-
-from zenml.enums import ArtifactType
+from typing import Any, Type
 
 from mindtrace.registry import Archiver, Registry
 
@@ -66,9 +64,6 @@ class LocalPriorityQueue:
 
 class PriorityQueueArchiver(Archiver):
     """Archiver for LocalPriorityQueue objects using JSON serialization."""
-
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (LocalPriorityQueue,)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.DATA
 
     def __init__(self, uri: str, **kwargs):
         super().__init__(uri=uri, **kwargs)

--- a/mindtrace/jobs/mindtrace/jobs/local/stack.py
+++ b/mindtrace/jobs/mindtrace/jobs/local/stack.py
@@ -1,9 +1,7 @@
 import json
 import queue
 from pathlib import Path
-from typing import Any, ClassVar, Tuple, Type
-
-from zenml.enums import ArtifactType
+from typing import Any, Type
 
 from mindtrace.registry import Archiver, Registry
 
@@ -55,9 +53,6 @@ class LocalStack:
 
 class StackArchiver(Archiver):
     """Archiver for LocalStack objects using JSON serialization."""
-
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (LocalStack,)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.DATA
 
     def __init__(self, uri: str, **kwargs):
         super().__init__(uri=uri, **kwargs)

--- a/mindtrace/models/mindtrace/models/archivers/README.md
+++ b/mindtrace/models/mindtrace/models/archivers/README.md
@@ -194,7 +194,7 @@ Each archiver guards its framework import. You only need to install the librarie
 | timm | `timm` |
 | Ultralytics (YOLO/SAM) | `ultralytics` |
 
-All archivers also depend on `zenml` for artifact type definitions and the `mindtrace.registry` package for the `Archiver` base class.
+All archivers depend on the `mindtrace.registry` package for the `Archiver` base class.
 
 ## API Reference
 

--- a/mindtrace/models/mindtrace/models/archivers/huggingface/hf_model_archiver.py
+++ b/mindtrace/models/mindtrace/models/archivers/huggingface/hf_model_archiver.py
@@ -7,9 +7,7 @@ Handles saving and loading of:
 """
 
 import os
-from typing import Any, ClassVar, Tuple, Type
-
-from zenml.enums import ArtifactType
+from typing import Any, Type
 
 from mindtrace.registry import Archiver, Registry
 
@@ -40,9 +38,6 @@ class HuggingFaceModelArchiver(Archiver):
         >>> registry.save("vit:v1", model)
         >>> loaded_model = registry.load("vit:v1")
     """
-
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (PreTrainedModel,) if _HF_AVAILABLE else (object,)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.MODEL
 
     def __init__(self, uri: str, **kwargs):
         super().__init__(uri=uri, **kwargs)

--- a/mindtrace/models/mindtrace/models/archivers/huggingface/hf_processor_archiver.py
+++ b/mindtrace/models/mindtrace/models/archivers/huggingface/hf_processor_archiver.py
@@ -8,15 +8,13 @@ Handles saving and loading of:
 """
 
 import os
-from typing import Any, ClassVar, Tuple, Type
-
-from zenml.enums import ArtifactType
+from typing import Any, Type
 
 from mindtrace.registry import Archiver, Registry
 
 # Check if transformers is available
 try:
-    from transformers import (
+    from transformers import (  # noqa: F401
         FeatureExtractionMixin,
         ImageProcessingMixin,
         PreTrainedTokenizerBase,
@@ -24,15 +22,8 @@ try:
     )
 
     _HF_AVAILABLE = True
-    _HF_PROCESSOR_TYPES: Tuple[Type[Any], ...] = (
-        PreTrainedTokenizerBase,
-        ProcessorMixin,
-        ImageProcessingMixin,
-        FeatureExtractionMixin,
-    )
 except ImportError:
     _HF_AVAILABLE = False
-    _HF_PROCESSOR_TYPES = (object,)  # Fallback to prevent ZenML error
 
 
 class HuggingFaceProcessorArchiver(Archiver):
@@ -50,9 +41,6 @@ class HuggingFaceProcessorArchiver(Archiver):
         >>> registry.save("vit_processor:v1", processor)
         >>> loaded_processor = registry.load("vit_processor:v1")
     """
-
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = _HF_PROCESSOR_TYPES
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.DATA
 
     def __init__(self, uri: str, **kwargs):
         super().__init__(uri=uri, **kwargs)

--- a/mindtrace/models/mindtrace/models/archivers/onnx/onnx_model_archiver.py
+++ b/mindtrace/models/mindtrace/models/archivers/onnx/onnx_model_archiver.py
@@ -5,9 +5,7 @@ Handles saving and loading of ONNX models with their metadata.
 
 import json
 import os
-from typing import Any, ClassVar, Tuple, Type
-
-from zenml.enums import ArtifactType
+from typing import Any, Type
 
 from mindtrace.registry import Archiver, Registry
 
@@ -37,11 +35,6 @@ class OnnxModelArchiver(Archiver):
         >>> registry.save("onnx_model:v1", model)
         >>> loaded_model = registry.load("onnx_model:v1")
     """
-
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (
-        (ModelProto,) if _ONNX_AVAILABLE else (object,)  # Fallback to prevent ZenML error
-    )
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.MODEL
 
     def __init__(self, uri: str, **kwargs):
         super().__init__(uri=uri, **kwargs)

--- a/mindtrace/models/mindtrace/models/archivers/timm/timm_model_archiver.py
+++ b/mindtrace/models/mindtrace/models/archivers/timm/timm_model_archiver.py
@@ -6,13 +6,9 @@ configuration and weights.
 
 import json
 import os
-from typing import Any, ClassVar, Tuple, Type
+from typing import Any, Type
 
 import torch
-
-# Import timm at module level for ASSOCIATED_TYPES
-from torch import nn
-from zenml.enums import ArtifactType
 
 from mindtrace.registry import Archiver
 
@@ -40,10 +36,6 @@ class TimmModelArchiver(Archiver):
         >>> registry.save("resnet:v1", model)
         >>> loaded_model = registry.load("resnet:v1")
     """
-
-    # timm models are nn.Module but we identify them via pretrained_cfg attribute
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (nn.Module,)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.MODEL
 
     def __init__(self, uri: str, **kwargs):
         super().__init__(uri=uri, **kwargs)

--- a/mindtrace/models/mindtrace/models/archivers/ultralytics/sam_archiver.py
+++ b/mindtrace/models/mindtrace/models/archivers/ultralytics/sam_archiver.py
@@ -5,11 +5,10 @@ identifying the correct architecture by parameter count.
 """
 
 import os
-from typing import Any, ClassVar, Tuple, Type
+from typing import Any, Type
 
 import torch
 from ultralytics import SAM
-from zenml.enums import ArtifactType
 
 from mindtrace.registry import Archiver, Registry
 
@@ -24,9 +23,6 @@ class SamArchiver(Archiver):
     parameter count during save and stored in the filename so that the correct
     SAM architecture is rebuilt on load.
     """
-
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (SAM,)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.MODEL
 
     model_name: dict[int, str] = {  # maps number of params to model name
         93735472: "sam_b",

--- a/mindtrace/models/mindtrace/models/archivers/ultralytics/yolo_archiver.py
+++ b/mindtrace/models/mindtrace/models/archivers/ultralytics/yolo_archiver.py
@@ -5,11 +5,10 @@ handling for pre-PyTorch-2.6 checkpoints that require weights_only=False.
 """
 
 import os
-from typing import Any, ClassVar, Tuple, Type
+from typing import Any, Type
 
 import torch
 from ultralytics import YOLO, YOLOWorld
-from zenml.enums import ArtifactType
 
 from mindtrace.registry import Archiver, Registry
 
@@ -23,9 +22,6 @@ class YoloArchiver(Archiver):
     Handles old-format (pre-PyTorch-2.6) checkpoints that fail with
     ``weights_only=True`` by temporarily patching ``torch.load``.
     """
-
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (YOLO, YOLOWorld)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.MODEL
 
     def __init__(self, uri: str, **kwargs):
         super().__init__(uri=uri, **kwargs)

--- a/mindtrace/models/mindtrace/models/archivers/ultralytics/yoloe_archiver.py
+++ b/mindtrace/models/mindtrace/models/archivers/ultralytics/yoloe_archiver.py
@@ -4,10 +4,9 @@ Handles saving and loading of YOLOE (YOLO with Embeddings) model checkpoints.
 """
 
 import os
-from typing import Any, ClassVar, Tuple, Type
+from typing import Any, Type
 
 from ultralytics import YOLOE
-from zenml.enums import ArtifactType
 
 from mindtrace.registry import Archiver, Registry
 
@@ -18,9 +17,6 @@ class YoloEArchiver(Archiver):
     Serialization format:
         - model.pt: YOLOE weights file inside the URI directory.
     """
-
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (YOLOE,)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.MODEL
 
     def __init__(self, uri: str, **kwargs):
         super().__init__(uri=uri, **kwargs)

--- a/mindtrace/registry/README.md
+++ b/mindtrace/registry/README.md
@@ -180,19 +180,39 @@ registry.save("model", obj, version="1.0.0", on_conflict="overwrite")
 
 ## Custom Materializers
 
-Register custom serialization handlers for your object types:
+A materializer is any class that exposes a `uri` attribute, a `save(data)` method, and a
+`load(data_type)` method. The contract is published as the runtime-checkable
+`mindtrace.registry.Materializer` Protocol — your class does **not** need to inherit from
+anything in mindtrace to be recognized. For convenience, you can inherit from
+`BaseMaterializer` (minimal) or `Archiver` (adds Mindtrace logging).
 
 ```python
-from mindtrace.registry import Registry
+from typing import Any, Type
+
+from mindtrace.registry import BaseMaterializer, Registry
+
+
+class MyMaterializer(BaseMaterializer):
+    def save(self, data: Any) -> None:
+        ...  # write to self.uri
+
+    def load(self, data_type: Type[Any]) -> Any:
+        ...  # read from self.uri
+
 
 registry = Registry()
 
-# Register a materializer for a custom class
+# Register a materializer for a custom class (by type or by fully-qualified string).
 registry.register_materializer("my_module.MyClass", "my_module.MyMaterializer")
 
-# Save with explicit materializer
+# Save with an explicit materializer override.
 registry.save("custom:obj", my_object, materializer=MyMaterializer)
 ```
+
+Built-in materializers cover scalars, container types, `bytes`, `pydantic.BaseModel`,
+`pathlib.Path`, numpy arrays, PIL images, PyTorch modules/dataloaders, and HuggingFace
+datasets. ML framework archivers for HuggingFace, ONNX, Ultralytics and timm models live
+in `mindtrace.models.archivers`.
 
 ## Metadata and Information
 

--- a/mindtrace/registry/mindtrace/registry/__init__.py
+++ b/mindtrace/registry/mindtrace/registry/__init__.py
@@ -1,3 +1,10 @@
+from mindtrace.registry.archivers.builtin_materializers import (
+    BuiltInContainerMaterializer,
+    BuiltInMaterializer,
+    BytesMaterializer,
+    CloudpickleMaterializer,
+    PydanticMaterializer,
+)
 from mindtrace.registry.archivers.config_archiver import ConfigArchiver
 from mindtrace.registry.archivers.default_archivers import register_default_materializers
 from mindtrace.registry.archivers.path_archiver import PathArchiver
@@ -5,6 +12,7 @@ from mindtrace.registry.backends.local_registry_backend import LocalRegistryBack
 from mindtrace.registry.backends.registry_backend import RegistryBackend
 from mindtrace.registry.backends.s3_registry_backend import MinioRegistryBackend, S3RegistryBackend
 from mindtrace.registry.core.archiver import Archiver
+from mindtrace.registry.core.base_materializer import BaseMaterializer, Materializer
 from mindtrace.registry.core.exceptions import (
     LockTimeoutError,
     StoreAmbiguousObjectError,
@@ -28,8 +36,15 @@ from mindtrace.registry.core.store import MountedRegistry, Store
 __all__ = [
     "Archiver",
     "AmbientAuth",
+    "BaseMaterializer",
+    "BuiltInContainerMaterializer",
+    "BuiltInMaterializer",
+    "BytesMaterializer",
+    "CloudpickleMaterializer",
     "ConfigArchiver",
+    "Materializer",
     "PathArchiver",
+    "PydanticMaterializer",
     "LocalRegistryBackend",
     "LockTimeoutError",
     "GCSMountConfig",

--- a/mindtrace/registry/mindtrace/registry/archivers/builtin_materializers.py
+++ b/mindtrace/registry/mindtrace/registry/archivers/builtin_materializers.py
@@ -1,0 +1,119 @@
+"""Built-in materializers for basic Python types."""
+
+import json
+import os
+from typing import Any, Type
+
+import cloudpickle
+
+from mindtrace.registry.core.base_materializer import BaseMaterializer
+
+
+class BuiltInMaterializer(BaseMaterializer):
+    """Handle JSON-serializable basic types (bool, float, int, str, NoneType)."""
+
+    def save(self, data: Any) -> None:
+        data_path = os.path.join(self.uri, "data.json")
+        with open(data_path, "w") as f:
+            json.dump(data, f)
+
+    def load(self, data_type: Type[Any]) -> Any:
+        data_path = os.path.join(self.uri, "data.json")
+        with open(data_path) as f:
+            return json.load(f)
+
+
+class BuiltInContainerMaterializer(BaseMaterializer):
+    """Handle built-in container types (dict, list, set, tuple).
+
+    JSON-serializable containers are stored as JSON; non-serializable
+    containers fall back to cloudpickle.
+    """
+
+    def save(self, data: Any) -> None:
+        try:
+            json_str = json.dumps(data, default=_json_default)
+            data_path = os.path.join(self.uri, "data.json")
+            with open(data_path, "w") as f:
+                f.write(json_str)
+        except (TypeError, ValueError, OverflowError):
+            data_path = os.path.join(self.uri, "data.pkl")
+            with open(data_path, "wb") as f:
+                cloudpickle.dump(data, f)
+
+    def load(self, data_type: Type[Any]) -> Any:
+        json_path = os.path.join(self.uri, "data.json")
+        pkl_path = os.path.join(self.uri, "data.pkl")
+
+        if os.path.exists(json_path):
+            with open(json_path) as f:
+                outputs = json.load(f)
+        elif os.path.exists(pkl_path):
+            with open(pkl_path, "rb") as f:
+                return cloudpickle.load(f)
+        else:
+            raise FileNotFoundError(f"No data found at {self.uri}")
+
+        if issubclass(data_type, dict) and not isinstance(outputs, dict):
+            keys, values = outputs
+            return data_type(zip(keys, values))
+        if issubclass(data_type, tuple):
+            return data_type(outputs)
+        if issubclass(data_type, set):
+            return data_type(outputs)
+        return outputs
+
+
+class BytesMaterializer(BaseMaterializer):
+    """Handle bytes data type."""
+
+    def save(self, data: bytes) -> None:
+        data_path = os.path.join(self.uri, "data.txt")
+        with open(data_path, "wb") as f:
+            f.write(data)
+
+    def load(self, data_type: Type[Any]) -> bytes:
+        data_path = os.path.join(self.uri, "data.txt")
+        with open(data_path, "rb") as f:
+            return f.read()
+
+
+class PydanticMaterializer(BaseMaterializer):
+    """Handle pydantic BaseModel objects via the model's own JSON serialization."""
+
+    def save(self, data: Any) -> None:
+        data_path = os.path.join(self.uri, "data.json")
+        json_str = data.model_dump_json()
+        with open(data_path, "w") as f:
+            json.dump(json_str, f)
+
+    def load(self, data_type: Type[Any]) -> Any:
+        data_path = os.path.join(self.uri, "data.json")
+        with open(data_path) as f:
+            json_str = json.load(f)
+        return data_type.model_validate_json(json_str)
+
+
+class CloudpickleMaterializer(BaseMaterializer):
+    """Fallback materializer using cloudpickle.
+
+    Can serialize almost any Python object but artifacts are not portable
+    across Python versions.
+    """
+
+    def save(self, data: Any) -> None:
+        filepath = os.path.join(self.uri, "artifact.pkl")
+        with open(filepath, "wb") as f:
+            cloudpickle.dump(data, f)
+
+    def load(self, data_type: Type[Any]) -> Any:
+        filepath = os.path.join(self.uri, "artifact.pkl")
+        with open(filepath, "rb") as f:
+            return cloudpickle.load(f)
+
+
+def _json_default(obj: Any) -> Any:
+    """Custom JSON converter for sets and tuples."""
+    if isinstance(obj, (set, tuple)):
+        return list(obj)
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")

--- a/mindtrace/registry/mindtrace/registry/archivers/config_archiver.py
+++ b/mindtrace/registry/mindtrace/registry/archivers/config_archiver.py
@@ -1,8 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, ClassVar, Tuple, Type
-
-from zenml.enums import ArtifactType
+from typing import Any, Type
 
 from mindtrace.core import Config
 from mindtrace.registry.core.archiver import Archiver
@@ -10,9 +8,6 @@ from mindtrace.registry.core.archiver import Archiver
 
 class ConfigArchiver(Archiver):
     """Archiver for mindtrace.core.Config objects."""
-
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (Config,)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.DATA
 
     def __init__(self, uri: str, **kwargs):
         super().__init__(uri=uri, **kwargs)

--- a/mindtrace/registry/mindtrace/registry/archivers/default_archivers.py
+++ b/mindtrace/registry/mindtrace/registry/archivers/default_archivers.py
@@ -3,27 +3,26 @@ from pathlib import Path, PosixPath, WindowsPath
 from mindtrace.registry.archivers.path_archiver import PathArchiver
 from mindtrace.registry.core.registry import Registry
 
+_BUILTIN = "mindtrace.registry.archivers.builtin_materializers"
+_INTEGRATION = "mindtrace.registry.archivers.integration_materializers"
+
 
 def register_default_materializers():
-    # Core zenml materializers
-    Registry.register_default_materializer(
-        "builtins.str", "zenml.materializers.built_in_materializer.BuiltInMaterializer"
-    )
-    Registry.register_default_materializer(
-        "builtins.int", "zenml.materializers.built_in_materializer.BuiltInMaterializer"
-    )
-    Registry.register_default_materializer(
-        "builtins.float", "zenml.materializers.built_in_materializer.BuiltInMaterializer"
-    )
-    Registry.register_default_materializer(
-        "builtins.bool", "zenml.materializers.built_in_materializer.BuiltInMaterializer"
-    )
-    Registry.register_default_materializer("builtins.list", "zenml.materializers.BuiltInContainerMaterializer")
-    Registry.register_default_materializer("builtins.dict", "zenml.materializers.BuiltInContainerMaterializer")
-    Registry.register_default_materializer("builtins.tuple", "zenml.materializers.BuiltInContainerMaterializer")
-    Registry.register_default_materializer("builtins.set", "zenml.materializers.BuiltInContainerMaterializer")
-    Registry.register_default_materializer("builtins.bytes", "zenml.materializers.BytesMaterializer")
-    Registry.register_default_materializer("pydantic.BaseModel", "zenml.materializers.PydanticMaterializer")
+    # Core built-in materializers.
+    Registry.register_default_materializer("builtins.str", f"{_BUILTIN}.BuiltInMaterializer")
+    Registry.register_default_materializer("builtins.int", f"{_BUILTIN}.BuiltInMaterializer")
+    Registry.register_default_materializer("builtins.float", f"{_BUILTIN}.BuiltInMaterializer")
+    Registry.register_default_materializer("builtins.bool", f"{_BUILTIN}.BuiltInMaterializer")
+    Registry.register_default_materializer("builtins.list", f"{_BUILTIN}.BuiltInContainerMaterializer")
+    Registry.register_default_materializer("builtins.dict", f"{_BUILTIN}.BuiltInContainerMaterializer")
+    Registry.register_default_materializer("builtins.tuple", f"{_BUILTIN}.BuiltInContainerMaterializer")
+    Registry.register_default_materializer("builtins.set", f"{_BUILTIN}.BuiltInContainerMaterializer")
+    Registry.register_default_materializer("builtins.bytes", f"{_BUILTIN}.BytesMaterializer")
+    # Pydantic re-exports ``BaseModel`` from the package root, but the class's real
+    # ``__module__`` is ``pydantic.main`` — register both so MRO-based dispatch hits.
+    Registry.register_default_materializer("pydantic.BaseModel", f"{_BUILTIN}.PydanticMaterializer")
+    Registry.register_default_materializer("pydantic.main.BaseModel", f"{_BUILTIN}.PydanticMaterializer")
+
     # Path types - use PathArchiver to preserve original filenames
     Registry.register_default_materializer(Path, PathArchiver)
     Registry.register_default_materializer(PosixPath, PathArchiver)
@@ -34,65 +33,41 @@ def register_default_materializers():
         "mindtrace.core.config.config.Config", "mindtrace.registry.archivers.config_archiver.ConfigArchiver"
     )
 
-    # (Optional) Huggingface materializers
+    # (Optional) HuggingFace datasets — register both the public import path and
+    # the real ``__module__`` path so MRO-based dispatch hits.
+    Registry.register_default_materializer("datasets.Dataset", f"{_INTEGRATION}.HFDatasetMaterializer")
+    Registry.register_default_materializer("datasets.arrow_dataset.Dataset", f"{_INTEGRATION}.HFDatasetMaterializer")
+    Registry.register_default_materializer("datasets.DatasetDict", f"{_INTEGRATION}.HFDatasetMaterializer")
+    Registry.register_default_materializer("datasets.dataset_dict.DatasetDict", f"{_INTEGRATION}.HFDatasetMaterializer")
+    Registry.register_default_materializer("datasets.IterableDataset", f"{_INTEGRATION}.HFDatasetMaterializer")
     Registry.register_default_materializer(
-        "datasets.Dataset",
-        "zenml.integrations.huggingface.materializers.huggingface_datasets_materializer.HFDatasetMaterializer",
-    )
-    Registry.register_default_materializer(
-        "datasets.DatasetDict",
-        "zenml.integrations.huggingface.materializers.huggingface_datasets_materializer.HFDatasetMaterializer",
-    )
-    Registry.register_default_materializer(
-        "datasets.IterableDataset",
-        "zenml.integrations.huggingface.materializers.huggingface_datasets_materializer.HFDatasetMaterializer",
-    )
-    Registry.register_default_materializer(
-        "transformers.PreTrainedModel",
-        "zenml.integrations.huggingface.materializers.huggingface_pt_model_materializer.HFPTModelMaterializer",
-    )
-    Registry.register_default_materializer(
-        "transformers.TFPreTrainedModel",
-        "zenml.integrations.huggingface.materializers.huggingface_pt_model_materializer.HFPTModelMaterializer",
+        "datasets.iterable_dataset.IterableDataset", f"{_INTEGRATION}.HFDatasetMaterializer"
     )
 
-    # (Optional) NumPy materializers
-    Registry.register_default_materializer(
-        "numpy.ndarray", "zenml.integrations.numpy.materializers.numpy_materializer.NumpyMaterializer"
-    )
+    # (Optional) NumPy
+    Registry.register_default_materializer("numpy.ndarray", f"{_INTEGRATION}.NumpyMaterializer")
 
-    # (Optional) Pillow materializers
-    Registry.register_default_materializer(
-        "PIL.Image.Image",
-        "zenml.integrations.pillow.materializers.pillow_image_materializer.PillowImageMaterializer",
-    )
+    # (Optional) Pillow
+    Registry.register_default_materializer("PIL.Image.Image", f"{_INTEGRATION}.PillowImageMaterializer")
 
-    # (Optional) PyTorch materializers
+    # (Optional) PyTorch
     Registry.register_default_materializer(
-        "torch.utils.data.DataLoader",
-        "zenml.integrations.pytorch.materializers.pytorch_dataloader_materializer.PyTorchDataLoaderMaterializer",
+        "torch.utils.data.DataLoader", f"{_INTEGRATION}.PyTorchDataLoaderMaterializer"
+    )
+    Registry.register_default_materializer("torch.utils.data.Dataset", f"{_INTEGRATION}.PyTorchDataLoaderMaterializer")
+    Registry.register_default_materializer(
+        "torch.utils.data.IterableDataset", f"{_INTEGRATION}.PyTorchDataLoaderMaterializer"
     )
     Registry.register_default_materializer(
-        "torch.utils.data.Dataset",
-        "zenml.integrations.pytorch.materializers.pytorch_dataloader_materializer.PyTorchDataLoaderMaterializer",
+        "torch.nn.modules.module.Module", f"{_INTEGRATION}.PyTorchModuleMaterializer"
     )
     Registry.register_default_materializer(
-        "torch.utils.data.IterableDataset",
-        "zenml.integrations.pytorch.materializers.pytorch_dataloader_materializer.PyTorchDataLoaderMaterializer",
-    )
-    Registry.register_default_materializer(
-        "torch.nn.modules.module.Module",
-        "zenml.integrations.pytorch.materializers.pytorch_module_materializer.PyTorchModuleMaterializer",
-    )
-    Registry.register_default_materializer(
-        "torch.jit._script.ScriptModule",
-        "zenml.integrations.pytorch.materializers.pytorch_module_materializer.PyTorchModuleMaterializer",
+        "torch.jit._script.ScriptModule", f"{_INTEGRATION}.PyTorchModuleMaterializer"
     )
 
     # ── ML framework archivers (string-based for lazy loading) ──────────
-    # These override ZenML defaults from above. The archiver classes live in
-    # mindtrace.models.archivers and are only imported when instantiate_target()
-    # resolves them during save/load.
+    # The archiver classes live in mindtrace.models.archivers and are only
+    # imported when instantiate_target() resolves them during save/load.
 
     # Ultralytics
     Registry.register_default_materializer(

--- a/mindtrace/registry/mindtrace/registry/archivers/default_archivers.py
+++ b/mindtrace/registry/mindtrace/registry/archivers/default_archivers.py
@@ -87,7 +87,13 @@ def register_default_materializers():
         "mindtrace.models.archivers.ultralytics.yoloe_archiver.YoloEArchiver",
     )
 
-    # HuggingFace models
+    # HuggingFace models. Both the public and ``__module__`` paths registered so
+    # MRO dispatch hits. ``TFPreTrainedModel`` is intentionally omitted —
+    # ``HuggingFaceModelArchiver`` is PyTorch-only.
+    Registry.register_default_materializer(
+        "transformers.PreTrainedModel",
+        "mindtrace.models.archivers.huggingface.hf_model_archiver.HuggingFaceModelArchiver",
+    )
     Registry.register_default_materializer(
         "transformers.modeling_utils.PreTrainedModel",
         "mindtrace.models.archivers.huggingface.hf_model_archiver.HuggingFaceModelArchiver",

--- a/mindtrace/registry/mindtrace/registry/archivers/integration_materializers.py
+++ b/mindtrace/registry/mindtrace/registry/archivers/integration_materializers.py
@@ -1,0 +1,89 @@
+"""Integration materializers for third-party ML frameworks.
+
+Framework imports are local to each method so that importing this module does
+not require the optional dependencies (torch, numpy, PIL, datasets) to be
+installed.
+"""
+
+import os
+from typing import Any, Type
+
+from mindtrace.registry.core.base_materializer import BaseMaterializer
+
+
+class NumpyMaterializer(BaseMaterializer):
+    """Handle numpy ndarray objects."""
+
+    def save(self, data: Any) -> None:
+        import numpy as np
+
+        filepath = os.path.join(self.uri, "data.npy")
+        np.save(filepath, data)
+
+    def load(self, data_type: Type[Any]) -> Any:
+        import numpy as np
+
+        filepath = os.path.join(self.uri, "data.npy")
+        return np.load(filepath, allow_pickle=False)
+
+
+class PillowImageMaterializer(BaseMaterializer):
+    """Handle PIL Image objects."""
+
+    def save(self, data: Any) -> None:
+        filepath = os.path.join(self.uri, "image.png")
+        data.save(filepath)
+
+    def load(self, data_type: Type[Any]) -> Any:
+        from PIL import Image
+
+        filepath = os.path.join(self.uri, "image.png")
+        return Image.open(filepath)
+
+
+class PyTorchModuleMaterializer(BaseMaterializer):
+    """Handle PyTorch nn.Module objects."""
+
+    def save(self, data: Any) -> None:
+        import cloudpickle
+        import torch
+
+        filepath = os.path.join(self.uri, "model.pt")
+        torch.save(data, filepath, pickle_module=cloudpickle)
+
+    def load(self, data_type: Type[Any]) -> Any:
+        import torch
+
+        filepath = os.path.join(self.uri, "model.pt")
+        return torch.load(filepath, weights_only=False)
+
+
+class PyTorchDataLoaderMaterializer(BaseMaterializer):
+    """Handle PyTorch DataLoader and Dataset objects."""
+
+    def save(self, data: Any) -> None:
+        import cloudpickle
+        import torch
+
+        filepath = os.path.join(self.uri, "dataloader.pt")
+        torch.save(data, filepath, pickle_module=cloudpickle)
+
+    def load(self, data_type: Type[Any]) -> Any:
+        import torch
+
+        filepath = os.path.join(self.uri, "dataloader.pt")
+        return torch.load(filepath, weights_only=False)
+
+
+class HFDatasetMaterializer(BaseMaterializer):
+    """Handle HuggingFace datasets (Dataset, DatasetDict, IterableDataset)."""
+
+    def save(self, data: Any) -> None:
+        filepath = os.path.join(self.uri, "hf_dataset")
+        data.save_to_disk(filepath)
+
+    def load(self, data_type: Type[Any]) -> Any:
+        from datasets import load_from_disk
+
+        filepath = os.path.join(self.uri, "hf_dataset")
+        return load_from_disk(filepath)

--- a/mindtrace/registry/mindtrace/registry/archivers/path_archiver.py
+++ b/mindtrace/registry/mindtrace/registry/archivers/path_archiver.py
@@ -5,23 +5,14 @@ import shutil
 import tarfile
 import tempfile
 from pathlib import Path, PosixPath, PurePath, WindowsPath
-from typing import Any, ClassVar, Tuple, Type
-
-from zenml.enums import ArtifactType
+from typing import Any, ClassVar, Type
 
 from mindtrace.registry.core.archiver import Archiver
 
 
 class PathArchiver(Archiver):
-    """Archiver for Path objects that preserves original filenames.
+    """Archiver for Path objects that preserves original filenames."""
 
-    Unlike ZenML's PathMaterializer which saves files with a generic name,
-    this archiver preserves the original filename (including extension)
-    when saving and loading Path objects.
-    """
-
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (Path, PosixPath, WindowsPath, PurePath)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.DATA
     METADATA_FILE: ClassVar[str] = "metadata.json"
     ARCHIVE_NAME: ClassVar[str] = "data.tar.gz"
 

--- a/mindtrace/registry/mindtrace/registry/core/_registry_core.py
+++ b/mindtrace/registry/mindtrace/registry/core/_registry_core.py
@@ -6,12 +6,10 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, Tuple, Type
 
-from zenml.artifact_stores import LocalArtifactStore, LocalArtifactStoreConfig
-from zenml.materializers.base_materializer import BaseMaterializer
-
 from mindtrace.core import Mindtrace, compute_dir_hash, first_not_none, ifnone, instantiate_target
 from mindtrace.registry.backends.local_registry_backend import LocalRegistryBackend
 from mindtrace.registry.backends.registry_backend import RegistryBackend
+from mindtrace.registry.core.base_materializer import Materializer
 from mindtrace.registry.core.exceptions import (
     RegistryCleanupRequired,
     RegistryObjectNotFound,
@@ -25,6 +23,35 @@ from mindtrace.registry.core.types import (
     VerifyLevel,
     Version,
 )
+
+# Legacy zenml materializer strings that may appear in metadata written by
+# earlier versions of the registry. Resolved transparently so existing on-disk
+# registries continue to load after zenml was removed.
+_LEGACY_MATERIALIZER_ALIASES = {
+    "zenml.materializers.built_in_materializer.BuiltInMaterializer": "mindtrace.registry.archivers.builtin_materializers.BuiltInMaterializer",
+    "zenml.materializers.BuiltInMaterializer": "mindtrace.registry.archivers.builtin_materializers.BuiltInMaterializer",
+    "zenml.materializers.built_in_materializer.BuiltInContainerMaterializer": "mindtrace.registry.archivers.builtin_materializers.BuiltInContainerMaterializer",
+    "zenml.materializers.BuiltInContainerMaterializer": "mindtrace.registry.archivers.builtin_materializers.BuiltInContainerMaterializer",
+    "zenml.materializers.bytes_materializer.BytesMaterializer": "mindtrace.registry.archivers.builtin_materializers.BytesMaterializer",
+    "zenml.materializers.BytesMaterializer": "mindtrace.registry.archivers.builtin_materializers.BytesMaterializer",
+    "zenml.materializers.pydantic_materializer.PydanticMaterializer": "mindtrace.registry.archivers.builtin_materializers.PydanticMaterializer",
+    "zenml.materializers.PydanticMaterializer": "mindtrace.registry.archivers.builtin_materializers.PydanticMaterializer",
+    "zenml.materializers.cloudpickle_materializer.CloudpickleMaterializer": "mindtrace.registry.archivers.builtin_materializers.CloudpickleMaterializer",
+    "zenml.materializers.CloudpickleMaterializer": "mindtrace.registry.archivers.builtin_materializers.CloudpickleMaterializer",
+    "zenml.integrations.numpy.materializers.numpy_materializer.NumpyMaterializer": "mindtrace.registry.archivers.integration_materializers.NumpyMaterializer",
+    "zenml.integrations.pillow.materializers.pillow_image_materializer.PillowImageMaterializer": "mindtrace.registry.archivers.integration_materializers.PillowImageMaterializer",
+    "zenml.integrations.pytorch.materializers.pytorch_module_materializer.PyTorchModuleMaterializer": "mindtrace.registry.archivers.integration_materializers.PyTorchModuleMaterializer",
+    "zenml.integrations.pytorch.materializers.pytorch_dataloader_materializer.PyTorchDataLoaderMaterializer": "mindtrace.registry.archivers.integration_materializers.PyTorchDataLoaderMaterializer",
+    "zenml.integrations.huggingface.materializers.huggingface_datasets_materializer.HFDatasetMaterializer": "mindtrace.registry.archivers.integration_materializers.HFDatasetMaterializer",
+    "zenml.integrations.huggingface.materializers.huggingface_pt_model_materializer.HFPTModelMaterializer": "mindtrace.models.archivers.huggingface.hf_model_archiver.HuggingFaceModelArchiver",
+}
+
+
+def _resolve_materializer_string(s: str | None) -> str | None:
+    """Translate a legacy zenml materializer path to its in-house equivalent (idempotent)."""
+    if s is None:
+        return None
+    return _LEGACY_MATERIALIZER_ALIASES.get(s, s)
 
 
 def _version_sort_key(v: str, digits: int) -> tuple[int, ...]:
@@ -92,18 +119,10 @@ class _RegistryCore(Mindtrace):
             version_digits_explicit=version_digits is not None,
         )
 
-        self._artifact_store = LocalArtifactStore(
-            name="local_artifact_store",
-            id=None,  # Will be auto-generated
-            config=LocalArtifactStoreConfig(
-                path=str(Path(self.config["MINDTRACE_DIR_PATHS"]["TEMP_DIR"]).expanduser().resolve() / "artifact_store")
-            ),
-            flavor="local",
-            type="artifact-store",
-            user=None,  # Will be auto-generated
-            created=None,  # Will be auto-generated
-            updated=None,  # Will be auto-generated
+        self._artifact_store_path = (
+            Path(self.config["MINDTRACE_DIR_PATHS"]["TEMP_DIR"]).expanduser().resolve() / "artifact_store"
         )
+        self._artifact_store_path.mkdir(parents=True, exist_ok=True)
 
         # Materializer cache to reduce lock contention
         self._materializer_cache = {}
@@ -240,7 +259,7 @@ class _RegistryCore(Mindtrace):
 
         return self._validate_version(version)
 
-    def _find_materializer(self, obj: Any, provided_materializer: Type[BaseMaterializer] | None = None) -> str:
+    def _find_materializer(self, obj: Any, provided_materializer: Type[Materializer] | None = None) -> str:
         """Find the appropriate materializer for an object.
 
         The order of precedence for determining the materializer is:
@@ -278,7 +297,7 @@ class _RegistryCore(Mindtrace):
                     self.registered_materializer(f"{base.__module__}.{base.__name__}")
                     for base in get_all_base_classes(type(obj))
                 ],
-                object_class if isinstance(obj, BaseMaterializer) else None,
+                object_class if isinstance(obj, Materializer) else None,
             )
         )
 
@@ -323,7 +342,7 @@ class _RegistryCore(Mindtrace):
         """Build registry metadata for a bytes artifact uploaded out-of-band."""
         return {
             "class": "builtins.bytes",
-            "materializer": "zenml.materializers.BytesMaterializer",
+            "materializer": "mindtrace.registry.archivers.builtin_materializers.BytesMaterializer",
             "init_params": {},
             "metadata": ifnone(metadata, default={}),
             "_files": ["data.txt"],
@@ -334,7 +353,7 @@ class _RegistryCore(Mindtrace):
         name: str | List[str],
         obj: Any | List[Any],
         *,
-        materializer: Type[BaseMaterializer] | None = None,
+        materializer: Type[Materializer] | None = None,
         version: str | None | List[str | None] = None,
         init_params: Dict[str, Any] | List[Dict[str, Any]] | None = None,
         metadata: Dict[str, Any] | List[Dict[str, Any]] | None = None,
@@ -391,7 +410,7 @@ class _RegistryCore(Mindtrace):
         self,
         name: str,
         obj: Any,
-        materializer: Type[BaseMaterializer] | None = None,
+        materializer: Type[Materializer] | None = None,
         version: str | None = None,
         init_params: Dict[str, Any] | None = None,
         metadata: Dict[str, Any] | None = None,
@@ -409,16 +428,14 @@ class _RegistryCore(Mindtrace):
 
         # Validate version
         validated_version = self._validate_version(version)
-        with TemporaryDirectory(dir=self._artifact_store.path) as base_temp_dir:
+        with TemporaryDirectory(dir=self._artifact_store_path) as base_temp_dir:
             object_class = f"{type(obj).__module__}.{type(obj).__name__}"
             materializer_class = self._find_materializer(obj, materializer)
 
             temp_dir = Path(base_temp_dir) / f"{name.replace(':', '_')}"
             temp_dir.mkdir(parents=True, exist_ok=True)
 
-            mat_instance = instantiate_target(
-                materializer_class, uri=str(temp_dir), artifact_store=self._artifact_store
-            )
+            mat_instance = instantiate_target(materializer_class, uri=str(temp_dir))
             mat_instance.save(obj)
 
             push_metadata = {
@@ -461,7 +478,7 @@ class _RegistryCore(Mindtrace):
         self,
         names: List[str],
         objs: Any | List[Any],
-        materializer: Type[BaseMaterializer] | None = None,
+        materializer: Type[Materializer] | None = None,
         versions: str | None | List[str | None] = None,
         init_params: Dict[str, Any] | List[Dict[str, Any]] | None = None,
         metadata: Dict[str, Any] | List[Dict[str, Any]] | None = None,
@@ -484,7 +501,7 @@ class _RegistryCore(Mindtrace):
         result = BatchResult()
         prep_errors: Dict[Tuple[str, str], Dict[str, str]] = {}
 
-        with TemporaryDirectory(dir=self._artifact_store.path) as base_temp_dir:
+        with TemporaryDirectory(dir=self._artifact_store_path) as base_temp_dir:
             # Prepare items for batch push
             push_items: List[Tuple[str, str | None, Path, dict]] = []
 
@@ -503,9 +520,7 @@ class _RegistryCore(Mindtrace):
                     temp_dir.mkdir(parents=True, exist_ok=True)
 
                     materializer_class = self._find_materializer(obj, materializer)
-                    mat_instance = instantiate_target(
-                        materializer_class, uri=str(temp_dir), artifact_store=self._artifact_store
-                    )
+                    mat_instance = instantiate_target(materializer_class, uri=str(temp_dir))
                     mat_instance.save(obj)
 
                     push_metadata = {
@@ -575,11 +590,11 @@ class _RegistryCore(Mindtrace):
     def _materialize(self, temp_dir: Path, metadata: dict, **kwargs) -> Any:
         """Materialize an object from a temp directory using metadata."""
         object_class = metadata["class"]
-        materializer_class = metadata["materializer"]
+        materializer_class = _resolve_materializer_string(metadata["materializer"])
         init_params = metadata.get("init_params", {}).copy()
         init_params.update(kwargs)
 
-        materializer = instantiate_target(materializer_class, uri=str(temp_dir), artifact_store=self._artifact_store)
+        materializer = instantiate_target(materializer_class, uri=str(temp_dir))
 
         if isinstance(object_class, str):
             try:
@@ -600,7 +615,7 @@ class _RegistryCore(Mindtrace):
     def serialization_hints_for_object(
         self,
         obj: Any,
-        materializer: Type[BaseMaterializer] | None = None,
+        materializer: Type[Materializer] | None = None,
     ) -> Dict[str, str]:
         """Return ``class`` and ``materializer`` strings for embedding in external metadata (e.g. datalake assets)."""
         return {
@@ -618,8 +633,9 @@ class _RegistryCore(Mindtrace):
         relative_path: str = "data.txt",
         **kwargs: Any,
     ) -> Any:
-        """Write *raw* to *relative_path* under a staged directory and run the ZenML materializer."""
-        with TemporaryDirectory(dir=self._artifact_store.path) as base:
+        """Write *raw* to *relative_path* under a staged directory and run the materializer."""
+        materializer = _resolve_materializer_string(materializer)
+        with TemporaryDirectory(dir=self._artifact_store_path) as base:
             temp_dir = Path(base) / "staged"
             temp_dir.mkdir(parents=True, exist_ok=True)
             target = temp_dir / relative_path
@@ -685,7 +701,7 @@ class _RegistryCore(Mindtrace):
         metadata = result.metadata
 
         # Pull and materialize
-        with TemporaryDirectory(dir=self._artifact_store.path) as base_temp_dir:
+        with TemporaryDirectory(dir=self._artifact_store_path) as base_temp_dir:
             temp_dir = Path(base_temp_dir) / f"{name}_{v}".replace(":", "_")
             temp_dir.mkdir(parents=True, exist_ok=True)
 
@@ -772,7 +788,7 @@ class _RegistryCore(Mindtrace):
 
         # Pull artifacts in batch
         items_to_pull = [item for item in valid_items if item not in result.errors]
-        with TemporaryDirectory(dir=self._artifact_store.path) as base_temp_dir:
+        with TemporaryDirectory(dir=self._artifact_store_path) as base_temp_dir:
             temp_dirs = {}
             paths = []
             for n, v in items_to_pull:
@@ -1112,7 +1128,7 @@ class _RegistryCore(Mindtrace):
         # Cache miss - need to check backend (slow path)
         # registered_materializers now returns Dict[str, str]
         result = self.backend.registered_materializers(object_class)
-        materializer = result.get(object_class)
+        materializer = _resolve_materializer_string(result.get(object_class))
 
         # Cache the result (even if None)
         with self._materializer_cache_lock:
@@ -1121,12 +1137,12 @@ class _RegistryCore(Mindtrace):
         return materializer
 
     def registered_materializers(self) -> Dict[str, str]:
-        """Get all registered materializers.
+        """Get all registered materializers, with legacy zenml strings resolved.
 
         Returns:
             Dictionary mapping object classes to their registered materializer classes.
         """
-        return self.backend.registered_materializers()
+        return {k: _resolve_materializer_string(v) for k, v in self.backend.registered_materializers().items()}
 
     def list_objects(self) -> List[str]:
         """Return a list of all registered object names.
@@ -1450,13 +1466,16 @@ class _RegistryCore(Mindtrace):
         default_materializers = self.get_default_materializers()
         existing_materializers = self.backend.registered_materializers()
 
-        # Filter materializers that need to be registered
+        # Filter materializers that need to be registered. Treat any stored
+        # legacy zenml string as equivalent to its in-house replacement so we
+        # also override stale registrations from previous registry versions.
         materializers_to_register = {}
         for object_class, materializer_class in default_materializers.items():
-            if override_preexisting_materializers or object_class not in existing_materializers:
-                # Ensure materializer_class is a string for JSON serialization
-                if isinstance(materializer_class, type):
-                    materializer_class = f"{materializer_class.__module__}.{materializer_class.__name__}"
+            # Ensure materializer_class is a string for JSON serialization
+            if isinstance(materializer_class, type):
+                materializer_class = f"{materializer_class.__module__}.{materializer_class.__name__}"
+            existing = _resolve_materializer_string(existing_materializers.get(object_class))
+            if override_preexisting_materializers or existing is None or existing != materializer_class:
                 materializers_to_register[object_class] = materializer_class
 
         if materializers_to_register:
@@ -1474,8 +1493,11 @@ class _RegistryCore(Mindtrace):
     def _warm_materializer_cache(self):
         """Warm the materializer cache to reduce lock contention during operations."""
         try:
-            # Get all registered materializers and cache them
-            all_materializers = self.backend.registered_materializers()
+            # Get all registered materializers and cache them, resolving any
+            # legacy zenml strings to their in-house equivalents in the cache.
+            all_materializers = {
+                k: _resolve_materializer_string(v) for k, v in self.backend.registered_materializers().items()
+            }
 
             with self._materializer_cache_lock:
                 self._materializer_cache.update(all_materializers)

--- a/mindtrace/registry/mindtrace/registry/core/archiver.py
+++ b/mindtrace/registry/mindtrace/registry/core/archiver.py
@@ -1,18 +1,18 @@
 from abc import abstractmethod
-from typing import Any, Set, Type
-
-from zenml.enums import ArtifactType
-from zenml.materializers.base_materializer import BaseMaterializer
+from typing import Any, Type
 
 from mindtrace.core import Mindtrace
+from mindtrace.registry.core.base_materializer import BaseMaterializer
 
 
 class Archiver(Mindtrace, BaseMaterializer):
-    """Base Archiver class for handling data persistence."""
+    """Base Archiver class for handling data persistence.
 
-    # Required by BaseMaterializer
-    ASSOCIATED_TYPES: Set[Type] = {Any}
-    ASSOCIATED_ARTIFACT_TYPE: ArtifactType = ArtifactType.DATA
+    Concrete archivers override :meth:`save` and :meth:`load`. Inheriting from
+    :class:`BaseMaterializer` is a convenience — any class exposing ``uri``,
+    ``save``, and ``load`` already satisfies the registry's
+    :class:`~mindtrace.registry.core.base_materializer.Materializer` Protocol.
+    """
 
     def __init__(self, uri: str, *args, **kwargs):
         super().__init__(uri=uri, *args, **kwargs)

--- a/mindtrace/registry/mindtrace/registry/core/base_materializer.py
+++ b/mindtrace/registry/mindtrace/registry/core/base_materializer.py
@@ -1,0 +1,33 @@
+"""Materializer contract for the Registry.
+
+The public contract is a :class:`Materializer` Protocol. Any class exposing
+``uri``, ``save(data)``, and ``load(data_type)`` satisfies it without needing
+to inherit from anything in mindtrace. The concrete :class:`BaseMaterializer`
+is provided as a convenience starting point for in-tree implementations.
+"""
+
+from typing import Any, Protocol, Type, runtime_checkable
+
+
+@runtime_checkable
+class Materializer(Protocol):
+    """Structural contract for objects that serialize to / deserialize from ``uri``."""
+
+    uri: str
+
+    def save(self, data: Any) -> None: ...
+
+    def load(self, data_type: Type[Any]) -> Any: ...
+
+
+class BaseMaterializer:
+    """Minimal concrete base. Subclasses override :meth:`save` and :meth:`load`."""
+
+    def __init__(self, uri: str, **_: Any):
+        self.uri = uri
+
+    def save(self, data: Any) -> None:
+        raise NotImplementedError
+
+    def load(self, data_type: Type[Any]) -> Any:
+        raise NotImplementedError

--- a/mindtrace/registry/mindtrace/registry/core/registry.py
+++ b/mindtrace/registry/mindtrace/registry/core/registry.py
@@ -12,12 +12,11 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Type, overload
 
-from zenml.materializers.base_materializer import BaseMaterializer
-
 from mindtrace.core import Mindtrace
 from mindtrace.registry.backends.local_registry_backend import LocalRegistryBackend
 from mindtrace.registry.backends.registry_backend import RegistryBackend
 from mindtrace.registry.core._registry_core import _RegistryCore
+from mindtrace.registry.core.base_materializer import Materializer
 from mindtrace.registry.core.exceptions import RegistryObjectNotFound
 from mindtrace.registry.core.mount import (
     AmbientAuth,
@@ -483,7 +482,7 @@ class Registry(Mindtrace):
         name: str | List[str],
         obj: Any | List[Any],
         *,
-        materializer: Type[BaseMaterializer] | None = None,
+        materializer: Type[Materializer] | None = None,
         version: str | None | List[str | None] = None,
         init_params: Dict[str, Any] | List[Dict[str, Any]] | None = None,
         metadata: Dict[str, Any] | List[Dict[str, Any]] | None = None,
@@ -572,9 +571,9 @@ class Registry(Mindtrace):
         self,
         obj: Any,
         *,
-        materializer: Type[BaseMaterializer] | None = None,
+        materializer: Type[Materializer] | None = None,
     ) -> Dict[str, str]:
-        """Return ZenML ``class`` and ``materializer`` strings for embedding in other metadata (e.g. datalake assets)."""
+        """Return ``class`` and ``materializer`` strings for embedding in external metadata (e.g. datalake assets)."""
         return self._core.serialization_hints_for_object(obj, materializer=materializer)
 
     def materialize_from_bytes(
@@ -587,7 +586,7 @@ class Registry(Mindtrace):
         relative_path: str = "data.txt",
         **kwargs: Any,
     ) -> Any:
-        """Materialize *raw* bytes laid out as a single file (default ZenML bytes layout: ``data.txt``)."""
+        """Materialize *raw* bytes laid out as a single file (default bytes layout: ``data.txt``)."""
         return self._core.materialize_from_bytes(
             raw,
             object_class=object_class,

--- a/mindtrace/registry/mindtrace/registry/core/store.py
+++ b/mindtrace/registry/mindtrace/registry/core/store.py
@@ -10,10 +10,9 @@ from pathlib import Path
 from tempfile import mkdtemp
 from typing import Any, Dict, List, Type
 
-from zenml.materializers.base_materializer import BaseMaterializer
-
 from mindtrace.core import Mindtrace
 from mindtrace.registry.backends.local_registry_backend import LocalRegistryBackend
+from mindtrace.registry.core.base_materializer import Materializer
 from mindtrace.registry.core.exceptions import (
     RegistryObjectNotFound,
     StoreAmbiguousObjectError,
@@ -266,7 +265,7 @@ class Store(Mindtrace):
         key: str,
         obj: Any,
         *,
-        materializer: Type[BaseMaterializer] | None = None,
+        materializer: Type[Materializer] | None = None,
         version: str | None = None,
         init_params: Dict[str, Any] | None = None,
         metadata: Dict[str, Any] | None = None,
@@ -297,7 +296,7 @@ class Store(Mindtrace):
         name: str | List[str],
         obj: Any | List[Any],
         *,
-        materializer: Type[BaseMaterializer] | None = None,
+        materializer: Type[Materializer] | None = None,
         version: str | None | List[str | None] = None,
         init_params: Dict[str, Any] | List[Dict[str, Any]] | None = None,
         metadata: Dict[str, Any] | List[Dict[str, Any]] | None = None,

--- a/mindtrace/registry/pyproject.toml
+++ b/mindtrace/registry/pyproject.toml
@@ -12,12 +12,12 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    "cloudpickle>=3.0",
     "mindtrace-core>=0.11.0",
     "mindtrace-storage>=0.11.0",
     "minio<7.2.19",
     "pydantic>=2.11.1",
     "pyyaml>=6.0.1",
-    "zenml>=0.82.1",
 ]
 
 [project.urls]

--- a/samples/registry/supported_registry_types.py
+++ b/samples/registry/supported_registry_types.py
@@ -24,7 +24,8 @@ def main():
     # Register materializer for our custom Pydantic model
     # Use the actual type of the model for registration
     registry.register_materializer(
-        f"{ExampleModel.__module__}.{ExampleModel.__name__}", "zenml.materializers.PydanticMaterializer"
+        f"{ExampleModel.__module__}.{ExampleModel.__name__}",
+        "mindtrace.registry.archivers.builtin_materializers.PydanticMaterializer",
     )
 
     # 1. Basic Python types

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,11 +63,6 @@ def configure_logging_for_tests(caplog):
     original_level = root_logger.level
     root_logger.setLevel(logging.DEBUG)
 
-    # Remove third-party handlers from the root logger that cause test-log noise.
-    # caplog's handler is managed by pytest and re-added each test automatically.
-    original_root_handlers = root_logger.handlers[:]
-    root_logger.handlers = [h for h in root_logger.handlers if type(h).__module__.startswith("_pytest")]
-
     # Suppress noisy third-party DEBUG logs
     noisy_loggers = [
         "botocore",
@@ -101,7 +96,6 @@ def configure_logging_for_tests(caplog):
 
     # Restore original settings
     root_logger.setLevel(original_level)
-    root_logger.handlers = original_root_handlers
     mindtrace_logger.propagate = original_propagate
     for name, lvl in original_noisy_levels.items():
         logging.getLogger(name).setLevel(lvl)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def configure_logging_for_tests(caplog):
     original_level = root_logger.level
     root_logger.setLevel(logging.DEBUG)
 
-    # Remove third-party handlers (e.g. ZenML) from root logger that cause noise.
+    # Remove third-party handlers from the root logger that cause test-log noise.
     # caplog's handler is managed by pytest and re-added each test automatically.
     original_root_handlers = root_logger.handlers[:]
     root_logger.handlers = [h for h in root_logger.handlers if type(h).__module__.startswith("_pytest")]

--- a/tests/integration/mindtrace/database/test_registry_odm.py
+++ b/tests/integration/mindtrace/database/test_registry_odm.py
@@ -7,11 +7,10 @@ with real file system operations using temporary directories.
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Any, ClassVar, Tuple, Type
+from typing import Any, Type
 
 import pytest
 from pydantic import BaseModel, Field
-from zenml.enums import ArtifactType
 
 from mindtrace.database import DocumentNotFoundError, RegistryMindtraceODM
 from mindtrace.registry import Archiver, LocalRegistryBackend, Registry
@@ -48,9 +47,6 @@ class ComplexUser(BaseModel):
 class UserArchiver(Archiver):
     """Custom archiver for User model that saves to JSON files."""
 
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (User,)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.DATA
-
     def save(self, user: User):
         """Save user to a JSON file."""
         with open(Path(self.uri) / "user.json", "w") as f:
@@ -65,9 +61,6 @@ class UserArchiver(Archiver):
 class UserWithAgeArchiver(Archiver):
     """Custom archiver for UserWithAge model."""
 
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (UserWithAge,)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.DATA
-
     def save(self, user: UserWithAge):
         """Save user to a JSON file."""
         with open(Path(self.uri) / "user_with_age.json", "w") as f:
@@ -81,9 +74,6 @@ class UserWithAgeArchiver(Archiver):
 
 class ComplexUserArchiver(Archiver):
     """Custom archiver for ComplexUser model."""
-
-    ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (ComplexUser,)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.DATA
 
     def save(self, user: ComplexUser):
         """Save user to a JSON file."""

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -6,6 +6,5 @@ markers =
     gcp: mark test as GCP-specific test.
     hardware: mark test as requiring physical hardware (cameras, scanners, etc.).
 filterwarnings =
-    ignore::UserWarning:zenml.*:
     ignore:coroutine.*was never awaited:RuntimeWarning
 asyncio_mode = auto

--- a/tests/stress/mindtrace/registry/test_registry_stress_test.py
+++ b/tests/stress/mindtrace/registry/test_registry_stress_test.py
@@ -24,7 +24,6 @@ from mindtrace.registry.core.exceptions import RegistryObjectNotFound
 
 # Suppress verbose logging during stress tests
 logging.getLogger("mindtrace.registry").setLevel(logging.WARNING)
-logging.getLogger("zenml").setLevel(logging.WARNING)
 logging.getLogger("mindtrace.core").setLevel(logging.WARNING)
 
 # For even cleaner output during stress tests, uncomment the following line:

--- a/tests/unit/mindtrace/datalake/test_vault_serialization.py
+++ b/tests/unit/mindtrace/datalake/test_vault_serialization.py
@@ -46,7 +46,7 @@ def test_extract_serialization_block_roundtrip():
     )
     block = extract_serialization_block(asset)
     assert block is not None
-    assert block["materializer"] == "zenml.materializers.BytesMaterializer"
+    assert block["materializer"] == "mindtrace.registry.archivers.builtin_materializers.BytesMaterializer"
 
 
 def test_materialize_payload_with_hints_bytes(tmp_path: Path):

--- a/tests/unit/mindtrace/registry/archivers/test_path_archiver.py
+++ b/tests/unit/mindtrace/registry/archivers/test_path_archiver.py
@@ -1,7 +1,7 @@
 """Unit tests for PathArchiver."""
 
 import tempfile
-from pathlib import Path, PosixPath
+from pathlib import Path
 
 import pytest
 
@@ -62,8 +62,6 @@ class TestPathArchiverInit:
         """Test PathArchiver class attributes."""
         assert PathArchiver.METADATA_FILE == "metadata.json"
         assert PathArchiver.ARCHIVE_NAME == "data.tar.gz"
-        assert Path in PathArchiver.ASSOCIATED_TYPES
-        assert PosixPath in PathArchiver.ASSOCIATED_TYPES
 
 
 class TestPathArchiverSaveFile:

--- a/tests/unit/mindtrace/registry/core/test_archiver.py
+++ b/tests/unit/mindtrace/registry/core/test_archiver.py
@@ -11,8 +11,6 @@ class TestArchiver:
 
         # Create a concrete implementation for testing
         class TestArchiverImpl(Archiver):
-            ASSOCIATED_TYPES = {str, int}
-
             def load(self, data_type: Type[Any]) -> Any:
                 return None
 
@@ -28,8 +26,6 @@ class TestArchiver:
         """Test that abstract methods raise NotImplementedError when not implemented."""
 
         class IncompleteArchiver(Archiver):
-            ASSOCIATED_TYPES = {str}
-
             def load(self, data_type: Type[Any]) -> Any:
                 return None
 
@@ -43,8 +39,6 @@ class TestArchiver:
         """Test that the load abstract method raises NotImplementedError when not implemented."""
 
         class IncompleteArchiver(Archiver):
-            ASSOCIATED_TYPES = {str}
-
             def save(self, data: Any) -> None:
                 pass
 

--- a/tests/unit/mindtrace/registry/core/test_materializer_protocol.py
+++ b/tests/unit/mindtrace/registry/core/test_materializer_protocol.py
@@ -1,0 +1,173 @@
+"""Tests for the Materializer Protocol and legacy zenml materializer-string aliasing."""
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Type
+
+import pytest
+from pydantic import BaseModel
+
+from mindtrace.registry import BaseMaterializer, Materializer, Registry
+from mindtrace.registry.core._registry_core import _LEGACY_MATERIALIZER_ALIASES, _resolve_materializer_string
+
+
+class _PydanticSample(BaseModel):
+    """Module-scope pydantic subclass so ``Registry.load`` can re-import its class."""
+
+    x: int
+    y: str
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Protocol structural checks
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+class _ForeignMaterializer:
+    """A materializer-shaped class that does NOT inherit from BaseMaterializer."""
+
+    def __init__(self, uri: str, **_: Any):
+        self.uri = uri
+
+    def save(self, data: Any) -> None:
+        with open(os.path.join(self.uri, "payload.txt"), "w") as f:
+            f.write(str(data))
+
+    def load(self, data_type: Type[Any]) -> Any:
+        with open(os.path.join(self.uri, "payload.txt")) as f:
+            return data_type(f.read())
+
+
+def test_protocol_accepts_foreign_classes_without_inheritance():
+    """A class with the right shape satisfies Materializer even without inheriting BaseMaterializer."""
+    instance = _ForeignMaterializer("/tmp/x")
+    assert isinstance(instance, Materializer)
+    assert not isinstance(instance, BaseMaterializer)
+
+
+def test_protocol_rejects_classes_missing_methods():
+    class Incomplete:
+        def __init__(self, uri: str, **_: Any):
+            self.uri = uri
+
+        def save(self, data: Any) -> None: ...
+
+        # `load` deliberately missing
+
+    assert not isinstance(Incomplete("/tmp/x"), Materializer)
+
+
+def test_base_materializer_satisfies_protocol():
+    class Concrete(BaseMaterializer):
+        def save(self, data: Any) -> None: ...
+
+        def load(self, data_type: Type[Any]) -> Any:
+            return None
+
+    assert isinstance(Concrete("/tmp/x"), Materializer)
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Foreign materializers integrate with the Registry via registration + dispatch
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+class StringHolder:
+    """Plain class round-tripped through the registry by a foreign materializer."""
+
+    def __init__(self, value: str):
+        self.value = value
+
+
+def test_registry_dispatches_to_foreign_materializer(tmp_path: Path):
+    reg = Registry(tmp_path / "reg", version_objects=False, mutable=True)
+    reg.register_materializer(
+        StringHolder,
+        f"{__name__}.StringHolderMaterializer",
+    )
+    obj = StringHolder("hello")
+    reg.save("holder", obj)
+    loaded = reg.load("holder")
+    assert isinstance(loaded, StringHolder)
+    assert loaded.value == "hello"
+
+
+class StringHolderMaterializer:
+    """A materializer for StringHolder that does NOT inherit BaseMaterializer."""
+
+    def __init__(self, uri: str, **_: Any):
+        self.uri = uri
+
+    def save(self, data: StringHolder) -> None:
+        Path(self.uri).mkdir(parents=True, exist_ok=True)
+        with open(os.path.join(self.uri, "data.json"), "w") as f:
+            json.dump({"value": data.value}, f)
+
+    def load(self, data_type: Type[Any]) -> StringHolder:
+        with open(os.path.join(self.uri, "data.json")) as f:
+            payload = json.load(f)
+        return StringHolder(value=payload["value"])
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Legacy zenml materializer-string alias map
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "legacy, expected",
+    list(_LEGACY_MATERIALIZER_ALIASES.items()),
+)
+def test_resolve_materializer_string_handles_all_documented_aliases(legacy: str, expected: str):
+    assert _resolve_materializer_string(legacy) == expected
+
+
+def test_resolve_materializer_string_is_idempotent_for_unknown_strings():
+    s = "some.unknown.path.Materializer"
+    assert _resolve_materializer_string(s) == s
+
+
+def test_resolve_materializer_string_none_passes_through():
+    assert _resolve_materializer_string(None) is None
+
+
+def test_legacy_zenml_materializer_string_resolves_in_materialize_from_bytes(tmp_path: Path):
+    reg = Registry(tmp_path / "reg", version_objects=False, mutable=True)
+    out = reg.materialize_from_bytes(
+        b"abc",
+        object_class="builtins.bytes",
+        materializer="zenml.materializers.BytesMaterializer",
+    )
+    assert out == b"abc"
+
+
+def test_pydantic_subclass_dispatches_via_basemodel_mro(tmp_path: Path):
+    """``pydantic.main.BaseModel`` must be registered so MRO-based dispatch hits user subclasses."""
+    reg = Registry(tmp_path / "reg", version_objects=False, mutable=True)
+    reg.save("m", _PydanticSample(x=7, y="hi"))
+    loaded = reg.load("m")
+    assert isinstance(loaded, _PydanticSample)
+    assert loaded.x == 7
+    assert loaded.y == "hi"
+
+
+def test_legacy_zenml_metadata_loads_via_alias_map(tmp_path: Path):
+    """Simulate a registry whose stored metadata still references zenml.* materializers."""
+    reg = Registry(tmp_path / "reg", version_objects=False, mutable=True)
+    version = reg.save("greeting", "hello")
+
+    # Rewrite the stored metadata to use a legacy zenml materializer string.
+    meta_path = reg.backend._object_metadata_path("greeting", version)
+    import yaml
+
+    with open(meta_path) as f:
+        meta = yaml.safe_load(f)
+    meta["materializer"] = "zenml.materializers.built_in_materializer.BuiltInMaterializer"
+    with open(meta_path, "w") as f:
+        yaml.safe_dump(meta, f)
+
+    # Drop the in-memory cache so the next load goes through the alias path.
+    reg._core._materializer_cache.clear()
+
+    assert reg.load("greeting") == "hello"

--- a/tests/unit/mindtrace/registry/core/test_registry.py
+++ b/tests/unit/mindtrace/registry/core/test_registry.py
@@ -10,10 +10,9 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from pydantic import BaseModel
-from zenml.materializers import CloudpickleMaterializer
 
 from mindtrace.core import Config, compute_dir_hash
-from mindtrace.registry import LocalRegistryBackend, Registry, S3RegistryBackend
+from mindtrace.registry import CloudpickleMaterializer, LocalRegistryBackend, Registry, S3RegistryBackend
 from mindtrace.registry.backends.registry_backend import RegistryBackend
 from mindtrace.registry.core._registry_core import _RegistryCore
 from mindtrace.registry.core.exceptions import (
@@ -120,13 +119,14 @@ def test_registry_serialization_hints_for_object_uses_core_materializer_lookup(r
 
     assert hints == {
         "class": "builtins.bytes",
-        "materializer": "zenml.materializers.BytesMaterializer",
+        "materializer": "mindtrace.registry.archivers.builtin_materializers.BytesMaterializer",
     }
 
 
 def test_registry_materialize_from_bytes_delegates_to_core(registry):
     raw = b"hello-bytes"
 
+    # Verify legacy zenml materializer strings still resolve via the alias map.
     out = registry.materialize_from_bytes(
         raw,
         object_class="builtins.bytes",
@@ -452,23 +452,19 @@ def test_find_materializer_with_class_object(registry, test_config):
 
     Note: When a materializer class object is provided (not a string), it is converted
     to a string using type(materializer) which returns the class's metaclass.
-    Archiver inherits from BaseMaterializer, so its metaclass is BaseMaterializerMeta.
+    Without a custom metaclass, type(SomeClass) is the built-in ``type``.
     """
     from mindtrace.registry.archivers.config_archiver import ConfigArchiver
 
-    # Call _find_materializer with a materializer class object (not a string)
-    # This should trigger the conversion:
-    # return f"{type(materializer).__module__}.{type(materializer).__name__}"
     materializer_str = registry._find_materializer(test_config, provided_materializer=ConfigArchiver)
 
-    assert materializer_str == "zenml.materializers.base_materializer.BaseMaterializerMeta"
+    assert materializer_str == "builtins.type"
     assert isinstance(materializer_str, str)
 
     # Verify that if we pass a regular class, type() returns builtins.type
     class SimpleMaterializer:
         pass
 
-    # This should convert type(SimpleMaterializer) which is builtins.type
     simple_str = registry._find_materializer(test_config, provided_materializer=SimpleMaterializer)
     assert simple_str == "builtins.type"
     assert isinstance(simple_str, str)
@@ -651,8 +647,11 @@ def test_registered_materializers(registry):
     assert "mindtrace.core.config.config.Config" in materializers
 
     # Verify the materializer classes are correct
-    assert materializers["builtins.str"] == "zenml.materializers.built_in_materializer.BuiltInMaterializer"
-    assert materializers["builtins.list"] == "zenml.materializers.BuiltInContainerMaterializer"
+    assert materializers["builtins.str"] == "mindtrace.registry.archivers.builtin_materializers.BuiltInMaterializer"
+    assert (
+        materializers["builtins.list"]
+        == "mindtrace.registry.archivers.builtin_materializers.BuiltInContainerMaterializer"
+    )
     assert (
         materializers["mindtrace.core.config.config.Config"]
         == "mindtrace.registry.archivers.config_archiver.ConfigArchiver"


### PR DESCRIPTION
This PR:
- Removes the zenml dependency (~50+ transitive packages) from mindtrace/registry
- Replaces it with a tiny in-house Materializer contract: a runtime_checkable Protocol + concrete BaseMaterializer base, so any class with uri / save / load plugs in without inheriting from mindtrace
- Ports the built-in materializers in-house (BuiltIn, BuiltInContainer, Bytes, Pydantic, Cloudpickle) plus integrations (Numpy, Pillow, PyTorch module/dataloader, HFDataset); cloudpickle>=3.0 added as a direct dep
- Drops LocalArtifactStore staging in favor of a plain temp Path; drops the unused ASSOCIATED_TYPES / ASSOCIATED_ARTIFACT_TYPE class attributes across all archivers (registry, models, jobs)
- Migrates downstream sites (datalake, jobs, models, tests) off zenml.* imports; vault serialization's BYTES_MATERIALIZER now points to the in-house path
- Backwards-compatible: legacy zenml.materializers.* strings in existing on-disk registries resolve transparently through a small alias map in _registry_core.py
- Side-fix: pydantic / huggingface-datasets default registrations now use the real __module__ paths (pydantic.main.BaseModel, datasets.arrow_dataset.Dataset, etc.) so MRO-based dispatch actually hits user subclasses

Tests
- `ds test` (should be all green and run faster)