### PR TITLE
fix(datalake): add compound indexes for cursor pagination sorts

### DIFF
--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -40,6 +40,7 @@ from mindtrace.datalake.types import (
     AssetRetention,
     Collection,
     CollectionItem,
+    DatalakeDocument,
     DatasetImportSession,
     DatasetVersion,
     Datum,
@@ -97,6 +98,107 @@ def _default_store_save_workers() -> int:
     """Return a conservative bounded worker count for blocking store writes."""
 
     return min(32, max(4, (os.cpu_count() or 1) * 2))
+
+
+PaginationSortSpec = tuple[list[tuple[str, int]], list[str]]
+
+PAGINATION_RESOURCE_MODELS: dict[str, type[DatalakeDocument]] = {
+    "assets": Asset,
+    "collections": Collection,
+    "collection_items": CollectionItem,
+    "asset_retentions": AssetRetention,
+    "annotation_schemas": AnnotationSchema,
+    "annotation_sets": AnnotationSet,
+    "annotation_records": AnnotationRecord,
+    "datums": Datum,
+    "dataset_versions": DatasetVersion,
+}
+
+PAGINATION_SNAPSHOT_FIELDS: dict[str, str] = {
+    "assets": "created_at",
+    "collections": "created_at",
+    "collection_items": "added_at",
+    "asset_retentions": "created_at",
+    "annotation_schemas": "created_at",
+    "annotation_sets": "created_at",
+    "annotation_records": "created_at",
+    "datums": "created_at",
+    "dataset_versions": "created_at",
+}
+
+PAGINATION_SORT_SPECS: dict[str, dict[str, PaginationSortSpec]] = {
+    "assets": {
+        "created_desc": ([("created_at", -1), ("asset_id", -1)], ["created_at", "asset_id"]),
+        "created_asc": ([("created_at", 1), ("asset_id", 1)], ["created_at", "asset_id"]),
+    },
+    "collections": {
+        "created_desc": ([("created_at", -1), ("collection_id", -1)], ["created_at", "collection_id"]),
+        "created_asc": ([("created_at", 1), ("collection_id", 1)], ["created_at", "collection_id"]),
+    },
+    "collection_items": {
+        "created_desc": ([("added_at", -1), ("collection_item_id", -1)], ["added_at", "collection_item_id"]),
+        "created_asc": ([("added_at", 1), ("collection_item_id", 1)], ["added_at", "collection_item_id"]),
+    },
+    "asset_retentions": {
+        "created_desc": (
+            [("created_at", -1), ("asset_retention_id", -1)],
+            ["created_at", "asset_retention_id"],
+        ),
+        "created_asc": (
+            [("created_at", 1), ("asset_retention_id", 1)],
+            ["created_at", "asset_retention_id"],
+        ),
+    },
+    "annotation_schemas": {
+        "created_desc": (
+            [("created_at", -1), ("annotation_schema_id", -1)],
+            ["created_at", "annotation_schema_id"],
+        ),
+        "created_asc": (
+            [("created_at", 1), ("annotation_schema_id", 1)],
+            ["created_at", "annotation_schema_id"],
+        ),
+    },
+    "annotation_sets": {
+        "created_desc": (
+            [("created_at", -1), ("annotation_set_id", -1)],
+            ["created_at", "annotation_set_id"],
+        ),
+        "created_asc": (
+            [("created_at", 1), ("annotation_set_id", 1)],
+            ["created_at", "annotation_set_id"],
+        ),
+    },
+    "annotation_records": {
+        "created_desc": (
+            [("created_at", -1), ("annotation_id", -1)],
+            ["created_at", "annotation_id"],
+        ),
+        "subject_created_desc": (
+            [("subject.kind", 1), ("subject.id", 1), ("created_at", -1), ("annotation_id", -1)],
+            ["subject.kind", "subject.id", "created_at", "annotation_id"],
+        ),
+    },
+    "datums": {
+        "created_desc": ([("created_at", -1), ("datum_id", -1)], ["created_at", "datum_id"]),
+        "split_created_desc": (
+            [("split", 1), ("created_at", -1), ("datum_id", -1)],
+            ["split", "created_at", "datum_id"],
+        ),
+    },
+    "dataset_versions": {
+        "created_desc": (
+            [("created_at", -1), ("dataset_version_id", -1)],
+            ["created_at", "dataset_version_id"],
+        ),
+        "dataset_version_desc": (
+            [("dataset_name", 1), ("version", -1), ("dataset_version_id", -1)],
+            ["dataset_name", "version", "dataset_version_id"],
+        ),
+    },
+}
+
+assert set(PAGINATION_RESOURCE_MODELS) == set(PAGINATION_SORT_SPECS) == set(PAGINATION_SNAPSHOT_FIELDS)
 
 
 class AsyncDatalake(Mindtrace):
@@ -378,18 +480,7 @@ class AsyncDatalake(Mindtrace):
 
     @staticmethod
     def _snapshot_field_for(resource: str) -> str | None:
-        snapshot_fields = {
-            "assets": "created_at",
-            "collections": "created_at",
-            "collection_items": "added_at",
-            "asset_retentions": "created_at",
-            "annotation_schemas": "created_at",
-            "annotation_sets": "created_at",
-            "annotation_records": "created_at",
-            "datums": "created_at",
-            "dataset_versions": "created_at",
-        }
-        return snapshot_fields.get(resource)
+        return PAGINATION_SNAPSHOT_FIELDS.get(resource)
 
     @classmethod
     def _encode_snapshot_token(cls, *, resource: str, field: str, cutoff: Any) -> str:
@@ -463,81 +554,10 @@ class AsyncDatalake(Mindtrace):
         return {"$and": [base, extra]}
 
     @staticmethod
-    def _sort_specs_for(resource: str) -> dict[str, tuple[list[tuple[str, int]], list[str]]]:
-        specs: dict[str, dict[str, tuple[list[tuple[str, int]], list[str]]]] = {
-            "assets": {
-                "created_desc": ([("created_at", -1), ("asset_id", -1)], ["created_at", "asset_id"]),
-                "created_asc": ([("created_at", 1), ("asset_id", 1)], ["created_at", "asset_id"]),
-            },
-            "collections": {
-                "created_desc": ([("created_at", -1), ("collection_id", -1)], ["created_at", "collection_id"]),
-                "created_asc": ([("created_at", 1), ("collection_id", 1)], ["created_at", "collection_id"]),
-            },
-            "collection_items": {
-                "created_desc": ([("added_at", -1), ("collection_item_id", -1)], ["added_at", "collection_item_id"]),
-                "created_asc": ([("added_at", 1), ("collection_item_id", 1)], ["added_at", "collection_item_id"]),
-            },
-            "asset_retentions": {
-                "created_desc": (
-                    [("created_at", -1), ("asset_retention_id", -1)],
-                    ["created_at", "asset_retention_id"],
-                ),
-                "created_asc": (
-                    [("created_at", 1), ("asset_retention_id", 1)],
-                    ["created_at", "asset_retention_id"],
-                ),
-            },
-            "annotation_schemas": {
-                "created_desc": (
-                    [("created_at", -1), ("annotation_schema_id", -1)],
-                    ["created_at", "annotation_schema_id"],
-                ),
-                "created_asc": (
-                    [("created_at", 1), ("annotation_schema_id", 1)],
-                    ["created_at", "annotation_schema_id"],
-                ),
-            },
-            "annotation_sets": {
-                "created_desc": (
-                    [("created_at", -1), ("annotation_set_id", -1)],
-                    ["created_at", "annotation_set_id"],
-                ),
-                "created_asc": (
-                    [("created_at", 1), ("annotation_set_id", 1)],
-                    ["created_at", "annotation_set_id"],
-                ),
-            },
-            "annotation_records": {
-                "created_desc": (
-                    [("created_at", -1), ("annotation_id", -1)],
-                    ["created_at", "annotation_id"],
-                ),
-                "subject_created_desc": (
-                    [("subject.kind", 1), ("subject.id", 1), ("created_at", -1), ("annotation_id", -1)],
-                    ["subject.kind", "subject.id", "created_at", "annotation_id"],
-                ),
-            },
-            "datums": {
-                "created_desc": ([("created_at", -1), ("datum_id", -1)], ["created_at", "datum_id"]),
-                "split_created_desc": (
-                    [("split", 1), ("created_at", -1), ("datum_id", -1)],
-                    ["split", "created_at", "datum_id"],
-                ),
-            },
-            "dataset_versions": {
-                "created_desc": (
-                    [("created_at", -1), ("dataset_version_id", -1)],
-                    ["created_at", "dataset_version_id"],
-                ),
-                "dataset_version_desc": (
-                    [("dataset_name", 1), ("version", -1), ("dataset_version_id", -1)],
-                    ["dataset_name", "version", "dataset_version_id"],
-                ),
-            },
-        }
-        if resource not in specs:
+    def _sort_specs_for(resource: str) -> dict[str, PaginationSortSpec]:
+        if resource not in PAGINATION_SORT_SPECS:
             raise ValueError(f"Unsupported pagination resource: {resource}")
-        return specs[resource]
+        return PAGINATION_SORT_SPECS[resource]
 
     @classmethod
     def _resolve_sort_spec(cls, resource: str, sort: str) -> tuple[list[tuple[str, int]], list[str]]:

--- a/mindtrace/datalake/mindtrace/datalake/types.py
+++ b/mindtrace/datalake/mindtrace/datalake/types.py
@@ -363,7 +363,6 @@ class Asset(DatalakeDocument):
             "metadata.origin.asset_id",
             [("metadata.origin.asset_id", 1), ("metadata.origin.lake_id", 1)],
             [("created_at", -1), ("asset_id", -1)],
-            [("created_at", 1), ("asset_id", 1)],
         ]
 
 
