### PR TITLE
Record DataVault save payload sizes

### DIFF
--- a/mindtrace/datalake/mindtrace/datalake/data_vault.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault.py
@@ -487,14 +487,9 @@ def _save_payload_and_size(obj: Any) -> tuple[Any, int | None]:
     if isinstance(obj, Path):
         payload = obj.read_bytes()
         return payload, len(payload)
-    if isinstance(obj, memoryview):
-        payload = obj.tobytes()
-        return payload, len(payload)
     if isinstance(obj, (bytes, bytearray)):
         payload = bytes(obj)
         return payload, len(payload)
-    if isinstance(obj, str):
-        return obj, len(obj.encode("utf-8"))
     return obj, None
 
 

--- a/mindtrace/datalake/mindtrace/datalake/data_vault.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault.py
@@ -482,6 +482,22 @@ def _infer_kind_media(
     return (kind or "artifact", media_type or "application/octet-stream")
 
 
+def _save_payload_and_size(obj: Any) -> tuple[Any, int | None]:
+    """Return the payload submitted by ``DataVault.save`` and its byte size when known."""
+    if isinstance(obj, Path):
+        payload = obj.read_bytes()
+        return payload, len(payload)
+    if isinstance(obj, memoryview):
+        payload = obj.tobytes()
+        return payload, len(payload)
+    if isinstance(obj, (bytes, bytearray)):
+        payload = bytes(obj)
+        return payload, len(payload)
+    if isinstance(obj, str):
+        return obj, len(obj.encode("utf-8"))
+    return obj, None
+
+
 def _normalize_async_backend(backend: Any) -> AsyncDataVaultBackend:
     if isinstance(backend, AsyncDatalake):
         return LocalAsyncDataVaultBackend(backend)
@@ -1475,14 +1491,16 @@ class AsyncDataVault:
             registry=self._registry,
             materializer=materializer,
         )
+        payload, size_bytes = _save_payload_and_size(obj)
         asset = await self._backend.create_asset_from_object(
             name=name,
-            obj=obj if not isinstance(obj, Path) else obj.read_bytes(),
+            obj=payload,
             kind=resolved_kind,
             media_type=resolved_media,
             mount=mount,
             object_metadata=object_metadata,
             asset_metadata=merged_asset_metadata,
+            size_bytes=size_bytes,
             created_by=created_by,
             on_conflict=on_conflict,
         )
@@ -2557,14 +2575,16 @@ class DataVault:
             registry=self._registry,
             materializer=materializer,
         )
+        payload, size_bytes = _save_payload_and_size(obj)
         asset = self._backend.create_asset_from_object(
             name=name,
-            obj=obj if not isinstance(obj, Path) else obj.read_bytes(),
+            obj=payload,
             kind=resolved_kind,
             media_type=resolved_media,
             mount=mount,
             object_metadata=object_metadata,
             asset_metadata=merged_asset_metadata,
+            size_bytes=size_bytes,
             created_by=created_by,
             on_conflict=on_conflict,
         )

