### PR TITLE
Less liveness logs

### DIFF
--- a/mindtrace/datalake/mindtrace/datalake/service.py
+++ b/mindtrace/datalake/mindtrace/datalake/service.py
@@ -489,7 +489,13 @@ class DatalakeService(Service):
         if live_service and initialize_on_startup:
             self.app.router.on_startup.append(self._startup_initialize)
 
-        self.add_endpoint("health", self.health, schema=DatalakeHealthSchema, as_tool=True)
+        self.add_endpoint(
+            "health",
+            self.health,
+            schema=DatalakeHealthSchema,
+            as_tool=True,
+            autolog_kwargs={"log_level": logging.DEBUG},
+        )
         self.add_endpoint("summary", self.summary, schema=DatalakeSummarySchema, as_tool=True)
         self.add_endpoint("mounts", self.mounts_info, schema=MountsSchema)
         self.add_endpoint("datalake.wipe", self.wipe_datalake, schema=DatalakeWipeSchema)

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/service.py
@@ -8,6 +8,7 @@ architecture with comprehensive MCP tool integration and typed client access.
 import asyncio
 import base64
 import io
+import logging
 import os
 import time
 from typing import Optional, Tuple
@@ -185,7 +186,14 @@ class CameraManagerService(Service):
     def _register_endpoints(self):
         """Register all service endpoints."""
         # Health check endpoint