@@ -459,7 +458,6 @@ class AnnotationSchema(DatalakeDocument):
             "task_type",
             IndexModel([("name", 1), ("version", 1)], unique=True),
             [("created_at", -1), ("annotation_schema_id", -1)],
-            [("created_at", 1), ("annotation_schema_id", 1)],
         ]
 
 
@@ -496,7 +494,6 @@ class AnnotationSet(DatalakeDocument):
             "status",
             "annotation_schema_id",
             [("created_at", -1), ("annotation_set_id", -1)],
-            [("created_at", 1), ("annotation_set_id", 1)],
         ]
 
 
@@ -521,7 +518,6 @@ class Collection(DatalakeDocument):
             "name",
             "status",
             [("created_at", -1), ("collection_id", -1)],
-            [("created_at", 1), ("collection_id", 1)],
         ]
 
 
@@ -550,7 +546,6 @@ class CollectionItem(DatalakeDocument):
             "status",
             [("collection_id", 1), ("asset_id", 1)],
             [("added_at", -1), ("collection_item_id", -1)],
-            [("added_at", 1), ("collection_item_id", 1)],
         ]
 
 
@@ -589,7 +584,6 @@ class AssetRetention(DatalakeDocument):
             "retention_policy",
             [("asset_id", 1), ("owner_type", 1), ("owner_id", 1)],
             [("created_at", -1), ("asset_retention_id", -1)],
