### PR TITLE
fix(database): migrate UnifiedMindtraceDocument to ConfigDict

### DIFF
--- a/mindtrace/database/mindtrace/database/backends/unified_odm.py
+++ b/mindtrace/database/mindtrace/database/backends/unified_odm.py
@@ -2,7 +2,7 @@ import asyncio
 from enum import Enum
 from typing import Dict, List, Optional, Type, TypeVar, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from redis_om.model.model import model_registry
 
 from mindtrace.database.backends.mindtrace_odm import InitMode, MindtraceODM
@@ -39,15 +39,11 @@ class UnifiedMindtraceDocument(BaseModel):
     # Optional ID field that can be used by both backends
     id: Optional[str] = Field(default=None, description="Document ID")
 
-    class Config:
-        """Common configuration for unified documents."""
-
-        # Allow arbitrary types for flexibility
-        arbitrary_types_allowed = True
-        # Use enum values for serialization
-        use_enum_values = True
-        # Validate assignment
-        validate_assignment = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_enum_values=True,
+        validate_assignment=True,
+    )
 
     class Meta:
         """


### PR DESCRIPTION
## Summary

- Migrate `UnifiedMindtraceDocument` from deprecated Pydantic v1 `class Config` to `model_config = ConfigDict(...)` in `unified_odm.py`
- Silences `PydanticDeprecatedSince20` warnings emitted on `from mindtrace.database import ...` (fixes #491)
- No behavior change: `arbitrary_types_allowed`, `use_enum_values`, and `validate_assignment` are preserved

## Why

Importing `mindtrace.database` currently raises a deprecation warning because `UnifiedMindtraceDocument` still uses Pydantic v1-style configuration. This shows up in consumer test suites and will break when Pydantic v3 removes class-based config support.

## Compatibility

Scanned `UnifiedMindtraceDocument` subclasses across mindtrace `dev` and downstream Chiron branches. No subclass overrides `class Config` or `model_config`, and no code introspects `self.Config`, `cls.Config`, or `UnifiedMindtraceDocument.Config`. All production subclasses use fields + `class Meta` only.

Subclasses that override Pydantic config via their own `class Config` or `model_config` remain functionally safe — child settings still override the base as before. The only difference is that such subclasses would continue to emit the deprecation warning themselves until they migrate to `ConfigDict`.

## Test plan

- [x] `uv run python -c "import warnings; warnings.filterwarnings('error', message='.*class-based .config.*'); from mindtrace.database import MindtraceDocument"`
- [x] `ruff check mindtrace/database/mindtrace/database/backends/unified_odm.py`
- [x] `ds test: tests/unit/mindtrace/database/` (601 passed)

Made with [Cursor](https://cursor.com)