### PR TITLE
Fix/plc hardware identify tag and tests

### DIFF
--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
@@ -976,41 +976,11 @@ class AllenBradleyPLC(BasePLC):
                 # CIP discovery failed, continue with fallback methods
                 pass
 
-            # Fallback: Check common IP addresses using CIPDriver.list_identity()
-            if not discovered_devices:
-                common_ips = [
-                    "192.168.1.10",
-                    "192.168.1.11",
-                    "192.168.1.12",
-                    "192.168.0.10",
-                    "192.168.0.11",
-                    "192.168.0.12",
-                    "10.0.0.10",
-                    "10.0.0.11",
-                    "10.0.0.12",
-                ]
-
-                for ip in common_ips:
-                    try:
-                        # Use official CIPDriver.list_identity() class method
-                        device_info = CIPDriver.list_identity(ip)
-                        if device_info:
-                            product_name = device_info.get("product_name", "")
-                            product_type = device_info.get("product_type", "")
-
-                            # Determine device type
-                            device_type = "CIP"
-                            if "ControlLogix" in product_name or "CompactLogix" in product_name:
-                                device_type = "Logix"
-                            elif "MicroLogix" in product_name or "SLC" in product_name:
-                                device_type = "SLC"
-                            elif product_type == "Programmable Logic Controller":
-                                device_type = "Logix"
-
-                            discovered_devices.append(f"AllenBradley:{ip}:{device_type}")
-
-                    except Exception:
-                        continue
+            # No hardcoded-IP fallback. Probing a fixed list of "common" IPs is
+            # noisy, almost always wrong, and looks like reconnaissance to OT
+            # security tooling. Broadcast (above) is the only segment-wide
+            # method here; for a known device use the targeted, unicast
+            # ``identify(host)`` instead.
 
             # Remove duplicates while preserving order
             seen = set()