-            [("created_at", 1), ("asset_retention_id", 1)],
         ]
 
 

--- a/mindtrace/datalake/mindtrace/datalake/types.py
+++ b/mindtrace/datalake/mindtrace/datalake/types.py
@@ -362,6 +362,8 @@ class Asset(DatalakeDocument):
             "subject.id",
             "metadata.origin.asset_id",
             [("metadata.origin.asset_id", 1), ("metadata.origin.lake_id", 1)],
+            [("created_at", -1), ("asset_id", -1)],
+            [("created_at", 1), ("asset_id", 1)],
         ]
 
 
@@ -420,6 +422,8 @@ class AnnotationRecord(DatalakeDocument):
             "source.name",
             "subject.kind",
             "subject.id",
+            [("created_at", -1), ("annotation_id", -1)],
+            [("subject.kind", 1), ("subject.id", 1), ("created_at", -1), ("annotation_id", -1)],
         ]
 
 
@@ -454,6 +458,8 @@ class AnnotationSchema(DatalakeDocument):
         indexes = [
             "task_type",
             IndexModel([("name", 1), ("version", 1)], unique=True),
+            [("created_at", -1), ("annotation_schema_id", -1)],
+            [("created_at", 1), ("annotation_schema_id", 1)],
         ]
 
 
