### PR TITLE
Test hardware capture byte-size congruence with DataVault

### DIFF
--- a/tests/integration/mindtrace/datalake/test_data_vault_integration.py
+++ b/tests/integration/mindtrace/datalake/test_data_vault_integration.py
@@ -16,8 +16,8 @@ from PIL import Image
 from mindtrace.datalake import AsyncDataVault, Datalake, DataVault
 from mindtrace.datalake.data_vault import _pil_image_to_png_bytes
 from mindtrace.hardware.cameras.core.async_camera_manager import AsyncCameraManager
-from mindtrace.hardware.cameras.core.capture_metadata import SavedCaptureInfo
 from mindtrace.hardware.services.cameras.models.requests import CaptureImageRequest
+from mindtrace.hardware.services.cameras.models.responses import CaptureResult
 from mindtrace.hardware.services.cameras.service import CameraManagerService
 
 _HOPPER = Path(__file__).resolve().parents[3] / "resources" / "hopper.png"
@@ -50,29 +50,29 @@ def _first_mock_basler_camera() -> str:
     return cameras[0]
 
 
-async def _capture_saved_file_with_mock_camera(tmp_path: Path, *, suffix: str) -> SavedCaptureInfo:
-    """Capture through the hardware manager's save-path route and return disk metadata.
+async def _capture_saved_file_with_mock_camera(tmp_path: Path, *, suffix: str) -> CaptureResult:
+    """Capture through the camera service save-path route and return disk metadata.
 
-    This is the same hardware boundary Chiron uses when it asks Mindtrace to
-    write a capture to disk.  The manager returns :class:`SavedCaptureInfo`,
-    whose ``file_size_bytes`` is computed from the encoded file on disk after
-    the mock camera/backend has written it.
+    Production callers use ``CameraManagerService.capture_image`` with
+    ``save_path``; the service reads ``image_size`` and ``file_size_bytes`` from
+    the encoded file on disk after the backend writes it.
     """
     camera = _first_mock_basler_camera()
+    save_path = str(tmp_path / f"capture.{suffix}")
     async with AsyncCameraManager(include_mocks=True) as manager:
         await manager.open([camera])
-        results = await manager.batch_capture(
-            [camera],
-            save_path_pattern=str(tmp_path / f"{{camera}}.{suffix}"),
-            output_format="numpy",
+        service = CameraManagerService(include_mocks=True)
+        service._camera_manager = manager
+        response = await service.capture_image(
+            CaptureImageRequest(camera=camera, save_path=save_path, output_format="numpy")
         )
 
-    saved = results[camera]
-    assert isinstance(saved, SavedCaptureInfo)
-    assert saved.path.endswith(f".{suffix}")
-    assert saved.file_size_bytes > 0
-    assert Path(saved.path).stat().st_size == saved.file_size_bytes
-    return saved
+    assert response.success is True
+    capture = response.data
+    assert capture.image_path == save_path
+    assert capture.file_size_bytes is not None and capture.file_size_bytes > 0
+    assert Path(save_path).stat().st_size == capture.file_size_bytes
+    return capture
 
 
 async def _capture_inline_with_mock_camera(*, output_format: str | None = None):
@@ -251,9 +251,9 @@ def test_sync_data_vault_save_path_records_payload_size(sync_datalake: Datalake)
 async def test_hardware_save_path_jpeg_file_size_matches_datalake_payload_size(async_datalake, tmp_path):
     """Hardware JPEG disk captures and DataVault path saves agree on encoded bytes.
 