@@ -1036,6 +1006,51 @@ class AllenBradleyPLC(BasePLC):
             List[str]: List of discovered PLC IP addresses.
         """
         return await asyncio.to_thread(cls.get_available_plcs)
+
+    @classmethod
+    async def identify(cls, host: str, *, port: "int | None" = None, timeout: float = 1.0) -> "Dict[str, Any] | None":
+        """Identify a single Allen-Bradley / EtherNet-IP device by unicast.
+
+        Sends ONE EtherNet/IP ListIdentity (CIP ``0x63``) to ``host`` on TCP/UDP
+        44818 via ``CIPDriver.list_identity`` — a targeted, read-only request to
+        the device's own management port. No broadcast, no scanning, no
+        fixed-IP probing, so it crosses routers/VLANs/containers and doesn't
+        look like recon. Returns the device identity plus the matching driver
+        (``logix`` / ``slc`` / ``cip``), or ``None`` if nothing answers as an
+        EtherNet/IP device at ``host``.
+        """
+        if not PYCOMM3_AVAILABLE:
+            return None
+        try:
+            info = await asyncio.wait_for(
+                asyncio.to_thread(CIPDriver.list_identity, host),
+                timeout=max(timeout, 0.5),
+            )
+        except Exception:
+            return None
+        if not info:
+            return None
+        product_name = info.get("product_name", "") or ""
+        product_type = info.get("product_type", "") or ""
+        driver = "cip"
+        if "ControlLogix" in product_name or "CompactLogix" in product_name:
+            driver = "logix"
+        elif "MicroLogix" in product_name or "SLC" in product_name:
+            driver = "slc"
+        elif product_type == "Programmable Logic Controller":
+            driver = "logix"
+        return {
+            "backend": "AllenBradley",
+            "driver": driver,
+            "ip": host,
+            "port": port or 44818,
+            "vendor": info.get("vendor", "") or "",
+            "product": product_name,
+            "product_type": product_type,
+            "revision": str(info.get("revision", "") or ""),
+            "serial": str(info.get("serial", "") or ""),
+            "reachable": True,
+        }
 
     @staticmethod
     def get_backend_info() -> Dict[str, Any]:

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
@@ -556,7 +556,17 @@ class AllenBradleyPLC(BasePLC):
             if self.driver_type == "LogixDriver":
                 # LogixDriver has built-in tag list functionality
                 tags_dict = await asyncio.to_thread(lambda: self.plc.tags)
-                self._tags_cache = list(tags_dict.keys()) if tags_dict else []
+                if not tags_dict:
+                    # We're connected, but the controller tag list came back
+                    # empty/None — for a Logix controller that means the upload
+                    # failed, not that the PLC is tag-less. Caching [] here would
+                    # silently report "no tags" and make every later lookup look
+                    # like a missing tag. Fail loudly instead.
+                    raise PLCTagError(
+                        f"Tag list upload from Allen Bradley PLC at {self.ip_address} "
+                        "returned empty; the controller tag list could not be read"
+                    )
+                self._tags_cache = list(tags_dict.keys())
 
             elif self.driver_type == "SLCDriver":
                 # Enhanced SLCDriver tag discovery with comprehensive data file mapping
@@ -776,6 +786,10 @@ class AllenBradleyPLC(BasePLC):
             self._cache_timestamp = current_time
             return self._tags_cache
 
+        except PLCTagError:
+            # Already a clear, intentional error (e.g. empty tag-list upload) —
+            # don't re-wrap it.
+            raise
         except Exception as e:
             self.logger.error(f"Failed to get tags: {e}")
             raise PLCTagError(f"Failed to get tags from Allen Bradley PLC: {e}")
@@ -797,6 +811,15 @@ class AllenBradleyPLC(BasePLC):
         try:
             if self.driver_type == "LogixDriver":
                 tags_dict = await asyncio.to_thread(lambda: self.plc.tags)
+                if not tags_dict:
+                    # Connected, but the controller tag list is empty/None — the
+                    # upload failed. We CANNOT conclude the tag is absent; raising
+                    # "not found" here is the long-standing bug that mislabels a
+                    # tag-list-fetch failure as a missing tag. Surface it honestly.
+                    raise PLCTagError(
+                        f"Could not read the tag list from Allen Bradley PLC at "
+                        f"{self.ip_address}; cannot verify whether tag '{tag_name}' exists"
+                    )
                 if tag_name in tags_dict:
                     tag_info = tags_dict[tag_name]
                     return {
@@ -829,6 +852,9 @@ class AllenBradleyPLC(BasePLC):
                 }
 
         except PLCTagNotFoundError:
+            raise
+        except PLCTagError:
+            # Intentional, already-clear error (e.g. tag list couldn't be read).
             raise
         except Exception as e:
             self.logger.error(f"Failed to get tag info: {e}")

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/base.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/base.py
@@ -267,6 +267,32 @@ class BasePLC(MindtraceABC):
         """
         pass
 
+    @classmethod
+    async def identify(cls, host: str, *, port: "int | None" = None, timeout: float = 1.0) -> "Dict[str, Any] | None":
+        """Probe a SINGLE host for its device identity (unicast, read-only).
+
+        The targeted, firewall-safe counterpart to ``get_available_plcs``:
+        rather than broadcasting or scanning, send ONE native identity request
+        to a host the operator named — on the device's own service port,
+        read-only — and return the device identity plus the driver that fits,
+        or ``None`` if the host doesn't answer as this backend's device type.
+
+        Backends override this with their protocol-native primitive (EtherNet/IP
+        ListIdentity, Siemens S7 SZL read, Modbus Read-Device-Identification).
+        The default is "not supported", so a backend that hasn't implemented it
+        never claims a host (the manager moves on to the next backend).
+
+        Args:
+            host: IP / hostname to probe.
+            port: Optional service-port override (backend default otherwise).
+            timeout: Per-probe timeout in seconds.
+
+        Returns:
+            Identity dict with keys ``backend, driver, ip, port, vendor,
+            product, revision, serial, reachable`` — or ``None``.
+        """
+        return None
+
     @staticmethod
     @abstractmethod
     def get_backend_info() -> Dict[str, Any]:

--- a/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
@@ -202,6 +202,47 @@ class PLCManager(Mindtrace):
 
         return discovered_plcs
 
