### PR TITLE
Fix DataVault save_image size metadata

### DIFF
--- a/mindtrace/datalake/mindtrace/datalake/data_vault.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault.py
@@ -1523,6 +1523,7 @@ class AsyncDataVault:
             mount=mount,
             object_metadata=object_metadata,
             asset_metadata=merged_asset_metadata,
+            size_bytes=len(png_bytes),
             created_by=created_by,
             on_conflict=on_conflict,
         )
@@ -2604,6 +2605,7 @@ class DataVault:
             mount=mount,
             object_metadata=object_metadata,
             asset_metadata=merged_asset_metadata,
+            size_bytes=len(png_bytes),
             created_by=created_by,
             on_conflict=on_conflict,
         )

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -2932,6 +2932,27 @@ async def test_async_data_vault_save_registers_secondary_alias(mock_async_datala
 
 
 @pytest.mark.asyncio
+async def test_async_data_vault_save_image_records_png_size(mock_async_datalake_for_alias_indexing):
+    created = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="vault/image", version="1"),
+        asset_id="asset_img",
+    )
+    mock_async_datalake_for_alias_indexing.create_asset_from_object = AsyncMock(return_value=created)
+
+    image = Image.new("RGB", (2, 2), color=(12, 34, 56))
+    expected_size = len(_pil_image_to_png_bytes(image))
+
+    vault = AsyncDataVault(mock_async_datalake_for_alias_indexing)
+    await vault.save_image("friendly-image", image)
+
+    kwargs = mock_async_datalake_for_alias_indexing.create_asset_from_object.await_args.kwargs
+    assert kwargs["media_type"] == "image/png"
+    assert kwargs["size_bytes"] == expected_size
+
+
+@pytest.mark.asyncio
 async def test_async_data_vault_save_skips_add_alias_when_same_as_asset_id(mock_async_datalake_for_alias_indexing):
     created = Asset(
         kind="artifact",
@@ -2977,6 +2998,26 @@ def test_data_vault_save_adds_secondary_alias(mock_sync_datalake_for_alias_index
     vault.save("friendly", b"bytes", kind="image", media_type="image/png")
 
     mock_sync_datalake_for_alias_indexing.add_alias.assert_called_once_with("new_asset", "friendly")
+
+
+def test_data_vault_save_image_records_png_size(mock_sync_datalake_for_alias_indexing):
+    created = Asset(
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="m", name="vault/image", version="1"),
+        asset_id="asset_img",
+    )
+    mock_sync_datalake_for_alias_indexing.create_asset_from_object = Mock(return_value=created)
+
+    image = Image.new("RGB", (2, 2), color=(12, 34, 56))
+    expected_size = len(_pil_image_to_png_bytes(image))
+
+    vault = DataVault(mock_sync_datalake_for_alias_indexing)
+    vault.save_image("friendly-image", image)
+
+    kwargs = mock_sync_datalake_for_alias_indexing.create_asset_from_object.call_args.kwargs
+    assert kwargs["media_type"] == "image/png"
+    assert kwargs["size_bytes"] == expected_size
 
 
 def test_data_vault_rejects_incomplete_duck():


### PR DESCRIPTION
## Summary

Fixes `DataVault.save_image()` and `AsyncDataVault.save_image()` so image assets record the actual serialized PNG payload size in datalake metadata.

Previously, `save_image()` serialized the PIL image to PNG bytes but did not pass the resulting byte length into asset creation. This could leave downstream consumers, including Chiron datalake views, showing saved image assets as `0 B` even though the payload existed.

Closes #479.

## What changed

- Pass `size_bytes=len(png_bytes)` when sync `DataVault.save_image()` creates the PNG asset.
- Pass `size_bytes=len(png_bytes)` when async `AsyncDataVault.save_image()` creates the PNG asset.
- Add focused sync and async unit coverage asserting `save_image()` forwards the actual PNG byte length to `create_asset_from_object(...)`.

## Testing

Run the focused regression tests with:

```bash
ds test: tests/unit/mindtrace/datalake/test_data_vault.py::test_data_vault_save_image_records_png_size tests/unit/mindtrace/datalake/test_data_vault.py::test_async_data_vault_save_image_records_png_size
```

Both regression tests should pass.
