### PR TITLE
Populate image_size and file_size_bytes on save-path camera captures

### DIFF
--- a/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera.py
@@ -201,7 +201,8 @@ class AsyncCamera(Mindtrace):
             at the boundary.
 
         Raises:
-            CameraCaptureError: If image capture ultimately fails after retries.
+            CameraCaptureError: If image capture ultimately fails after retries,
+                or the captured image cannot be written to ``save_path``.
             CameraConnectionError: If the camera connection fails during capture.
             CameraTimeoutError: If the capture exceeds the configured timeout.
             RuntimeError: For unexpected errors after exhausting retries.
@@ -224,7 +225,10 @@ class AsyncCamera(Mindtrace):
                             dirname = os.path.dirname(save_path)
                             if dirname:
                                 await asyncio.to_thread(os.makedirs, dirname, exist_ok=True)
-                            await asyncio.to_thread(cv2.imwrite, save_path, image)
+                            if not await asyncio.to_thread(cv2.imwrite, save_path, image):
+                                raise CameraCaptureError(
+                                    f"Failed to write captured image to '{save_path}' for camera '{self._full_name}'"
+                                )
                             self.logger.debug(f"Saved captured image to '{save_path}'")
 
                         self.logger.debug(

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/service.py
@@ -1029,6 +1029,26 @@ class CameraManagerService(Service):
             return None, None, None
 
     @staticmethod
+    def _file_size_bytes(path: str) -> Optional[int]:
+        """On-disk byte size of ``path``, or ``None`` if it can't be read."""
+        try:
+            return os.path.getsize(path)
+        except OSError:
+            return None
+
+    @staticmethod
+    def _image_size_on_disk(path: str) -> Optional[Tuple[int, int]]:
+        """``(width, height)`` parsed from the image header at ``path``, or ``None``.
+
+        ``PIL.Image.open`` is lazy — this reads the header without decoding pixels.
+        """
+        try:
+            with PILImage.open(path) as im:
+                return im.size
+        except Exception:
+            return None
+
+    @staticmethod
     def _backend_return_type(output_format: str) -> str:
         """Translate a wire format to the in-memory type the backend should return.
 
@@ -1042,10 +1062,10 @@ class CameraManagerService(Service):
         """Capture a single image with timeout protection.
 
         When ``save_path`` is set, the image is written to disk and the response
-        carries ``image_path``. When it is omitted, the image is encoded inline
-        as a base64 JPEG in ``image_data`` (with ``image_size`` and
-        ``file_size_bytes`` populated) so callers don't need a stream or a
-        round-trip through ``/cameras/images/...``.
+        carries ``image_path`` plus ``image_size`` and ``file_size_bytes`` for
+        the saved file. When ``save_path`` is omitted, the image is encoded
+        inline as base64 in ``image_data`` (with the same size fields) so
+        callers don't need a stream or a round-trip through ``/cameras/images/...``.
         """
         try:
             manager = await self._get_camera_manager()
@@ -1073,6 +1093,8 @@ class CameraManagerService(Service):
                         success=True,
                         image_path=request.save_path,
                         capture_time=datetime.now(timezone.utc),
+                        image_size=self._image_size_on_disk(request.save_path),
+                        file_size_bytes=self._file_size_bytes(request.save_path),
                     )
                 else:
                     image_data, image_size, file_size_bytes = self._encode_inline_image(captured, request.output_format)
@@ -1136,7 +1158,11 @@ class CameraManagerService(Service):
                     if request.save_path_pattern:
                         # Image is the file path string
                         capture_results[camera] = CaptureResult(
-                            success=True, image_path=image, capture_time=datetime.now(timezone.utc)
+                            success=True,
+                            image_path=image,
+                            capture_time=datetime.now(timezone.utc),
+                            image_size=self._image_size_on_disk(image),
+                            file_size_bytes=self._file_size_bytes(image),
                         )
                     else:
                         # Image is numpy/PIL data — encode inline in the requested wire format

--- a/tests/unit/mindtrace/hardware/cameras/core/test_async_camera_manager.py
+++ b/tests/unit/mindtrace/hardware/cameras/core/test_async_camera_manager.py
@@ -742,3 +742,28 @@ def test_discover_mixed_backends_filters(monkeypatch):
     assert isinstance(lst, list)
     for n in lst:
         assert n.startswith("MockBasler:")
+
+
+@pytest.mark.asyncio
+async def test_batch_capture_save_path_pattern_returns_paths(tmp_path):
+    """Batch save-path captures return per-camera file paths to written files."""
+    manager = AsyncCameraManager(include_mocks=True, max_concurrent_captures=2)
+    mock_cameras = [n for n in AsyncCameraManager.discover(include_mocks=True) if n.startswith("MockBasler:")][:2]
+    if len(mock_cameras) < 2:
+        pytest.skip("Need at least two mock Basler cameras")
+
+    try:
+        await manager.open(mock_cameras)
+        pattern = str(tmp_path / "{camera}.jpg")
+        results = await manager.batch_capture(
+            mock_cameras,
+            save_path_pattern=pattern,
+            output_format="numpy",
+        )
+        assert set(results.keys()) == set(mock_cameras)
+        for camera_name, path in results.items():
+            safe_name = camera_name.replace(":", "_").replace("/", "_")
+            assert path == str(tmp_path / f"{safe_name}.jpg")
+            assert (tmp_path / f"{safe_name}.jpg").exists()
+    finally:
+        await manager.close(None)

--- a/tests/unit/mindtrace/hardware/services/cameras/test_hardware_services_cameras_service.py
+++ b/tests/unit/mindtrace/hardware/services/cameras/test_hardware_services_cameras_service.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import numpy as np
 import pytest
+from PIL import Image as PILImage
 
 from mindtrace.hardware.core.exceptions import (
     CameraConfigurationError,
@@ -411,16 +412,23 @@ class TestCameraManagerServiceBusinessLogic:
         mock_manager.open.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_capture_image_with_active_camera(self, service_with_mock_manager):
+    async def test_capture_image_with_active_camera(self, service_with_mock_manager, tmp_path):
         """Test capture image business logic with active camera."""
         service, mock_manager = service_with_mock_manager
+        save_path = tmp_path / "test.jpg"
 
-        # Set up active camera
+        # Set up active camera; per the proxy contract, capture writes save_path
+        async def _capture(save_path, output_format):
+            image = PILImage.new("RGB", (1280, 720))
+            image.save(save_path)
+            return image
+
         mock_camera = AsyncMock()
+        mock_camera.capture = AsyncMock(side_effect=_capture)
         mock_manager.active_cameras = ["ActiveCamera"]
         mock_manager.open = AsyncMock(return_value=mock_camera)
 
-        request = CaptureImageRequest(camera="ActiveCamera", save_path="/tmp/test.jpg")
+        request = CaptureImageRequest(camera="ActiveCamera", save_path=str(save_path))
 
         response = await service.capture_image(request)
 
@@ -428,12 +436,14 @@ class TestCameraManagerServiceBusinessLogic:
         assert response.success is True
         assert "Image captured from camera 'ActiveCamera'" in response.message
         assert response.data.success is True
-        assert response.data.image_path == "/tmp/test.jpg"
+        assert response.data.image_path == str(save_path)
+        assert response.data.image_size == (1280, 720)
+        assert response.data.file_size_bytes == save_path.stat().st_size
         assert isinstance(response.data.capture_time, datetime)
 
         # Test business logic: parameters passed correctly
         mock_camera.capture.assert_called_once_with(
-            save_path="/tmp/test.jpg",
+            save_path=str(save_path),
             output_format="pil",  # Default value
         )
 
@@ -915,18 +925,24 @@ class TestCameraManagerServiceCaptureAndHomography:
         assert response.data.error == "capture exploded"
 
     @pytest.mark.asyncio
-    async def test_capture_images_batch_formats_saved_paths(self, service_with_mock_manager):
+    async def test_capture_images_batch_formats_saved_paths(self, service_with_mock_manager, tmp_path):
         service, mock_manager = service_with_mock_manager
-        mock_manager.batch_capture.return_value = {"Basler:cam1": "/tmp/cam1.jpg", "Basler:cam2": None}
+        saved = tmp_path / "cam1.jpg"
+        PILImage.new("RGB", (640, 480)).save(saved)
+        mock_manager.batch_capture.return_value = {"Basler:cam1": str(saved), "Basler:cam2": None}
 
         response = await service.capture_images_batch(
-            CaptureBatchRequest(cameras=["Basler:cam1", "Basler:cam2"], save_path_pattern="/tmp/{camera}.jpg")
+            CaptureBatchRequest(
+                cameras=["Basler:cam1", "Basler:cam2"], save_path_pattern=str(tmp_path / "{camera}.jpg")
+            )
         )
 
         assert response.success is True
         assert response.successful_count == 1
         assert response.failed_count == 1
-        assert response.data["Basler:cam1"].image_path == "/tmp/cam1.jpg"
+        assert response.data["Basler:cam1"].image_path == str(saved)
+        assert response.data["Basler:cam1"].image_size == (640, 480)
+        assert response.data["Basler:cam1"].file_size_bytes == saved.stat().st_size
         assert response.data["Basler:cam2"].success is False
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Save-path `CaptureResult` responses now include `image_size` and `file_size_bytes`, matching inline capture behavior.
- Metadata is read from the **saved file on disk** in `CameraManagerService` (`_image_size_on_disk` via lazy PIL header read, `_file_size_bytes` via `os.path.getsize`) after the backend writes the file.
- `AsyncCameraManager.batch_capture` with `save_path_pattern` still returns **path strings**; the service enriches batch results the same way as single capture.
- `AsyncCamera.capture` raises `CameraCaptureError` when `cv2.imwrite` fails, so a failed disk write does not surface as a successful capture.

**Depends on:** nothing (targets `dev`; branch includes merged `dev` so DataVault #485 sizing is already present).

**Stacked PR:** [#488](https://github.com/Mindtrace/mindtrace/pull/488) adds DataVault congruence tests on top of this branch.

## Design note

Metadata stays at the **service boundary** (disk read after write) rather than threading structured types through `AsyncCameraManager`.

## Test plan

- [x] `ds test: tests/unit/mindtrace/hardware/cameras/core/test_async_camera_manager.py::test_batch_capture_save_path_pattern_returns_paths`
- [x] `ds test: tests/unit/mindtrace/hardware/services/cameras/test_hardware_services_cameras_service.py::TestCameraManagerServiceBusinessLogic::test_capture_image_with_active_camera`
- [x] `ds test: tests/unit/mindtrace/hardware/services/cameras/test_hardware_services_cameras_service.py::TestCameraManagerServiceCaptureAndHomography::test_capture_images_batch_formats_saved_paths`
- [x] `ruff check` / `ruff format --check` on changed files