### PR TITLE
refactor: consolidate utcnow

### DIFF
--- a/docs/core/benchmarks.md
+++ b/docs/core/benchmarks.md
@@ -206,7 +206,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 
 
@@ -237,7 +237,7 @@ class EchoLoopThroughputSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         monotonic_start = time.perf_counter()
         chunk = int(config.parameters.get("iter_chunk", 100))
         deadline = reporter.deadline(config.duration_seconds)
@@ -259,7 +259,7 @@ class EchoLoopThroughputSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/agents/mindtrace/agents/memory/_store.py
+++ b/mindtrace/agents/mindtrace/agents/memory/_store.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
+
+from mindtrace.core import utcnow
 
 
 @dataclass
@@ -10,8 +12,8 @@ class MemoryEntry:
     key: str
     value: str
     metadata: dict = field(default_factory=dict)
-    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
-    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    created_at: datetime = field(default_factory=utcnow)
+    updated_at: datetime = field(default_factory=utcnow)
 
 
 class AbstractMemoryStore(ABC):

--- a/mindtrace/agents/mindtrace/agents/memory/in_memory.py
+++ b/mindtrace/agents/mindtrace/agents/memory/in_memory.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from mindtrace.core import utcnow
 
 from ._store import AbstractMemoryStore, MemoryEntry
 
@@ -12,7 +12,7 @@ class InMemoryStore(AbstractMemoryStore):
         self._data: dict[str, MemoryEntry] = {}
 
     async def save(self, key: str, value: str, metadata: dict | None = None) -> None:
-        now = datetime.now(timezone.utc)
+        now = utcnow()
         existing = self._data.get(key)
         self._data[key] = MemoryEntry(
             key=key,

--- a/mindtrace/agents/mindtrace/agents/memory/json_file.py
+++ b/mindtrace/agents/mindtrace/agents/memory/json_file.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
+
+from mindtrace.core import utcnow
 
 from ._store import AbstractMemoryStore, MemoryEntry
 
@@ -46,7 +48,7 @@ class JsonFileStore(AbstractMemoryStore):
         self._path.write_text(json.dumps({k: _entry_to_dict(v) for k, v in self._data.items()}, indent=2))
 
     async def save(self, key: str, value: str, metadata: dict | None = None) -> None:
-        now = datetime.now(timezone.utc)
+        now = utcnow()
         existing = self._data.get(key)
         self._data[key] = MemoryEntry(
             key=key,

--- a/mindtrace/cluster/mindtrace/cluster/core/cluster.py
+++ b/mindtrace/cluster/mindtrace/cluster/core/cluster.py
@@ -3,7 +3,6 @@ import threading
 import urllib.parse
 import uuid
 from abc import abstractmethod
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -13,7 +12,7 @@ from pydantic import BaseModel
 
 from mindtrace.cluster.core import types as cluster_types
 from mindtrace.cluster.workers.environments.git_env import GitEnvironment
-from mindtrace.core import TaskSchema, Timeout, get_class
+from mindtrace.core import TaskSchema, Timeout, get_class, utcnow
 from mindtrace.database import BackendType, UnifiedMindtraceODM
 from mindtrace.jobs import Consumer, Job, JobSchema, Orchestrator, RabbitMQClient
 from mindtrace.registry import Archiver, Registry
@@ -440,7 +439,7 @@ class ClusterManager(Gateway):
                     worker_url=worker_url,
                     status=cluster_types.WorkerStatusEnum.IDLE,
                     job_id=None,
-                    last_heartbeat=datetime.now(),
+                    last_heartbeat=utcnow(),
                 )
             )
         self.logger.info(f"Connected {worker_url} to cluster {str(self._url)} listening on queue {job_type}")
@@ -582,7 +581,7 @@ class ClusterManager(Gateway):
                 {
                     "status": cluster_types.WorkerStatusEnum.NONEXISTENT,
                     "job_id": None,
-                    "last_heartbeat": datetime.now(),
+                    "last_heartbeat": utcnow(),
                 },
             )
             return our_status
@@ -591,7 +590,7 @@ class ClusterManager(Gateway):
             self.worker_status_database,
             "worker_id",
             worker_id,
-            {"status": worker_status.status, "job_id": worker_status.job_id, "last_heartbeat": datetime.now()},
+            {"status": worker_status.status, "job_id": worker_status.job_id, "last_heartbeat": utcnow()},
         )
         return our_status
 
@@ -638,14 +637,14 @@ class ClusterManager(Gateway):
             {
                 "status": cluster_types.JobStatusEnum.RUNNING,
                 "worker_id": payload["worker_id"],
-                "job.started_at": datetime.now().isoformat(),
+                "job.started_at": utcnow().isoformat(),
             },
         )
         update_database(
             self.worker_status_database,
             "worker_id",
             payload["worker_id"],
-            {"status": cluster_types.WorkerStatusEnum.RUNNING, "job_id": job_id, "last_heartbeat": datetime.now()},
+            {"status": cluster_types.WorkerStatusEnum.RUNNING, "job_id": job_id, "last_heartbeat": utcnow()},
         )
         self.logger.info(f"Worker {payload['worker_id']} alerted cluster manager that job {job_id} has started")
 
@@ -663,7 +662,7 @@ class ClusterManager(Gateway):
             self.job_status_database,
             "job_id",
             job_id,
-            {"status": status_enum, "output": payload["output"], "job.completed_at": datetime.now().isoformat()},
+            {"status": status_enum, "output": payload["output"], "job.completed_at": utcnow().isoformat()},
         )
         if job_status.worker_id != payload["worker_id"]:
             self.logger.warning(
@@ -688,7 +687,7 @@ class ClusterManager(Gateway):
             self.worker_status_database,
             "worker_id",
             payload["worker_id"],
-            {"status": cluster_types.WorkerStatusEnum.IDLE, "job_id": None, "last_heartbeat": datetime.now()},
+            {"status": cluster_types.WorkerStatusEnum.IDLE, "job_id": None, "last_heartbeat": utcnow()},
         )
 
     def requeue_from_dlq(self, payload: dict):

--- a/mindtrace/cluster/mindtrace/cluster/core/cluster.py
+++ b/mindtrace/cluster/mindtrace/cluster/core/cluster.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 
 from mindtrace.cluster.core import types as cluster_types
 from mindtrace.cluster.workers.environments.git_env import GitEnvironment
-from mindtrace.core import TaskSchema, Timeout, get_class, utcnow
+from mindtrace.core import TaskSchema, Timeout, get_class, utcnow, utcnow_iso
 from mindtrace.database import BackendType, UnifiedMindtraceODM
 from mindtrace.jobs import Consumer, Job, JobSchema, Orchestrator, RabbitMQClient
 from mindtrace.registry import Archiver, Registry