+    async def identify(
+        self,
+        host: str,
+        *,
+        backend: "str | None" = None,
+        port: "int | None" = None,
+        timeout: float = 1.0,
+    ) -> "Dict[str, Any] | None":
+        """Identify the device at ``host`` with one unicast probe per backend.
+
+        Targeted counterpart to :meth:`discover_plcs`: instead of broadcasting,
+        try the enabled backends' ``identify`` (optionally just ``backend``) in
+        priority order and return the first that answers. No broadcast, no
+        scanning, no fixed-IP probing — only a unicast to ``host`` on each
+        backend's own service port. Works across routed/VLAN/container networks
+        and doesn't trip OT intrusion detection.
+
+        Returns the identity dict (with ``backend`` filled in) or ``None`` if
+        no enabled backend recognizes the host.
+        """
+
+        def _norm(s: str) -> str:
+            return s.strip().lower().replace("_", "").replace("-", "").replace(" ", "")
+
+        backends = self._get_enabled_backends()
+        if backend:
+            wanted = _norm(backend)
+            backends = {name: cls for name, cls in backends.items() if wanted in _norm(name)}
+
+        for backend_name, backend_class in backends.items():
+            try:
+                identity = await backend_class.identify(host, port=port, timeout=timeout)
+            except Exception as e:
+                self.logger.debug(f"identify via {backend_name} failed for {host}: {e}")
+                identity = None
+            if identity:
+                identity.setdefault("backend", backend_name)
+                self.logger.info(f"Identified {host} as {identity.get('product') or backend_name}")
+                return identity
+        return None
+
     def _get_enabled_backends(self) -> Dict[str, type]:
         """
         Get enabled PLC backends based on configuration.

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
@@ -1994,25 +1994,6 @@ class TestAllenBradleyPLCStaticMethods:
         assert "AllenBradley:192.168.1.10:Logix" in plcs
         assert "AllenBradley:192.168.1.11:Drive" in plcs
 
-    def test_get_available_plcs_fallback_list_identity(self, mock_pycomm3_available):
-        """Test get_available_plcs fallback to list_identity."""
-        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
-            AllenBradleyPLC,
-            CIPDriver,
-        )
-
-        CIPDriver.discover.side_effect = Exception("Discovery failed")
-        CIPDriver.list_identity.return_value = {
-            "ip_address": "192.168.1.10",
-            "product_name": "ControlLogix L75",
-            "product_type": "Programmable Logic Controller",
-        }
-
-        plcs = AllenBradleyPLC.get_available_plcs()
-
-        assert isinstance(plcs, list)
-        assert len(plcs) > 0
-
     def test_get_available_plcs_without_pycomm3(self, mock_pycomm3_unavailable):
         """Test get_available_plcs when pycomm3 is unavailable."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import AllenBradleyPLC
@@ -2108,40 +2089,43 @@ class TestAllenBradleyPLCStaticMethods:
         assert "AllenBradley:192.168.1.12:Logix" in plcs
         assert "AllenBradley:192.168.1.13:CIP" in plcs
 
-    def test_get_available_plcs_fallback_list_identity_exception(self, mock_pycomm3_available):
-        """Test get_available_plcs fallback when list_identity raises exception."""
+    @pytest.mark.asyncio
+    async def test_identify_returns_device_identity(self, mock_pycomm3_available):
+        """identify() returns the device identity + matching driver from one unicast probe."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             CIPDriver,
         )
 
-        CIPDriver.discover.side_effect = Exception("Discovery failed")
-        CIPDriver.list_identity.side_effect = Exception("List identity failed")
-
-        plcs = AllenBradleyPLC.get_available_plcs()
-
-        assert isinstance(plcs, list)
-        assert len(plcs) == 0
-
-    def test_get_available_plcs_fallback_list_identity_success(self, mock_pycomm3_available):
-        """Test get_available_plcs fallback when list_identity succeeds."""
-        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
-            AllenBradleyPLC,
-            CIPDriver,
-        )
-
-        CIPDriver.discover.side_effect = Exception("Discovery failed")
         CIPDriver.list_identity.return_value = {
-            "product_name": "MicroLogix 1400",
+            "product_name": "1756-L75 ControlLogix",
             "product_type": "Programmable Logic Controller",
+            "vendor": "Rockwell Automation",
+            "revision": "32.11",
+            "serial": "00C0FFEE",
         }
 
-        plcs = AllenBradleyPLC.get_available_plcs()
+        identity = await AllenBradleyPLC.identify("10.0.0.42")
 
-        assert isinstance(plcs, list)
-        assert len(plcs) > 0
-        # Should have found devices from common IPs
-        assert any("SLC" in p or "Logix" in p for p in plcs)
+        assert identity is not None
+        assert identity["backend"] == "AllenBradley"
+        assert identity["ip"] == "10.0.0.42"
+        assert identity["port"] == 44818
+        assert identity["driver"] == "logix"
+        assert identity["product"] == "1756-L75 ControlLogix"
+        assert identity["serial"] == "00C0FFEE"
+
+    @pytest.mark.asyncio
+    async def test_identify_returns_none_when_no_response(self, mock_pycomm3_available):
+        """identify() returns None when nothing answers as EtherNet/IP at the host."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            CIPDriver,
+        )
+
+        CIPDriver.list_identity.return_value = None
+
+        assert await AllenBradleyPLC.identify("10.0.0.99") is None
 
     def test_get_available_plcs_outer_exception(self, mock_pycomm3_available):
         """Test get_available_plcs when outer exception occurs."""

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
@@ -1324,10 +1324,11 @@ class TestAllenBradleyPLCTagDiscovery:
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
 