@@ -484,7 +490,14 @@ class AnnotationSet(DatalakeDocument):
 
     class Settings:
         name = "datalake_annotation_sets"
-        indexes = ["purpose", "source_type", "status", "annotation_schema_id"]
+        indexes = [
+            "purpose",
+            "source_type",
+            "status",
+            "annotation_schema_id",
+            [("created_at", -1), ("annotation_set_id", -1)],
+            [("created_at", 1), ("annotation_set_id", 1)],
+        ]
 
 
 class Collection(DatalakeDocument):
@@ -504,7 +517,12 @@ class Collection(DatalakeDocument):
 
     class Settings:
         name = "datalake_collections"
-        indexes = ["name", "status"]
+        indexes = [
+            "name",
+            "status",
+            [("created_at", -1), ("collection_id", -1)],
+            [("created_at", 1), ("collection_id", 1)],
+        ]
 
 
 class CollectionItem(DatalakeDocument):
@@ -531,6 +549,8 @@ class CollectionItem(DatalakeDocument):
             "split",
             "status",
             [("collection_id", 1), ("asset_id", 1)],
+            [("added_at", -1), ("collection_item_id", -1)],
+            [("added_at", 1), ("collection_item_id", 1)],
         ]
 
 
@@ -568,6 +588,8 @@ class AssetRetention(DatalakeDocument):
             "owner_id",
             "retention_policy",
             [("asset_id", 1), ("owner_type", 1), ("owner_id", 1)],
+            [("created_at", -1), ("asset_retention_id", -1)],
+            [("created_at", 1), ("asset_retention_id", 1)],
         ]
 
 
@@ -587,7 +609,11 @@ class Datum(DatalakeDocument):
 
     class Settings:
         name = "datalake_datums"
-        indexes = ["split"]
+        indexes = [
+            "split",
+            [("created_at", -1), ("datum_id", -1)],
+            [("split", 1), ("created_at", -1), ("datum_id", -1)],
+        ]
 
 
 class DatasetVersion(DatalakeDocument):
@@ -608,7 +634,11 @@ class DatasetVersion(DatalakeDocument):
 
     class Settings:
         name = "datalake_dataset_versions"
-        indexes = [[("dataset_name", 1), ("version", 1)]]
+        indexes = [
+            [("dataset_name", 1), ("version", 1)],
+            [("created_at", -1), ("dataset_version_id", -1)],
+            [("dataset_name", 1), ("version", -1), ("dataset_version_id", -1)],
+        ]
 
 
 class ResolvedCollectionItem(BaseModel):

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -407,6 +407,15 @@ class TestAsyncDatalakeUnit:
                 return tuple(index_def.document["key"])
             raise TypeError(f"Unsupported index definition: {index_def!r}")
 