@@ -637,7 +637,7 @@ class ClusterManager(Gateway):
             {
                 "status": cluster_types.JobStatusEnum.RUNNING,
                 "worker_id": payload["worker_id"],
-                "job.started_at": utcnow().isoformat(),
+                "job.started_at": utcnow_iso(),
             },
         )
         update_database(
@@ -662,7 +662,7 @@ class ClusterManager(Gateway):
             self.job_status_database,
             "job_id",
             job_id,
-            {"status": status_enum, "output": payload["output"], "job.completed_at": utcnow().isoformat()},
+            {"status": status_enum, "output": payload["output"], "job.completed_at": utcnow_iso()},
         )
         if job_status.worker_id != payload["worker_id"]:
             self.logger.warning(

--- a/mindtrace/core/mindtrace/core/__init__.py
+++ b/mindtrace/core/mindtrace/core/__init__.py
@@ -21,7 +21,6 @@ from mindtrace.core.testing import (
     TestSuite,
     UnknownSuiteIdError,
     build_bench_suite_config,
-    utc_now_iso,
     validate_suite_id,
 )
 from mindtrace.core.types.task_schema import TaskSchema
@@ -44,6 +43,7 @@ from mindtrace.core.utils.network import (
     wait_for_service,
 )
 from mindtrace.core.utils.system_metrics_collector import SystemMetricsCollector
+from mindtrace.core.utils.time import utcnow, utcnow_iso
 from mindtrace.core.utils.timers import Timeout, Timer, TimerCollection
 
 __all__ = [
@@ -62,7 +62,8 @@ __all__ = [
     "TestSuite",
     "UnknownSuiteIdError",
     "build_bench_suite_config",
-    "utc_now_iso",
+    "utcnow",
+    "utcnow_iso",
     "validate_suite_id",
     "check_libs",
     "check_port_available",

--- a/mindtrace/core/mindtrace/core/__init__.py
+++ b/mindtrace/core/mindtrace/core/__init__.py
@@ -43,7 +43,7 @@ from mindtrace.core.utils.network import (
     wait_for_service,
 )
 from mindtrace.core.utils.system_metrics_collector import SystemMetricsCollector
-from mindtrace.core.utils.time import utcnow, utcnow_iso
+from mindtrace.core.utils.time import as_utc, utcnow, utcnow_iso
 from mindtrace.core.utils.timers import Timeout, Timer, TimerCollection
 
 __all__ = [
@@ -62,6 +62,7 @@ __all__ = [
     "TestSuite",
     "UnknownSuiteIdError",
     "build_bench_suite_config",
+    "as_utc",
     "utcnow",
     "utcnow_iso",
     "validate_suite_id",

--- a/mindtrace/core/mindtrace/core/testing/__init__.py
+++ b/mindtrace/core/mindtrace/core/testing/__init__.py
@@ -9,7 +9,7 @@ from mindtrace.core.testing.bench_framework import (
     BenchSuiteConfig,
     CancellationToken,
     latency_summary,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.bench_suite import BenchTestSuite, build_bench_suite_config, coerce_bench_config
 from mindtrace.core.testing.matrix import expand_param_matrix
@@ -52,6 +52,6 @@ __all__ = [
     "latency_summary",
     "parse_size_bytes",
     "run_threaded_until_deadline",
-    "utc_now_iso",
+    "utcnow_iso",
     "validate_suite_id",
 ]

--- a/mindtrace/core/mindtrace/core/testing/__main__.py
+++ b/mindtrace/core/mindtrace/core/testing/__main__.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import argparse
 import sys
-from datetime import UTC, datetime
 
 from mindtrace.core.testing.runner import TestRunner
+from mindtrace.core.utils.time import utcnow
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -50,7 +50,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"No suites tagged with profile={args.profile!r}.", file=sys.stderr)
         return 2
 
-    run_id = args.run_id or datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%SZ")
+    run_id = args.run_id or utcnow().strftime("%Y-%m-%dT%H-%M-%SZ")
 
     def _progress(ev: object) -> None:
         kind = getattr(ev, "kind", "?")

--- a/mindtrace/core/mindtrace/core/testing/bench_framework.py
+++ b/mindtrace/core/mindtrace/core/testing/bench_framework.py
@@ -6,7 +6,6 @@ Runners own discovery and aggregation; suites measure operations via :class:`Ben
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
 from pathlib import Path
 from statistics import median, quantiles
 from time import perf_counter
@@ -14,17 +13,13 @@ from typing import Any, Callable, Protocol, TextIO
 
 from pydantic import BaseModel, Field
 
+from mindtrace.core.utils.time import utcnow_iso
+
 
 class CancellationToken(Protocol):
     """Minimal protocol for cooperative cancellation."""
 
     def is_cancelled(self) -> bool: ...
-
-
-def utc_now_iso() -> str:
-    """Return a stable UTC timestamp for result payloads."""
-
-    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 @dataclass(frozen=True)
@@ -169,7 +164,7 @@ class BenchReporter:
     def event(self, event_type: str, **fields: Any) -> None:
         import json
 
-        payload = {"timestamp": utc_now_iso(), "suite_id": self.suite_id, "event": event_type, **fields}
+        payload = {"timestamp": utcnow_iso(), "suite_id": self.suite_id, "event": event_type, **fields}
         if self.run_id:
             payload["run_id"] = self.run_id
         if self.variant_id:
@@ -188,7 +183,7 @@ class BenchReporter:
         import json
 
         payload = {
-            "timestamp": utc_now_iso(),
+            "timestamp": utcnow_iso(),
             "suite_id": self.suite_id,
             "variant_id": self.variant_id,
             "error_type": type(error).__name__,

--- a/mindtrace/core/mindtrace/core/testing/runner.py
+++ b/mindtrace/core/mindtrace/core/testing/runner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import importlib.metadata as importlib_metadata
 import threading
 from collections.abc import Callable, Mapping, Sequence
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Generic, Type, TypeVar
 
@@ -27,14 +26,11 @@ from mindtrace.core.testing.types import (
     validate_suite_id,
 )
 from mindtrace.core.types.task_schema import TaskSchema
+from mindtrace.core.utils.time import utcnow_iso
 
 _TS = TypeVar("_TS", bound=type[TestSuite])
 _T = TypeVar("_T")
 _BENCHMARK_ENTRY_POINT_GROUP = "mindtrace.benchmark_suites"
-
-
-def _utc_iso() -> str:
-    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _pydantic_model_json_schema(model: Type[BaseModel]) -> dict[str, Any]:
@@ -307,7 +303,7 @@ class TestRunner(Mindtrace):
     ) -> RunOutcome:
         """Batch driver; ``execute`` sees the stored :class:`SuiteContribution`."""
 
-        started = _utc_iso()
+        started = utcnow_iso()
         with self._lock:
             if suite_ids is None:
                 ordered_ids = sorted(self._registry.keys())
@@ -317,7 +313,7 @@ class TestRunner(Mindtrace):
         rows: list[SuiteExecutionResult] = []
 
         if not ordered_ids:
-            ended = _utc_iso()
+            ended = utcnow_iso()
             return RunOutcome(overall="empty", suites=(), started_at=started, finished_at=ended)
 
         for sid in ordered_ids:
@@ -337,7 +333,7 @@ class TestRunner(Mindtrace):
 
             rows.append(row)
 
-        ended = _utc_iso()
+        ended = utcnow_iso()
         overall: OverallStatus = "passed" if all(r.status == "passed" for r in rows) else "failed"
         return RunOutcome(
             overall=overall,

--- a/mindtrace/core/mindtrace/core/utils/__init__.py
+++ b/mindtrace/core/mindtrace/core/utils/__init__.py
@@ -18,6 +18,7 @@ from mindtrace.core.utils.network import (
 )
 from mindtrace.core.utils.paths import expand_tilde, expand_tilde_str
 from mindtrace.core.utils.system_metrics_collector import SystemMetricsCollector
+from mindtrace.core.utils.time import utcnow, utcnow_iso
 
 __all__ = [
     "check_libs",
@@ -42,5 +43,7 @@ __all__ = [
     "PortInUseError",
     "ServiceTimeoutError",
     "SystemMetricsCollector",
+    "utcnow",
+    "utcnow_iso",
     "wait_for_service",
 ]

--- a/mindtrace/core/mindtrace/core/utils/__init__.py
+++ b/mindtrace/core/mindtrace/core/utils/__init__.py
@@ -18,7 +18,7 @@ from mindtrace.core.utils.network import (
 )
 from mindtrace.core.utils.paths import expand_tilde, expand_tilde_str
 from mindtrace.core.utils.system_metrics_collector import SystemMetricsCollector
-from mindtrace.core.utils.time import utcnow, utcnow_iso
+from mindtrace.core.utils.time import as_utc, utcnow, utcnow_iso
 
 __all__ = [
     "check_libs",
@@ -42,6 +42,7 @@ __all__ = [
     "NoFreePortError",
     "PortInUseError",
     "ServiceTimeoutError",
+    "as_utc",
     "SystemMetricsCollector",
     "utcnow",
     "utcnow_iso",

--- a/mindtrace/core/mindtrace/core/utils/time.py
+++ b/mindtrace/core/mindtrace/core/utils/time.py
@@ -1,0 +1,11 @@
+from datetime import datetime, timezone
+
+
+def utcnow() -> datetime:
+    """Timezone-aware current time in UTC."""
+    return datetime.now(timezone.utc)
+
+
+def utcnow_iso() -> str:
+    """Current UTC time as an ISO-8601 string with a trailing ``Z``."""
+    return utcnow().isoformat().replace("+00:00", "Z")

--- a/mindtrace/core/mindtrace/core/utils/time.py
+++ b/mindtrace/core/mindtrace/core/utils/time.py
@@ -9,3 +9,10 @@ def utcnow() -> datetime:
 def utcnow_iso() -> str:
     """Current UTC time as an ISO-8601 string with a trailing ``Z``."""
     return utcnow().isoformat().replace("+00:00", "Z")
+
+
+def as_utc(value: datetime) -> datetime:
+    """Return ``value`` as a timezone-aware UTC datetime, treating naive inputs as UTC."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)

--- a/mindtrace/database/mindtrace/database/sample/user.py
+++ b/mindtrace/database/mindtrace/database/sample/user.py
@@ -2,9 +2,11 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from mindtrace.core import utcnow
+
 
 class User(BaseModel):
     name: str
     id: int | None = None
-    created_at: datetime = Field(default_factory=datetime.now)
-    updated_at: datetime = Field(default_factory=datetime.now)
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime = Field(default_factory=utcnow)

--- a/mindtrace/database/mindtrace/database/testing/suites/mongo_crud.py
+++ b/mindtrace/database/mindtrace/database/testing/suites/mongo_crud.py
@@ -17,7 +17,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.database import MongoMindtraceODM
 from mindtrace.database.testing.suites._models import DatabaseBenchDocument
@@ -58,7 +58,7 @@ class DatabaseMongoCrudSmokeSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         mono = time.perf_counter()
         mongo_backend, mongo_uri, mongo_db_name = resolve_mongo_resources(config)
         odm = MongoMindtraceODM(model_cls=DatabaseBenchDocument, db_uri=mongo_uri, db_name=mongo_db_name)
@@ -95,7 +95,7 @@ class DatabaseMongoCrudSmokeSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/database/mindtrace/database/testing/suites/mongo_insert.py
+++ b/mindtrace/database/mindtrace/database/testing/suites/mongo_insert.py
@@ -17,7 +17,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.database import MongoMindtraceODM
 from mindtrace.database.testing.suites._models import DatabaseBenchDocument
@@ -64,7 +64,7 @@ class DatabaseMongoInsertCeilingSuite(BenchTestSuite):
 
 
 async def _run_async(config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-    started = utc_now_iso()
+    started = utcnow_iso()
     mono = time.perf_counter()
     mongo_backend, mongo_uri, mongo_db_name = resolve_mongo_resources(config)
     batch_size = int(config.parameters.get("batch_size", 100))
@@ -97,7 +97,7 @@ async def _run_async(config: BenchSuiteConfig, reporter: BenchReporter) -> Bench
         suite_id=config.suite_id,
         status="passed" if reporter.failures == 0 else "failed",
         started_at=started,
-        ended_at=utc_now_iso(),
+        ended_at=utcnow_iso(),
         duration_seconds=elapsed,
         operations=reporter.operations * batch_size,
         successes=reporter.successes * batch_size,

--- a/mindtrace/database/mindtrace/database/testing/suites/mongo_read.py
+++ b/mindtrace/database/mindtrace/database/testing/suites/mongo_read.py
@@ -18,7 +18,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.database import MongoMindtraceODM
 from mindtrace.database.testing.suites._models import DatabaseBenchDocument
@@ -71,7 +71,7 @@ class DatabaseMongoReadCeilingSuite(BenchTestSuite):
 
 
 async def _run_async(config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-    started = utc_now_iso()
+    started = utcnow_iso()
     mono = time.perf_counter()
     mongo_backend, mongo_uri, mongo_db_name = resolve_mongo_resources(config)
     dataset_size = int(config.parameters.get("dataset_size", 1000))
@@ -115,7 +115,7 @@ async def _run_async(config: BenchSuiteConfig, reporter: BenchReporter) -> Bench
         suite_id=config.suite_id,
         status="passed" if reporter.failures == 0 else "failed",
         started_at=started,
-        ended_at=utc_now_iso(),
+        ended_at=utcnow_iso(),
         duration_seconds=elapsed,
         operations=reporter.operations,
         successes=reporter.successes,

--- a/mindtrace/database/mindtrace/database/testing/suites/mongo_update.py
+++ b/mindtrace/database/mindtrace/database/testing/suites/mongo_update.py
@@ -18,7 +18,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.database import MongoMindtraceODM
 from mindtrace.database.testing.suites._models import DatabaseBenchDocument
@@ -67,7 +67,7 @@ class DatabaseMongoUpdateCeilingSuite(BenchTestSuite):
 
 
 async def _run_async(config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-    started = utc_now_iso()
+    started = utcnow_iso()
     mono = time.perf_counter()
     mongo_backend, mongo_uri, mongo_db_name = resolve_mongo_resources(config)
     dataset_size = int(config.parameters.get("dataset_size", 1000))
@@ -107,7 +107,7 @@ async def _run_async(config: BenchSuiteConfig, reporter: BenchReporter) -> Bench
         suite_id=config.suite_id,
         status="passed" if reporter.failures == 0 else "failed",
         started_at=started,
-        ended_at=utc_now_iso(),
+        ended_at=utcnow_iso(),
         duration_seconds=elapsed,
         operations=reporter.operations,
         successes=reporter.successes,

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -16,7 +16,7 @@ from typing import Any, TypeVar
 
 from motor.motor_asyncio import AsyncIOMotorClient
 
-from mindtrace.core import Mindtrace
+from mindtrace.core import Mindtrace, utcnow
 from mindtrace.database import MongoMindtraceODM
 from mindtrace.database.core.exceptions import DocumentNotFoundError, DuplicateInsertError
 from mindtrace.datalake.pagination_types import (
@@ -308,7 +308,7 @@ class AsyncDatalake(Mindtrace):
 
     @staticmethod
     def _utc_now() -> datetime:
-        return datetime.now(timezone.utc)
+        return utcnow()
 
     @staticmethod
     def _coerce_utc(dt: datetime) -> datetime:

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -8,7 +8,7 @@ import os
 import warnings
 from collections.abc import AsyncIterator, Iterable
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from enum import StrEnum
 from functools import partial
 from pathlib import Path
@@ -16,7 +16,7 @@ from typing import Any, TypeVar
 
 from motor.motor_asyncio import AsyncIOMotorClient
 
-from mindtrace.core import Mindtrace, utcnow
+from mindtrace.core import Mindtrace, as_utc, utcnow
 from mindtrace.database import MongoMindtraceODM
 from mindtrace.database.core.exceptions import DocumentNotFoundError, DuplicateInsertError
 from mindtrace.datalake.pagination_types import (
@@ -307,16 +307,6 @@ class AsyncDatalake(Mindtrace):
         return datalake
 
     @staticmethod
-    def _utc_now() -> datetime:
-        return utcnow()
-
-    @staticmethod
-    def _coerce_utc(dt: datetime) -> datetime:
-        if dt.tzinfo is None:
-            return dt.replace(tzinfo=timezone.utc)
-        return dt.astimezone(timezone.utc)
-
-    @staticmethod
     def _normalize_storage_ref(storage_ref: StorageRef) -> StorageRef:
         return StorageRef(
             mount=storage_ref.mount,
@@ -585,7 +575,7 @@ class AsyncDatalake(Mindtrace):
         sort_spec, cursor_fields = self._resolve_sort_spec(resource, sort)
         snapshot_field = self._snapshot_field_for(resource)
         snapshot_token = (
-            self._encode_snapshot_token(resource=resource, field=snapshot_field, cutoff=self._utc_now())
+            self._encode_snapshot_token(resource=resource, field=snapshot_field, cutoff=utcnow())
             if snapshot_field is not None
             else None
         )
@@ -904,7 +894,7 @@ class AsyncDatalake(Mindtrace):
         except Exception as exc:
             asset.payload_status = "corrupt"
             asset.payload_status_reason = f"payload read failed: {exc}"
-            asset.payload_status_updated_at = self._utc_now()
+            asset.payload_status_updated_at = utcnow()
             await self.asset_database.update(asset)
             raise
 
@@ -996,7 +986,7 @@ class AsyncDatalake(Mindtrace):
             on_conflict=on_conflict,
             upload_method="local_path",
             content_type=content_type,
-            expires_at=self._utc_now() + timedelta(minutes=expires_in_minutes),
+            expires_at=utcnow() + timedelta(minutes=expires_in_minutes),
             created_by=created_by,
         )
         key = self.store.build_key(target_mount, name, version)
@@ -1033,10 +1023,10 @@ class AsyncDatalake(Mindtrace):
 
     async def reconcile_upload_sessions(self, limit: int = 100) -> list[DirectUploadSession]:
         pending = await self.direct_upload_session_database.find({"status": "pending"})
-        now = self._utc_now()
+        now = utcnow()
         reconciled: list[DirectUploadSession] = []
         for session in pending[:limit]:
-            session.expires_at = self._coerce_utc(session.expires_at)
+            session.expires_at = as_utc(session.expires_at)
             if session.expires_at <= now:
                 reconciled.append(
                     await self._verify_and_finalize_upload_session(
@@ -1059,15 +1049,15 @@ class AsyncDatalake(Mindtrace):
 
         key = self.store.build_key(session.mount, session.name, session.requested_version)
         session.verification_attempts += 1
-        session.last_verified_at = self._utc_now()
-        session.expires_at = self._coerce_utc(session.expires_at)
+        session.last_verified_at = utcnow()
+        session.expires_at = as_utc(session.expires_at)
 
         inspection = self.store.inspect_direct_upload_target(key, staged_target=session.staged_reference)
         if not inspection.get("exists"):
-            if allow_pending_missing and session.expires_at <= self._utc_now():
+            if allow_pending_missing and session.expires_at <= utcnow():
                 session.status = "expired"
                 session.failure_reason = "Upload did not complete before expiry."
-                session.cleanup_completed_at = self._utc_now()
+                session.cleanup_completed_at = utcnow()
             await self.direct_upload_session_database.update(session)
             if allow_pending_missing:
                 return session
@@ -1086,7 +1076,7 @@ class AsyncDatalake(Mindtrace):
             session.status = "failed"
             session.failure_reason = str(e)
             if cleanup_ok:
-                session.cleanup_completed_at = self._utc_now()
+                session.cleanup_completed_at = utcnow()
             await self.direct_upload_session_database.update(session)
             raise
 
@@ -1099,7 +1089,7 @@ class AsyncDatalake(Mindtrace):
         )
         session.status = "completed"
         session.failure_reason = None
-        session.completed_at = self._utc_now()
+        session.completed_at = utcnow()
         session.cleanup_completed_at = session.completed_at
         return await self.direct_upload_session_database.update(session)
 
@@ -1119,7 +1109,7 @@ class AsyncDatalake(Mindtrace):
         payload_verified_at: datetime | None = None,
     ) -> Asset:
         normalized_storage_ref = self._normalize_storage_ref(storage_ref)
-        now = self._utc_now()
+        now = utcnow()
         asset = self._build_document(
             Asset,
             kind=kind,
@@ -1158,7 +1148,7 @@ class AsyncDatalake(Mindtrace):
             alias=asset.asset_id,
             asset_id=asset.asset_id,
             is_primary=True,
-            created_at=self._utc_now(),
+            created_at=utcnow(),
         )
         return await self.asset_alias_database.insert(doc)
 
@@ -1191,7 +1181,7 @@ class AsyncDatalake(Mindtrace):
                     alias=asset_id,
                     asset_id=asset_id,
                     is_primary=True,
-                    created_at=self._utc_now(),
+                    created_at=utcnow(),
                 )
             )
         if missing_docs:
@@ -1220,7 +1210,7 @@ class AsyncDatalake(Mindtrace):
             alias=alias,
             asset_id=asset_id,
             is_primary=False,
-            created_at=self._utc_now(),
+            created_at=utcnow(),
         )
         try:
             return await self.asset_alias_database.insert(doc)
@@ -1294,7 +1284,7 @@ class AsyncDatalake(Mindtrace):
     async def update_asset_metadata(self, asset_id: str, metadata: dict[str, Any]) -> Asset:
         asset = await self.get_asset(asset_id)
         asset.metadata = metadata
-        asset.updated_at = self._utc_now()
+        asset.updated_at = utcnow()
         return await self.asset_database.update(asset)
 
     async def delete_asset(self, asset_id: str) -> None:
@@ -1326,7 +1316,7 @@ class AsyncDatalake(Mindtrace):
             status=status,
             metadata=metadata or {},
             created_by=created_by,
-            updated_at=self._utc_now(),
+            updated_at=utcnow(),
         )
         return await self.collection_database.insert(collection)
 
@@ -1363,7 +1353,7 @@ class AsyncDatalake(Mindtrace):
         collection = await self.get_collection(collection_id)
         for key, value in changes.items():
             setattr(collection, key, value)
-        collection.updated_at = self._utc_now()
+        collection.updated_at = utcnow()
         return await self.collection_database.update(collection)
 
     async def delete_collection(self, collection_id: str) -> None:
@@ -1393,7 +1383,7 @@ class AsyncDatalake(Mindtrace):
             status=status,
             metadata=metadata or {},
             added_by=added_by,
-            updated_at=self._utc_now(),
+            updated_at=utcnow(),
         )
         return await self.collection_item_database.insert(collection_item)
 
@@ -1444,7 +1434,7 @@ class AsyncDatalake(Mindtrace):
             await self.get_asset(changes["asset_id"])
         for key, value in changes.items():
             setattr(collection_item, key, value)
-        collection_item.updated_at = self._utc_now()
+        collection_item.updated_at = utcnow()
         return await self.collection_item_database.update(collection_item)
 
     async def delete_collection_item(self, collection_item_id: str) -> None:
@@ -1470,7 +1460,7 @@ class AsyncDatalake(Mindtrace):
             retention_policy=retention_policy,
             metadata=metadata or {},
             created_by=created_by,
-            updated_at=self._utc_now(),
+            updated_at=utcnow(),
         )
         return await self.asset_retention_database.insert(asset_retention)
 
@@ -1509,7 +1499,7 @@ class AsyncDatalake(Mindtrace):
             await self.get_asset(changes["asset_id"])
         for key, value in changes.items():
             setattr(asset_retention, key, value)
-        asset_retention.updated_at = self._utc_now()
+        asset_retention.updated_at = utcnow()
         return await self.asset_retention_database.update(asset_retention)
 
     async def delete_asset_retention(self, asset_retention_id: str) -> None:
@@ -1551,7 +1541,7 @@ class AsyncDatalake(Mindtrace):
             allow_additional_attributes=allow_additional_attributes,
             metadata=metadata or {},
             created_by=created_by,
-            updated_at=self._utc_now(),
+            updated_at=utcnow(),
         )
         try:
             return await self.annotation_schema_database.insert(schema)
@@ -1602,7 +1592,7 @@ class AsyncDatalake(Mindtrace):
             ]
         for key, value in changes.items():
             setattr(schema, key, value)
-        schema.updated_at = self._utc_now()
+        schema.updated_at = utcnow()
         return await self.annotation_schema_database.update(schema)
 
     async def delete_annotation_schema(self, annotation_schema_id: str) -> None:
@@ -1680,7 +1670,7 @@ class AsyncDatalake(Mindtrace):
 
     def _coerce_annotation_record(self, annotation: AnnotationRecord | dict[str, Any]) -> AnnotationRecord:
         if isinstance(annotation, AnnotationRecord):
-            annotation.updated_at = self._utc_now()
+            annotation.updated_at = utcnow()
             return annotation
 
         source = annotation.get("source")
@@ -1700,7 +1690,7 @@ class AsyncDatalake(Mindtrace):
             geometry=annotation.get("geometry", {}),
             attributes=annotation.get("attributes", {}),
             metadata=annotation.get("metadata", {}),
-            updated_at=self._utc_now(),
+            updated_at=utcnow(),
         )
 
     async def _rollback_inserted_annotation_records(self, inserted_records: list[AnnotationRecord]) -> None:
@@ -1738,13 +1728,13 @@ class AsyncDatalake(Mindtrace):
             annotation_schema_id=annotation_schema_id,
             metadata=metadata or {},
             created_by=created_by,
-            updated_at=self._utc_now(),
+            updated_at=utcnow(),
         )
         inserted = await self.annotation_set_database.insert(annotation_set)
         if datum is not None:
             if inserted.annotation_set_id not in datum.annotation_set_ids:
                 datum.annotation_set_ids.append(inserted.annotation_set_id)
-                datum.updated_at = self._utc_now()
+                datum.updated_at = utcnow()
                 try:
                     await self.datum_database.update(datum)
                 except Exception:
@@ -1790,7 +1780,7 @@ class AsyncDatalake(Mindtrace):
             await self.get_annotation_schema(changes["annotation_schema_id"])
         for key, value in changes.items():
             setattr(annotation_set, key, value)
-        annotation_set.updated_at = self._utc_now()
+        annotation_set.updated_at = utcnow()
         return await self.annotation_set_database.update(annotation_set)
 
     def _assert_asset_subject_for_set_less_records(self, records: list[AnnotationRecord]) -> None:
@@ -1952,7 +1942,7 @@ class AsyncDatalake(Mindtrace):
                 next_record_ids.append(inserted.annotation_id)
 
         annotation_set.annotation_record_ids = next_record_ids
-        annotation_set.updated_at = self._utc_now()
+        annotation_set.updated_at = utcnow()
         try:
             await self.annotation_set_database.update(annotation_set)
         except Exception:
@@ -2044,7 +2034,7 @@ class AsyncDatalake(Mindtrace):
             if key == "source" and isinstance(value, dict):
                 value = AnnotationSource(**value)
             setattr(record, key, value)
-        record.updated_at = self._utc_now()
+        record.updated_at = utcnow()
         return await self.annotation_record_database.update(record)
 
     async def delete_annotation_record(self, annotation_id: str) -> None:
@@ -2055,7 +2045,7 @@ class AsyncDatalake(Mindtrace):
                 annotation_set.annotation_record_ids = [
                     existing_id for existing_id in annotation_set.annotation_record_ids if existing_id != annotation_id
                 ]
-                annotation_set.updated_at = self._utc_now()
+                annotation_set.updated_at = utcnow()
                 await self.annotation_set_database.update(annotation_set)
         await self.annotation_record_database.delete(record.id)
 
@@ -2075,7 +2065,7 @@ class AsyncDatalake(Mindtrace):
             asset_refs=asset_refs,
             metadata=metadata or {},
             annotation_set_ids=annotation_set_ids or [],
-            updated_at=self._utc_now(),
+            updated_at=utcnow(),
         )
         return await self.datum_database.insert(datum)
 
@@ -2142,7 +2132,7 @@ class AsyncDatalake(Mindtrace):
             await self._validate_annotation_set_ids_exist(changes["annotation_set_ids"])
         for key, value in changes.items():
             setattr(datum, key, value)
-        datum.updated_at = self._utc_now()
+        datum.updated_at = utcnow()
         return await self.datum_database.update(datum)
 
     async def create_dataset_version(

--- a/mindtrace/datalake/mindtrace/datalake/data_vault.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault.py
@@ -52,7 +52,7 @@ import json
 import re
 import warnings
 from collections.abc import AsyncIterator, Iterator, Sequence
-from datetime import UTC, datetime
+from datetime import datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -61,6 +61,7 @@ from uuid import uuid4
 from PIL import Image
 from pydantic import BaseModel, Field
 
+from mindtrace.core import utcnow
 from mindtrace.database.core.exceptions import DocumentNotFoundError
 from mindtrace.datalake.annotations import AnnotationVariants, annotation_from_record
 from mindtrace.datalake.async_datalake import (
@@ -257,7 +258,7 @@ def _snapshot_dataset_version_name(collection: Collection, snapshot_name: str | 
 
 
 def _snapshot_dataset_version_version(snapshot_version: str | None) -> str:
-    return snapshot_version or f"export-{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}-{uuid4().hex[:8]}"
+    return snapshot_version or f"export-{utcnow().strftime('%Y%m%d%H%M%S')}-{uuid4().hex[:8]}"
 
 
 def _snapshot_primary_role(asset: Asset) -> str:

--- a/mindtrace/datalake/mindtrace/datalake/replication.py
+++ b/mindtrace/datalake/mindtrace/datalake/replication.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import mimetypes
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 from urllib import request as urllib_request
 
+from mindtrace.core import utcnow
 from mindtrace.database.core.exceptions import DocumentNotFoundError
 from mindtrace.datalake.async_datalake import AsyncDatalake
 from mindtrace.datalake.blocking_payload_io import mkdir_and_write_bytes
@@ -93,7 +94,7 @@ class ReplicationManager:
 
     @staticmethod
     def _utc_now() -> datetime:
-        return datetime.now(timezone.utc)
+        return utcnow()
 
     @staticmethod
     def get_payload_status(asset: Asset) -> PayloadStatus | None:

--- a/mindtrace/datalake/mindtrace/datalake/replication.py
+++ b/mindtrace/datalake/mindtrace/datalake/replication.py
@@ -93,10 +93,6 @@ class ReplicationManager:
         return _apply_mount_map_to_storage_ref(storage_ref, mount_map)
 
     @staticmethod
-    def _utc_now() -> datetime:
-        return utcnow()
-
-    @staticmethod
     def get_payload_status(asset: Asset) -> PayloadStatus | None:
         status = getattr(asset, "payload_status", None)
         return status if isinstance(status, str) else None
@@ -197,12 +193,12 @@ class ReplicationManager:
                     **asset.model_dump(),
                     "storage_ref": mapped_storage_ref.model_dump(),
                     "payload_status": payload_status,
-                    "payload_status_updated_at": self._utc_now(),
+                    "payload_status_updated_at": utcnow(),
                     "payload_status_reason": None if payload_status == "present" else "metadata_first_pending_payload",
                     "payload_storage_ref": mapped_storage_ref.model_dump(),
                     "payload_checksum": asset.checksum,
                     "payload_size_bytes": asset.size_bytes,
-                    "payload_verified_at": self._utc_now() if payload_status == "present" else None,
+                    "payload_verified_at": utcnow() if payload_status == "present" else None,
                     "metadata": self.build_asset_replication_metadata(
                         metadata_for_replication,
                         origin_lake_id=request.origin_lake_id,
@@ -293,7 +289,7 @@ class ReplicationManager:
         await self._set_asset_replication_state(
             target_asset,
             payload_status="uploading",
-            payload_last_attempt_at=self._utc_now(),
+            payload_last_attempt_at=utcnow(),
             payload_last_error=None,
         )
 
@@ -306,8 +302,8 @@ class ReplicationManager:
                 refreshed_target_asset,
                 payload_status="present",
                 payload_available=True,
-                payload_last_attempt_at=self._utc_now(),
-                payload_verified_at=self._utc_now(),
+                payload_last_attempt_at=utcnow(),
+                payload_verified_at=utcnow(),
                 payload_last_error=None,
             )
             return refreshed_target_asset
@@ -317,7 +313,7 @@ class ReplicationManager:
                 failed_asset,
                 payload_status="corrupt",
                 payload_available=False,
-                payload_last_attempt_at=self._utc_now(),
+                payload_last_attempt_at=utcnow(),
                 payload_last_error=str(exc),
             )
             raise
@@ -370,7 +366,7 @@ class ReplicationManager:
             raise RuntimeError(f"Source asset {asset_id} is not delete-eligible until target payload is verified")
         await self._set_source_asset_reclaim_state(
             source_asset,
-            local_delete_eligible_at=when or self._utc_now(),
+            local_delete_eligible_at=when or utcnow(),
             payload_last_error=None,
         )
         return source_asset
@@ -386,13 +382,13 @@ class ReplicationManager:
         version = payload_ref.version if payload_ref.version is not None else "latest"
         self.source.store.delete(key, version=version)
         source_asset.payload_status = "missing"
-        source_asset.payload_status_updated_at = self._utc_now()
+        source_asset.payload_status_updated_at = utcnow()
         source_asset.payload_status_reason = "local payload deleted"
         source_asset.payload_storage_ref = LOCAL_PAYLOAD_TOMBSTONE_STORAGE_REF
         source_asset.payload_verified_at = None
         await self._set_source_asset_reclaim_state(
             source_asset,
-            local_deleted_at=self._utc_now(),
+            local_deleted_at=utcnow(),
             payload_available=False,
             payload_last_error=None,
         )
@@ -546,10 +542,10 @@ class ReplicationManager:
         metadata["replication"] = state.model_dump(mode="json")
         asset.metadata = metadata
         asset.payload_status = payload_status
-        asset.payload_status_updated_at = self._utc_now()
+        asset.payload_status_updated_at = utcnow()
         asset.payload_status_reason = payload_last_error
         if payload_status == "present":
-            asset.payload_verified_at = payload_verified_at or self._utc_now()
+            asset.payload_verified_at = payload_verified_at or utcnow()
             asset.payload_storage_ref = asset.storage_ref
             asset.payload_checksum = asset.checksum
             asset.payload_size_bytes = asset.size_bytes

--- a/mindtrace/datalake/mindtrace/datalake/replication_queue.py
+++ b/mindtrace/datalake/mindtrace/datalake/replication_queue.py
@@ -13,7 +13,7 @@ from mindtrace.datalake.types import (
     ReplicationHydratePolicy,
     ReplicationTask,
     ReplicationTaskStatus,
-    utc_now,
+    utcnow,
 )
 
 _TERMINAL_TASK_STATUSES: set[ReplicationTaskStatus] = {"complete", "dead", "cancelled"}
@@ -181,7 +181,7 @@ class ReplicationQueueManager:
         claim without changing callers.
         """
 
-        current = _as_utc(now or utc_now())
+        current = _as_utc(now or utcnow())
         claimed: list[ReplicationTask] = []
         rows = await self.database.find(
             {
@@ -234,7 +234,7 @@ class ReplicationQueueManager:
         task = await self.get_task(task_id)
         if worker_id is not None and task.claimed_by not in {None, worker_id}:
             raise RuntimeError(f"replication task {task_id} is claimed by {task.claimed_by!r}")
-        now = utc_now()
+        now = utcnow()
         task.status = status
         task.updated_at = now
         task.last_error = error
@@ -268,7 +268,7 @@ class ReplicationQueueManager:
         task = await self.get_task(task_id)
         if worker_id is not None and task.claimed_by not in {None, worker_id}:
             raise RuntimeError(f"replication task {task_id} is claimed by {task.claimed_by!r}")
-        now = utc_now()
+        now = utcnow()
         task.attempts += 1
         task.status = "dead" if task.attempts >= task.max_attempts else "failed"
         task.last_error = error
@@ -285,7 +285,7 @@ class ReplicationQueueManager:
         task = await self.get_task(task_id)
         if task.status == "complete":
             raise RuntimeError(f"replication task {task_id} is already complete")
-        now = utc_now()
+        now = utcnow()
         task.status = "pending"
         task.next_attempt_at = now
         task.claimed_by = None
@@ -319,7 +319,7 @@ class ReplicationQueueManager:
                 allowed = sorted(REPLICATION_TASK_PURGEABLE_STATUSES)
                 raise ValueError(f"purge_terminal_tasks only supports archival statuses {allowed}; got {s!r}")
 
-        clock = _as_utc(now or utc_now())
+        clock = _as_utc(now or utcnow())
         cutoff = clock - timedelta(seconds=older_than_seconds)
         rows = await self.database.find({"status": {"$in": sorted(sts_tuple)}, "completed_at": {"$lte": cutoff}})
         ordered = sorted(

--- a/mindtrace/datalake/mindtrace/datalake/replication_queue.py
+++ b/mindtrace/datalake/mindtrace/datalake/replication_queue.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any
 
+from mindtrace.core import as_utc
 from mindtrace.database.core.exceptions import DuplicateInsertError
 from mindtrace.datalake.types import (
     DEFAULT_REPLICATION_TASK_PURGE_STATUSES,
@@ -23,22 +24,16 @@ _RECLAIM_EXPIRED_LEASE_STATUSES: frozenset[ReplicationTaskStatus] = frozenset(
 )
 
 
-def _as_utc(value: datetime) -> datetime:
-    if value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc)
-
-
 def _task_is_claimable_at(task: ReplicationTask, current: datetime) -> bool:
     """Return True when a worker may steal/assign a fresh lease without manual repair."""
     if task.status in _TERMINAL_TASK_STATUSES:
         return False
-    if task.lease_expires_at is not None and _as_utc(task.lease_expires_at) > current:
+    if task.lease_expires_at is not None and as_utc(task.lease_expires_at) > current:
         return False
     if task.status in _RETRYABLE_TASK_STATUSES:
-        return _as_utc(task.next_attempt_at) <= current
+        return as_utc(task.next_attempt_at) <= current
     if task.status in _RECLAIM_EXPIRED_LEASE_STATUSES:
-        return task.lease_expires_at is not None and _as_utc(task.lease_expires_at) <= current
+        return task.lease_expires_at is not None and as_utc(task.lease_expires_at) <= current
     return False
 
 
@@ -181,7 +176,7 @@ class ReplicationQueueManager:
         claim without changing callers.
         """
 
-        current = _as_utc(now or utcnow())
+        current = as_utc(now or utcnow())
         claimed: list[ReplicationTask] = []
         rows = await self.database.find(
             {
@@ -319,12 +314,12 @@ class ReplicationQueueManager:
                 allowed = sorted(REPLICATION_TASK_PURGEABLE_STATUSES)
                 raise ValueError(f"purge_terminal_tasks only supports archival statuses {allowed}; got {s!r}")
 
-        clock = _as_utc(now or utcnow())
+        clock = as_utc(now or utcnow())
         cutoff = clock - timedelta(seconds=older_than_seconds)
         rows = await self.database.find({"status": {"$in": sorted(sts_tuple)}, "completed_at": {"$lte": cutoff}})
         ordered = sorted(
             rows,
-            key=lambda t: (_as_utc(t.completed_at) if t.completed_at else clock, t.created_at),
+            key=lambda t: (as_utc(t.completed_at) if t.completed_at else clock, t.created_at),
         )
         total = len(ordered)
         slice_rows = ordered[: max(0, limit)]

--- a/mindtrace/datalake/mindtrace/datalake/service.py
+++ b/mindtrace/datalake/mindtrace/datalake/service.py
@@ -10,12 +10,13 @@ import traceback
 from collections.abc import Awaitable
 from contextlib import suppress
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any
 from uuid import uuid4
 
 from fastapi import HTTPException
 
+from mindtrace.core import as_utc
 from mindtrace.database.core.exceptions import DocumentNotFoundError, DocumentTooLargeError
 from mindtrace.datalake.async_datalake import AsyncDatalake, SlowOperationDisabledError, SlowOpsPolicy
 from mindtrace.datalake.replication import ReplicationManager
@@ -278,8 +279,7 @@ _LOGGER = logging.getLogger(__name__)
 def _import_session_expired(expires_at: datetime, *, now: datetime | None = None) -> bool:
     """Compare session expiry to current UTC time, treating naive datetimes as UTC (Mongo round-trip)."""
     current = now if now is not None else utcnow()
-    deadline = expires_at if expires_at.tzinfo is not None else expires_at.replace(tzinfo=timezone.utc)
-    return current > deadline
+    return current > as_utc(expires_at)
 
 
 class _ImportSessionProgressWriter:

--- a/mindtrace/datalake/mindtrace/datalake/service.py
+++ b/mindtrace/datalake/mindtrace/datalake/service.py
@@ -267,7 +267,7 @@ from mindtrace.datalake.sync_types import (
     DatasetSyncProgress,
     ObjectPayloadDescriptor,
 )
-from mindtrace.datalake.types import Asset, DatasetImportSession, StorageRef, utc_now
+from mindtrace.datalake.types import Asset, DatasetImportSession, StorageRef, utcnow
 from mindtrace.registry import Mount
 from mindtrace.registry.core.exceptions import RegistryObjectNotFound
 from mindtrace.services import Service
@@ -277,7 +277,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def _import_session_expired(expires_at: datetime, *, now: datetime | None = None) -> bool:
     """Compare session expiry to current UTC time, treating naive datetimes as UTC (Mongo round-trip)."""
-    current = now if now is not None else datetime.now(timezone.utc)
+    current = now if now is not None else utcnow()
     deadline = expires_at if expires_at.tzinfo is not None else expires_at.replace(tzinfo=timezone.utc)
     return current > deadline
 
@@ -315,7 +315,7 @@ class _ImportSessionProgressWriter:
         sess.import_progress_bytes_total = progress.bytes_total
         sess.import_progress_skipped_items = progress.skipped_items
         sess.import_progress_failed_items = progress.failed_items
-        sess.import_progress_updated_at = utc_now()
+        sess.import_progress_updated_at = utcnow()
         sess.metadata_commit_cursor_entity_kind = progress.entity_kind
         sess.metadata_commit_cursor_completed_items = progress.entity_completed_items
         sess.metadata_commit_cursor_total_items = progress.entity_total_items
@@ -1671,7 +1671,7 @@ class DatalakeService(Service):
                 continue
             setattr(existing, key, value)
         if hasattr(existing, "updated_at"):
-            existing.updated_at = utc_now()
+            existing.updated_at = utcnow()
         updated = await database.update(existing)
         return updated, False
 
@@ -1686,7 +1686,7 @@ class DatalakeService(Service):
             if key in {"id", "_id"}:
                 continue
             setattr(existing, key, value)
-        existing.updated_at = utc_now()
+        existing.updated_at = utcnow()
         updated = await datalake.asset_database.update(existing)
         return updated, False
 
@@ -1694,7 +1694,7 @@ class DatalakeService(Service):
         self, payload: DatasetStreamingImportStartInput
     ) -> DatasetStreamingImportStartOutput:
         datalake = await self._ensure_datalake()
-        now = utc_now()
+        now = utcnow()
         session = DatasetImportSession(
             bundle_data={},
             transfer_policy=payload.transfer_policy,
@@ -1817,7 +1817,7 @@ class DatalakeService(Service):
                         "storage_ref": mapped_storage_ref.model_dump(),
                         "payload_storage_ref": mapped_payload_ref.model_dump(),
                         **resolved_payload_updates,
-                        "updated_at": utc_now(),
+                        "updated_at": utcnow(),
                     }
                 )
                 row, _ = await self._streaming_upsert_asset(datalake, mapped_asset)
@@ -1970,7 +1970,7 @@ class DatalakeService(Service):
         session.import_progress_completed_items = processed_total
         session.import_progress_total_items = session.expected_manifest_total
         session.import_progress_bytes_completed = bytes_completed
-        session.import_progress_updated_at = utc_now()
+        session.import_progress_updated_at = utcnow()
         await datalake.dataset_import_session_database.update(session)
         return DatasetStreamingImportPushBatchOutput(
             session_id=session.import_session_id,
@@ -2037,7 +2037,7 @@ class DatalakeService(Service):
         if rows:
             dataset_version = rows[0]
             dataset_version.manifest = list(session.ordered_manifest_ids)
-            dataset_version.updated_at = utc_now()
+            dataset_version.updated_at = utcnow()
             dataset_version = await datalake.dataset_version_database.update(dataset_version)
         else:
             dataset_version = await datalake.create_dataset_version(
@@ -2153,7 +2153,7 @@ class DatalakeService(Service):
             )
 
         required = [row.asset_id for row in plan.payloads if row.transfer_required]
-        now = utc_now()
+        now = utcnow()
         session = DatasetImportSession(
             bundle_data={},
             transfer_policy=payload.transfer_policy,

--- a/mindtrace/datalake/mindtrace/datalake/sync.py
+++ b/mindtrace/datalake/mindtrace/datalake/sync.py
@@ -32,7 +32,7 @@ from mindtrace.datalake.types import (
     DatasetVersion,
     Datum,
     StorageRef,
-    utc_now,
+    utcnow,
 )
 
 
@@ -765,7 +765,7 @@ class DatasetSyncManager:
                 )
                 payload_status = "present"
                 payload_status_reason = None
-                payload_verified_at = utc_now()
+                payload_verified_at = utcnow()
                 if replication_manager is not None:
                     merged_origin = replication_manager.build_asset_replication_metadata(
                         merged_origin,
@@ -782,7 +782,7 @@ class DatasetSyncManager:
                         **asset.model_dump(),
                         "storage_ref": storage_ref.model_dump(),
                         "payload_status": payload_status,
-                        "payload_status_updated_at": utc_now(),
+                        "payload_status_updated_at": utcnow(),
                         "payload_status_reason": payload_status_reason,
                         "payload_storage_ref": storage_ref.model_dump(),
                         "payload_checksum": asset.checksum,
@@ -1023,7 +1023,7 @@ class DatasetSyncManager:
 
         await self._verify_transferred_payload(payload_descriptor, payload_bytes, staged_storage_ref)
         asset = await self.target.get_asset(asset_id)
-        now = utc_now()
+        now = utcnow()
         asset.storage_ref = staged_storage_ref
         asset.size_bytes = len(payload_bytes)
         if payload_descriptor.checksum:
@@ -1041,7 +1041,7 @@ class DatasetSyncManager:
         await rm._set_asset_replication_state(
             asset,
             payload_status="present",
-            payload_verified_at=utc_now(),
+            payload_verified_at=utcnow(),
             payload_last_error=None,
         )
         return await self.target.get_asset(asset_id)
@@ -1317,7 +1317,7 @@ class DatasetSyncManager:
                     **asset.model_dump(),
                     "storage_ref": _apply_mount_map_to_storage_ref(asset.storage_ref, request.mount_map).model_dump(),
                     "payload_status": "missing",
-                    "payload_status_updated_at": utc_now(),
+                    "payload_status_updated_at": utcnow(),
                     "payload_status_reason": "fast_sync_pending_payload",
                     "payload_storage_ref": _apply_mount_map_to_storage_ref(
                         asset.storage_ref, request.mount_map

--- a/mindtrace/datalake/mindtrace/datalake/testing/suites/collection_item.py
+++ b/mindtrace/datalake/mindtrace/datalake/testing/suites/collection_item.py
@@ -16,7 +16,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.workloads import deterministic_payload, parse_size_bytes, run_threaded_until_deadline
 from mindtrace.datalake import Datalake
@@ -87,7 +87,7 @@ class DatalakeCollectionItemSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         monotonic_start = time.perf_counter()
         backend = str(config.parameters.get("backend", "local")).lower()
         mongo_backend, mongo_uri, mongo_db_name = resolve_mongo_triple(config)
@@ -152,7 +152,7 @@ class DatalakeCollectionItemSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/datalake/mindtrace/datalake/testing/suites/create_asset.py
+++ b/mindtrace/datalake/mindtrace/datalake/testing/suites/create_asset.py
@@ -16,7 +16,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.workloads import deterministic_payload, parse_size_bytes, run_threaded_until_deadline
 from mindtrace.datalake import Datalake
@@ -97,7 +97,7 @@ class DatalakeCreateAssetFromObjectSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         monotonic_start = time.perf_counter()
         backend = str(config.parameters.get("backend", "local")).lower()
         mongo_backend, mongo_uri, mongo_db_name = resolve_mongo_triple(config)
@@ -155,7 +155,7 @@ class DatalakeCreateAssetFromObjectSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/datalake/mindtrace/datalake/testing/suites/mixed_rw.py
+++ b/mindtrace/datalake/mindtrace/datalake/testing/suites/mixed_rw.py
@@ -17,7 +17,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.workloads import deterministic_payload, parse_size_bytes, run_threaded_until_deadline
 from mindtrace.datalake import Datalake
@@ -79,7 +79,7 @@ class DatalakeMixedRwSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         monotonic_start = time.perf_counter()
         backend = str(config.parameters.get("backend", "local")).lower()
         payload_size = parse_size_bytes(config.parameters.get("payload_size"), default=64 * 1024)
@@ -148,7 +148,7 @@ class DatalakeMixedRwSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/datalake/mindtrace/datalake/testing/suites/mongo_insert.py
+++ b/mindtrace/datalake/mindtrace/datalake/testing/suites/mongo_insert.py
@@ -17,7 +17,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.database import MongoMindtraceODM
 from mindtrace.datalake.testing.mongo_resolve import resolve_mongo_triple
@@ -76,7 +76,7 @@ class DatalakeMongoInsertCeilingSuite(BenchTestSuite):
 
 
 async def _run_async(config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-    started = utc_now_iso()
+    started = utcnow_iso()
     monotonic_start = time.perf_counter()
     mongo_backend, mongo_uri, mongo_db_name = resolve_mongo_triple(config)
     batch_size = int(config.parameters.get("batch_size", 100))
@@ -111,7 +111,7 @@ async def _run_async(config: BenchSuiteConfig, reporter: BenchReporter) -> Bench
         suite_id=config.suite_id,
         status="passed" if reporter.failures == 0 else "failed",
         started_at=started,
-        ended_at=utc_now_iso(),
+        ended_at=utcnow_iso(),
         duration_seconds=elapsed,
         operations=reporter.operations * batch_size,
         successes=reporter.successes * batch_size,

--- a/mindtrace/datalake/mindtrace/datalake/testing/suites/payload_read.py
+++ b/mindtrace/datalake/mindtrace/datalake/testing/suites/payload_read.py
@@ -17,7 +17,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.workloads import deterministic_payload, parse_size_bytes, run_threaded_until_deadline
 from mindtrace.datalake import Datalake
@@ -79,7 +79,7 @@ class DatalakePayloadReadCeilingSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         monotonic_start = time.perf_counter()
         backend = str(config.parameters.get("backend", "local")).lower()
         payload_size = parse_size_bytes(config.parameters.get("payload_size"), default=64 * 1024)
@@ -135,7 +135,7 @@ class DatalakePayloadReadCeilingSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/datalake/mindtrace/datalake/testing/suites/payload_write.py
+++ b/mindtrace/datalake/mindtrace/datalake/testing/suites/payload_write.py
@@ -16,7 +16,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.workloads import deterministic_payload, parse_size_bytes, run_threaded_until_deadline
 from mindtrace.datalake import Datalake
@@ -82,7 +82,7 @@ class DatalakePayloadWriteCeilingSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         monotonic_start = time.perf_counter()
         backend = str(config.parameters.get("backend", "local")).lower()
         payload_size = parse_size_bytes(
@@ -134,7 +134,7 @@ class DatalakePayloadWriteCeilingSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/datalake/mindtrace/datalake/testing/suites/retention.py
+++ b/mindtrace/datalake/mindtrace/datalake/testing/suites/retention.py
@@ -16,7 +16,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.workloads import deterministic_payload, parse_size_bytes, run_threaded_until_deadline
 from mindtrace.datalake import Datalake
@@ -87,7 +87,7 @@ class DatalakeRetentionSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         monotonic_start = time.perf_counter()
         backend = str(config.parameters.get("backend", "local")).lower()
         mongo_backend, mongo_uri, mongo_db_name = resolve_mongo_triple(config)
@@ -150,7 +150,7 @@ class DatalakeRetentionSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/datalake/mindtrace/datalake/testing/suites/smoke.py
+++ b/mindtrace/datalake/mindtrace/datalake/testing/suites/smoke.py
@@ -15,7 +15,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.workloads import deterministic_payload
 from mindtrace.datalake import Datalake
@@ -58,7 +58,7 @@ class DatalakeSmokeSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         mono = time.perf_counter()
         backend = str(config.parameters.get("backend", "local")).lower()
         mongo_uri = require_resource(config, "mongo_uri")
@@ -100,7 +100,7 @@ class DatalakeSmokeSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/datalake/mindtrace/datalake/types.py
+++ b/mindtrace/datalake/mindtrace/datalake/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Annotated, Any, Literal
 from uuid import uuid4
 
@@ -9,6 +9,7 @@ from beanie.exceptions import CollectionWasNotInitialized
 from pydantic import BaseModel, Field, model_validator
 from pymongo import IndexModel
 
+from mindtrace.core import utcnow
 from mindtrace.database import MindtraceDocument
 
 AnnotationTaskType = Literal["classification", "detection", "segmentation", "keypoint", "other"]
@@ -25,10 +26,6 @@ AnnotationKind = Literal[
     "instance_mask",
     "pointcloud_segmentation",
 ]
-
-
-def utc_now() -> datetime:
-    return datetime.now(timezone.utc)
 
 
 def new_id(prefix: str) -> str:
@@ -99,7 +96,7 @@ class DirectUploadSession(DatalakeDocument):
     failure_reason: str | None = None
     verification_attempts: int = 0
     last_verified_at: datetime | None = None
-    created_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
     expires_at: datetime
     completed_at: datetime | None = None
     cleanup_completed_at: datetime | None = None
@@ -169,7 +166,7 @@ class DatasetImportSession(DatalakeDocument):
     import_progress_failed_items: int | None = None
     import_progress_updated_at: datetime | None = None
     import_progress_error: str | None = None
-    created_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
     expires_at: datetime
 
     class Settings:
@@ -261,8 +258,8 @@ class ReplicationRule(DatalakeDocument):
     batch_size: int = 100
     max_attempts: int = 5
     metadata: dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=utc_now)
-    updated_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime = Field(default_factory=utcnow)
 
     class Settings:
         name = "datalake_replication_rules"
@@ -289,7 +286,7 @@ class ReplicationTask(DatalakeDocument):
     include_graph: bool = True
     attempts: int = 0
     max_attempts: int = 5
-    next_attempt_at: datetime = Field(default_factory=utc_now)
+    next_attempt_at: datetime = Field(default_factory=utcnow)
     claimed_by: str | None = None
     claimed_at: datetime | None = None
     lease_expires_at: datetime | None = None
@@ -301,8 +298,8 @@ class ReplicationTask(DatalakeDocument):
     last_progress_bytes_completed: int | None = None
     last_progress_bytes_total: int | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=utc_now)
-    updated_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime = Field(default_factory=utcnow)
     completed_at: datetime | None = None
 
     class Settings:
@@ -338,7 +335,7 @@ class Asset(DatalakeDocument):
     checksum: str | None = None
     size_bytes: int | None = None
     payload_status: PayloadStatus = "present"
-    payload_status_updated_at: datetime | None = Field(default_factory=utc_now)
+    payload_status_updated_at: datetime | None = Field(default_factory=utcnow)
     payload_status_reason: str | None = None
     payload_storage_ref: StorageRef | None = None
     payload_checksum: str | None = None
@@ -346,9 +343,9 @@ class Asset(DatalakeDocument):
     payload_verified_at: datetime | None = None
     subject: SubjectRef | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
     created_by: str | None = None
-    updated_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utcnow)
 
     class Settings:
         name = "datalake_assets"
@@ -379,7 +376,7 @@ class AssetAlias(DatalakeDocument):
     alias: Annotated[str, Indexed(unique=True)]
     asset_id: Annotated[str, Indexed()]
     is_primary: bool = False
-    created_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
 
     class Settings:
         name = "datalake_asset_aliases"
@@ -411,8 +408,8 @@ class AnnotationRecord(DatalakeDocument):
     geometry: dict[str, Any] = Field(default_factory=dict)
     attributes: dict[str, Any] = Field(default_factory=dict)
     metadata: dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=utc_now)
-    updated_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime = Field(default_factory=utcnow)
 
     class Settings:
         name = "datalake_annotation_records"
@@ -448,9 +445,9 @@ class AnnotationSchema(DatalakeDocument):
     optional_attributes: list[str] = Field(default_factory=list)
     allow_additional_attributes: bool = False
     metadata: dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
     created_by: str | None = None
-    updated_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utcnow)
 
     class Settings:
         name = "datalake_annotation_schemas"
@@ -481,9 +478,9 @@ class AnnotationSet(DatalakeDocument):
     annotation_schema_id: str | None = None
     annotation_record_ids: list[str] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
     created_by: str | None = None
-    updated_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utcnow)
 
     class Settings:
         name = "datalake_annotation_sets"
@@ -501,9 +498,9 @@ class Collection(DatalakeDocument):
     description: str | None = None
     status: Literal["active", "archived", "deleted"] = "active"
     metadata: dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
     created_by: str | None = None
-    updated_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utcnow)
 
     class Settings:
         name = "datalake_collections"
@@ -522,9 +519,9 @@ class CollectionItem(DatalakeDocument):
     split: Literal["train", "val", "test"] | None = None
     status: Literal["active", "hidden", "removed"] = "active"
     metadata: dict[str, Any] = Field(default_factory=dict)
-    added_at: datetime = Field(default_factory=utc_now)
+    added_at: datetime = Field(default_factory=utcnow)
     added_by: str | None = None
-    updated_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utcnow)
 
     class Settings:
         name = "datalake_collection_items"
@@ -559,9 +556,9 @@ class AssetRetention(DatalakeDocument):
     owner_id: str
     retention_policy: Literal["retain", "delete_when_unreferenced", "archive_when_unreferenced"] = "retain"
     metadata: dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
     created_by: str | None = None
-    updated_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utcnow)
 
     class Settings:
         name = "datalake_asset_retentions"
@@ -585,8 +582,8 @@ class Datum(DatalakeDocument):
     asset_refs: dict[str, str] = Field(default_factory=dict)
     metadata: dict[str, Any] = Field(default_factory=dict)
     annotation_set_ids: list[str] = Field(default_factory=list)
-    created_at: datetime = Field(default_factory=utc_now)
-    updated_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime = Field(default_factory=utcnow)
 
     class Settings:
         name = "datalake_datums"
@@ -606,7 +603,7 @@ class DatasetVersion(DatalakeDocument):
     manifest: list[str] = Field(default_factory=list)
     source_dataset_version_id: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=utc_now)
+    created_at: datetime = Field(default_factory=utcnow)
     created_by: str | None = None
 
     class Settings:

--- a/mindtrace/hardware/mindtrace/hardware/cli/core/process_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/cli/core/process_manager.py
@@ -11,7 +11,7 @@ from typing import Any, Dict
 
 import psutil
 
-from mindtrace.core import utcnow
+from mindtrace.core import utcnow_iso
 
 
 class ProcessManager:
@@ -119,7 +119,7 @@ class ProcessManager:
             "pid": process.pid,
             "host": host,
             "port": port,
-            "start_time": utcnow().isoformat(),
+            "start_time": utcnow_iso(),
             "command": " ".join(cmd),
         }
         self.save_pids()
@@ -170,7 +170,7 @@ class ProcessManager:
             "pid": process.pid,
             "host": host,
             "port": port,
-            "start_time": utcnow().isoformat(),
+            "start_time": utcnow_iso(),
             "command": " ".join(cmd),
         }
         self.save_pids()
@@ -229,7 +229,7 @@ class ProcessManager:
             "pid": process.pid,
             "host": host,
             "port": port,
-            "start_time": utcnow().isoformat(),
+            "start_time": utcnow_iso(),
             "command": " ".join(cmd),
         }
         self.save_pids()
@@ -288,7 +288,7 @@ class ProcessManager:
             "pid": process.pid,
             "host": host,
             "port": port,
-            "start_time": utcnow().isoformat(),
+            "start_time": utcnow_iso(),
             "command": " ".join(cmd),
         }
         self.save_pids()

--- a/mindtrace/hardware/mindtrace/hardware/cli/core/process_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/cli/core/process_manager.py
@@ -6,11 +6,12 @@ import signal
 import subprocess
 import sys
 import time
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 
 import psutil
+
+from mindtrace.core import utcnow
 
 
 class ProcessManager:
@@ -118,7 +119,7 @@ class ProcessManager:
             "pid": process.pid,
             "host": host,
             "port": port,
-            "start_time": datetime.now().isoformat(),
+            "start_time": utcnow().isoformat(),
             "command": " ".join(cmd),
         }
         self.save_pids()
@@ -169,7 +170,7 @@ class ProcessManager:
             "pid": process.pid,
             "host": host,
             "port": port,
-            "start_time": datetime.now().isoformat(),
+            "start_time": utcnow().isoformat(),
             "command": " ".join(cmd),
         }
         self.save_pids()
@@ -228,7 +229,7 @@ class ProcessManager:
             "pid": process.pid,
             "host": host,
             "port": port,
-            "start_time": datetime.now().isoformat(),
+            "start_time": utcnow().isoformat(),
             "command": " ".join(cmd),
         }
         self.save_pids()
@@ -287,7 +288,7 @@ class ProcessManager:
             "pid": process.pid,
             "host": host,
             "port": port,
-            "start_time": datetime.now().isoformat(),
+            "start_time": utcnow().isoformat(),
             "command": " ".join(cmd),
         }
         self.save_pids()

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/models/responses.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/models/responses.py
@@ -5,11 +5,12 @@ Contains all Pydantic models for API responses, ensuring consistent
 response formatting across all camera management endpoints.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
+from mindtrace.core import utcnow
 from mindtrace.hardware.core.types import ServiceStatus
 
 
@@ -18,7 +19,7 @@ class BaseResponse(BaseModel):
 
     success: bool
     message: str
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    timestamp: datetime = Field(default_factory=utcnow)
 
 
 class BoolResponse(BaseResponse):
@@ -195,7 +196,7 @@ class CaptureResult(BaseModel):
     error: Optional[str] = None
     image_data: Optional[str] = None  # Base64 encoded image
     image_path: Optional[str] = None
-    capture_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    capture_time: datetime = Field(default_factory=utcnow)
     image_size: Optional[Tuple[int, int]] = None
     file_size_bytes: Optional[int] = None
 
@@ -221,7 +222,7 @@ class HDRCaptureResult(BaseModel):
     images: Optional[List[str]] = None  # Base64 encoded images
     image_paths: Optional[List[str]] = None
     exposure_levels: List[float]
-    capture_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    capture_time: datetime = Field(default_factory=utcnow)
     successful_captures: int
 
 

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/service.py
@@ -10,12 +10,12 @@ import base64
 import io
 import os
 import time
-from datetime import datetime, timezone
 from typing import Optional, Tuple
 
 from fastapi.middleware.cors import CORSMiddleware
 from PIL import Image as PILImage
 
+from mindtrace.core import utcnow
 from mindtrace.core.utils.conversions import ndarray_to_pil
 from mindtrace.hardware.cameras.core.async_camera_manager import AsyncCameraManager
 from mindtrace.hardware.core.exceptions import (
@@ -1072,13 +1072,13 @@ class CameraManagerService(Service):
                     result = CaptureResult(
                         success=True,
                         image_path=request.save_path,
-                        capture_time=datetime.now(timezone.utc),
+                        capture_time=utcnow(),
                     )
                 else:
                     image_data, image_size, file_size_bytes = self._encode_inline_image(captured, request.output_format)
                     result = CaptureResult(
                         success=True,
-                        capture_time=datetime.now(timezone.utc),
+                        capture_time=utcnow(),
                         image_data=image_data,
                         image_size=image_size,
                         file_size_bytes=file_size_bytes,
@@ -1098,22 +1098,16 @@ class CameraManagerService(Service):
         except CameraTimeoutError as e:
             # Return timeout error as failed response with detailed message
             self.logger.error(f"Capture timeout: {e}")
-            result = CaptureResult(
-                success=False, image_path=None, capture_time=datetime.now(timezone.utc), error=str(e)
-            )
+            result = CaptureResult(success=False, image_path=None, capture_time=utcnow(), error=str(e))
             return CaptureResponse(success=False, message=str(e), data=result)
         except CameraNotFoundError as e:
             # Return not found error as failed response
             self.logger.warning(f"Camera not found: {e}")
-            result = CaptureResult(
-                success=False, image_path=None, capture_time=datetime.now(timezone.utc), error=str(e)
-            )
+            result = CaptureResult(success=False, image_path=None, capture_time=utcnow(), error=str(e))
             return CaptureResponse(success=False, message=str(e), data=result)
         except Exception as e:
             self.logger.error(f"Failed to capture image from '{request.camera}': {e}")
-            result = CaptureResult(
-                success=False, image_path=None, capture_time=datetime.now(timezone.utc), error=str(e)
-            )
+            result = CaptureResult(success=False, image_path=None, capture_time=utcnow(), error=str(e))
             return CaptureResponse(success=False, message=f"Capture failed: {str(e)}", data=result)
 
     async def capture_images_batch(self, request: CaptureBatchRequest) -> BatchCaptureResponse:
@@ -1135,9 +1129,7 @@ class CameraManagerService(Service):
                 if image is not None:
                     if request.save_path_pattern:
                         # Image is the file path string
-                        capture_results[camera] = CaptureResult(
-                            success=True, image_path=image, capture_time=datetime.now(timezone.utc)
-                        )
+                        capture_results[camera] = CaptureResult(success=True, image_path=image, capture_time=utcnow())
                     else:
                         # Image is numpy/PIL data — encode inline in the requested wire format
                         image_data, image_size, file_size_bytes = self._encode_inline_image(
@@ -1145,14 +1137,14 @@ class CameraManagerService(Service):
                         )
                         capture_results[camera] = CaptureResult(
                             success=True,
-                            capture_time=datetime.now(timezone.utc),
+                            capture_time=utcnow(),
                             image_data=image_data,
                             image_size=image_size,
                             file_size_bytes=file_size_bytes,
                         )
                     successful_count += 1
                 else:
-                    capture_results[camera] = CaptureResult(success=False, capture_time=datetime.now(timezone.utc))
+                    capture_results[camera] = CaptureResult(success=False, capture_time=utcnow())
 
             return BatchCaptureResponse(
                 success=successful_count > 0,
@@ -1200,7 +1192,7 @@ class CameraManagerService(Service):
                 images=images,
                 image_paths=hdr_result.get("image_paths"),
                 exposure_levels=hdr_result.get("exposure_levels", []),
-                capture_time=datetime.now(timezone.utc),
+                capture_time=utcnow(),
                 successful_captures=hdr_result.get("successful_captures", 0),
             )
 
@@ -1215,7 +1207,7 @@ class CameraManagerService(Service):
                 images=None,
                 image_paths=None,
                 exposure_levels=[],
-                capture_time=datetime.now(timezone.utc),
+                capture_time=utcnow(),
                 successful_captures=0,
             )
             return HDRCaptureResponse(success=False, message=str(e), data=result)
@@ -1227,7 +1219,7 @@ class CameraManagerService(Service):
                 images=None,
                 image_paths=None,
                 exposure_levels=[],
-                capture_time=datetime.now(timezone.utc),
+                capture_time=utcnow(),
                 successful_captures=0,
             )
             return HDRCaptureResponse(success=False, message=f"HDR capture failed: {str(e)}", data=result)
@@ -1268,7 +1260,7 @@ class CameraManagerService(Service):
                         images=images,
                         image_paths=hdr_data.get("image_paths"),
                         exposure_levels=hdr_data.get("exposure_levels", []),
-                        capture_time=datetime.now(timezone.utc),
+                        capture_time=utcnow(),
                         successful_captures=hdr_data.get("successful_captures", 0),
                     )
                     successful_count += 1
@@ -1278,7 +1270,7 @@ class CameraManagerService(Service):
                         images=None,
                         image_paths=None,
                         exposure_levels=[],
-                        capture_time=datetime.now(timezone.utc),
+                        capture_time=utcnow(),
                         successful_captures=0,
                     )
 
@@ -1526,15 +1518,13 @@ class CameraManagerService(Service):
             # Track this stream as active (always update, even if already exists)
             self._active_streams[request.camera] = {
                 "stream_url": stream_url,
-                "start_time": datetime.now(timezone.utc),
+                "start_time": utcnow(),
                 "camera_proxy": camera_proxy,
                 "quality": request.quality,
                 "fps": request.fps,
             }
 
-            stream_info = StreamInfo(
-                camera=request.camera, streaming=True, stream_url=stream_url, start_time=datetime.now(timezone.utc)
-            )
+            stream_info = StreamInfo(camera=request.camera, streaming=True, stream_url=stream_url, start_time=utcnow())
 
             return StreamInfoResponse(
                 success=True, message=f"Stream started for camera '{request.camera}'", data=stream_info
@@ -1598,7 +1588,7 @@ class CameraManagerService(Service):
             if is_streaming:
                 stream_info = self._active_streams[request.camera]
                 stream_url = stream_info["stream_url"]
-                uptime_seconds = (datetime.now(timezone.utc) - stream_info["start_time"]).total_seconds()
+                uptime_seconds = (utcnow() - stream_info["start_time"]).total_seconds()
 
             stream_status = StreamStatus(
                 camera=request.camera,

--- a/mindtrace/hardware/mindtrace/hardware/services/plcs/models/responses.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/plcs/models/responses.py
@@ -5,11 +5,12 @@ Contains all Pydantic models for API responses, ensuring consistent
 response formatting across all PLC management endpoints.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from mindtrace.core import utcnow
 from mindtrace.hardware.core.types import ServiceStatus
 
 
@@ -18,7 +19,7 @@ class BaseResponse(BaseModel):
 
     success: bool
     message: str
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    timestamp: datetime = Field(default_factory=utcnow)
 
 
 class BoolResponse(BaseResponse):

--- a/mindtrace/hardware/mindtrace/hardware/services/scanners_3d/models/responses.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/scanners_3d/models/responses.py
@@ -5,11 +5,12 @@ Contains all Pydantic models for API responses, ensuring consistent
 response formatting across all 3D scanner management endpoints.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
+from mindtrace.core import utcnow
 from mindtrace.hardware.core.types import ServiceStatus
 
 
@@ -18,7 +19,7 @@ class BaseResponse(BaseModel):
 
     success: bool
     message: str
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    timestamp: datetime = Field(default_factory=utcnow)
 
 
 class BoolResponse(BaseResponse):

--- a/mindtrace/hardware/mindtrace/hardware/services/scanners_3d/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/scanners_3d/service.py
@@ -13,7 +13,7 @@ import psutil
 from fastapi import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
-from mindtrace.core import utcnow
+from mindtrace.core import utcnow_iso
 from mindtrace.hardware.core.exceptions import (
     CameraNotFoundError,
 )
@@ -702,7 +702,7 @@ class Scanner3DService(Service):
                 confidence_saved_path=request.save_confidence_path if result.confidence is not None else None,
                 normal_saved_path=request.save_normal_path if result.normal_map is not None else None,
                 color_saved_path=request.save_color_path if result.color is not None else None,
-                capture_timestamp=utcnow().isoformat(),
+                capture_timestamp=utcnow_iso(),
             )
 
             return ScanCaptureResponse(success=True, message="Scan captured", data=capture_result)
@@ -743,7 +743,7 @@ class Scanner3DService(Service):
                     frame_number=result.frame_number,
                     range_shape=result.range_map.shape if result.range_map is not None else None,
                     intensity_shape=result.intensity.shape if result.intensity is not None else None,
-                    capture_timestamp=utcnow().isoformat(),
+                    capture_timestamp=utcnow_iso(),
                 )
 
                 results.append(capture_result)
@@ -796,7 +796,7 @@ class Scanner3DService(Service):
                 saved_path=request.save_path,
                 points_shape=point_cloud.points.shape if point_cloud.points is not None else None,
                 colors_shape=point_cloud.colors.shape if point_cloud.colors is not None else None,
-                capture_timestamp=utcnow().isoformat(),
+                capture_timestamp=utcnow_iso(),
             )
 
             return PointCloudResponse(success=True, message="Point cloud captured", data=result)
@@ -832,7 +832,7 @@ class Scanner3DService(Service):
                     scanner_name=scanner_name,
                     num_points=point_cloud.num_points,
                     has_colors=point_cloud.has_colors,
-                    capture_timestamp=utcnow().isoformat(),
+                    capture_timestamp=utcnow_iso(),
                 )
 
                 results.append(result)

--- a/mindtrace/hardware/mindtrace/hardware/services/scanners_3d/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/scanners_3d/service.py
@@ -6,7 +6,6 @@ This service provides comprehensive REST API and MCP tools for managing
 """
 
 import time
-from datetime import datetime, timezone
 from typing import Dict
 
 import numpy as np
@@ -14,6 +13,7 @@ import psutil
 from fastapi import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
+from mindtrace.core import utcnow
 from mindtrace.hardware.core.exceptions import (
     CameraNotFoundError,
 )
@@ -702,7 +702,7 @@ class Scanner3DService(Service):
                 confidence_saved_path=request.save_confidence_path if result.confidence is not None else None,
                 normal_saved_path=request.save_normal_path if result.normal_map is not None else None,
                 color_saved_path=request.save_color_path if result.color is not None else None,
-                capture_timestamp=datetime.now(timezone.utc).isoformat(),
+                capture_timestamp=utcnow().isoformat(),
             )
 
             return ScanCaptureResponse(success=True, message="Scan captured", data=capture_result)
@@ -743,7 +743,7 @@ class Scanner3DService(Service):
                     frame_number=result.frame_number,
                     range_shape=result.range_map.shape if result.range_map is not None else None,
                     intensity_shape=result.intensity.shape if result.intensity is not None else None,
-                    capture_timestamp=datetime.now(timezone.utc).isoformat(),
+                    capture_timestamp=utcnow().isoformat(),
                 )
 
                 results.append(capture_result)
@@ -796,7 +796,7 @@ class Scanner3DService(Service):
                 saved_path=request.save_path,
                 points_shape=point_cloud.points.shape if point_cloud.points is not None else None,
                 colors_shape=point_cloud.colors.shape if point_cloud.colors is not None else None,
-                capture_timestamp=datetime.now(timezone.utc).isoformat(),
+                capture_timestamp=utcnow().isoformat(),
             )
 
             return PointCloudResponse(success=True, message="Point cloud captured", data=result)
@@ -832,7 +832,7 @@ class Scanner3DService(Service):
                     scanner_name=scanner_name,
                     num_points=point_cloud.num_points,
                     has_colors=point_cloud.has_colors,
-                    capture_timestamp=datetime.now(timezone.utc).isoformat(),
+                    capture_timestamp=utcnow().isoformat(),
                 )
 
                 results.append(result)

--- a/mindtrace/hardware/mindtrace/hardware/services/stereo_cameras/models/responses.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/stereo_cameras/models/responses.py
@@ -5,11 +5,12 @@ Contains all Pydantic models for API responses, ensuring consistent
 response formatting across all stereo camera management endpoints.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
+from mindtrace.core import utcnow
 from mindtrace.hardware.core.types import ServiceStatus
 
 
@@ -18,7 +19,7 @@ class BaseResponse(BaseModel):
 
     success: bool
     message: str
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    timestamp: datetime = Field(default_factory=utcnow)
 
 
 class BoolResponse(BaseResponse):

--- a/mindtrace/hardware/mindtrace/hardware/services/stereo_cameras/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/stereo_cameras/service.py
@@ -14,7 +14,7 @@ from fastapi import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
-from mindtrace.core import utcnow
+from mindtrace.core import utcnow, utcnow_iso
 from mindtrace.hardware.core.exceptions import (
     CameraNotFoundError,
 )
@@ -625,7 +625,7 @@ class StereoCameraService(Service):
                 disparity_shape=result.disparity.shape if result.disparity is not None else None,
                 intensity_saved_path=request.save_intensity_path,
                 disparity_saved_path=request.save_disparity_path,
-                capture_timestamp=utcnow().isoformat(),
+                capture_timestamp=utcnow_iso(),
             )
 
             return StereoCaptureResponse(success=True, message="Stereo capture successful", data=capture_result)
@@ -667,7 +667,7 @@ class StereoCameraService(Service):
                     disparity_shape=result.disparity.shape if result.disparity is not None else None,
                     intensity_saved_path=capture_config.get("save_intensity_path"),
                     disparity_saved_path=capture_config.get("save_disparity_path"),
-                    capture_timestamp=utcnow().isoformat(),
+                    capture_timestamp=utcnow_iso(),
                 )
 
                 results.append(capture_result)
@@ -714,7 +714,7 @@ class StereoCameraService(Service):
                 saved_path=request.save_path,
                 points_shape=point_cloud.points.shape if point_cloud.points is not None else None,
                 colors_shape=point_cloud.colors.shape if point_cloud.colors is not None else None,
-                capture_timestamp=utcnow().isoformat(),
+                capture_timestamp=utcnow_iso(),
             )
 
             return PointCloudResponse(success=True, message="Point cloud captured", data=result)
@@ -754,7 +754,7 @@ class StereoCameraService(Service):
                     saved_path=capture_config.get("save_path"),
                     points_shape=point_cloud.points.shape if point_cloud.points is not None else None,
                     colors_shape=point_cloud.colors.shape if point_cloud.colors is not None else None,
-                    capture_timestamp=utcnow().isoformat(),
+                    capture_timestamp=utcnow_iso(),
                 )
 
                 results.append(result)
@@ -802,7 +802,7 @@ class StereoCameraService(Service):
                 "camera": camera,
                 "streaming": True,
                 "stream_url": stream_url,
-                "start_time": utcnow().isoformat(),
+                "start_time": utcnow_iso(),
             },
         }
 

--- a/mindtrace/hardware/mindtrace/hardware/services/stereo_cameras/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/stereo_cameras/service.py
@@ -7,7 +7,6 @@ Basler Stereo ace cameras with multi-component capture (intensity, disparity, de
 
 import asyncio
 import time
-from datetime import datetime, timezone
 from typing import Dict
 
 import numpy as np
@@ -15,6 +14,7 @@ from fastapi import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
+from mindtrace.core import utcnow
 from mindtrace.hardware.core.exceptions import (
     CameraNotFoundError,
 )
@@ -625,7 +625,7 @@ class StereoCameraService(Service):
                 disparity_shape=result.disparity.shape if result.disparity is not None else None,
                 intensity_saved_path=request.save_intensity_path,
                 disparity_saved_path=request.save_disparity_path,
-                capture_timestamp=datetime.now(timezone.utc).isoformat(),
+                capture_timestamp=utcnow().isoformat(),
             )
 
             return StereoCaptureResponse(success=True, message="Stereo capture successful", data=capture_result)
@@ -667,7 +667,7 @@ class StereoCameraService(Service):
                     disparity_shape=result.disparity.shape if result.disparity is not None else None,
                     intensity_saved_path=capture_config.get("save_intensity_path"),
                     disparity_saved_path=capture_config.get("save_disparity_path"),
-                    capture_timestamp=datetime.now(timezone.utc).isoformat(),
+                    capture_timestamp=utcnow().isoformat(),
                 )
 
                 results.append(capture_result)
@@ -714,7 +714,7 @@ class StereoCameraService(Service):
                 saved_path=request.save_path,
                 points_shape=point_cloud.points.shape if point_cloud.points is not None else None,
                 colors_shape=point_cloud.colors.shape if point_cloud.colors is not None else None,
-                capture_timestamp=datetime.now(timezone.utc).isoformat(),
+                capture_timestamp=utcnow().isoformat(),
             )
 
             return PointCloudResponse(success=True, message="Point cloud captured", data=result)
@@ -754,7 +754,7 @@ class StereoCameraService(Service):
                     saved_path=capture_config.get("save_path"),
                     points_shape=point_cloud.points.shape if point_cloud.points is not None else None,
                     colors_shape=point_cloud.colors.shape if point_cloud.colors is not None else None,
-                    capture_timestamp=datetime.now(timezone.utc).isoformat(),
+                    capture_timestamp=utcnow().isoformat(),
                 )
 
                 results.append(result)
@@ -790,7 +790,7 @@ class StereoCameraService(Service):
         # Track active stream
         self._active_streams[camera] = {
             "stream_url": stream_url,
-            "start_time": datetime.now(timezone.utc),
+            "start_time": utcnow(),
             "quality": quality,
             "fps": fps,
         }
@@ -802,7 +802,7 @@ class StereoCameraService(Service):
                 "camera": camera,
                 "streaming": True,
                 "stream_url": stream_url,
-                "start_time": datetime.now(timezone.utc).isoformat(),
+                "start_time": utcnow().isoformat(),
             },
         }
 

--- a/mindtrace/hardware/mindtrace/hardware/testing/suites/_camera_common.py
+++ b/mindtrace/hardware/mindtrace/hardware/testing/suites/_camera_common.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from mindtrace.core import BenchReporter, BenchResult, BenchSuiteConfig, utc_now_iso
+from mindtrace.core import BenchReporter, BenchResult, BenchSuiteConfig, utcnow_iso
 
 DEFAULT_MOCK_CAMERAS = ("MockBasler:mock_basler_1",)
 
@@ -116,7 +116,7 @@ def make_result(
         suite_id=config.suite_id,
         status=status_from_reporter(reporter),
         started_at=started,
-        ended_at=utc_now_iso(),
+        ended_at=utcnow_iso(),
         duration_seconds=elapsed,
         operations=reporter.operations,
         successes=reporter.successes,

--- a/mindtrace/jobs/mindtrace/jobs/utils/schemas.py
+++ b/mindtrace/jobs/mindtrace/jobs/utils/schemas.py
@@ -1,6 +1,6 @@
 import uuid
 
-from mindtrace.core import utcnow
+from mindtrace.core import utcnow_iso
 from mindtrace.jobs.types.job_specs import Job, JobSchema
 
 
@@ -25,7 +25,7 @@ def job_from_schema(schema: JobSchema, input_data) -> Job:
         name=schema.name,
         schema_name=schema.name,
         payload=payload,
-        created_at=utcnow().isoformat(),
+        created_at=utcnow_iso(),
     )
 
     return job

--- a/mindtrace/jobs/mindtrace/jobs/utils/schemas.py
+++ b/mindtrace/jobs/mindtrace/jobs/utils/schemas.py
@@ -1,6 +1,6 @@
 import uuid
-from datetime import datetime
 
+from mindtrace.core import utcnow
 from mindtrace.jobs.types.job_specs import Job, JobSchema
 
 
@@ -25,7 +25,7 @@ def job_from_schema(schema: JobSchema, input_data) -> Job:
         name=schema.name,
         schema_name=schema.name,
         payload=payload,
-        created_at=datetime.now().isoformat(),
+        created_at=utcnow().isoformat(),
     )
 
     return job

--- a/mindtrace/models/mindtrace/models/lifecycle/card.py
+++ b/mindtrace/models/mindtrace/models/lifecycle/card.py
@@ -39,10 +39,11 @@ import json
 import logging
 import math
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from mindtrace.core import utcnow
 from mindtrace.models.lifecycle.stages import (
     VALID_DEMOTIONS,
     VALID_PROMOTIONS,
@@ -68,7 +69,7 @@ class EvalResult:
     value: float
     dataset: str = ""
     split: str = "val"
-    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    timestamp: datetime = field(default_factory=utcnow)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -86,9 +87,7 @@ class EvalResult:
             value=float(data["value"]),
             dataset=data.get("dataset", ""),
             split=data.get("split", "val"),
-            timestamp=(
-                datetime.fromisoformat(data["timestamp"]) if "timestamp" in data else datetime.now(timezone.utc)
-            ),
+            timestamp=(datetime.fromisoformat(data["timestamp"]) if "timestamp" in data else utcnow()),
         )
 
 
@@ -116,7 +115,7 @@ class PromotionResult:
     model_name: str
     model_version: str
     failed_requirements: dict[str, tuple[float, float]] = field(default_factory=dict)
-    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    timestamp: datetime = field(default_factory=utcnow)
 
 
 @dataclass
@@ -154,7 +153,7 @@ class ModelCard:
     eval_results: list[EvalResult] = field(default_factory=list)
     known_limitations: list[str] = field(default_factory=list)
     description: str = ""
-    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    created_at: datetime = field(default_factory=utcnow)
     extra: dict[str, Any] = field(default_factory=dict)
     _model_saved: bool = field(default=False, init=False, repr=False)
 
@@ -460,7 +459,7 @@ class ModelCard:
         """Deserialize from a dict."""
         eval_results = [EvalResult.from_dict(r) for r in data.get("eval_results", [])]
         created_at_raw = data.get("created_at")
-        created_at = datetime.fromisoformat(created_at_raw) if created_at_raw else datetime.now(timezone.utc)
+        created_at = datetime.fromisoformat(created_at_raw) if created_at_raw else utcnow()
         return cls(
             name=data["name"],
             version=data["version"],

--- a/mindtrace/registry/mindtrace/registry/backends/gcp_registry_backend.py
+++ b/mindtrace/registry/mindtrace/registry/backends/gcp_registry_backend.py
@@ -8,11 +8,12 @@ import json
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import quote
 
+from mindtrace.core import utcnow
 from mindtrace.registry.backends.registry_backend import (
     ConcreteVersionArg,
     MetadataArg,
@@ -274,7 +275,7 @@ class GCPRegistryBackend(RegistryBackend):
             prepared_meta["path"] = f"gs://{self.gcs.bucket_name}/{remote_key}"
             prepared_meta["_storage"] = {
                 "uuid": uuid_str,
-                "created_at": datetime.now(timezone.utc).isoformat(),
+                "created_at": utcnow().isoformat(),
             }
             meta_result = self._save_metadata_single(
                 name,
@@ -338,7 +339,7 @@ class GCPRegistryBackend(RegistryBackend):
             - Uses list_blobs to find all UUID folders for that object
             - Deletes UUIDs not matching current metadata's _storage.uuid
         """
-        expires_at = datetime.now(timezone.utc) + timedelta(hours=expires_hours)
+        expires_at = utcnow() + timedelta(hours=expires_hours)
 
         plan = {
             "name": name,
@@ -681,7 +682,7 @@ class GCPRegistryBackend(RegistryBackend):
             prepared_meta["path"] = f"gs://{self.gcs.bucket_name}/{remote_key}"
             prepared_meta["_storage"] = {
                 "uuid": uuid_str,
-                "created_at": datetime.now(timezone.utc).isoformat(),
+                "created_at": utcnow().isoformat(),
             }
 
             # Step 7: Write metadata (the "commit point")

--- a/mindtrace/registry/mindtrace/registry/backends/gcp_registry_backend.py
+++ b/mindtrace/registry/mindtrace/registry/backends/gcp_registry_backend.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import quote
 
-from mindtrace.core import utcnow
+from mindtrace.core import utcnow, utcnow_iso
 from mindtrace.registry.backends.registry_backend import (
     ConcreteVersionArg,
     MetadataArg,
@@ -275,7 +275,7 @@ class GCPRegistryBackend(RegistryBackend):
             prepared_meta["path"] = f"gs://{self.gcs.bucket_name}/{remote_key}"
             prepared_meta["_storage"] = {
                 "uuid": uuid_str,
-                "created_at": utcnow().isoformat(),
+                "created_at": utcnow_iso(),
             }
             meta_result = self._save_metadata_single(
                 name,
@@ -682,7 +682,7 @@ class GCPRegistryBackend(RegistryBackend):
             prepared_meta["path"] = f"gs://{self.gcs.bucket_name}/{remote_key}"
             prepared_meta["_storage"] = {
                 "uuid": uuid_str,
-                "created_at": utcnow().isoformat(),
+                "created_at": utcnow_iso(),
             }
 
             # Step 7: Write metadata (the "commit point")

--- a/mindtrace/registry/mindtrace/registry/backends/s3_registry_backend.py
+++ b/mindtrace/registry/mindtrace/registry/backends/s3_registry_backend.py
@@ -8,11 +8,12 @@ import json
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import quote
 
+from mindtrace.core import utcnow
 from mindtrace.registry.backends.registry_backend import (
     ConcreteVersionArg,
     MetadataArg,
@@ -307,7 +308,7 @@ class S3RegistryBackend(RegistryBackend):
             prepared_meta["path"] = f"s3://{self._bucket}/{remote_key}"
             prepared_meta["_storage"] = {
                 "uuid": uuid_str,
-                "created_at": datetime.now(timezone.utc).isoformat(),
+                "created_at": utcnow().isoformat(),
             }
             meta_result = self._save_metadata_single(
                 name,
@@ -371,7 +372,7 @@ class S3RegistryBackend(RegistryBackend):
             - Uses list_blobs to find all UUID folders for that object
             - Deletes UUIDs not matching current metadata's _storage.uuid
         """
-        expires_at = datetime.now(timezone.utc) + timedelta(hours=expires_hours)
+        expires_at = utcnow() + timedelta(hours=expires_hours)
 
         plan = {
             "name": name,
@@ -722,7 +723,7 @@ class S3RegistryBackend(RegistryBackend):
             prepared_meta["path"] = f"s3://{self._bucket}/{remote_key}"
             prepared_meta["_storage"] = {
                 "uuid": uuid_str,
-                "created_at": datetime.now(timezone.utc).isoformat(),
+                "created_at": utcnow().isoformat(),
             }
 
             # Step 7: Write metadata (the "commit point")

--- a/mindtrace/registry/mindtrace/registry/backends/s3_registry_backend.py
+++ b/mindtrace/registry/mindtrace/registry/backends/s3_registry_backend.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import quote
 
-from mindtrace.core import utcnow
+from mindtrace.core import utcnow, utcnow_iso
 from mindtrace.registry.backends.registry_backend import (
     ConcreteVersionArg,
     MetadataArg,
@@ -308,7 +308,7 @@ class S3RegistryBackend(RegistryBackend):
             prepared_meta["path"] = f"s3://{self._bucket}/{remote_key}"
             prepared_meta["_storage"] = {
                 "uuid": uuid_str,
-                "created_at": utcnow().isoformat(),
+                "created_at": utcnow_iso(),
             }
             meta_result = self._save_metadata_single(
                 name,
@@ -723,7 +723,7 @@ class S3RegistryBackend(RegistryBackend):
             prepared_meta["path"] = f"s3://{self._bucket}/{remote_key}"
             prepared_meta["_storage"] = {
                 "uuid": uuid_str,
-                "created_at": utcnow().isoformat(),
+                "created_at": utcnow_iso(),
             }
 
             # Step 7: Write metadata (the "commit point")

--- a/mindtrace/registry/mindtrace/registry/testing/suites/mixed_rw.py
+++ b/mindtrace/registry/mindtrace/registry/testing/suites/mixed_rw.py
@@ -17,7 +17,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.workloads import deterministic_payload, parse_size_bytes, run_threaded_until_deadline
 from mindtrace.registry.testing.suites._backends import RegistryBackendResources, build_registry
@@ -58,7 +58,7 @@ class RegistryMixedRwSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         monotonic_start = time.perf_counter()
         backend = str(config.parameters.get("backend", "local")).lower()
         payload_size = parse_size_bytes(config.parameters.get("payload_size"), default=64 * 1024)
@@ -119,7 +119,7 @@ class RegistryMixedRwSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/registry/mindtrace/registry/testing/suites/read_ceiling.py
+++ b/mindtrace/registry/mindtrace/registry/testing/suites/read_ceiling.py
@@ -17,7 +17,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.workloads import deterministic_payload, parse_size_bytes, run_threaded_until_deadline
 from mindtrace.registry.testing.suites._backends import RegistryBackendResources, build_registry
@@ -58,7 +58,7 @@ class RegistryReadCeilingSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         monotonic_start = time.perf_counter()
         backend = str(config.parameters.get("backend", "local")).lower()
         payload_size = parse_size_bytes(config.parameters.get("payload_size"), default=64 * 1024)
@@ -112,7 +112,7 @@ class RegistryReadCeilingSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/registry/mindtrace/registry/testing/suites/smoke.py
+++ b/mindtrace/registry/mindtrace/registry/testing/suites/smoke.py
@@ -17,7 +17,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.workloads import deterministic_payload
 from mindtrace.registry import Registry
@@ -50,7 +50,7 @@ class RegistrySmokeSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         mono = time.perf_counter()
         registry_path = Path(mkdtemp(prefix="mindtrace-registry-smoke-"))
         registry = Registry(backend=registry_path, version_objects=True, mutable=True)
@@ -80,7 +80,7 @@ class RegistrySmokeSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/registry/mindtrace/registry/testing/suites/version_churn.py
+++ b/mindtrace/registry/mindtrace/registry/testing/suites/version_churn.py
@@ -16,7 +16,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.workloads import deterministic_payload, parse_size_bytes, run_threaded_until_deadline
 from mindtrace.registry.testing.suites._backends import RegistryBackendResources, build_registry
@@ -57,7 +57,7 @@ class RegistryVersionChurnSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         monotonic_start = time.perf_counter()
         backend = str(config.parameters.get("backend", "local")).lower()
         payload_size = parse_size_bytes(config.parameters.get("payload_size"), default=16 * 1024)
@@ -111,7 +111,7 @@ class RegistryVersionChurnSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/mindtrace/registry/mindtrace/registry/testing/suites/write_ceiling.py
+++ b/mindtrace/registry/mindtrace/registry/testing/suites/write_ceiling.py
@@ -16,7 +16,7 @@ from mindtrace.core import (
     BenchSuiteConfig,
     BenchTestSuite,
     TaskSchema,
-    utc_now_iso,
+    utcnow_iso,
 )
 from mindtrace.core.testing.workloads import deterministic_payload, parse_size_bytes, run_threaded_until_deadline
 from mindtrace.registry.testing.suites._backends import RegistryBackendResources, build_registry
@@ -60,7 +60,7 @@ class RegistryWriteCeilingSuite(BenchTestSuite):
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        started = utc_now_iso()
+        started = utcnow_iso()
         monotonic_start = time.perf_counter()
         backend = str(config.parameters.get("backend", "local")).lower()
         payload_size = parse_size_bytes(
@@ -103,7 +103,7 @@ class RegistryWriteCeilingSuite(BenchTestSuite):
             suite_id=config.suite_id,
             status="passed" if reporter.failures == 0 else "failed",
             started_at=started,
-            ended_at=utc_now_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=elapsed,
             operations=reporter.operations,
             successes=reporter.successes,

--- a/tests/integration/mindtrace/datalake/test_datalake_integration.py
+++ b/tests/integration/mindtrace/datalake/test_datalake_integration.py
@@ -1,11 +1,12 @@
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from pymongo import MongoClient
 
+from mindtrace.core import utcnow
 from mindtrace.database.core.exceptions import DocumentNotFoundError
 from mindtrace.datalake import Datalake, DatalakeDirectUploadClient
 from mindtrace.datalake.types import AnnotationLabelDefinition, SubjectRef
@@ -352,7 +353,7 @@ def test_sync_datalake_reconcile_upload_sessions(sync_datalake: Datalake):
         collection = mongo_client[sync_datalake.mongo_db_name]["datalake_direct_upload_sessions"]
         collection.update_one(
             {"upload_session_id": session.upload_session_id},
-            {"$set": {"expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)}},
+            {"$set": {"expires_at": utcnow() - timedelta(seconds=1)}},
         )
     finally:
         mongo_client.close()

--- a/tests/integration/mindtrace/datalake/test_service_integration.py
+++ b/tests/integration/mindtrace/datalake/test_service_integration.py
@@ -1,6 +1,6 @@
 import base64
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 from uuid import uuid4
 
@@ -10,6 +10,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from pymongo import MongoClient
 
+from mindtrace.core import utcnow
 from mindtrace.datalake import DatalakeDirectUploadClient, DatalakeService, StorageRef, SubjectRef
 from mindtrace.datalake.pagination_types import DatasetViewExpand
 from mindtrace.datalake.service_types import (
@@ -719,7 +720,7 @@ class TestDatalakeServiceIntegration:
                 collection = mongo_client[db_name]["datalake_direct_upload_sessions"]
                 collection.update_one(
                     {"upload_session_id": session.upload_session_id},
-                    {"$set": {"expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)}},
+                    {"$set": {"expires_at": utcnow() - timedelta(seconds=1)}},
                 )
 
                 assert client.portal is not None

--- a/tests/integration/mindtrace/jobs/conftest.py
+++ b/tests/integration/mindtrace/jobs/conftest.py
@@ -3,7 +3,7 @@ import time
 import pytest
 from pydantic import BaseModel
 
-from mindtrace.core import utcnow
+from mindtrace.core import utcnow_iso
 from mindtrace.jobs import Consumer, job_from_schema
 from mindtrace.jobs.types.job_specs import Job, JobSchema
 
@@ -52,7 +52,7 @@ def unique_queue_name():
 
 @pytest.fixture
 def test_timestamp():
-    return utcnow().isoformat()
+    return utcnow_iso()
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/mindtrace/jobs/conftest.py
+++ b/tests/integration/mindtrace/jobs/conftest.py
@@ -1,9 +1,9 @@
 import time
-from datetime import datetime
 
 import pytest
 from pydantic import BaseModel
 
+from mindtrace.core import utcnow
 from mindtrace.jobs import Consumer, job_from_schema
 from mindtrace.jobs.types.job_specs import Job, JobSchema
 
@@ -52,7 +52,7 @@ def unique_queue_name():
 
 @pytest.fixture
 def test_timestamp():
-    return datetime.now().isoformat()
+    return utcnow().isoformat()
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/mindtrace/models/archivers/test_ml_archiver_dispatch.py
+++ b/tests/integration/mindtrace/models/archivers/test_ml_archiver_dispatch.py
@@ -22,6 +22,19 @@ HAS_TIMM = importlib.util.find_spec("timm") is not None
 HAS_ONNX = importlib.util.find_spec("onnx") is not None
 
 
+def _hf_bert_tiny():
+    """Build the tiny-BERT model, skipping the test on Hub network errors."""
+    from huggingface_hub.errors import HfHubHTTPError
+    from requests.exceptions import RequestException
+    from transformers import AutoConfig, AutoModel
+
+    try:
+        config = AutoConfig.from_pretrained("lyeonii/bert-tiny")
+    except (HfHubHTTPError, RequestException, OSError) as e:
+        pytest.skip(f"Could not reach HuggingFace Hub: {e}")
+    return AutoModel.from_config(config)
+
+
 @pytest.fixture
 def temp_dir():
     """Create a temporary directory for testing."""
@@ -42,10 +55,7 @@ class TestArchiverDispatch:
     @pytest.mark.skipif(not HAS_TRANSFORMERS, reason="transformers not installed")
     def test_hf_model_dispatches_to_hf_archiver(self, registry):
         """A PreTrainedModel should be handled by HuggingFaceModelArchiver."""
-        from transformers import AutoConfig, AutoModel
-
-        config = AutoConfig.from_pretrained("lyeonii/bert-tiny")
-        model = AutoModel.from_config(config)
+        model = _hf_bert_tiny()
 
         materializer = registry._find_materializer(model)
         assert "HuggingFaceModelArchiver" in materializer
@@ -89,10 +99,7 @@ class TestArchiverDispatch:
     @pytest.mark.skipif(not HAS_TRANSFORMERS or not HAS_TIMM, reason="transformers and timm required")
     def test_hf_model_not_dispatched_to_timm(self, registry):
         """PreTrainedModel (more specific) should NOT fall through to timm's nn.Module."""
-        from transformers import AutoConfig, AutoModel
-
-        config = AutoConfig.from_pretrained("lyeonii/bert-tiny")
-        model = AutoModel.from_config(config)
+        model = _hf_bert_tiny()
 
         materializer = registry._find_materializer(model)
         assert "HuggingFaceModelArchiver" in materializer
@@ -143,13 +150,10 @@ class TestArchiverRoundtrip:
     @pytest.mark.skipif(not HAS_TRANSFORMERS, reason="transformers not installed")
     def test_hf_model_roundtrip(self, temp_dir):
         """Test HuggingFace model save/load roundtrip."""
-        from transformers import AutoConfig, AutoModel
-
         from mindtrace.models.archivers.huggingface.hf_model_archiver import HuggingFaceModelArchiver
 
         archiver = HuggingFaceModelArchiver(uri=temp_dir)
-        config = AutoConfig.from_pretrained("lyeonii/bert-tiny")
-        model = AutoModel.from_config(config)
+        model = _hf_bert_tiny()
         model.eval()
 
         archiver.save(model)

--- a/tests/integration/mindtrace/models/test_optional_deps.py
+++ b/tests/integration/mindtrace/models/test_optional_deps.py
@@ -12,6 +12,7 @@ batch=4, 32x32) keep every test fast (<5s on CPU).
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 
 import numpy as np
@@ -80,6 +81,23 @@ try:
     _HAS_PEFT = True
 except ImportError:
     _HAS_PEFT = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def skip_on_hub_error():
+    """Skip the enclosed test on Hub network errors (rate limits, connectivity)."""
+    from huggingface_hub.errors import HfHubHTTPError
+    from requests.exceptions import RequestException
+
+    try:
+        yield
+    except (HfHubHTTPError, RequestException, OSError) as e:
+        pytest.skip(f"Could not reach HuggingFace Hub: {e}")
 
 
 # ---------------------------------------------------------------------------
@@ -280,7 +298,8 @@ class TestHuggingFaceDINOBackbone:
         """Build dino_v2_small (no pretrained), verify output is (B, D)."""
         from mindtrace.models.architectures.backbones.registry import build_backbone
 
-        info = build_backbone("dino_v2_small", pretrained=False)
+        with skip_on_hub_error():
+            info = build_backbone("dino_v2_small", pretrained=False)
         backbone = info.model
         backbone.eval()
 
@@ -292,7 +311,8 @@ class TestHuggingFaceDINOBackbone:
 
     def test_dino_v2_small_with_linear_head(self):
         """Build full model: dino_v2_small + linear head, verify logit shape."""
-        model = build_model("dino_v2_small", "linear", num_classes=NUM_CLASSES, pretrained=False)
+        with skip_on_hub_error():
+            model = build_model("dino_v2_small", "linear", num_classes=NUM_CLASSES, pretrained=False)
         model.eval()
 
         x = torch.randn(2, 3, 224, 224)
@@ -302,13 +322,14 @@ class TestHuggingFaceDINOBackbone:
 
     def test_dino_v2_small_with_mlp_head(self):
         """Build full model: dino_v2_small + MLP head, verify logit shape."""
-        model = build_model(
-            "dino_v2_small",
-            "mlp",
-            num_classes=NUM_CLASSES,
-            pretrained=False,
-            hidden_dim=64,
-        )
+        with skip_on_hub_error():
+            model = build_model(
+                "dino_v2_small",
+                "mlp",
+                num_classes=NUM_CLASSES,
+                pretrained=False,
+                hidden_dim=64,
+            )
         model.eval()
 
         x = torch.randn(2, 3, 224, 224)
@@ -531,13 +552,14 @@ class TestPeftLoRA:
 
         # LoRA requires pretrained=True to freeze base weights then add adapters
         lora_cfg = LoRAConfig(r=4, lora_alpha=4, target_modules="qv")
-        model = build_model(
-            "dino_v2_small_reg",
-            "linear",
-            num_classes=NUM_CLASSES,
-            pretrained=True,
-            lora_config=lora_cfg,
-        )
+        with skip_on_hub_error():
+            model = build_model(
+                "dino_v2_small_reg",
+                "linear",
+                num_classes=NUM_CLASSES,
+                pretrained=True,
+                lora_config=lora_cfg,
+            )
         backbone = model.backbone
 
         total = sum(p.numel() for p in backbone.parameters())
@@ -550,13 +572,14 @@ class TestPeftLoRA:
         """LoRA-adapted backbone produces the same output shape."""
         from mindtrace.models.architectures.backbones.dino_hf import LoRAConfig
 
-        model = build_model(
-            "dino_v2_small_reg",
-            "linear",
-            num_classes=NUM_CLASSES,
-            pretrained=False,
-            lora_config=LoRAConfig(r=4, target_modules="qv"),
-        )
+        with skip_on_hub_error():
+            model = build_model(
+                "dino_v2_small_reg",
+                "linear",
+                num_classes=NUM_CLASSES,
+                pretrained=False,
+                lora_config=LoRAConfig(r=4, target_modules="qv"),
+            )
         model.eval()
 
         x = torch.randn(2, 3, 224, 224)
@@ -568,13 +591,14 @@ class TestPeftLoRA:
         """Train LoRA-adapted model for 1 epoch, verify loss is finite."""
         from mindtrace.models.architectures.backbones.dino_hf import LoRAConfig
 
-        model = build_model(
-            "dino_v2_small_reg",
-            "linear",
-            num_classes=NUM_CLASSES,
-            pretrained=False,
-            lora_config=LoRAConfig(r=4, target_modules="qv"),
-        )
+        with skip_on_hub_error():
+            model = build_model(
+                "dino_v2_small_reg",
+                "linear",
+                num_classes=NUM_CLASSES,
+                pretrained=False,
+                lora_config=LoRAConfig(r=4, target_modules="qv"),
+            )
         optimizer = build_optimizer("adamw", model, lr=1e-3)
 
         x = torch.randn(8, 3, 224, 224)

--- a/tests/stress/mindtrace/registry/test_registry_stress_test.py
+++ b/tests/stress/mindtrace/registry/test_registry_stress_test.py
@@ -11,7 +11,6 @@ import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
 from pathlib import Path
 from statistics import mean
 from tempfile import TemporaryDirectory
@@ -19,6 +18,7 @@ from tempfile import TemporaryDirectory
 import pytest
 from tqdm import tqdm
 
+from mindtrace.core import utcnow
 from mindtrace.registry import Registry
 from mindtrace.registry.core.exceptions import RegistryObjectNotFound
 
@@ -1010,7 +1010,7 @@ class TestRegistryThroughput:
 
         # Save to results directory
         filepath = results_dir / filename
-        timestamp = datetime.now().isoformat()
+        timestamp = utcnow().isoformat()
         results_with_timestamp = {"timestamp": timestamp, "results": results}
 
         with open(filepath, "w") as f:

--- a/tests/stress/mindtrace/registry/test_registry_stress_test.py
+++ b/tests/stress/mindtrace/registry/test_registry_stress_test.py
@@ -18,7 +18,7 @@ from tempfile import TemporaryDirectory
 import pytest
 from tqdm import tqdm
 
-from mindtrace.core import utcnow
+from mindtrace.core import utcnow_iso
 from mindtrace.registry import Registry
 from mindtrace.registry.core.exceptions import RegistryObjectNotFound
 
@@ -1010,7 +1010,7 @@ class TestRegistryThroughput:
 
         # Save to results directory
         filepath = results_dir / filename
-        timestamp = utcnow().isoformat()
+        timestamp = utcnow_iso()
         results_with_timestamp = {"timestamp": timestamp, "results": results}
 
         with open(filepath, "w") as f:

--- a/tests/stress/mindtrace/services/test_service_stress_test.py
+++ b/tests/stress/mindtrace/services/test_service_stress_test.py
@@ -18,7 +18,7 @@ from statistics import mean, median
 import pytest
 from tqdm import tqdm
 
-from mindtrace.core import utcnow
+from mindtrace.core import utcnow, utcnow_iso
 from mindtrace.services.samples.echo_service import EchoService
 
 # Suppress verbose HTTP logging during stress tests
@@ -1002,7 +1002,7 @@ class TestEchoServiceThroughput:
         """
         Save stress test results to a JSON file for tracking performance over time and comparing configurations.
         """
-        timestamp = utcnow().isoformat()
+        timestamp = utcnow_iso()
         results_with_timestamp = {"timestamp": timestamp, "results": results}
         with open(filename, "w") as f:
             json.dump(results_with_timestamp, f)

--- a/tests/stress/mindtrace/services/test_service_stress_test.py
+++ b/tests/stress/mindtrace/services/test_service_stress_test.py
@@ -12,13 +12,13 @@ import threading
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
 from pathlib import Path
 from statistics import mean, median
 
 import pytest
 from tqdm import tqdm
 
+from mindtrace.core import utcnow
 from mindtrace.services.samples.echo_service import EchoService
 
 # Suppress verbose HTTP logging during stress tests
@@ -616,7 +616,7 @@ class TestEchoServiceThroughput:
             },
         }
 
-        filename = results_dir / f"multi_worker_test_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        filename = results_dir / f"multi_worker_test_{utcnow().strftime('%Y%m%d_%H%M%S')}.json"
         self.save_results(summary_results, filename)
         print(f"\nResults saved to: {filename}")
 
@@ -882,7 +882,7 @@ class TestEchoServiceThroughput:
             },
         }
 
-        filename = results_dir / f"delayed_processing_test_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        filename = results_dir / f"delayed_processing_test_{utcnow().strftime('%Y%m%d_%H%M%S')}.json"
         self.save_results(summary_results, filename)
         print(f"\nResults saved to: {filename}")
 
@@ -994,7 +994,7 @@ class TestEchoServiceThroughput:
             },
         }
 
-        filename = results_dir / f"baseline_test_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        filename = results_dir / f"baseline_test_{utcnow().strftime('%Y%m%d_%H%M%S')}.json"
         self.save_results(summary_results, filename)
         print(f"\nResults saved to: {filename}")
 
@@ -1002,7 +1002,7 @@ class TestEchoServiceThroughput:
         """
         Save stress test results to a JSON file for tracking performance over time and comparing configurations.
         """
-        timestamp = datetime.now().isoformat()
+        timestamp = utcnow().isoformat()
         results_with_timestamp = {"timestamp": timestamp, "results": results}
         with open(filename, "w") as f:
             json.dump(results_with_timestamp, f)

--- a/tests/unit/mindtrace/agents/test_memory.py
+++ b/tests/unit/mindtrace/agents/test_memory.py
@@ -13,6 +13,7 @@ from mindtrace.agents.memory import (
     MemoryEntry,
     MemoryToolset,
 )
+from mindtrace.core import utcnow
 
 
 def _ctx() -> RunContext:
@@ -29,9 +30,8 @@ class TestMemoryEntry:
 
     def test_fields_stored(self):
         """MemoryEntry stores key, value, and metadata."""
-        from datetime import datetime, timezone
 
-        now = datetime.now(timezone.utc)
+        now = utcnow()
         entry = MemoryEntry(key="k", value="v", metadata={"tag": "x"}, created_at=now, updated_at=now)
         assert entry.key == "k"
         assert entry.value == "v"
@@ -39,9 +39,8 @@ class TestMemoryEntry:
 
     def test_default_metadata_is_empty_dict(self):
         """metadata defaults to an empty dict."""
-        from datetime import datetime, timezone
 
-        now = datetime.now(timezone.utc)
+        now = utcnow()
         entry = MemoryEntry(key="k", value="v", created_at=now, updated_at=now)
         assert entry.metadata == {}
 

--- a/tests/unit/mindtrace/cluster/test_cluster.py
+++ b/tests/unit/mindtrace/cluster/test_cluster.py
@@ -1,6 +1,5 @@
 import json
 import uuid
-from datetime import datetime
 from pathlib import Path
 from unittest.mock import ANY, MagicMock, Mock, patch
 from uuid import uuid4
@@ -11,6 +10,7 @@ from urllib3.exceptions import ConnectionError
 
 from mindtrace.cluster.core import types as cluster_types
 from mindtrace.cluster.core.cluster import ClusterManager, Node, Worker, update_database
+from mindtrace.core import utcnow
 from mindtrace.jobs import Job
 from mindtrace.jobs.types.job_specs import ExecutionStatus
 from mindtrace.registry.backends.registry_backend import RegistryBackend
@@ -1207,7 +1207,7 @@ def test_get_worker_status_success(cluster_manager):
         worker_url="http://worker:8080",
         status=cluster_types.WorkerStatusEnum.IDLE,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
 
     cluster_manager.worker_status_database.find.return_value = [expected_worker_status]
@@ -1247,7 +1247,7 @@ def test_get_worker_status_by_url_success(cluster_manager):
         worker_url=worker_url,
         status=cluster_types.WorkerStatusEnum.RUNNING,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
 
     cluster_manager.worker_status_database.find.return_value = [expected_worker_status]
@@ -1289,7 +1289,7 @@ def test_get_worker_status_with_different_statuses(cluster_manager):
         worker_url="http://worker:8080",
         status=cluster_types.WorkerStatusEnum.IDLE,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [idle_worker]
 
@@ -1304,7 +1304,7 @@ def test_get_worker_status_with_different_statuses(cluster_manager):
         worker_url="http://worker:8080",
         status=cluster_types.WorkerStatusEnum.RUNNING,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [running_worker]
 
@@ -1318,7 +1318,7 @@ def test_get_worker_status_with_different_statuses(cluster_manager):
         worker_url="http://worker:8080",
         status=cluster_types.WorkerStatusEnum.ERROR,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [error_worker]
 
@@ -1336,7 +1336,7 @@ def test_get_worker_status_by_url_with_different_urls(cluster_manager):
         worker_url=http_url,
         status=cluster_types.WorkerStatusEnum.IDLE,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [http_worker]
 
@@ -1352,7 +1352,7 @@ def test_get_worker_status_by_url_with_different_urls(cluster_manager):
         worker_url=https_url,
         status=cluster_types.WorkerStatusEnum.RUNNING,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [https_worker]
 
@@ -1368,7 +1368,7 @@ def test_get_worker_status_by_url_with_different_urls(cluster_manager):
         worker_url=localhost_url,
         status=cluster_types.WorkerStatusEnum.SHUTDOWN,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [localhost_worker]
 
@@ -1472,7 +1472,7 @@ def test_get_worker_status_multiple_results(cluster_manager):
         worker_url="http://worker1:8080",
         status=cluster_types.WorkerStatusEnum.IDLE,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     worker2 = cluster_types.WorkerStatus(
         worker_id=worker_id,
@@ -1480,7 +1480,7 @@ def test_get_worker_status_multiple_results(cluster_manager):
         worker_url="http://worker2:8080",
         status=cluster_types.WorkerStatusEnum.RUNNING,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
 
     cluster_manager.worker_status_database.find.return_value = [worker1, worker2]
@@ -1503,7 +1503,7 @@ def test_get_worker_status_by_url_multiple_results(cluster_manager):
         worker_url=worker_url,
         status=cluster_types.WorkerStatusEnum.IDLE,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     worker2 = cluster_types.WorkerStatus(
         worker_id="worker-456",
@@ -1511,7 +1511,7 @@ def test_get_worker_status_by_url_multiple_results(cluster_manager):
         worker_url=worker_url,
         status=cluster_types.WorkerStatusEnum.RUNNING,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
 
     cluster_manager.worker_status_database.find.return_value = [worker1, worker2]
@@ -1609,7 +1609,7 @@ def test_query_worker_status_success(cluster_manager):
         worker_url=worker_url,
         status=cluster_types.WorkerStatusEnum.IDLE,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [existing_worker_status]
 
@@ -1676,7 +1676,7 @@ def test_query_worker_status_worker_down(cluster_manager):
         worker_url=worker_url,
         status=cluster_types.WorkerStatusEnum.IDLE,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [existing_worker_status]
 
@@ -1719,7 +1719,7 @@ def test_query_worker_status_worker_connection_failure(cluster_manager):
         worker_url=worker_url,
         status=cluster_types.WorkerStatusEnum.IDLE,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [existing_worker_status]
 
@@ -1759,7 +1759,7 @@ def test_query_worker_status_by_url_success(cluster_manager):
                 worker_url=worker_url,
                 status=cluster_types.WorkerStatusEnum.IDLE,
                 job_id=None,
-                last_heartbeat=datetime.now(),
+                last_heartbeat=utcnow(),
             )
             mock_query_status.return_value = expected_result
 
@@ -1806,7 +1806,7 @@ def test_url_to_id_success(cluster_manager):
         worker_url=worker_url,
         status=cluster_types.WorkerStatusEnum.IDLE,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [existing_worker_status]
 
@@ -1848,7 +1848,7 @@ def test_url_to_id_multiple_entries(cluster_manager):
         worker_url=worker_url,
         status=cluster_types.WorkerStatusEnum.IDLE,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     existing_worker_status2 = cluster_types.WorkerStatus(
         worker_id=worker_id2,
@@ -1856,7 +1856,7 @@ def test_url_to_id_multiple_entries(cluster_manager):
         worker_url=worker_url,
         status=cluster_types.WorkerStatusEnum.IDLE,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [existing_worker_status1, existing_worker_status2]
 
@@ -1938,7 +1938,7 @@ def test_query_worker_status_edge_cases(cluster_manager):
         worker_url=worker_url,
         status=cluster_types.WorkerStatusEnum.IDLE,
         job_id=None,
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [existing_worker_status]
 
@@ -1995,7 +1995,7 @@ def test_update_database_edge_cases():
         {"status": "completed"},
         {"output": {"result": "test"}},
         {"worker_id": "new-worker-id"},
-        {"status": "running", "job_id": "job-123", "last_heartbeat": datetime.now()},
+        {"status": "running", "job_id": "job-123", "last_heartbeat": utcnow()},
         {},  # Empty update dict
     ]
 
@@ -2043,7 +2043,7 @@ def test_query_worker_status_by_url_edge_cases(cluster_manager):
                         worker_url=worker_url,
                         status=cluster_types.WorkerStatusEnum.IDLE,
                         job_id=None,
-                        last_heartbeat=datetime.now(),
+                        last_heartbeat=utcnow(),
                     )
                     mock_query_status.return_value = expected_result
                 else:  # Empty URL
@@ -2511,7 +2511,7 @@ def test_worker_alert_completed_job_with_mismatched_worker_id(cluster_manager):
         worker_url="http://worker:8080",
         status=cluster_types.WorkerStatusEnum.RUNNING,
         job_id="job-123",
-        last_heartbeat=datetime.now(),
+        last_heartbeat=utcnow(),
     )
     cluster_manager.worker_status_database.find.return_value = [worker_status]
 

--- a/tests/unit/mindtrace/core/testing/test_bench_suite.py
+++ b/tests/unit/mindtrace/core/testing/test_bench_suite.py
@@ -6,7 +6,7 @@ from types import MappingProxyType
 
 import pytest
 
-from mindtrace.core.testing.bench_framework import BenchReporter, BenchResult, utc_now_iso
+from mindtrace.core.testing.bench_framework import BenchReporter, BenchResult, utcnow_iso
 from mindtrace.core.testing.bench_suite import BenchTestSuite, build_bench_suite_config
 from mindtrace.core.testing.runner import TestRunner
 
@@ -32,8 +32,8 @@ class DummyBenchSuite(BenchTestSuite):
         return BenchResult(
             suite_id=config.suite_id,
             status="passed",
-            started_at=utc_now_iso(),
-            ended_at=utc_now_iso(),
+            started_at=utcnow_iso(),
+            ended_at=utcnow_iso(),
             duration_seconds=0.0,
         )
 

--- a/tests/unit/mindtrace/core/testing/test_runner_unit.py
+++ b/tests/unit/mindtrace/core/testing/test_runner_unit.py
@@ -14,7 +14,7 @@ from mindtrace.core import (
     UnknownSuiteIdError,
     validate_suite_id,
 )
-from mindtrace.core.testing import BenchReporter, BenchResult, utc_now_iso
+from mindtrace.core.testing import BenchReporter, BenchResult, utcnow_iso
 
 
 @pytest.fixture(autouse=True)
@@ -49,7 +49,7 @@ class SampleBenchSuite(BenchTestSuite):
     profiles = {"smoke": {"duration_seconds": 0.1, "resources": {"from_profile": True}}}
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        now = utc_now_iso()
+        now = utcnow_iso()
         return BenchResult(
             suite_id=config.suite_id,
             status="passed",

--- a/tests/unit/mindtrace/core/utils/test_time.py
+++ b/tests/unit/mindtrace/core/utils/test_time.py
@@ -1,0 +1,48 @@
+"""Tests for mindtrace.core.utils.time module."""
+
+from datetime import datetime, timedelta, timezone
+
+from mindtrace.core.utils.time import as_utc, utcnow, utcnow_iso
+
+
+class TestUtcnow:
+    """Tests for utcnow function."""
+
+    def test_utcnow_is_timezone_aware_utc(self):
+        """utcnow returns a timezone-aware datetime in UTC."""
+        now = utcnow()
+        assert now.tzinfo is not None
+        assert now.utcoffset() == timedelta(0)
+
+
+class TestUtcnowIso:
+    """Tests for utcnow_iso function."""
+
+    def test_utcnow_iso_ends_with_z(self):
+        """utcnow_iso returns an ISO-8601 string with a trailing Z (not +00:00)."""
+        stamp = utcnow_iso()
+        assert stamp.endswith("Z")
+        assert "+00:00" not in stamp
+
+
+class TestAsUtc:
+    """Tests for as_utc function."""
+
+    def test_as_utc_treats_naive_as_utc(self):
+        """A naive datetime is tagged as UTC without shifting the wall-clock value."""
+        naive = datetime(2026, 1, 1, 12, 0, 0)
+
+        result = as_utc(naive)
+
+        assert result.tzinfo is timezone.utc
+        assert result == datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_as_utc_converts_aware_to_utc(self):
+        """An aware datetime in another zone is converted to the equivalent UTC instant."""
+        eastern = timezone(timedelta(hours=-5))
+        aware = datetime(2026, 1, 1, 7, 0, 0, tzinfo=eastern)
+
+        result = as_utc(aware)
+
+        assert result.utcoffset() == timedelta(0)
+        assert result == datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)

--- a/tests/unit/mindtrace/datalake/fake_replication_task_database.py
+++ b/tests/unit/mindtrace/datalake/fake_replication_task_database.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
+from mindtrace.core import as_utc
 from mindtrace.database.core.exceptions import DocumentNotFoundError
 from mindtrace.datalake.types import ReplicationTask
 
@@ -20,23 +19,18 @@ class FakeReplicationTaskDatabase:
         self._tasks = {t.task_id: t for t in tasks}
         self._extra_due = list(extra_due_candidates or [])
 
-    def _normalize_utc(self, value: datetime) -> datetime:
-        if value.tzinfo is None:
-            return value.replace(tzinfo=timezone.utc)
-        return value.astimezone(timezone.utc)
-
     def _matches_due_branch(self, branch: dict, task: ReplicationTask) -> bool:
         allowed = set(branch["status"]["$in"])
         if task.status not in allowed:
             return False
         if "next_attempt_at" in branch:
-            lte = self._normalize_utc(branch["next_attempt_at"]["$lte"])
-            return self._normalize_utc(task.next_attempt_at) <= lte
+            lte = as_utc(branch["next_attempt_at"]["$lte"])
+            return as_utc(task.next_attempt_at) <= lte
         if "lease_expires_at" in branch:
-            lte = self._normalize_utc(branch["lease_expires_at"]["$lte"])
+            lte = as_utc(branch["lease_expires_at"]["$lte"])
             if task.lease_expires_at is None:
                 return False
-            return self._normalize_utc(task.lease_expires_at) <= lte
+            return as_utc(task.lease_expires_at) <= lte
         return True
 
     def _matches_or_query(self, query: dict, task: ReplicationTask) -> bool:
@@ -46,8 +40,8 @@ class FakeReplicationTaskDatabase:
         allowed = set(query["status"]["$in"])
         if task.status not in allowed:
             return False
-        lte = self._normalize_utc(query["next_attempt_at"]["$lte"])
-        return self._normalize_utc(task.next_attempt_at) <= lte
+        lte = as_utc(query["next_attempt_at"]["$lte"])
+        return as_utc(task.next_attempt_at) <= lte
 
     async def find(self, query: dict) -> list[ReplicationTask]:
         if "task_id" in query:
@@ -77,15 +71,13 @@ class FakeReplicationTaskDatabase:
                 and "next_attempt_at" not in query
             ):
                 allowed = set(query["status"]["$in"])
-                cutoff = self._normalize_utc(query["completed_at"]["$lte"])
+                cutoff = as_utc(query["completed_at"]["$lte"])
                 rows = [
                     t
                     for t in self._tasks.values()
-                    if t.status in allowed
-                    and t.completed_at is not None
-                    and self._normalize_utc(t.completed_at) <= cutoff
+                    if t.status in allowed and t.completed_at is not None and as_utc(t.completed_at) <= cutoff
                 ]
-                return sorted(rows, key=lambda t: (self._normalize_utc(t.completed_at), t.created_at))
+                return sorted(rows, key=lambda t: (as_utc(t.completed_at), t.created_at))
             base = [t for t in self._tasks.values() if self._matches_due_query(query, t)]
             extra = [t for t in self._extra_due if self._matches_due_query(query, t)]
             return base + extra

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -17,6 +17,7 @@ from export_test_utils import (
     resolved_dataset_version as export_fixture_resolved_dataset_version,
 )
 
+from mindtrace.core import utcnow
 from mindtrace.database.core.exceptions import DocumentNotFoundError, DuplicateInsertError
 from mindtrace.datalake import AsyncDatalake
 from mindtrace.datalake.async_datalake import (
@@ -2744,7 +2745,7 @@ def _alias_fixture_row(alias: str, asset_id: str, *, is_primary: bool = False) -
         alias=alias,
         asset_id=asset_id,
         is_primary=is_primary,
-        created_at=datetime.now(timezone.utc),
+        created_at=utcnow(),
     )
 
 

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -249,17 +249,6 @@ class TestAsyncDatalakeUnit:
 
         async_datalake._guard_slow_list_operation.assert_called()
 
-    def test_utc_now_returns_timezone_aware_datetime(self, async_datalake):
-        now = async_datalake._utc_now()
-        assert now.tzinfo is not None
-
-    def test_coerce_utc_attaches_timezone_to_naive_datetime(self, async_datalake):
-        naive = datetime(2026, 1, 1, 12, 0, 0)
-
-        coerced = async_datalake._coerce_utc(naive)
-
-        assert coerced.tzinfo is not None
-
     def test_build_document_uses_model_construct(self, async_datalake):
         class Dummy:
             @classmethod
@@ -508,7 +497,7 @@ class TestAsyncDatalakeUnit:
         mock_odm.find_window = AsyncMock(side_effect=find_window_side_effect)
         mock_odm.count_documents = AsyncMock(return_value=2)
 
-        with patch.object(async_datalake, "_utc_now", return_value=cutoff):
+        with patch("mindtrace.datalake.async_datalake.utcnow", return_value=cutoff):
             first_page = await async_datalake.list_assets_page(
                 filters={"kind": "image"},
                 limit=1,
@@ -1037,7 +1026,7 @@ class TestAsyncDatalakeUnit:
             upload_method="local_path",
             upload_path="/tmp/direct-upload/data.txt",
             staged_reference={"kind": "local_file", "path": "/tmp/direct-upload/data.txt"},
-            expires_at=async_datalake._utc_now(),
+            expires_at=utcnow(),
         )
         mock_odm.find.return_value = [session]
 
@@ -1061,7 +1050,7 @@ class TestAsyncDatalakeUnit:
             upload_method="local_path",
             upload_path="/tmp/direct-upload/data.txt",
             staged_reference={"kind": "local_file", "path": "/tmp/direct-upload/data.txt"},
-            expires_at=async_datalake._utc_now(),
+            expires_at=utcnow(),
         )
         mock_odm.find.return_value = [session]
 
@@ -1080,7 +1069,7 @@ class TestAsyncDatalakeUnit:
             upload_method="local_path",
             upload_path="/tmp/direct-upload/data.txt",
             staged_reference={"kind": "local_file", "path": "/tmp/direct-upload/data.txt"},
-            expires_at=async_datalake._utc_now(),
+            expires_at=utcnow(),
         )
         mock_odm.find.return_value = [session]
         mock_store.inspect_direct_upload_target.return_value = {"exists": False}
@@ -1103,7 +1092,7 @@ class TestAsyncDatalakeUnit:
             upload_method="local_path",
             upload_path="/tmp/direct-upload/data.txt",
             staged_reference={"kind": "local_file", "path": "/tmp/direct-upload/data.txt"},
-            expires_at=async_datalake._utc_now(),
+            expires_at=utcnow(),
         )
         mock_odm.find.return_value = [session]
         mock_store.inspect_direct_upload_target.return_value = {"exists": False}
@@ -1124,7 +1113,7 @@ class TestAsyncDatalakeUnit:
             status="completed",
             upload_path="/tmp/direct-upload/data.txt",
             staged_reference={"kind": "local_file", "path": "/tmp/direct-upload/data.txt"},
-            expires_at=async_datalake._utc_now(),
+            expires_at=utcnow(),
         )
 
         completed = await async_datalake._verify_and_finalize_upload_session(
@@ -1148,7 +1137,7 @@ class TestAsyncDatalakeUnit:
             upload_method="local_path",
             upload_path="/tmp/direct-upload/data.txt",
             staged_reference={"kind": "local_file", "path": "/tmp/direct-upload/data.txt"},
-            expires_at=async_datalake._utc_now(),
+            expires_at=utcnow(),
         )
         mock_odm.find.return_value = [session]
         mock_store.commit_direct_upload.side_effect = RuntimeError("commit failed")

--- a/tests/unit/mindtrace/datalake/test_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_datalake.py
@@ -1,11 +1,11 @@
 import asyncio
 import threading
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from datalake_unit_mongo_uri import DATALAKE_UNIT_MONGO_URI
 
+from mindtrace.core import utcnow
 from mindtrace.datalake import Datalake
 from mindtrace.datalake.async_datalake import SlowOpsPolicy
 from mindtrace.datalake.pagination_types import CursorPage, DatasetViewInfo, DatasetViewPage, DatasetViewRow, PageInfo
@@ -94,7 +94,7 @@ class TestDatalakeSyncFacade:
             upload_method="local_path",
             upload_path="/tmp/direct-upload/data.txt",
             staged_reference={"kind": "local_file", "path": "/tmp/direct-upload/data.txt"},
-            expires_at=datetime.now(timezone.utc),
+            expires_at=utcnow(),
         )
         for name, value in {
             "close": None,
@@ -204,7 +204,7 @@ class TestDatalakeSyncFacade:
                 alias="asset_1",
                 asset_id="asset_1",
                 is_primary=True,
-                created_at=datetime.now(timezone.utc),
+                created_at=utcnow(),
             ),
             "resolve_alias": "resolved_asset_id",
             "add_alias": AssetAlias.model_construct(
@@ -212,7 +212,7 @@ class TestDatalakeSyncFacade:
                 alias="nick",
                 asset_id="asset_1",
                 is_primary=False,
-                created_at=datetime.now(timezone.utc),
+                created_at=utcnow(),
             ),
             "remove_alias": None,
             "list_aliases_for_asset": ["asset_1", "nick"],

--- a/tests/unit/mindtrace/datalake/test_replication_queue.py
+++ b/tests/unit/mindtrace/datalake/test_replication_queue.py
@@ -9,7 +9,7 @@ from bson import ObjectId
 
 from mindtrace.database.core.exceptions import DuplicateInsertError
 from mindtrace.datalake.replication_queue import ReplicationQueueManager, _task_is_claimable_at
-from mindtrace.datalake.types import ReplicationTask, utc_now
+from mindtrace.datalake.types import ReplicationTask, utcnow
 from tests.unit.mindtrace.datalake.fake_replication_task_database import FakeReplicationTaskDatabase
 
 
@@ -113,7 +113,7 @@ async def test_claim_due_tasks_sets_lease(queue_manager, task_database):
     )
     task_database.find.side_effect = [[task], [task]]
 
-    claimed = await queue_manager.claim_due_tasks(worker_id="worker-1", limit=1, lease_seconds=30, now=utc_now())
+    claimed = await queue_manager.claim_due_tasks(worker_id="worker-1", limit=1, lease_seconds=30, now=utcnow())
 
     assert len(claimed) == 1
     assert claimed[0].status == "claimed"

--- a/tests/unit/mindtrace/hardware/services/cameras/test_service_streams_and_performance.py
+++ b/tests/unit/mindtrace/hardware/services/cameras/test_service_streams_and_performance.py
@@ -1,10 +1,10 @@
 """Additional unit tests for CameraManagerService stream/performance paths."""
 
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from mindtrace.core import utcnow
 from mindtrace.hardware.core.exceptions import CameraNotFoundError
 from mindtrace.hardware.services.cameras.models.requests import (
     CameraPerformanceSettingsRequest,
@@ -179,7 +179,7 @@ async def test_get_stream_status_active_stream(service_and_manager):
 
     service._active_streams["Basler:cam1"] = {
         "stream_url": "http://localhost:8002/stream/Basler_cam1",
-        "start_time": datetime.now(timezone.utc),
+        "start_time": utcnow(),
     }
 
     response = await service.get_stream_status(StreamStatusRequest(camera="Basler:cam1"))

--- a/tests/unit/mindtrace/jobs/conftest.py
+++ b/tests/unit/mindtrace/jobs/conftest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from pydantic import BaseModel
 
-from mindtrace.core import utcnow
+from mindtrace.core import utcnow_iso
 from mindtrace.jobs import Consumer, Job, JobSchema, LocalClient, job_from_schema
 from mindtrace.registry import Registry
 
@@ -59,7 +59,7 @@ def unique_queue_name():
 
 @pytest.fixture
 def test_timestamp():
-    return utcnow().isoformat()
+    return utcnow_iso()
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/mindtrace/jobs/conftest.py
+++ b/tests/unit/mindtrace/jobs/conftest.py
@@ -1,11 +1,11 @@
 import tempfile
 import time
-from datetime import datetime
 from pathlib import Path
 
 import pytest
 from pydantic import BaseModel
 
+from mindtrace.core import utcnow
 from mindtrace.jobs import Consumer, Job, JobSchema, LocalClient, job_from_schema
 from mindtrace.registry import Registry
 
@@ -59,7 +59,7 @@ def unique_queue_name():
 
 @pytest.fixture
 def test_timestamp():
-    return datetime.now().isoformat()
+    return utcnow().isoformat()
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/mindtrace/jobs/core/test_orchestrator.py
+++ b/tests/unit/mindtrace/jobs/core/test_orchestrator.py
@@ -1,12 +1,11 @@
 import tempfile
-from datetime import datetime
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
 from pydantic import BaseModel
 
-from mindtrace.core import TaskSchema
+from mindtrace.core import TaskSchema, utcnow
 from mindtrace.jobs.core.orchestrator import Orchestrator
 from mindtrace.jobs.local.client import LocalClient
 from mindtrace.jobs.types.job_specs import ExecutionStatus, Job, JobSchema
@@ -68,7 +67,7 @@ def sample_job():
         schema_name="test-schema",
         payload={"data": "test"},
         status=ExecutionStatus.QUEUED,
-        created_at=datetime.now().isoformat(),
+        created_at=utcnow().isoformat(),
     )
 
 

--- a/tests/unit/mindtrace/jobs/core/test_orchestrator.py
+++ b/tests/unit/mindtrace/jobs/core/test_orchestrator.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import pytest
 from pydantic import BaseModel
 
-from mindtrace.core import TaskSchema, utcnow
+from mindtrace.core import TaskSchema, utcnow_iso
 from mindtrace.jobs.core.orchestrator import Orchestrator
 from mindtrace.jobs.local.client import LocalClient
 from mindtrace.jobs.types.job_specs import ExecutionStatus, Job, JobSchema
@@ -67,7 +67,7 @@ def sample_job():
         schema_name="test-schema",
         payload={"data": "test"},
         status=ExecutionStatus.QUEUED,
-        created_at=utcnow().isoformat(),
+        created_at=utcnow_iso(),
     )
 
 

--- a/tests/unit/mindtrace/jobs/utils/test_schemas.py
+++ b/tests/unit/mindtrace/jobs/utils/test_schemas.py
@@ -40,8 +40,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.datetime") as mock_datetime:
-                mock_datetime.now.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
+                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
 
                 result = job_from_schema(schema, input_data)
 
@@ -59,8 +59,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.datetime") as mock_datetime:
-                mock_datetime.now.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
+                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
 
                 result = job_from_schema(schema, input_data)
 
@@ -80,8 +80,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.datetime") as mock_datetime:
-                mock_datetime.now.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
+                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
 
                 result = job_from_schema(schema, input_data)
 
@@ -97,8 +97,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.datetime") as mock_datetime:
-                mock_datetime.now.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
+                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
 
                 result = job_from_schema(schema, input_data)
 
@@ -132,8 +132,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.datetime") as mock_datetime:
-                mock_datetime.now.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
+                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
 
                 result = job_from_schema(schema, input_data)
 
@@ -175,8 +175,8 @@ class TestJobFromSchema:
         schema = MockJobSchema()
         input_data = MockInputSchema(data="test-data")
 
-        with patch("mindtrace.jobs.utils.schemas.datetime") as mock_datetime:
-            mock_datetime.now.return_value = datetime(2023, 1, 1, 12, 0, 0)
+        with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
+            mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
 
             job1 = job_from_schema(schema, input_data)
             job2 = job_from_schema(schema, input_data)
@@ -192,8 +192,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.datetime") as mock_datetime:
-                mock_datetime.now.return_value = datetime(2023, 1, 1, 12, 30, 45, 123456)
+            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
+                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 30, 45, 123456)
 
                 result = job_from_schema(schema, input_data)
 
@@ -206,8 +206,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.datetime") as mock_datetime:
-                mock_datetime.now.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
+                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
 
                 result = job_from_schema(schema, input_data)
 
@@ -232,8 +232,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.datetime") as mock_datetime:
-                mock_datetime.now.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
+                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
 
                 result = job_from_schema(schema, input_data)
 

--- a/tests/unit/mindtrace/jobs/utils/test_schemas.py
+++ b/tests/unit/mindtrace/jobs/utils/test_schemas.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -40,8 +39,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
-                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow_iso") as mock_utcnow_iso:
+                mock_utcnow_iso.return_value = "2023-01-01T12:00:00Z"
 
                 result = job_from_schema(schema, input_data)
 
@@ -50,7 +49,7 @@ class TestJobFromSchema:
                 assert result.name == "test-job"
                 assert result.schema_name == "test-job"
                 assert result.payload == input_data
-                assert result.created_at == "2023-01-01T12:00:00"
+                assert result.created_at == "2023-01-01T12:00:00Z"
 
     def test_job_from_schema_with_dictionary_input(self):
         """Test creating a job with dictionary input data."""
@@ -59,8 +58,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
-                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow_iso") as mock_utcnow_iso:
+                mock_utcnow_iso.return_value = "2023-01-01T12:00:00Z"
 
                 result = job_from_schema(schema, input_data)
 
@@ -71,7 +70,7 @@ class TestJobFromSchema:
                 assert isinstance(result.payload, MockInputSchema)
                 assert result.payload.data == "test-data"
                 assert result.payload.count == 10
-                assert result.created_at == "2023-01-01T12:00:00"
+                assert result.created_at == "2023-01-01T12:00:00Z"
 
     def test_job_from_schema_with_partial_dictionary_input(self):
         """Test creating a job with partial dictionary input (using defaults)."""
@@ -80,8 +79,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
-                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow_iso") as mock_utcnow_iso:
+                mock_utcnow_iso.return_value = "2023-01-01T12:00:00Z"
 
                 result = job_from_schema(schema, input_data)
 
@@ -97,8 +96,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
-                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow_iso") as mock_utcnow_iso:
+                mock_utcnow_iso.return_value = "2023-01-01T12:00:00Z"
 
                 result = job_from_schema(schema, input_data)
 
@@ -132,8 +131,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
-                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow_iso") as mock_utcnow_iso:
+                mock_utcnow_iso.return_value = "2023-01-01T12:00:00Z"
 
                 result = job_from_schema(schema, input_data)
 
@@ -175,8 +174,8 @@ class TestJobFromSchema:
         schema = MockJobSchema()
         input_data = MockInputSchema(data="test-data")
 
-        with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
-            mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
+        with patch("mindtrace.jobs.utils.schemas.utcnow_iso") as mock_utcnow_iso:
+            mock_utcnow_iso.return_value = "2023-01-01T12:00:00Z"
 
             job1 = job_from_schema(schema, input_data)
             job2 = job_from_schema(schema, input_data)
@@ -192,12 +191,12 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
-                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 30, 45, 123456)
+            with patch("mindtrace.jobs.utils.schemas.utcnow_iso") as mock_utcnow_iso:
+                mock_utcnow_iso.return_value = "2023-01-01T12:30:45.123456Z"
 
                 result = job_from_schema(schema, input_data)
 
-                assert result.created_at == "2023-01-01T12:30:45.123456"
+                assert result.created_at == "2023-01-01T12:30:45.123456Z"
 
     def test_job_from_schema_payload_immutability(self):
         """Test that the payload is properly set and not modified."""
@@ -206,8 +205,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
-                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow_iso") as mock_utcnow_iso:
+                mock_utcnow_iso.return_value = "2023-01-01T12:00:00Z"
 
                 result = job_from_schema(schema, input_data)
 
@@ -232,8 +231,8 @@ class TestJobFromSchema:
 
         with patch("mindtrace.jobs.utils.schemas.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = uuid4()
-            with patch("mindtrace.jobs.utils.schemas.utcnow") as mock_utcnow:
-                mock_utcnow.return_value = datetime(2023, 1, 1, 12, 0, 0)
+            with patch("mindtrace.jobs.utils.schemas.utcnow_iso") as mock_utcnow_iso:
+                mock_utcnow_iso.return_value = "2023-01-01T12:00:00Z"
 
                 result = job_from_schema(schema, input_data)
 

--- a/tests/unit/mindtrace/models/test_lifecycle.py
+++ b/tests/unit/mindtrace/models/test_lifecycle.py
@@ -11,12 +11,12 @@ Tests cover:
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
+from mindtrace.core import utcnow
 from mindtrace.models.lifecycle import (
     EvalResult,
     ModelCard,
@@ -88,9 +88,9 @@ class TestEvalResult:
         assert result.split == "val"
 
     def test_timestamp_set_on_creation(self):
-        before = datetime.now(timezone.utc)
+        before = utcnow()
         result = EvalResult(metric="acc", value=0.9)
-        after = datetime.now(timezone.utc)
+        after = utcnow()
         assert before <= result.timestamp <= after
 
     def test_to_dict_roundtrip(self):


### PR DESCRIPTION
#### Summary
  - Add `mindtrace.core.utcnow()` / `utcnow_iso()` / `as_utc()` as the single source of truth for UTC time
  - Replace ~70 inline `datetime.now(timezone.utc)/now(UTC)` calls and collapse lambda default_factories
  - Remove 6 duplicate helpers (utc_now, utc_now_iso, _utc_iso, _utc_now ×2, _coerce_utc/_as_utc/_normalize_utc)
  - Fix 12 naive `datetime.now()` sites (local-time bugs) → tz-aware UTC
  - Tests: patch the looked-up name; new core `test_time.py`; all tests pass, ruff clean