-        tags = await plc.get_all_tags()
-
-        assert isinstance(tags, list)
-        assert len(tags) == 0
+        # An empty tag dict from a *connected* Logix controller means the
+        # tag-list upload failed (a real controller always has tags), so it's
+        # surfaced as an error rather than silently reported as "no tags".
+        with pytest.raises(PLCTagError):
+            await plc.get_all_tags()
 
     @pytest.mark.asyncio
     async def test_get_all_tags_slc(self, mock_pycomm3_available, mock_slc_driver):
@@ -1657,7 +1658,9 @@ class TestAllenBradleyPLCTagInfo:
             LogixDriver,
         )
 
-        mock_logix_driver.tags = {}
+        # A *populated* tag list that simply lacks the queried tag — the genuine
+        # "not found" case, distinct from an empty/failed upload (PLCTagError).
+        mock_logix_driver.tags = {"ExistingTag": MagicMock()}
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver

--- a/tests/unit/mindtrace/hardware/testing/test_camera_manager_suites.py
+++ b/tests/unit/mindtrace/hardware/testing/test_camera_manager_suites.py
@@ -38,6 +38,10 @@ class FakeCameraManager:
             return {name: FakeCamera() for name in names}
         return FakeCamera()
 
+    def batch_capture(self, names, output_format: str = "numpy"):
+        assert output_format == "numpy"
+        return {name: np.zeros((4, 5, 3), dtype=np.uint8) for name in names}
+
     def close(self, names=None):  # noqa: ARG002
         self.closed = True
 


### PR DESCRIPTION
# PLC hardware: unicast identify + tag fetch-vs-missing fix + test repairs


**What:** Three related PLC-hardware changes, bundled because the test repairs
depend on the identify code:

1. **Targeted unicast `identify`** (`feat`): add `BasePLC.identify(host, *,
   port=None, timeout=1.0)` (default `None` → backends opt in), an
   `AllenBradleyPLC.identify` that sends ONE EtherNet/IP ListIdentity
   (`CIPDriver.list_identity`, read-only, port 44818) and maps the device to the
   right driver (logix/slc/cip), and `PLCManager.identify` that tries enabled
   backends in order. Removes the hardcoded-IP discovery fallback from
   `get_available_plcs`.
   *Why:* the old broadcast + 9-fixed-IP sweep doesn't cross routers/VLANs/Docker
   and looks like recon to OT security tooling — so on a real plant it finds
   nothing.

2. **Tag fetch-vs-missing fix** (`fix`): in the `LogixDriver` branch of
   `get_all_tags` / `get_tag_info`, if connected but the uploaded tag list comes
   back empty/None, raise `PLCTagError` ("tag list could not be read") instead of
   caching `[]` / raising not-found. A genuine not-found is only reported when the
   list was actually retrieved and the tag is absent.
   *Why:* an empty upload was being reported as "tag not found" — the false
   negative behind the setup-wizard tag-validation complaints, which also hid the
   real connectivity/upload failure.

3. **Test/fixture repairs** (`test`): replace the obsolete
   `get_available_plcs` hardcoded-IP fallback tests with `identify` coverage;
   align the AB tag tests with the new fetch-vs-missing distinction; and give the
   camera stress-suite test double a `batch_capture` method (the suite calls it;
   it was raising `AttributeError`).