+        def reverse_index_keys(keys: tuple[tuple[str, int], ...]) -> tuple[tuple[str, int], ...]:
+            return tuple((field, -direction) for field, direction in keys)
+
+        def index_covers_sort(
+            declared: set[tuple[tuple[str, int], ...]],
+            sort_keys: tuple[tuple[str, int], ...],
+        ) -> bool:
+            return sort_keys in declared or reverse_index_keys(sort_keys) in declared
+
         resource_models = {
             "assets": Asset,
             "collections": Collection,
@@ -422,9 +431,9 @@ class TestAsyncDatalakeUnit:
             declared = {index_keys(index_def) for index_def in model.Settings.indexes}
             for sort_name, (sort_keys, _) in AsyncDatalake._sort_specs_for(resource).items():
                 key = tuple(sort_keys)
-                assert key in declared, (
-                    f"{model.__name__}.Settings.indexes is missing compound index {key!r} "
-                    f"required by {resource!r} sort {sort_name!r}"
+                assert index_covers_sort(declared, key), (
+                    f"{model.__name__}.Settings.indexes has no compound index that can serve sort "
+                    f"{key!r} (forward or exact-reverse scan) required by {resource!r} sort {sort_name!r}"
                 )
 
     @pytest.mark.parametrize(

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -393,6 +393,40 @@ class TestAsyncDatalakeUnit:
                 ),
             )
 
+    def test_pagination_sort_indexes_are_declared_on_models(self):
+        """Cursor pagination sort keys must have matching MongoDB compound indexes."""
+
+        def index_keys(index_def: object) -> tuple[tuple[str, int], ...]:
+            if isinstance(index_def, str):
+                return ((index_def, 1),)
+            if isinstance(index_def, list):
+                return tuple(index_def)
+            from pymongo import IndexModel
+
+            if isinstance(index_def, IndexModel):
+                return tuple(index_def.document["key"])
+            raise TypeError(f"Unsupported index definition: {index_def!r}")
+
+        resource_models = {
+            "assets": Asset,
+            "collections": Collection,
+            "collection_items": CollectionItem,
+            "asset_retentions": AssetRetention,
+            "annotation_schemas": AnnotationSchema,
+            "annotation_sets": AnnotationSet,
+            "annotation_records": AnnotationRecord,
+            "datums": Datum,
+            "dataset_versions": DatasetVersion,
+        }
+        for resource, model in resource_models.items():
+            declared = {index_keys(index_def) for index_def in model.Settings.indexes}
+            for sort_name, (sort_keys, _) in AsyncDatalake._sort_specs_for(resource).items():
+                key = tuple(sort_keys)
+                assert key in declared, (
+                    f"{model.__name__}.Settings.indexes is missing compound index {key!r} "
+                    f"required by {resource!r} sort {sort_name!r}"
+                )
+
     @pytest.mark.parametrize(
         ("filter_item", "item", "expected"),
         [

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -21,6 +21,8 @@ from mindtrace.core import utcnow
 from mindtrace.database.core.exceptions import DocumentNotFoundError, DuplicateInsertError
 from mindtrace.datalake import AsyncDatalake
 from mindtrace.datalake.async_datalake import (
+    PAGINATION_RESOURCE_MODELS,
+    PAGINATION_SORT_SPECS,
     AnnotationSchemaInUseError,
     AnnotationSchemaValidationError,
     DuplicateAnnotationSchemaError,
@@ -416,20 +418,9 @@ class TestAsyncDatalakeUnit:
         ) -> bool:
             return sort_keys in declared or reverse_index_keys(sort_keys) in declared
 
-        resource_models = {
-            "assets": Asset,
-            "collections": Collection,
-            "collection_items": CollectionItem,
-            "asset_retentions": AssetRetention,
-            "annotation_schemas": AnnotationSchema,
-            "annotation_sets": AnnotationSet,
-            "annotation_records": AnnotationRecord,
-            "datums": Datum,
-            "dataset_versions": DatasetVersion,
-        }
-        for resource, model in resource_models.items():
+        for resource, model in PAGINATION_RESOURCE_MODELS.items():
             declared = {index_keys(index_def) for index_def in model.Settings.indexes}
-            for sort_name, (sort_keys, _) in AsyncDatalake._sort_specs_for(resource).items():
+            for sort_name, (sort_keys, _) in PAGINATION_SORT_SPECS[resource].items():
                 key = tuple(sort_keys)
                 assert index_covers_sort(declared, key), (
                     f"{model.__name__}.Settings.indexes has no compound index that can serve sort "


### PR DESCRIPTION
## Summary
- Add MongoDB compound indexes on all datalake models that match `AsyncDatalake._sort_specs_for()` pagination keys (e.g. `(created_at, asset_id)` for assets).
- Prevents `QueryExceededMemoryLimitNoDiskUseAllowed` on large Atlas collections when listing with `created_desc` / `created_asc`.
- Add a regression test ensuring every pagination sort spec has a corresponding index declared on its model.

## Why
Remote-test datalake with ~60k assets returned 500s on `assets.list_page` with `created_desc` because MongoDB attempted an in-memory sort without indexes on the compound pagination keys. Small local databases masked the gap.

Indexes are created automatically on `AsyncDatalake.initialize()` via Beanie `init_beanie`.

## Test plan
- [x] `ds test: tests/unit/mindtrace/datalake/test_async_datalake.py::TestAsyncDatalakeUnit::test_pagination_sort_indexes_are_declared_on_models`
- [ ] `ds test: datalake --unit`
- [ ] Deploy to remote-test datalake and confirm `assets.list_page` with `created_desc` returns results


Made with [Cursor](https://cursor.com)