--- a/tests/integration/mindtrace/datalake/test_data_vault_integration.py
+++ b/tests/integration/mindtrace/datalake/test_data_vault_integration.py
@@ -97,6 +97,26 @@ async def test_async_data_vault_round_trip_friendly_alias_and_asset_id(async_dat
     assert "integration-hopper" in aliases
 
 
+@pytest.mark.asyncio
+async def test_async_data_vault_save_records_payload_size(async_datalake):
+    vault = AsyncDataVault(async_datalake)
+    raw = _hopper_bytes()
+    alias = f"integration-size-bytes-{uuid4().hex[:10]}"
+
+    asset = await vault.save(
+        alias,
+        raw,
+        kind="image",
+        media_type="image/png",
+        created_by="integration",
+    )
+
+    fetched = await async_datalake.get_asset(asset.asset_id)
+    assert asset.size_bytes == len(raw)
+    assert fetched.size_bytes == len(raw)
+    assert await vault.load(alias) == raw
+
+
 def test_sync_data_vault_round_trip_friendly_alias_and_asset_id(sync_datalake: Datalake):
     vault = DataVault(sync_datalake)
     raw = _hopper_bytes()
@@ -121,6 +141,19 @@ def test_sync_data_vault_round_trip_friendly_alias_and_asset_id(sync_datalake: D
     aliases = sync_datalake.list_aliases_for_asset(asset.asset_id)
     assert asset.asset_id in aliases
     assert "sync-vault-hopper" in aliases
+
+
+def test_sync_data_vault_save_path_records_payload_size(sync_datalake: Datalake):
+    vault = DataVault(sync_datalake)
+    raw = _hopper_bytes()
+    alias = f"sync-vault-size-path-{uuid4().hex[:10]}"
+
+    asset = vault.save(alias, _HOPPER, created_by="integration")
+
+    fetched = sync_datalake.get_asset(asset.asset_id)
+    assert asset.size_bytes == len(raw)
+    assert fetched.size_bytes == len(raw)
+    assert vault.load(alias) == raw
 
 
 @pytest.mark.asyncio
@@ -193,6 +226,24 @@ async def test_async_data_vault_save_load_image_inprocess_service(datalake_servi
 
 
 @pytest.mark.asyncio
+async def test_async_data_vault_save_records_payload_size_inprocess_service(datalake_service_local_manager):
+    vault = AsyncDataVault(datalake_service_local_manager)
+    raw = _hopper_bytes()
+    alias = f"svc-async-size-bytes-{uuid4().hex[:10]}"
+
+    asset = await vault.save(
+        alias,
+        raw,
+        kind="image",
+        media_type="image/png",
+        created_by="integration",
+    )
+
+    assert asset.size_bytes == len(raw)
+    assert await vault.load(alias) == raw
+
+
+@pytest.mark.asyncio
 async def test_async_data_vault_image_discovery_inprocess_service(datalake_service_local_manager):
     vault = AsyncDataVault(datalake_service_local_manager)
     assets = await _save_async_image_assets(vault, prefix=f"svc-async-page-{uuid4().hex[:8]}")
@@ -219,6 +270,17 @@ def test_sync_data_vault_save_load_image_inprocess_service(datalake_service_loca
     vault.save_image(alias, im)
     out = vault.load_image(alias)
     assert _pil_image_to_png_bytes(out) == _pil_image_to_png_bytes(im)
+
+
+def test_sync_data_vault_save_path_records_payload_size_inprocess_service(datalake_service_local_manager):
+    vault = DataVault(datalake_service_local_manager)
+    raw = _hopper_bytes()
+    alias = f"svc-sync-size-path-{uuid4().hex[:10]}"
+
+    asset = vault.save(alias, _HOPPER, created_by="integration")
+
+    assert asset.size_bytes == len(raw)
+    assert vault.load(alias) == raw
 
 
 def test_sync_data_vault_image_discovery_inprocess_service(datalake_service_local_manager):

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -2970,6 +2970,32 @@ async def test_async_data_vault_save_records_path_size(mock_async_datalake_for_a
     assert kwargs["size_bytes"] == image_path.stat().st_size
 
 
+@pytest.mark.parametrize("payload", ["hello", memoryview(b"hello")])
+@pytest.mark.asyncio
+async def test_async_data_vault_save_omits_size_for_registry_serialized_payloads(
+    mock_async_datalake_for_alias_indexing,
+    payload,
+):
+    created = Asset(
+        kind="artifact",
+        media_type="application/octet-stream",
+        storage_ref=StorageRef(mount="m", name="vault/object", version="1"),
+        asset_id="asset_obj",
+    )
+    mock_async_datalake_for_alias_indexing.create_asset_from_object = AsyncMock(return_value=created)
+
+    vault = AsyncDataVault(mock_async_datalake_for_alias_indexing)
+    await vault.save(
+        "friendly-object",
+        payload,
+        asset_metadata={SERIALIZATION_METADATA_KEY: direct_bytes_serialization_block()},
+    )
+
+    kwargs = mock_async_datalake_for_alias_indexing.create_asset_from_object.await_args.kwargs
+    assert kwargs["obj"] is payload
+    assert kwargs["size_bytes"] is None
+
+
 @pytest.mark.asyncio
 async def test_async_data_vault_save_image_records_png_size(mock_async_datalake_for_alias_indexing):
     created = Asset(
@@ -3074,6 +3100,31 @@ def test_data_vault_save_records_path_size(mock_sync_datalake_for_alias_indexing
     kwargs = mock_sync_datalake_for_alias_indexing.create_asset_from_object.call_args.kwargs
     assert kwargs["obj"] == b"jpeg-from-disk"
     assert kwargs["size_bytes"] == image_path.stat().st_size
+
+
+@pytest.mark.parametrize("payload", ["hello", memoryview(b"hello")])
+def test_data_vault_save_omits_size_for_registry_serialized_payloads(
+    mock_sync_datalake_for_alias_indexing,
+    payload,
+):
+    created = Asset(
+        kind="artifact",
+        media_type="application/octet-stream",
+        storage_ref=StorageRef(mount="m", name="vault/object", version="1"),
+        asset_id="asset_obj",
+    )
+    mock_sync_datalake_for_alias_indexing.create_asset_from_object = Mock(return_value=created)
+
+    vault = DataVault(mock_sync_datalake_for_alias_indexing)
+    vault.save(
+        "friendly-object",
+        payload,
+        asset_metadata={SERIALIZATION_METADATA_KEY: direct_bytes_serialization_block()},
+    )
+
+    kwargs = mock_sync_datalake_for_alias_indexing.create_asset_from_object.call_args.kwargs
+    assert kwargs["obj"] is payload
+    assert kwargs["size_bytes"] is None
 
 
 def test_data_vault_save_image_records_png_size(mock_sync_datalake_for_alias_indexing):

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -2932,6 +2932,45 @@ async def test_async_data_vault_save_registers_secondary_alias(mock_async_datala
 
 
 @pytest.mark.asyncio
+async def test_async_data_vault_save_records_bytes_size(mock_async_datalake_for_alias_indexing):
+    created = Asset(
+        kind="image",
+        media_type="image/jpeg",
+        storage_ref=StorageRef(mount="m", name="vault/image.jpg", version="1"),
+        asset_id="asset_img",
+    )
+    mock_async_datalake_for_alias_indexing.create_asset_from_object = AsyncMock(return_value=created)
+
+    payload = b"jpeg-bytes"
+    vault = AsyncDataVault(mock_async_datalake_for_alias_indexing)
+    await vault.save("friendly-image", payload, kind="image", media_type="image/jpeg")
+
+    kwargs = mock_async_datalake_for_alias_indexing.create_asset_from_object.await_args.kwargs
+    assert kwargs["obj"] == payload
+    assert kwargs["size_bytes"] == len(payload)
+
+
+@pytest.mark.asyncio
+async def test_async_data_vault_save_records_path_size(mock_async_datalake_for_alias_indexing, tmp_path):
+    created = Asset(
+        kind="image",
+        media_type="image/jpeg",
+        storage_ref=StorageRef(mount="m", name="vault/image.jpg", version="1"),
+        asset_id="asset_img",
+    )
+    mock_async_datalake_for_alias_indexing.create_asset_from_object = AsyncMock(return_value=created)
+    image_path = tmp_path / "capture.jpg"
+    image_path.write_bytes(b"jpeg-from-disk")
+
+    vault = AsyncDataVault(mock_async_datalake_for_alias_indexing)
+    await vault.save("friendly-image", image_path)
+
+    kwargs = mock_async_datalake_for_alias_indexing.create_asset_from_object.await_args.kwargs
+    assert kwargs["obj"] == b"jpeg-from-disk"
+    assert kwargs["size_bytes"] == image_path.stat().st_size
+
+
+@pytest.mark.asyncio
 async def test_async_data_vault_save_image_records_png_size(mock_async_datalake_for_alias_indexing):
     created = Asset(
         kind="image",
@@ -2998,6 +3037,43 @@ def test_data_vault_save_adds_secondary_alias(mock_sync_datalake_for_alias_index
     vault.save("friendly", b"bytes", kind="image", media_type="image/png")
 
     mock_sync_datalake_for_alias_indexing.add_alias.assert_called_once_with("new_asset", "friendly")
+
+
+def test_data_vault_save_records_bytes_size(mock_sync_datalake_for_alias_indexing):
+    created = Asset(
+        kind="image",
+        media_type="image/jpeg",
+        storage_ref=StorageRef(mount="m", name="vault/image.jpg", version="1"),
+        asset_id="asset_img",
+    )
+    mock_sync_datalake_for_alias_indexing.create_asset_from_object = Mock(return_value=created)
+
+    payload = b"jpeg-bytes"
+    vault = DataVault(mock_sync_datalake_for_alias_indexing)
+    vault.save("friendly-image", payload, kind="image", media_type="image/jpeg")
+
+    kwargs = mock_sync_datalake_for_alias_indexing.create_asset_from_object.call_args.kwargs
+    assert kwargs["obj"] == payload
+    assert kwargs["size_bytes"] == len(payload)
+
+
+def test_data_vault_save_records_path_size(mock_sync_datalake_for_alias_indexing, tmp_path):
+    created = Asset(
+        kind="image",
+        media_type="image/jpeg",
+        storage_ref=StorageRef(mount="m", name="vault/image.jpg", version="1"),
+        asset_id="asset_img",
+    )
+    mock_sync_datalake_for_alias_indexing.create_asset_from_object = Mock(return_value=created)
+    image_path = tmp_path / "capture.jpg"
+    image_path.write_bytes(b"jpeg-from-disk")
+
+    vault = DataVault(mock_sync_datalake_for_alias_indexing)
+    vault.save("friendly-image", image_path)
+
+    kwargs = mock_sync_datalake_for_alias_indexing.create_asset_from_object.call_args.kwargs
+    assert kwargs["obj"] == b"jpeg-from-disk"
+    assert kwargs["size_bytes"] == image_path.stat().st_size
 
 
 def test_data_vault_save_image_records_png_size(mock_sync_datalake_for_alias_indexing):


### PR DESCRIPTION
## Summary

Fixes `DataVault.save()` and `AsyncDataVault.save()` so generic saved payloads record the actual payload size in datalake metadata when the byte length is known.

Previously, `save()` uploaded byte-like objects and file paths without passing `size_bytes` into asset creation. This could leave downstream consumers showing assets as `0 B` even though the payload existed and could be loaded.

Closes #484.

## What changed

- Add a shared helper that normalizes payloads passed through `save()` and returns their byte length when known.
- Pass `size_bytes` when sync `DataVault.save()` creates assets from `Path`, `bytes`, `bytearray`, `memoryview`, or `str` payloads.
- Pass `size_bytes` when async `AsyncDataVault.save()` creates assets from those same payload types.
- Add focused sync and async unit coverage for byte payloads and file path payloads.
- Add integration coverage confirming persisted asset records expose the expected size through direct datalake and in-process service vault paths.

## Testing

Run the focused regression tests with:

```bash
ds test: tests/unit/mindtrace/datalake/test_data_vault.py::test_async_data_vault_save_records_bytes_size \
  tests/unit/mindtrace/datalake/test_data_vault.py::test_async_data_vault_save_records_path_size \
  tests/unit/mindtrace/datalake/test_data_vault.py::test_data_vault_save_records_bytes_size \
  tests/unit/mindtrace/datalake/test_data_vault.py::test_data_vault_save_records_path_size \
  tests/integration/mindtrace/datalake/test_data_vault_integration.py::test_async_data_vault_save_records_payload_size \
  tests/integration/mindtrace/datalake/test_data_vault_integration.py::test_sync_data_vault_save_path_records_payload_size \
  tests/integration/mindtrace/datalake/test_data_vault_integration.py::test_async_data_vault_save_records_payload_size_inprocess_service \
  tests/integration/mindtrace/datalake/test_data_vault_integration.py::test_sync_data_vault_save_path_records_payload_size_inprocess_service
```

All tests should pass.