### PR TITLE
Add hardware camera benchmark suites

### DIFF
--- a/mindtrace/hardware/mindtrace/hardware/testing/__init__.py
+++ b/mindtrace/hardware/mindtrace/hardware/testing/__init__.py
@@ -15,12 +15,12 @@ def register_benchmark_suites(*, runner: TestRunner | None = None, replace: bool
     target = runner or TestRunner.default()
 
     from mindtrace.hardware.testing.suites.camera_manager import (
-        HardwareCameraManagerCaptureStressSuite,
         HardwareCameraManagerCaptureSmokeSuite,
+        HardwareCameraManagerCaptureStressSuite,
     )
     from mindtrace.hardware.testing.suites.camera_service import (
-        HardwareCameraServiceCaptureStressSuite,
         HardwareCameraServiceCaptureSmokeSuite,
+        HardwareCameraServiceCaptureStressSuite,
     )
 
     for cls in (

--- a/mindtrace/hardware/mindtrace/hardware/testing/__init__.py
+++ b/mindtrace/hardware/mindtrace/hardware/testing/__init__.py
@@ -1,0 +1,33 @@
+"""Embedded benchmark suites for ``mindtrace-hardware``.
+
+Use ``register_benchmark_suites`` directly or discover it through the
+``mindtrace.benchmark_suites`` entry point group.
+"""
+
+from __future__ import annotations
+
+from mindtrace.core import TestRunner
+
+
+def register_benchmark_suites(*, runner: TestRunner | None = None, replace: bool = True) -> None:
+    """Register hardware benchmark suites on ``runner`` or the default runner."""
+
+    target = runner or TestRunner.default()
+
+    from mindtrace.hardware.testing.suites.camera_manager import (
+        HardwareCameraManagerCaptureStressSuite,
+        HardwareCameraManagerCaptureSmokeSuite,
+    )
+    from mindtrace.hardware.testing.suites.camera_service import (
+        HardwareCameraServiceCaptureStressSuite,
+        HardwareCameraServiceCaptureSmokeSuite,
+    )
+
+    for cls in (
+        HardwareCameraManagerCaptureSmokeSuite,
+        HardwareCameraManagerCaptureStressSuite,
+        HardwareCameraServiceCaptureSmokeSuite,
+        HardwareCameraServiceCaptureStressSuite,
+    ):
+        if replace or cls.suite_id not in target.registered_suites():
+            target.register_test_suite(cls, replace=replace)

--- a/mindtrace/hardware/mindtrace/hardware/testing/suites/__init__.py
+++ b/mindtrace/hardware/mindtrace/hardware/testing/suites/__init__.py
@@ -1,0 +1,17 @@
+"""Hardware benchmark suite implementations."""
+
+from mindtrace.hardware.testing.suites.camera_manager import (
+    HardwareCameraManagerCaptureStressSuite,
+    HardwareCameraManagerCaptureSmokeSuite,
+)
+from mindtrace.hardware.testing.suites.camera_service import (
+    HardwareCameraServiceCaptureStressSuite,
+    HardwareCameraServiceCaptureSmokeSuite,
+)
+
+__all__ = [
+    "HardwareCameraManagerCaptureSmokeSuite",
+    "HardwareCameraManagerCaptureStressSuite",
+    "HardwareCameraServiceCaptureSmokeSuite",
+    "HardwareCameraServiceCaptureStressSuite",
+]

--- a/mindtrace/hardware/mindtrace/hardware/testing/suites/__init__.py
+++ b/mindtrace/hardware/mindtrace/hardware/testing/suites/__init__.py
@@ -1,12 +1,12 @@
 """Hardware benchmark suite implementations."""
 
 from mindtrace.hardware.testing.suites.camera_manager import (
-    HardwareCameraManagerCaptureStressSuite,
     HardwareCameraManagerCaptureSmokeSuite,
+    HardwareCameraManagerCaptureStressSuite,
 )
 from mindtrace.hardware.testing.suites.camera_service import (
-    HardwareCameraServiceCaptureStressSuite,
     HardwareCameraServiceCaptureSmokeSuite,
+    HardwareCameraServiceCaptureStressSuite,
 )
 
 __all__ = [

--- a/mindtrace/hardware/mindtrace/hardware/testing/suites/_camera_common.py
+++ b/mindtrace/hardware/mindtrace/hardware/testing/suites/_camera_common.py
@@ -1,0 +1,134 @@
+"""Shared helpers for camera benchmark suites."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterable
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from mindtrace.core import BenchReporter, BenchResult, BenchSuiteConfig, utc_now_iso
+
+DEFAULT_MOCK_CAMERAS = ("MockBasler:mock_basler_1",)
+
+
+class HardwareCameraInput(BaseModel):
+    cameras: list[str] = Field(
+        default_factory=lambda: list(DEFAULT_MOCK_CAMERAS),
+        description="Camera names to open and capture from. Mock camera names are valid defaults.",
+    )
+    include_mocks: bool = Field(True, description="Whether discovery/open should include mock cameras.")
+    output_format: Literal["numpy", "pil", "png", "jpeg", "jpg"] = Field(
+        "numpy",
+        description="Capture output format. Service suites may use an encoded wire format such as png.",
+    )
+    max_concurrent_captures: int | None = Field(
+        None,
+        ge=1,
+        description="Optional CameraManager concurrency limit for batch capture.",
+    )
+    test_connection: bool = Field(False, description="Whether to test camera connections during open.")
+
+
+class HardwareCameraServiceResources(BaseModel):
+    service_url: str | None = Field(
+        None,
+        description=(
+            "Optional CameraManagerService base URL. If omitted, the suite instantiates CameraManagerService in-process."
+        ),
+    )
+
+
+def camera_names_from_config(config: BenchSuiteConfig) -> list[str]:
+    raw = config.parameters.get("cameras") or DEFAULT_MOCK_CAMERAS
+    if isinstance(raw, str):
+        names = [item.strip() for item in raw.split(",") if item.strip()]
+    else:
+        names = [str(item).strip() for item in raw if str(item).strip()]
+    if not names:
+        raise ValueError("At least one camera name is required")
+    return names
+
+
+def status_from_reporter(reporter: BenchReporter) -> str:
+    return "passed" if reporter.operations > 0 and reporter.failures == 0 else "failed"
+
+
+def image_bytes_processed(image: Any) -> int:
+    if image is None:
+        return 0
+    nbytes = getattr(image, "nbytes", None)
+    if isinstance(nbytes, int):
+        return nbytes
+    size = getattr(image, "size", None)
+    if isinstance(size, tuple) and size:
+        bands = len(getattr(image, "getbands", lambda: ())()) or 1
+        total = 1
+        for dim in size:
+            total *= int(dim)
+        return total * bands
+    if isinstance(size, int):
+        return size
+    if isinstance(image, (bytes, bytearray, memoryview)):
+        return len(image)
+    return 0
+
+
+def service_capture_bytes(result: Any) -> int:
+    if result is None:
+        return 0
+    if isinstance(result, dict):
+        file_size = result.get("file_size_bytes")
+        if isinstance(file_size, int):
+            return file_size
+        image_data = result.get("image_data")
+        if isinstance(image_data, str):
+            return len(image_data)
+        image_size = result.get("image_size")
+    else:
+        file_size = getattr(result, "file_size_bytes", None)
+        if isinstance(file_size, int):
+            return file_size
+        image_data = getattr(result, "image_data", None)
+        if isinstance(image_data, str):
+            return len(image_data)
+        image_size = getattr(result, "image_size", None)
+    if isinstance(image_size, Iterable) and not isinstance(image_size, (str, bytes, bytearray)):
+        dims = [int(dim) for dim in image_size]
+        if len(dims) >= 2:
+            return dims[0] * dims[1]
+    return 0
+
+
+def make_result(
+    *,
+    config: BenchSuiteConfig,
+    reporter: BenchReporter,
+    started: str,
+    monotonic_start: float,
+    cameras: list[str],
+    mode: str,
+    extra_metrics: dict[str, Any] | None = None,
+) -> BenchResult:
+    elapsed = time.perf_counter() - monotonic_start
+    return BenchResult(
+        suite_id=config.suite_id,
+        status=status_from_reporter(reporter),
+        started_at=started,
+        ended_at=utc_now_iso(),
+        duration_seconds=elapsed,
+        operations=reporter.operations,
+        successes=reporter.successes,
+        failures=reporter.failures,
+        bytes_processed=reporter.bytes_processed,
+        latency_seconds=reporter.latency_seconds,
+        error_counts=reporter.error_counts,
+        metrics={
+            **reporter.metrics,
+            "mode": mode,
+            "camera_count": len(cameras),
+            "cameras": cameras,
+            **(extra_metrics or {}),
+        },
+    )

--- a/mindtrace/hardware/mindtrace/hardware/testing/suites/camera_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/testing/suites/camera_manager.py
@@ -88,6 +88,7 @@ class _CameraManagerCaptureMixin(BenchTestSuite):
 
 class HardwareCameraManagerCaptureSmokeSuite(_CameraManagerCaptureMixin):
     suite_id = "hardware.smoke.camera_manager_capture"
+    tags = frozenset({"smoke", "hardware", "camera"})
     title = "Hardware smoke — CameraManager capture"
     description = "Opens configured cameras through CameraManager, captures one image from each, and closes them."
     safety = "Defaults to mock cameras; physical cameras are touched only when explicitly named."
@@ -117,6 +118,7 @@ class HardwareCameraManagerCaptureSmokeSuite(_CameraManagerCaptureMixin):
 
 class HardwareCameraManagerCaptureStressSuite(_CameraManagerCaptureMixin):
     suite_id = "hardware.stress.camera_manager_capture_ceiling"
+    tags = frozenset({"stress", "hardware", "camera"})
     title = "Hardware stress — CameraManager capture ceiling"
     description = "Measures repeated CameraManager capture throughput and latency for configured cameras."
     safety = "Defaults to mock cameras; physical cameras are touched only when explicitly named."

--- a/mindtrace/hardware/mindtrace/hardware/testing/suites/camera_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/testing/suites/camera_manager.py
@@ -1,0 +1,144 @@
+"""CameraManager benchmark suites."""
+
+from __future__ import annotations
+
+import time
+from collections import Counter
+from types import MappingProxyType
+
+from mindtrace.core import BenchReporter, BenchResult, BenchResultSchema, BenchSuiteConfig, BenchTestSuite, TaskSchema
+from mindtrace.hardware.cameras.core.camera_manager import CameraManager
+from mindtrace.hardware.testing.suites._camera_common import (
+    HardwareCameraInput,
+    camera_names_from_config,
+    image_bytes_processed,
+    make_result,
+)
+
+
+class _CameraManagerCaptureMixin(BenchTestSuite):
+    tags = frozenset({"hardware", "camera"})
+    requires = ("camera",)
+    resource_schema = None
+
+    def _run_capture_loop(
+        self,
+        config: BenchSuiteConfig,
+        reporter: BenchReporter,
+        *,
+        capture_once: bool,
+    ) -> BenchResult:
+        started = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        monotonic_start = time.perf_counter()
+        cameras = camera_names_from_config(config)
+        output_format = str(config.parameters.get("output_format", "numpy"))
+        include_mocks = bool(config.parameters.get("include_mocks", True))
+        test_connection = bool(config.parameters.get("test_connection", False))
+        max_concurrent = config.parameters.get("max_concurrent_captures")
+        max_concurrent_captures = int(max_concurrent) if max_concurrent is not None else None
+        per_camera_successes: Counter[str] = Counter()
+        per_camera_failures: Counter[str] = Counter()
+
+        manager = CameraManager(include_mocks=include_mocks, max_concurrent_captures=max_concurrent_captures)
+        try:
+            manager.open(cameras, test_connection=test_connection)
+            deadline = reporter.deadline(config.duration_seconds)
+            while not reporter.is_cancelled():
+                if not capture_once and time.perf_counter() >= deadline:
+                    break
+                for camera in cameras:
+                    op_start = time.perf_counter()
+                    try:
+                        image = manager.open(camera, test_connection=False).capture(output_format=output_format)
+                    except Exception as exc:  # noqa: BLE001 - benchmark records failures and continues.
+                        per_camera_failures[camera] += 1
+                        reporter.record_operation(
+                            success=False,
+                            latency_seconds=time.perf_counter() - op_start,
+                            error=exc,
+                            camera=camera,
+                        )
+                        continue
+                    per_camera_successes[camera] += 1
+                    reporter.record_operation(
+                        success=True,
+                        latency_seconds=time.perf_counter() - op_start,
+                        bytes_processed=image_bytes_processed(image),
+                        camera=camera,
+                    )
+                if capture_once:
+                    break
+        finally:
+            manager.close()
+
+        return make_result(
+            config=config,
+            reporter=reporter,
+            started=started,
+            monotonic_start=monotonic_start,
+            cameras=cameras,
+            mode="camera_manager",
+            extra_metrics={
+                "per_camera_successes": dict(per_camera_successes),
+                "per_camera_failures": dict(per_camera_failures),
+                "output_format": output_format,
+            },
+        )
+
+
+class HardwareCameraManagerCaptureSmokeSuite(_CameraManagerCaptureMixin):
+    suite_id = "hardware.smoke.camera_manager_capture"
+    title = "Hardware smoke — CameraManager capture"
+    description = "Opens configured cameras through CameraManager, captures one image from each, and closes them."
+    safety = "Defaults to mock cameras; physical cameras are touched only when explicitly named."
+    task_schema = TaskSchema(name=suite_id, input_schema=HardwareCameraInput, output_schema=BenchResultSchema)
+    profiles = MappingProxyType(
+        {
+            "smoke": {
+                "duration_seconds": 1.0,
+                "cameras": ["MockBasler:mock_basler_1"],
+                "include_mocks": True,
+                "output_format": "numpy",
+                "test_connection": False,
+            },
+            "stress": {
+                "duration_seconds": 1.0,
+                "cameras": ["MockBasler:mock_basler_1"],
+                "include_mocks": True,
+                "output_format": "numpy",
+                "test_connection": False,
+            },
+        }
+    )
+
+    def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
+        return self._run_capture_loop(config, reporter, capture_once=True)
+
+
+class HardwareCameraManagerCaptureStressSuite(_CameraManagerCaptureMixin):
+    suite_id = "hardware.stress.camera_manager_capture_ceiling"
+    title = "Hardware stress — CameraManager capture ceiling"
+    description = "Measures repeated CameraManager capture throughput and latency for configured cameras."
+    safety = "Defaults to mock cameras; physical cameras are touched only when explicitly named."
+    task_schema = TaskSchema(name=suite_id, input_schema=HardwareCameraInput, output_schema=BenchResultSchema)
+    profiles = MappingProxyType(
+        {
+            "smoke": {
+                "duration_seconds": 1.0,
+                "cameras": ["MockBasler:mock_basler_1"],
+                "include_mocks": True,
+                "output_format": "numpy",
+                "test_connection": False,
+            },
+            "stress": {
+                "duration_seconds": 10.0,
+                "cameras": ["MockBasler:mock_basler_1"],
+                "include_mocks": True,
+                "output_format": "numpy",
+                "test_connection": False,
+            },
+        }
+    )
+
+    def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
+        return self._run_capture_loop(config, reporter, capture_once=False)

--- a/mindtrace/hardware/mindtrace/hardware/testing/suites/camera_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/testing/suites/camera_manager.py
@@ -27,6 +27,7 @@ class _CameraManagerCaptureMixin(BenchTestSuite):
         reporter: BenchReporter,
         *,
         capture_once: bool,
+        batch_capture: bool,
     ) -> BenchResult:
         started = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         monotonic_start = time.perf_counter()
@@ -46,26 +47,58 @@ class _CameraManagerCaptureMixin(BenchTestSuite):
             while not reporter.is_cancelled():
                 if not capture_once and time.perf_counter() >= deadline:
                     break
-                for camera in cameras:
+                if batch_capture:
                     op_start = time.perf_counter()
                     try:
-                        image = manager.open(camera, test_connection=False).capture(output_format=output_format)
+                        results = manager.batch_capture(cameras, output_format=output_format)
                     except Exception as exc:  # noqa: BLE001 - benchmark records failures and continues.
-                        per_camera_failures[camera] += 1
+                        for camera in cameras:
+                            per_camera_failures[camera] += 1
                         reporter.record_operation(
                             success=False,
                             latency_seconds=time.perf_counter() - op_start,
                             error=exc,
+                            cameras=cameras,
+                        )
+                    else:
+                        bytes_processed = 0
+                        failed_cameras: list[str] = []
+                        for camera in cameras:
+                            image = results.get(camera)
+                            if image is None:
+                                per_camera_failures[camera] += 1
+                                failed_cameras.append(camera)
+                                continue
+                            per_camera_successes[camera] += 1
+                            bytes_processed += image_bytes_processed(image)
+                        reporter.record_operation(
+                            success=not failed_cameras,
+                            latency_seconds=time.perf_counter() - op_start,
+                            bytes_processed=bytes_processed,
+                            cameras=cameras,
+                            failed_cameras=failed_cameras,
+                        )
+                else:
+                    for camera in cameras:
+                        op_start = time.perf_counter()
+                        try:
+                            image = manager.open(camera, test_connection=False).capture(output_format=output_format)
+                        except Exception as exc:  # noqa: BLE001 - benchmark records failures and continues.
+                            per_camera_failures[camera] += 1
+                            reporter.record_operation(
+                                success=False,
+                                latency_seconds=time.perf_counter() - op_start,
+                                error=exc,
+                                camera=camera,
+                            )
+                            continue
+                        per_camera_successes[camera] += 1
+                        reporter.record_operation(
+                            success=True,
+                            latency_seconds=time.perf_counter() - op_start,
+                            bytes_processed=image_bytes_processed(image),
                             camera=camera,
                         )
-                        continue
-                    per_camera_successes[camera] += 1
-                    reporter.record_operation(
-                        success=True,
-                        latency_seconds=time.perf_counter() - op_start,
-                        bytes_processed=image_bytes_processed(image),
-                        camera=camera,
-                    )
                 if capture_once:
                     break
         finally:
@@ -82,6 +115,8 @@ class _CameraManagerCaptureMixin(BenchTestSuite):
                 "per_camera_successes": dict(per_camera_successes),
                 "per_camera_failures": dict(per_camera_failures),
                 "output_format": output_format,
+                "batch_capture": batch_capture,
+                "max_concurrent_captures": max_concurrent_captures,
             },
         )
 
@@ -113,7 +148,7 @@ class HardwareCameraManagerCaptureSmokeSuite(_CameraManagerCaptureMixin):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        return self._run_capture_loop(config, reporter, capture_once=True)
+        return self._run_capture_loop(config, reporter, capture_once=True, batch_capture=False)
 
 
 class HardwareCameraManagerCaptureStressSuite(_CameraManagerCaptureMixin):
@@ -143,4 +178,4 @@ class HardwareCameraManagerCaptureStressSuite(_CameraManagerCaptureMixin):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        return self._run_capture_loop(config, reporter, capture_once=False)
+        return self._run_capture_loop(config, reporter, capture_once=False, batch_capture=True)

--- a/mindtrace/hardware/mindtrace/hardware/testing/suites/camera_service.py
+++ b/mindtrace/hardware/mindtrace/hardware/testing/suites/camera_service.py
@@ -27,7 +27,9 @@ class _CameraServiceCaptureMixin(BenchTestSuite):
 
     async def _open_cameras(self, client: Any, cameras: list[str], *, test_connection: bool) -> Any:
         if isinstance(client, CameraManagerService):
-            return await client.open_cameras_batch(CameraOpenBatchRequest(cameras=cameras, test_connection=test_connection))
+            return await client.open_cameras_batch(
+                CameraOpenBatchRequest(cameras=cameras, test_connection=test_connection)
+            )
         return await client.open_cameras_batch(cameras=cameras, test_connection=test_connection)
 
     async def _capture_batch(self, client: Any, cameras: list[str], *, output_format: str) -> Any:
@@ -99,7 +101,11 @@ class _CameraServiceCaptureMixin(BenchTestSuite):
                 bytes_processed = 0
                 if isinstance(data, dict):
                     for camera, result in data.items():
-                        result_success = bool(result.get("success", True)) if isinstance(result, dict) else bool(getattr(result, "success", True))
+                        result_success = (
+                            bool(result.get("success", True))
+                            if isinstance(result, dict)
+                            else bool(getattr(result, "success", True))
+                        )
                         if result_success:
                             per_camera_successes[str(camera)] += 1
                         else:
@@ -146,7 +152,9 @@ class _CameraServiceCaptureMixin(BenchTestSuite):
 class HardwareCameraServiceCaptureSmokeSuite(_CameraServiceCaptureMixin):
     suite_id = "hardware.smoke.camera_service_capture"
     title = "Hardware smoke — CameraManagerService capture"
-    description = "Opens configured cameras through CameraManagerService, captures one image from each, and closes them."
+    description = (
+        "Opens configured cameras through CameraManagerService, captures one image from each, and closes them."
+    )
     safety = "Defaults to mock cameras and in-process service; physical cameras are touched only when explicitly named."
     task_schema = TaskSchema(name=suite_id, input_schema=HardwareCameraInput, output_schema=BenchResultSchema)
     profiles = MappingProxyType(

--- a/mindtrace/hardware/mindtrace/hardware/testing/suites/camera_service.py
+++ b/mindtrace/hardware/mindtrace/hardware/testing/suites/camera_service.py
@@ -151,6 +151,7 @@ class _CameraServiceCaptureMixin(BenchTestSuite):
 
 class HardwareCameraServiceCaptureSmokeSuite(_CameraServiceCaptureMixin):
     suite_id = "hardware.smoke.camera_service_capture"
+    tags = frozenset({"smoke", "hardware", "camera", "service"})
     title = "Hardware smoke — CameraManagerService capture"
     description = (
         "Opens configured cameras through CameraManagerService, captures one image from each, and closes them."
@@ -182,6 +183,7 @@ class HardwareCameraServiceCaptureSmokeSuite(_CameraServiceCaptureMixin):
 
 class HardwareCameraServiceCaptureStressSuite(_CameraServiceCaptureMixin):
     suite_id = "hardware.stress.camera_service_capture_ceiling"
+    tags = frozenset({"stress", "hardware", "camera", "service"})
     title = "Hardware stress — CameraManagerService capture ceiling"
     description = "Measures repeated CameraManagerService capture throughput and latency for configured cameras."
     safety = "Defaults to mock cameras and in-process service; physical cameras are touched only when explicitly named."

--- a/mindtrace/hardware/mindtrace/hardware/testing/suites/camera_service.py
+++ b/mindtrace/hardware/mindtrace/hardware/testing/suites/camera_service.py
@@ -1,0 +1,201 @@
+"""CameraManagerService benchmark suites."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import Counter
+from types import MappingProxyType
+from typing import Any
+
+from mindtrace.core import BenchReporter, BenchResult, BenchResultSchema, BenchSuiteConfig, BenchTestSuite, TaskSchema
+from mindtrace.hardware.services.cameras.models import CameraOpenBatchRequest, CaptureBatchRequest
+from mindtrace.hardware.services.cameras.service import CameraManagerService
+from mindtrace.hardware.testing.suites._camera_common import (
+    HardwareCameraInput,
+    HardwareCameraServiceResources,
+    camera_names_from_config,
+    make_result,
+    service_capture_bytes,
+)
+
+
+class _CameraServiceCaptureMixin(BenchTestSuite):
+    tags = frozenset({"hardware", "camera", "service"})
+    requires = ("camera_service",)
+    resource_schema = HardwareCameraServiceResources
+
+    async def _open_cameras(self, client: Any, cameras: list[str], *, test_connection: bool) -> Any:
+        if isinstance(client, CameraManagerService):
+            return await client.open_cameras_batch(CameraOpenBatchRequest(cameras=cameras, test_connection=test_connection))
+        return await client.open_cameras_batch(cameras=cameras, test_connection=test_connection)
+
+    async def _capture_batch(self, client: Any, cameras: list[str], *, output_format: str) -> Any:
+        if isinstance(client, CameraManagerService):
+            return await client.capture_images_batch(CaptureBatchRequest(cameras=cameras, output_format=output_format))
+        return await client.capture_images_batch(cameras=cameras, output_format=output_format)
+
+    async def _close_all(self, client: Any) -> None:
+        close_all = getattr(client, "close_all_cameras", None)
+        if close_all is None:
+            return
+        result = close_all()
+        if hasattr(result, "__await__"):
+            await result
+
+    async def _run_capture_loop_async(
+        self,
+        config: BenchSuiteConfig,
+        reporter: BenchReporter,
+        *,
+        capture_once: bool,
+    ) -> BenchResult:
+        started = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        monotonic_start = time.perf_counter()
+        cameras = camera_names_from_config(config)
+        output_format = str(config.parameters.get("output_format", "png"))
+        include_mocks = bool(config.parameters.get("include_mocks", True))
+        test_connection = bool(config.parameters.get("test_connection", False))
+        service_url = config.resources.get("service_url")
+        per_camera_successes: Counter[str] = Counter()
+        per_camera_failures: Counter[str] = Counter()
+        owned_service: CameraManagerService | None = None
+
+        if service_url:
+            client = CameraManagerService.connect(str(service_url))
+        else:
+            owned_service = CameraManagerService(include_mocks=include_mocks)
+            client = owned_service
+
+        try:
+            await self._open_cameras(client, cameras, test_connection=test_connection)
+            deadline = reporter.deadline(config.duration_seconds)
+            while not reporter.is_cancelled():
+                if not capture_once and time.perf_counter() >= deadline:
+                    break
+                op_start = time.perf_counter()
+                try:
+                    response = await self._capture_batch(client, cameras, output_format=output_format)
+                except Exception as exc:  # noqa: BLE001 - benchmark records failures and continues.
+                    for camera in cameras:
+                        per_camera_failures[camera] += 1
+                    reporter.record_operation(
+                        success=False,
+                        latency_seconds=time.perf_counter() - op_start,
+                        error=exc,
+                        cameras=cameras,
+                    )
+                    if capture_once:
+                        break
+                    continue
+
+                data = response.get("data", response) if isinstance(response, dict) else getattr(response, "data", {})
+                failed_count = int(
+                    response.get("failed_count", 0)
+                    if isinstance(response, dict)
+                    else getattr(response, "failed_count", 0)
+                )
+                success = failed_count == 0
+                bytes_processed = 0
+                if isinstance(data, dict):
+                    for camera, result in data.items():
+                        result_success = bool(result.get("success", True)) if isinstance(result, dict) else bool(getattr(result, "success", True))
+                        if result_success:
+                            per_camera_successes[str(camera)] += 1
+                        else:
+                            per_camera_failures[str(camera)] += 1
+                        bytes_processed += service_capture_bytes(result)
+                reporter.record_operation(
+                    success=success,
+                    latency_seconds=time.perf_counter() - op_start,
+                    bytes_processed=bytes_processed,
+                    cameras=cameras,
+                )
+                if capture_once:
+                    break
+        finally:
+            await self._close_all(client)
+            if owned_service is not None:
+                await owned_service.shutdown_cleanup()
+
+        return make_result(
+            config=config,
+            reporter=reporter,
+            started=started,
+            monotonic_start=monotonic_start,
+            cameras=cameras,
+            mode="camera_manager_service",
+            extra_metrics={
+                "per_camera_successes": dict(per_camera_successes),
+                "per_camera_failures": dict(per_camera_failures),
+                "output_format": output_format,
+                "service_url": str(service_url) if service_url else None,
+            },
+        )
+
+    def _run_capture_loop(
+        self,
+        config: BenchSuiteConfig,
+        reporter: BenchReporter,
+        *,
+        capture_once: bool,
+    ) -> BenchResult:
+        return asyncio.run(self._run_capture_loop_async(config, reporter, capture_once=capture_once))
+
+
+class HardwareCameraServiceCaptureSmokeSuite(_CameraServiceCaptureMixin):
+    suite_id = "hardware.smoke.camera_service_capture"
+    title = "Hardware smoke — CameraManagerService capture"
+    description = "Opens configured cameras through CameraManagerService, captures one image from each, and closes them."
+    safety = "Defaults to mock cameras and in-process service; physical cameras are touched only when explicitly named."
+    task_schema = TaskSchema(name=suite_id, input_schema=HardwareCameraInput, output_schema=BenchResultSchema)
+    profiles = MappingProxyType(
+        {
+            "smoke": {
+                "duration_seconds": 1.0,
+                "cameras": ["MockBasler:mock_basler_1"],
+                "include_mocks": True,
+                "output_format": "png",
+                "test_connection": False,
+            },
+            "stress": {
+                "duration_seconds": 1.0,
+                "cameras": ["MockBasler:mock_basler_1"],
+                "include_mocks": True,
+                "output_format": "png",
+                "test_connection": False,
+            },
+        }
+    )
+
+    def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
+        return self._run_capture_loop(config, reporter, capture_once=True)
+
+
+class HardwareCameraServiceCaptureStressSuite(_CameraServiceCaptureMixin):
+    suite_id = "hardware.stress.camera_service_capture_ceiling"
+    title = "Hardware stress — CameraManagerService capture ceiling"
+    description = "Measures repeated CameraManagerService capture throughput and latency for configured cameras."
+    safety = "Defaults to mock cameras and in-process service; physical cameras are touched only when explicitly named."
+    task_schema = TaskSchema(name=suite_id, input_schema=HardwareCameraInput, output_schema=BenchResultSchema)
+    profiles = MappingProxyType(
+        {
+            "smoke": {
+                "duration_seconds": 1.0,
+                "cameras": ["MockBasler:mock_basler_1"],
+                "include_mocks": True,
+                "output_format": "png",
+                "test_connection": False,
+            },
+            "stress": {
+                "duration_seconds": 10.0,
+                "cameras": ["MockBasler:mock_basler_1"],
+                "include_mocks": True,
+                "output_format": "png",
+                "test_connection": False,
+            },
+        }
+    )
+
+    def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
+        return self._run_capture_loop(config, reporter, capture_once=False)

--- a/mindtrace/hardware/pyproject.toml
+++ b/mindtrace/hardware/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
     "aiomqtt>=2.4.0",
 ]
 
+[project.entry-points."mindtrace.benchmark_suites"]
+hardware = "mindtrace.hardware.testing:register_benchmark_suites"
+
 [project.scripts]
 # Main CLI
 mindtrace-hw = "mindtrace.hardware.cli.__main__:main"

--- a/tests/unit/mindtrace/hardware/testing/test_camera_manager_suites.py
+++ b/tests/unit/mindtrace/hardware/testing/test_camera_manager_suites.py
@@ -1,0 +1,99 @@
+"""Unit tests for CameraManager benchmark suites."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+
+from mindtrace.core import BenchReporter
+from mindtrace.core.testing.bench_suite import build_bench_suite_config
+from mindtrace.hardware.testing.suites.camera_manager import (
+    HardwareCameraManagerCaptureSmokeSuite,
+    HardwareCameraManagerCaptureStressSuite,
+)
+
+
+class FakeCamera:
+    name = "MockBasler:mock_basler_1"
+
+    def capture(self, output_format: str = "numpy"):
+        assert output_format == "numpy"
+        return np.zeros((4, 5, 3), dtype=np.uint8)
+
+
+class FakeCameraManager:
+    instances: list["FakeCameraManager"] = []
+
+    def __init__(self, *, include_mocks: bool = False, max_concurrent_captures: int | None = None):
+        self.include_mocks = include_mocks
+        self.max_concurrent_captures = max_concurrent_captures
+        self.open_calls: list[object] = []
+        self.closed = False
+        FakeCameraManager.instances.append(self)
+
+    def open(self, names=None, test_connection: bool = True, **_kwargs):
+        self.open_calls.append((names, test_connection))
+        if isinstance(names, list):
+            return {name: FakeCamera() for name in names}
+        return FakeCamera()
+
+    def close(self, names=None):  # noqa: ARG002
+        self.closed = True
+
+
+def _config_for(suite_cls, *, duration_seconds: float = 0.0):
+    contrib = suite_cls.as_contribution()
+    cfg = build_bench_suite_config(
+        contrib,
+        profile="smoke",
+        run_id="unit-run",
+        extra_parameters={
+            "cameras": ["MockBasler:mock_basler_1", "MockBasler:mock_basler_2"],
+            "include_mocks": True,
+            "output_format": "numpy",
+            "test_connection": False,
+            "max_concurrent_captures": 2,
+        },
+        resources={},
+    )
+    return dataclasses.replace(cfg, duration_seconds=duration_seconds)
+
+
+def test_camera_manager_smoke_suite_opens_captures_and_closes(monkeypatch):
+    import mindtrace.hardware.testing.suites.camera_manager as module
+
+    FakeCameraManager.instances.clear()
+    monkeypatch.setattr(module, "CameraManager", FakeCameraManager)
+
+    config = _config_for(HardwareCameraManagerCaptureSmokeSuite)
+    reporter = BenchReporter(suite_id=HardwareCameraManagerCaptureSmokeSuite.suite_id)
+    result = HardwareCameraManagerCaptureSmokeSuite().execute_bench(config, reporter)
+
+    assert result.status == "passed"
+    assert result.operations == 2
+    assert result.successes == 2
+    assert result.failures == 0
+    assert result.bytes_processed == 2 * 4 * 5 * 3
+    assert result.metrics["mode"] == "camera_manager"
+    assert result.metrics["camera_count"] == 2
+    manager = FakeCameraManager.instances[-1]
+    assert manager.include_mocks is True
+    assert manager.max_concurrent_captures == 2
+    assert manager.closed is True
+
+
+def test_camera_manager_stress_suite_repeats_until_deadline(monkeypatch):
+    import mindtrace.hardware.testing.suites.camera_manager as module
+
+    FakeCameraManager.instances.clear()
+    monkeypatch.setattr(module, "CameraManager", FakeCameraManager)
+
+    config = _config_for(HardwareCameraManagerCaptureStressSuite, duration_seconds=0.01)
+    reporter = BenchReporter(suite_id=HardwareCameraManagerCaptureStressSuite.suite_id)
+    result = HardwareCameraManagerCaptureStressSuite().execute_bench(config, reporter)
+
+    assert result.status == "passed"
+    assert result.operations >= 2
+    assert result.successes == result.operations
+    assert FakeCameraManager.instances[-1].closed is True

--- a/tests/unit/mindtrace/hardware/testing/test_camera_service_suites.py
+++ b/tests/unit/mindtrace/hardware/testing/test_camera_service_suites.py
@@ -1,0 +1,106 @@
+"""Unit tests for CameraManagerService benchmark suites."""
+
+from __future__ import annotations
+
+import dataclasses
+
+from mindtrace.core import BenchReporter
+from mindtrace.core.testing.bench_suite import build_bench_suite_config
+from mindtrace.hardware.testing.suites.camera_service import (
+    HardwareCameraServiceCaptureSmokeSuite,
+    HardwareCameraServiceCaptureStressSuite,
+)
+
+
+class FakeCameraManagerService:
+    instances: list["FakeCameraManagerService"] = []
+
+    def __init__(self, *, include_mocks: bool = False, **_kwargs):
+        self.include_mocks = include_mocks
+        self.open_calls: list[object] = []
+        self.capture_calls: list[object] = []
+        self.closed = False
+        self.shutdown = False
+        FakeCameraManagerService.instances.append(self)
+
+    async def open_cameras_batch(self, request):
+        self.open_calls.append(request)
+        return {camera: True for camera in request.cameras}
+
+    async def capture_images_batch(self, request):
+        self.capture_calls.append(request)
+        return {
+            "data": {
+                camera: {
+                    "success": True,
+                    "image_data": "abc123",
+                    "image_size": (2, 3),
+                    "file_size_bytes": 6,
+                }
+                for camera in request.cameras
+            },
+            "successful_count": len(request.cameras),
+            "failed_count": 0,
+        }
+
+    async def close_all_cameras(self):
+        self.closed = True
+        return True
+
+    async def shutdown_cleanup(self):
+        self.shutdown = True
+
+
+def _config_for(suite_cls, *, duration_seconds: float = 0.0):
+    contrib = suite_cls.as_contribution()
+    cfg = build_bench_suite_config(
+        contrib,
+        profile="smoke",
+        run_id="unit-run",
+        extra_parameters={
+            "cameras": ["MockBasler:mock_basler_1", "MockBasler:mock_basler_2"],
+            "include_mocks": True,
+            "output_format": "png",
+            "test_connection": False,
+        },
+        resources={},
+    )
+    return dataclasses.replace(cfg, duration_seconds=duration_seconds)
+
+
+def test_camera_service_smoke_suite_opens_captures_and_closes(monkeypatch):
+    import mindtrace.hardware.testing.suites.camera_service as module
+
+    FakeCameraManagerService.instances.clear()
+    monkeypatch.setattr(module, "CameraManagerService", FakeCameraManagerService)
+
+    config = _config_for(HardwareCameraServiceCaptureSmokeSuite)
+    reporter = BenchReporter(suite_id=HardwareCameraServiceCaptureSmokeSuite.suite_id)
+    result = HardwareCameraServiceCaptureSmokeSuite().execute_bench(config, reporter)
+
+    assert result.status == "passed"
+    assert result.operations == 1
+    assert result.successes == 1
+    assert result.failures == 0
+    assert result.bytes_processed == 12
+    assert result.metrics["mode"] == "camera_manager_service"
+    service = FakeCameraManagerService.instances[-1]
+    assert service.include_mocks is True
+    assert service.closed is True
+    assert service.shutdown is True
+
+
+def test_camera_service_stress_suite_repeats_until_deadline(monkeypatch):
+    import mindtrace.hardware.testing.suites.camera_service as module
+
+    FakeCameraManagerService.instances.clear()
+    monkeypatch.setattr(module, "CameraManagerService", FakeCameraManagerService)
+
+    config = _config_for(HardwareCameraServiceCaptureStressSuite, duration_seconds=0.01)
+    reporter = BenchReporter(suite_id=HardwareCameraServiceCaptureStressSuite.suite_id)
+    result = HardwareCameraServiceCaptureStressSuite().execute_bench(config, reporter)
+
+    assert result.status == "passed"
+    assert result.operations >= 1
+    assert result.successes == result.operations
+    assert FakeCameraManagerService.instances[-1].closed is True

--- a/tests/unit/mindtrace/hardware/testing/test_hardware_benchmark_registration.py
+++ b/tests/unit/mindtrace/hardware/testing/test_hardware_benchmark_registration.py
@@ -1,0 +1,43 @@
+"""Hardware benchmark suite registration tests."""
+
+from __future__ import annotations
+
+
+def _assert_suite_schema_contract(suite_schema: object, *, suite_id: str) -> None:
+    assert getattr(suite_schema, "suite_id") == suite_id
+    task_schema = getattr(suite_schema, "task_schema")
+    resource_json_schema = getattr(suite_schema, "resource_json_schema")
+
+    assert task_schema is not None
+    assert task_schema["name"] == suite_id
+    assert task_schema["input_json_schema"] is not None
+    assert task_schema["output_json_schema"] is not None
+    assert task_schema["output_json_schema"]["title"] == "BenchResultSchema"
+
+    if resource_json_schema is not None:
+        assert resource_json_schema["type"] == "object"
+        assert "properties" in resource_json_schema
+
+
+def test_hardware_testing_registers_expected_ids_and_schemas() -> None:
+    import mindtrace.hardware.testing as ht
+    from mindtrace.core import TestRunner
+
+    TestRunner.clear_registry()
+    ht.register_benchmark_suites()
+
+    expected = {
+        "hardware.smoke.camera_manager_capture",
+        "hardware.stress.camera_manager_capture_ceiling",
+        "hardware.smoke.camera_service_capture",
+        "hardware.stress.camera_service_capture_ceiling",
+    }
+    assert expected.issubset(set(TestRunner.registered_suites()))
+
+    for suite_id in expected:
+        _assert_suite_schema_contract(TestRunner.get_suite_schema(suite_id), suite_id=suite_id)
+
+    manager_smoke = TestRunner.get_suite_schema("hardware.smoke.camera_manager_capture")
+    input_properties = manager_smoke.task_schema["input_json_schema"]["properties"]
+    assert "cameras" in input_properties
+    assert manager_smoke.profiles["smoke"]["cameras"] == ["MockBasler:mock_basler_1"]

--- a/tests/unit/mindtrace/hardware/testing/test_hardware_benchmark_registration.py
+++ b/tests/unit/mindtrace/hardware/testing/test_hardware_benchmark_registration.py
@@ -41,3 +41,14 @@ def test_hardware_testing_registers_expected_ids_and_schemas() -> None:
     input_properties = manager_smoke.task_schema["input_json_schema"]["properties"]
     assert "cameras" in input_properties
     assert manager_smoke.profiles["smoke"]["cameras"] == ["MockBasler:mock_basler_1"]
+
+    smoke_suites = set(TestRunner.suite_ids_for_profile("smoke"))
+    stress_suites = set(TestRunner.suite_ids_for_profile("stress"))
+    assert {
+        "hardware.smoke.camera_manager_capture",
+        "hardware.smoke.camera_service_capture",
+    }.issubset(smoke_suites)
+    assert {
+        "hardware.stress.camera_manager_capture_ceiling",
+        "hardware.stress.camera_service_capture_ceiling",
+    }.issubset(stress_suites)


### PR DESCRIPTION
## Summary

This PR adds first-class Mindtrace hardware camera benchmark suites on top of `dev`.

The main changes are:

- add smoke and stress benchmark suites for `CameraManager`
- add smoke and stress benchmark suites for `CameraManagerService`
- register the hardware benchmark package through `mindtrace.hardware.testing`
- add shared camera benchmark helpers for camera selection, capture byte accounting, and result shaping
- add focused unit coverage for suite execution and benchmark registration

## What changed

### CameraManager benchmark suites

This branch introduces:

- `hardware.smoke.camera_manager_capture`
- `hardware.stress.camera_manager_capture_ceiling`

Both suites open configured cameras through `CameraManager`, capture images, record per-camera success/failure counts, and close the manager in `finally`.

The smoke suite captures once per configured camera. The stress suite repeatedly captures until the benchmark deadline or cancellation token is reached.

### CameraManagerService benchmark suites

This branch also introduces:

- `hardware.smoke.camera_service_capture`
- `hardware.stress.camera_service_capture_ceiling`

These exercise the service-oriented camera path via `CameraManagerService`. If `resources.service_url` is provided, the suite connects to an external service. Otherwise it creates an in-process service with mock support enabled by default.

The suites close opened cameras and shut down owned in-process services during cleanup.

### Benchmark inputs and safety defaults

The shared hardware camera input schema supports:

```python
cameras: list[str]
include_mocks: bool
output_format: "numpy" | "pil" | "png" | "jpeg" | "jpg"
max_concurrent_captures: int | None
test_connection: bool
```

Defaults are intentionally safe:

- mock Basler camera by default: `MockBasler:mock_basler_1`
- `include_mocks=True`
- physical cameras are touched only when explicitly named
- smoke profiles run a single capture pass

### Registration

`mindtrace.hardware.testing.register_benchmark_suites(...)` registers the new hardware benchmark contributions with the core `TestRunner`, matching the embedded benchmark pattern used by the other Mindtrace packages.

## How to run the hardware benchmark suite

From a fresh checkout:

```bash
uv sync --dev
```

List the hardware benchmark suites exposed by the plugin:

```bash
uv run python -m mindtrace.core.testing hardware --profile stress --list
```

Run the hardware stress benchmark profile with the default mock Basler camera:

```bash
uv run python -m mindtrace.core.testing hardware \
  --profile stress \
  --run-id hardware-stress-$(date -u +%Y%m%dT%H%M%SZ)
```

That runs the hardware benchmark plugin’s stress-profile suites, including:

- `hardware.stress.camera_manager_capture_ceiling`
- `hardware.stress.camera_service_capture_ceiling`

The default configuration uses `MockBasler:mock_basler_1`, so it does not require physical camera hardware.

To run against real hardware, pass explicit camera parameters to the benchmark suite configuration. For example, when constructing a benchmark request programmatically:

```json
{
  "profile": "stress",
  "packages": ["hardware"],
  "suites": ["hardware.stress.camera_manager_capture_ceiling"],
  "cases": [
    {
      "suite_id": "hardware.stress.camera_manager_capture_ceiling",
      "parameters": {
        "cameras": ["Basler:your_camera_name"],
        "include_mocks": false,
        "output_format": "numpy",
        "test_connection": true
      }
    }
  ]
}
```

For the service benchmark path, use `hardware.stress.camera_service_capture_ceiling`. If `resources.service_url` is provided, the suite connects to that camera service; otherwise it starts an in-process `CameraManagerService`.

## How to run validation tests

Run the targeted hardware benchmark unit tests:

```bash
uv run pytest tests/unit/mindtrace/hardware/testing -q
```

Or, using the repository test wrapper:

```bash
ds test: tests/unit/mindtrace/hardware/testing/
```

Run the full unit suite before marking ready:

```bash
ds test --unit
```

Run Ruff formatting/lint checks:

```bash
uv run ruff format --check .
uv run ruff check .
```

## Validation / coverage added

This branch adds unit coverage for:

- `CameraManager` smoke/stress suite execution with mock cameras
- `CameraManagerService` smoke/stress suite execution with mock cameras / in-process service behavior
- hardware benchmark registration through `mindtrace.hardware.testing`
- schema exposure for the new hardware benchmark suites

Relevant touched test areas include:

- `tests/unit/mindtrace/hardware/testing/test_camera_manager_suites.py`
- `tests/unit/mindtrace/hardware/testing/test_camera_service_suites.py`
- `tests/unit/mindtrace/hardware/testing/test_hardware_benchmark_registration.py`

Latest local validation:

```text
uv run ruff format --check .
949 files already formatted

uv run ruff check .
All checks passed!

uv run pytest tests/unit/mindtrace/hardware/testing -q
5 passed, 1 warning in 1.32s
```

## Notes

- This PR targets `dev` directly.
- It is limited to the hardware package benchmark definitions and unit tests.
- The default suite configuration uses mock cameras so the tests and smoke profiles do not require physical camera hardware.
- Physical camera benchmarking is available by passing explicit camera names through the benchmark input.