-    This covers the production-style save-path route: the hardware manager asks
-    the camera backend to write a ``.jpg`` file, reports ``SavedCaptureInfo``
-    from that encoded file, and a caller then hands the same path to DataVault.
+    This covers the production-style save-path route: the camera service writes
+    a ``.jpg`` file, reports ``file_size_bytes`` from that encoded file, and a
+    caller then hands the same path to DataVault.
     The assertion is deliberately about the JPEG file bytes on disk, not the
     in-memory image dimensions or uncompressed pixels.
     """
@@ -261,7 +261,7 @@ async def test_hardware_save_path_jpeg_file_size_matches_datalake_payload_size(a
 
     asset = await _assert_datalake_asset_size_matches_hardware_bytes(
         async_datalake,
-        payload=Path(saved.path),
+        payload=Path(saved.image_path),
         hardware_file_size_bytes=saved.file_size_bytes,
         alias_prefix="hardware-save-path-jpeg",
     )
@@ -281,7 +281,7 @@ async def test_hardware_save_path_png_file_size_matches_datalake_payload_size(as
 
     asset = await _assert_datalake_asset_size_matches_hardware_bytes(
         async_datalake,
-        payload=Path(saved.path),
+        payload=Path(saved.image_path),
         hardware_file_size_bytes=saved.file_size_bytes,
         alias_prefix="hardware-save-path-png",
     )

--- a/tests/integration/mindtrace/datalake/test_data_vault_integration.py
+++ b/tests/integration/mindtrace/datalake/test_data_vault_integration.py
@@ -5,6 +5,7 @@ Requires MongoDB at ``mongodb://localhost:27018`` (see ``conftest.py``).
 
 from __future__ import annotations
 
+import base64
 import socket
 from pathlib import Path
 from uuid import uuid4
@@ -14,6 +15,10 @@ from PIL import Image
 
 from mindtrace.datalake import AsyncDataVault, Datalake, DataVault
 from mindtrace.datalake.data_vault import _pil_image_to_png_bytes
+from mindtrace.hardware.cameras.core.async_camera_manager import AsyncCameraManager
+from mindtrace.hardware.cameras.core.capture_metadata import SavedCaptureInfo
+from mindtrace.hardware.services.cameras.models.requests import CaptureImageRequest
+from mindtrace.hardware.services.cameras.service import CameraManagerService
 
 _HOPPER = Path(__file__).resolve().parents[3] / "resources" / "hopper.png"
 
@@ -36,6 +41,92 @@ def _hopper_bytes() -> bytes:
     if not _HOPPER.is_file():
         pytest.skip(f"Missing test fixture: {_HOPPER}")
     return _HOPPER.read_bytes()
+
+
+def _first_mock_basler_camera() -> str:
+    cameras = [name for name in AsyncCameraManager.discover(include_mocks=True) if name.startswith("MockBasler:")]
+    if not cameras:
+        pytest.skip("Need at least one mock Basler camera")
+    return cameras[0]
+
+
+async def _capture_saved_file_with_mock_camera(tmp_path: Path, *, suffix: str) -> SavedCaptureInfo:
+    """Capture through the hardware manager's save-path route and return disk metadata.
+
+    This is the same hardware boundary Chiron uses when it asks Mindtrace to
+    write a capture to disk.  The manager returns :class:`SavedCaptureInfo`,
+    whose ``file_size_bytes`` is computed from the encoded file on disk after
+    the mock camera/backend has written it.
+    """
+    camera = _first_mock_basler_camera()
+    async with AsyncCameraManager(include_mocks=True) as manager:
+        await manager.open([camera])
+        results = await manager.batch_capture(
+            [camera],
+            save_path_pattern=str(tmp_path / f"{{camera}}.{suffix}"),
+            output_format="numpy",
+        )
+
+    saved = results[camera]
+    assert isinstance(saved, SavedCaptureInfo)
+    assert saved.path.endswith(f".{suffix}")
+    assert saved.file_size_bytes > 0
+    assert Path(saved.path).stat().st_size == saved.file_size_bytes
+    return saved
+
+
+async def _capture_inline_with_mock_camera(*, output_format: str | None = None):
+    """Capture through the camera service's inline wire-encoding route.
+
+    The service is intentionally used here (rather than calling the manager
+    directly) because inline base64 encoding and its ``file_size_bytes`` value
+    live at the service boundary.  That is the hardware API path a caller would
+    hand to DataVault as bytes.
+    """
+    camera = _first_mock_basler_camera()
+    async with AsyncCameraManager(include_mocks=True) as manager:
+        await manager.open([camera])
+        service = CameraManagerService(include_mocks=True)
+        service._camera_manager = manager
+        kwargs = {"camera": camera}
+        if output_format is not None:
+            kwargs["output_format"] = output_format
+        response = await service.capture_image(CaptureImageRequest(**kwargs))
+
+    assert response.success is True
+    assert response.data.image_data is not None
+    assert response.data.file_size_bytes is not None
+    payload = base64.b64decode(response.data.image_data)
+    assert len(payload) == response.data.file_size_bytes
+    return response.data, payload
+
+
+async def _assert_datalake_asset_size_matches_hardware_bytes(
+    async_datalake,
+    *,
+    payload: bytes | Path,
+    hardware_file_size_bytes: int,
+    alias_prefix: str,
+    media_type: str | None = None,
+):
+    """Persist hardware capture bytes through DataVault and verify stored asset metadata.
+
+    The unit tests prove DataVault passes size values to its backend.  This
+    integration helper proves the end-to-end persistence path: real DataVault,
+    real AsyncDatalake metadata, and real local object storage agree with the
+    size the hardware layer reported for the same encoded representation.
+    """
+    vault = AsyncDataVault(async_datalake)
+    kwargs = {"kind": "image", "created_by": "hardware-datalake-integration"}
+    if media_type is not None:
+        kwargs["media_type"] = media_type
+    asset = await vault.save(f"{alias_prefix}-{uuid4().hex[:10]}", payload, **kwargs)
+    fetched = await async_datalake.get_asset(asset.asset_id)
+
+    assert asset.size_bytes == hardware_file_size_bytes
+    assert fetched.size_bytes == hardware_file_size_bytes
+    assert await vault.load(asset.asset_id) == (payload.read_bytes() if isinstance(payload, Path) else payload)
+    return fetched
 
 
 async def _save_async_image_assets(vault: AsyncDataVault, *, prefix: str, count: int = 3):
@@ -154,6 +245,100 @@ def test_sync_data_vault_save_path_records_payload_size(sync_datalake: Datalake)
     assert asset.size_bytes == len(raw)
     assert fetched.size_bytes == len(raw)
     assert vault.load(alias) == raw
+
+
+@pytest.mark.asyncio
+async def test_hardware_save_path_jpeg_file_size_matches_datalake_payload_size(async_datalake, tmp_path):
+    """Hardware JPEG disk captures and DataVault path saves agree on encoded bytes.
+
+    This covers the production-style save-path route: the hardware manager asks
+    the camera backend to write a ``.jpg`` file, reports ``SavedCaptureInfo``
+    from that encoded file, and a caller then hands the same path to DataVault.
+    The assertion is deliberately about the JPEG file bytes on disk, not the
+    in-memory image dimensions or uncompressed pixels.
+    """
+    saved = await _capture_saved_file_with_mock_camera(tmp_path, suffix="jpg")
+
+    asset = await _assert_datalake_asset_size_matches_hardware_bytes(
+        async_datalake,
+        payload=Path(saved.path),
+        hardware_file_size_bytes=saved.file_size_bytes,
+        alias_prefix="hardware-save-path-jpeg",
+    )
+
+    assert asset.media_type == "image/jpeg"
+
+
+@pytest.mark.asyncio
+async def test_hardware_save_path_png_file_size_matches_datalake_payload_size(async_datalake, tmp_path):
+    """Hardware PNG disk captures and DataVault path saves agree on encoded bytes.
+
+    This is the same save-path contract as the JPEG test, but with a PNG file
+    extension.  It protects against the hardware and Datalake modules silently
+    disagreeing when a caller chooses lossless disk output instead of JPEG.
+    """
+    saved = await _capture_saved_file_with_mock_camera(tmp_path, suffix="png")
+
+    asset = await _assert_datalake_asset_size_matches_hardware_bytes(
+        async_datalake,
+        payload=Path(saved.path),
+        hardware_file_size_bytes=saved.file_size_bytes,
+        alias_prefix="hardware-save-path-png",
+    )
+
+    assert asset.media_type == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_hardware_inline_jpeg_file_size_matches_datalake_payload_size(async_datalake):
+    """Hardware inline JPEG responses and DataVault byte saves agree on encoded bytes.
+
+    Inline captures do not write a file first.  The camera service encodes the
+    in-memory mock-camera frame as base64 JPEG, reports ``file_size_bytes`` for
+    those exact encoded response bytes, and callers can persist those decoded
+    bytes directly with DataVault.
+    """
+    capture, payload = await _capture_inline_with_mock_camera(output_format="jpeg")
+
+    asset = await _assert_datalake_asset_size_matches_hardware_bytes(
+        async_datalake,
+        payload=payload,
+        hardware_file_size_bytes=capture.file_size_bytes,
+        alias_prefix="hardware-inline-jpeg",
+        media_type="image/jpeg",
+    )
+
+    assert payload.startswith(b"\xff\xd8\xff")
+    assert asset.media_type == "image/jpeg"
+
+
+@pytest.mark.asyncio
+async def test_hardware_inline_default_png_file_size_matches_datalake_payload_size(async_datalake):
+    """The default inline hardware response is PNG and matches DataVault bytes.
+
+    ``CaptureImageRequest.output_format`` currently defaults to ``"pil"``.
+    That value names the in-memory backend return type, but an HTTP/service
+    response must still carry bytes.  The camera service intentionally encodes
+    the default inline wire payload as PNG because it is lossless and neutral.
+
+    This test documents that subtle default behavior for future reviewers and
+    agents: omitting ``output_format`` does **not** mean DataVault receives a
+    PIL object.  It receives decoded PNG bytes, and the hardware-reported
+    ``file_size_bytes`` must match the persisted Datalake asset size for those
+    PNG bytes.
+    """
+    capture, payload = await _capture_inline_with_mock_camera()
+
+    asset = await _assert_datalake_asset_size_matches_hardware_bytes(
+        async_datalake,
+        payload=payload,
+        hardware_file_size_bytes=capture.file_size_bytes,
+        alias_prefix="hardware-inline-default-png",
+        media_type="image/png",
+    )
+
+    assert payload.startswith(b"\x89PNG\r\n\x1a\n")
+    assert asset.media_type == "image/png"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -80,7 +80,7 @@ from mindtrace.datalake.vault_serialization import (
     SERIALIZATION_METADATA_KEY,
     direct_bytes_serialization_block,
 )
-from mindtrace.hardware.cameras.core.capture_metadata import file_size_bytes_for_path, image_dimensions
+from mindtrace.hardware.services.cameras.service import CameraManagerService
 from mindtrace.registry import Registry
 from mindtrace.services import Service
 from mindtrace.services.core.utils import generate_connection_manager
@@ -3084,8 +3084,8 @@ def test_data_vault_save_path_size_matches_hardware_saved_file_metadata(
     jpg_path = tmp_path / "frame.jpg"
     image.save(jpg_path, format="JPEG", quality=95)
 
-    hardware_image_size = image_dimensions(image)
-    hardware_file_size = file_size_bytes_for_path(str(jpg_path))
+    hardware_image_size = CameraManagerService._image_size_on_disk(str(jpg_path))
+    hardware_file_size = CameraManagerService._file_size_bytes(str(jpg_path))
 
     DataVault(mock_sync_datalake_for_alias_indexing).save("frame-from-path", jpg_path)
 
@@ -3129,7 +3129,7 @@ def test_data_vault_save_inline_bytes_size_matches_hardware_encoded_response_met
     )
 
     kwargs = mock_sync_datalake_for_alias_indexing.create_asset_from_object.call_args.kwargs
-    assert image_dimensions(image) == image.size
+    assert image.size == (16, 12)
     assert kwargs["kind"] == "image"
     assert kwargs["media_type"] == media_type
     assert kwargs["obj"] == encoded

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock
@@ -79,6 +80,7 @@ from mindtrace.datalake.vault_serialization import (
     SERIALIZATION_METADATA_KEY,
     direct_bytes_serialization_block,
 )
+from mindtrace.hardware.cameras.core.capture_metadata import file_size_bytes_for_path, image_dimensions
 from mindtrace.registry import Registry
 from mindtrace.services import Service
 from mindtrace.services.core.utils import generate_connection_manager
@@ -3065,6 +3067,75 @@ def test_data_vault_save_adds_secondary_alias(mock_sync_datalake_for_alias_index
     mock_sync_datalake_for_alias_indexing.add_alias.assert_called_once_with("new_asset", "friendly")
 
 
+def test_data_vault_save_path_size_matches_hardware_saved_file_metadata(
+    mock_sync_datalake_for_alias_indexing,
+    tmp_path,
+):
+    """Save-path captures and ``DataVault.save(Path)`` measure the same encoded file bytes."""
+    created = Asset(
+        kind="image",
+        media_type="image/jpeg",
+        storage_ref=StorageRef(mount="m", name="vault/frame", version="1"),
+        asset_id="asset_jpg_path",
+    )
+    mock_sync_datalake_for_alias_indexing.create_asset_from_object = Mock(return_value=created)
+
+    image = Image.new("RGB", (16, 12), color=(12, 34, 56))
+    jpg_path = tmp_path / "frame.jpg"
+    image.save(jpg_path, format="JPEG", quality=95)
+
+    hardware_image_size = image_dimensions(image)
+    hardware_file_size = file_size_bytes_for_path(str(jpg_path))
+
+    DataVault(mock_sync_datalake_for_alias_indexing).save("frame-from-path", jpg_path)
+
+    kwargs = mock_sync_datalake_for_alias_indexing.create_asset_from_object.call_args.kwargs
+    assert hardware_image_size == image.size
+    assert hardware_file_size == jpg_path.stat().st_size
+    assert kwargs["kind"] == "image"
+    assert kwargs["media_type"] == "image/jpeg"
+    assert kwargs["obj"] == jpg_path.read_bytes()
+    assert kwargs["size_bytes"] == hardware_file_size
+
+
+@pytest.mark.parametrize(
+    ("pil_format", "media_type"),
+    [("PNG", "image/png"), ("JPEG", "image/jpeg")],
+)
+def test_data_vault_save_inline_bytes_size_matches_hardware_encoded_response_metadata(
+    mock_sync_datalake_for_alias_indexing,
+    pil_format,
+    media_type,
+):
+    """Inline captures and ``DataVault.save(bytes)`` measure the same encoded response bytes."""
+    created = Asset(
+        kind="image",
+        media_type=media_type,
+        storage_ref=StorageRef(mount="m", name="vault/frame", version="1"),
+        asset_id="asset_encoded_bytes",
+    )
+    mock_sync_datalake_for_alias_indexing.create_asset_from_object = Mock(return_value=created)
+
+    image = Image.new("RGB", (16, 12), color=(80, 120, 160))
+    buf = BytesIO()
+    image.save(buf, format=pil_format)
+    encoded = buf.getvalue()
+
+    DataVault(mock_sync_datalake_for_alias_indexing).save(
+        "frame-from-inline-bytes",
+        encoded,
+        kind="image",
+        media_type=media_type,
+    )
+
+    kwargs = mock_sync_datalake_for_alias_indexing.create_asset_from_object.call_args.kwargs
+    assert image_dimensions(image) == image.size
+    assert kwargs["kind"] == "image"
+    assert kwargs["media_type"] == media_type
+    assert kwargs["obj"] == encoded
+    assert kwargs["size_bytes"] == len(encoded)
+
+
 def test_data_vault_save_records_bytes_size(mock_sync_datalake_for_alias_indexing):
     created = Asset(
         kind="image",
@@ -3125,6 +3196,7 @@ def test_data_vault_save_omits_size_for_registry_serialized_payloads(
     kwargs = mock_sync_datalake_for_alias_indexing.create_asset_from_object.call_args.kwargs
     assert kwargs["obj"] is payload
     assert kwargs["size_bytes"] is None
+
 
 
 def test_data_vault_save_image_records_png_size(mock_sync_datalake_for_alias_indexing):

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -3198,7 +3198,6 @@ def test_data_vault_save_omits_size_for_registry_serialized_payloads(
     assert kwargs["size_bytes"] is None
 
 
-
 def test_data_vault_save_image_records_png_size(mock_sync_datalake_for_alias_indexing):
     created = Asset(
         kind="image",


### PR DESCRIPTION
## Summary

Adds tests that prove **hardware-reported `file_size_bytes`** matches what **DataVault** persists as `size_bytes` for the same encoded payload.

**Base branch:** [#486](https://github.com/Mindtrace/mindtrace/pull/486) (`feat/hardware/image-size-and-bytes-in-save-path`) — merge that PR first.

This PR contains **tests only** (no production code). It assumes the service-layer disk metadata approach from #486:

- Save-path metadata via `CameraManagerService._file_size_bytes` / `_image_size_on_disk`
- Save-path integration exercises `capture_image(save_path=...)` (not `SavedCaptureInfo` from the manager)

DataVault direct-payload sizing (#485) is already on `dev`; this PR validates end-to-end congruence with hardware capture responses.

## Tests added

### Unit (`tests/unit/mindtrace/datalake/test_data_vault.py`)

- `test_data_vault_save_path_size_matches_hardware_saved_file_metadata`
  - Writes a real JPEG with PIL; compares `CameraManagerService` disk helpers to `DataVault.save(Path)` `size_bytes`.
- `test_data_vault_save_inline_bytes_size_matches_hardware_encoded_response_metadata` (PNG + JPEG parametrize)
  - Saves encoded bytes with `DataVault.save(...)`; asserts `size_bytes == len(encoded_bytes)`.

### Integration (`tests/integration/mindtrace/datalake/test_data_vault_integration.py`)

Requires MongoDB at `mongodb://localhost:27018`.

- `test_hardware_save_path_jpeg_file_size_matches_datalake_payload_size`
- `test_hardware_save_path_png_file_size_matches_datalake_payload_size`
  - Mock Basler capture via `CameraManagerService.capture_image` + `save_path`; persist path with `AsyncDataVault.save`; assert Datalake `size_bytes` == `CaptureResult.file_size_bytes`.
- `test_hardware_inline_jpeg_file_size_matches_datalake_payload_size`
- `test_hardware_inline_default_png_file_size_matches_datalake_payload_size`
  - Inline service responses (JPEG / default PNG wire encoding); persist decoded bytes; assert sizes match.

## How to run

```bash
ds test: \
  tests/unit/mindtrace/datalake/test_data_vault.py::test_data_vault_save_path_size_matches_hardware_saved_file_metadata \
  tests/unit/mindtrace/datalake/test_data_vault.py::test_data_vault_save_inline_bytes_size_matches_hardware_encoded_response_metadata \
  tests/integration/mindtrace/datalake/test_data_vault_integration.py::test_hardware_save_path_jpeg_file_size_matches_datalake_payload_size \
  tests/integration/mindtrace/datalake/test_data_vault_integration.py::test_hardware_save_path_png_file_size_matches_datalake_payload_size \
  tests/integration/mindtrace/datalake/test_data_vault_integration.py::test_hardware_inline_jpeg_file_size_matches_datalake_payload_size \
  tests/integration/mindtrace/datalake/test_data_vault_integration.py::test_hardware_inline_default_png_file_size_matches_datalake_payload_size
```

## Test plan

- [ ] Unit tests above pass
- [ ] Integration tests above pass (MongoDB available)
- [ ] `ruff check` on changed test files