-        self.add_endpoint("health", self.health_check, HealthSchema, methods=["GET"], as_tool=False)
+        self.add_endpoint(
+            "health",
+            self.health_check,
+            HealthSchema,
+            methods=["GET"],
+            as_tool=False,
+            autolog_kwargs={"log_level": logging.DEBUG},
+        )
 
         # Backend & Discovery
         self.add_endpoint(

--- a/mindtrace/hardware/mindtrace/hardware/services/plcs/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/plcs/service.py
@@ -5,6 +5,7 @@ This service wraps PLCManager functionality in a Service-based
 architecture with comprehensive MCP tool integration and typed client access.
 """
 
+import logging
 import time
 from typing import Optional
 
@@ -160,7 +161,14 @@ class PLCManagerService(Service):
         )
 
         # Health check endpoint (for container healthcheck - not an MCP tool)
-        self.add_endpoint("health", self.health_check, HealthSchema, methods=["GET"], as_tool=False)
+        self.add_endpoint(
+            "health",
+            self.health_check,
+            HealthSchema,
+            methods=["GET"],
+            as_tool=False,
+            autolog_kwargs={"log_level": logging.DEBUG},
+        )
 
     # Backend & Discovery Operations
     def discover_backends(self) -> BackendsResponse:

--- a/mindtrace/hardware/mindtrace/hardware/services/scanners_3d/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/scanners_3d/service.py
@@ -5,6 +5,7 @@ This service provides comprehensive REST API and MCP tools for managing
 3D scanners (Photoneo PhoXi, etc.) with multi-component capture capabilities.
 """
 
+import logging
 import time
 from typing import Dict
 
@@ -122,7 +123,14 @@ class Scanner3DService(Service):
         """Register all REST API endpoints using add_endpoint pattern."""
 
         # Health check endpoint
-        self.add_endpoint("health", self.health_check, HealthSchema, methods=["GET"], as_tool=False)
+        self.add_endpoint(
+            "health",
+            self.health_check,
+            HealthSchema,
+            methods=["GET"],
+            as_tool=False,
+            autolog_kwargs={"log_level": logging.DEBUG},
+        )
 
         # Backend & Discovery
         self.add_endpoint(

--- a/mindtrace/hardware/mindtrace/hardware/services/sensors/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/sensors/service.py
@@ -1,5 +1,6 @@
 """Sensor Manager Service providing MCP endpoints for sensor operations."""
 
+import logging
 import time
 from typing import Dict, Optional
 
@@ -61,7 +62,14 @@ class SensorManagerService(Service):
         """Register all sensor management endpoints as MCP tools."""
 
         # Health check endpoint
-        self.add_endpoint("health", self.health_check, HealthSchema, methods=["GET"], as_tool=False)
+        self.add_endpoint(
+            "health",
+            self.health_check,
+            HealthSchema,
+            methods=["GET"],
+            as_tool=False,
+            autolog_kwargs={"log_level": logging.DEBUG},
+        )
 
         # Lifecycle management endpoints
         self.add_endpoint(

--- a/mindtrace/hardware/mindtrace/hardware/services/stereo_cameras/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/stereo_cameras/service.py
@@ -6,6 +6,7 @@ Basler Stereo ace cameras with multi-component capture (intensity, disparity, de
 """
 
 import asyncio
+import logging
 import time
 from typing import Dict
 
@@ -121,7 +122,14 @@ class StereoCameraService(Service):
         """Register all REST API endpoints using add_endpoint pattern."""
 
         # Health check endpoint
-        self.add_endpoint("health", self.health_check, HealthSchema, methods=["GET"], as_tool=False)
+        self.add_endpoint(
+            "health",
+            self.health_check,
+            HealthSchema,
+            methods=["GET"],
+            as_tool=False,
+            autolog_kwargs={"log_level": logging.DEBUG},
+        )
 
         # Backend & Discovery
         self.add_endpoint(

--- a/mindtrace/services/mindtrace/services/core/middleware.py
+++ b/mindtrace/services/mindtrace/services/core/middleware.py
@@ -1,6 +1,7 @@
 import time
 import traceback
 import uuid
+from collections.abc import Iterable
 from typing import Any, Optional
 
 import structlog.contextvars
@@ -11,6 +12,22 @@ from starlette.responses import Response
 
 from mindtrace.core.logging.logger import get_logger
 from mindtrace.core.utils.system_metrics_collector import SystemMetricsCollector
+
+# Liveness/infra paths whose request envelopes are noise. Exact-match, so
+# prefixed routes (e.g. "/api/v1/inference/status") are unaffected.
+DEFAULT_FILTERED_PATHS = frozenset(
+    {
+        "/",
+        "/docs",
+        "/favicon.ico",
+        "/health",
+        "/healthz",
+        "/heartbeat",
+        "/openapi.json",
+        "/redoc",
+        "/status",
+    }
+)
 
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
@@ -36,6 +53,7 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         metrics_interval: Optional[int] = None,
         metrics_to_collect: Optional[list[str]] = ["cpu_percent", "memory_percent"],
         add_request_id_header: bool = True,
+        exclude_paths: Optional[Iterable[str]] = None,
         logger: Optional[Any] = None,
     ) -> None:
         super().__init__(app)
@@ -43,6 +61,7 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         self.log_metrics = log_metrics
         self.add_request_id_header = add_request_id_header
         self.service_name = service_name
+        self._filtered = DEFAULT_FILTERED_PATHS | frozenset(exclude_paths or ())
         self.metrics_collector = (
             SystemMetricsCollector(interval=metrics_interval, metrics_to_collect=metrics_to_collect)
             if log_metrics
@@ -50,10 +69,8 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         )
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        # Filter out common web requests that don't need detailed logging
-        filtered_paths = {"/favicon.ico", "/docs", "/openapi.json", "/redoc", "/"}
-        if request.url.path in filtered_paths:
-            # Just pass through without logging
+        if request.url.path in self._filtered:
+            # Pass through without logging (liveness/infra noise).
             return await call_next(request)
 
         # Clear any existing context variables

--- a/mindtrace/services/mindtrace/services/core/service.py
+++ b/mindtrace/services/mindtrace/services/core/service.py
@@ -144,12 +144,19 @@ class Service(Mindtrace):
             schema=EndpointsSchema,
             as_tool=True,
         )
-        self.add_endpoint(path="/status", func=self.status_func, schema=StatusSchema, as_tool=True)
+        self.add_endpoint(
+            path="/status",
+            func=self.status_func,
+            schema=StatusSchema,
+            as_tool=True,
+            autolog_kwargs={"log_level": logging.DEBUG},
+        )
         self.add_endpoint(
             path="/heartbeat",
             func=self.heartbeat_func,
             schema=HeartbeatSchema,
             as_tool=True,
+            autolog_kwargs={"log_level": logging.DEBUG},
         )
         self.add_endpoint(
             path="/server_id", func=named_lambda("server_id", lambda: {"server_id": self.id}), schema=ServerIDSchema

--- a/tests/unit/mindtrace/services/core/test_middleware.py
+++ b/tests/unit/mindtrace/services/core/test_middleware.py
@@ -43,6 +43,19 @@ class TestRequestLoggingMiddleware:
         client.get("/docs")
         mock_logger.info.assert_not_called()
 
+    @pytest.mark.parametrize("path", ["/health", "/healthz", "/status", "/heartbeat"])
+    def test_default_liveness_paths_skip_logging(self, mock_logger: MagicMock, path: str) -> None:
+        """Liveness/infra probes are skipped by default (no per-service config)."""
+        client = _client(mock_logger)
+        client.get(path)
+        mock_logger.info.assert_not_called()
+
+    def test_exclude_paths_skips_envelope_logging(self, mock_logger: MagicMock) -> None:
+        """Caller-supplied exclude_paths are skipped alongside the defaults."""
+        client = _client(mock_logger, exclude_paths={"/api/ping"})
+        client.get("/api/ping")
+        mock_logger.info.assert_not_called()
+
     def test_success_logs_started_and_completed(self, mock_logger: MagicMock) -> None:
         client = _client(mock_logger)
         client.get("/api/ping")


### PR DESCRIPTION
### Summary
- `RequestLoggingMiddleware`: add `exclude_paths` param to allow overriding the previously hardcoded list of exempt endpoints
- Default skip set gains `/health`, `/healthz`, `/status`, `/heartbeat`
- `/status`, `/heartbeat`, `/health` (camera and plc services) autolog → DEBUG
- Tests for defaults + `exclude_paths`

### Tests
`ds test`
Downstream services (and their container logs) should get improved signal-to-noise ratio in logs by leveraging `exclude_paths` for their specific `/api/v1/live`-like endpoints.