### PR TITLE
[Jobs Update 1 of 3] Add backend-agnostic batch publishing to mindtrace.jobs

### DIFF
--- a/mindtrace/jobs/README.md
+++ b/mindtrace/jobs/README.md
@@ -72,6 +72,35 @@ orchestrator.publish("maths_operations", job)
 consumer.consume(num_messages=1)
 ```
 
+## Batch publishing
+
+Use `publish_batch()` when several jobs should be sent to the same queue with
+the same backend options:
+
+```python
+jobs = [
+    job_from_schema(schema, MathsInput(operation="add", a=1, b=2)),
+    job_from_schema(schema, MathsInput(operation="multiply", a=3, b=4)),
+]
+
+result = orchestrator.publish_batch("maths_operations", jobs)
+
+print(result.job_ids)
+print(result.successful_indices)
+print(result.failed_indices)
+print(result.unattempted_indices)
+```
+
+The complete input batch is validated before it reaches the backend. Batch
+publication itself is not atomic: if a backend fails while publishing an item,
+earlier messages may already be queued. `BatchPublishResult` preserves their
+job IDs, records the failed item, and identifies later items that were not
+attempted.
+
+RabbitMQ publishes a non-empty batch through one connection and channel. Local,
+Redis, and custom backends use the backend-neutral fallback unless they provide
+their own optimized `publish_batch()` implementation.
+
 In practice, the jobs package is built around four concepts:
 
 - a **schema** describing the job payload

--- a/mindtrace/jobs/README.md
+++ b/mindtrace/jobs/README.md
@@ -99,7 +99,10 @@ attempted.
 
 RabbitMQ publishes a non-empty batch through one connection and channel. Local,
 Redis, and custom backends use the backend-neutral fallback unless they provide
-their own optimized `publish_batch()` implementation.
+their own optimized `publish_batch()` implementation. RabbitMQ publisher confirms
+are not enabled, so returned job IDs represent calls that completed without a
+synchronous publish error rather than broker-confirmed acceptance. A later
+asynchronous broker rejection may not map precisely to the reported input index.
 
 In practice, the jobs package is built around four concepts:
 

--- a/mindtrace/jobs/mindtrace/jobs/__init__.py
+++ b/mindtrace/jobs/mindtrace/jobs/__init__.py
@@ -9,11 +9,13 @@ from mindtrace.jobs.rabbitmq.client import RabbitMQClient
 from mindtrace.jobs.rabbitmq.consumer_backend import RabbitMQConsumerBackend
 from mindtrace.jobs.redis.client import RedisClient
 from mindtrace.jobs.redis.consumer_backend import RedisConsumerBackend
+from mindtrace.jobs.types.batch import BatchPublishResult
 from mindtrace.jobs.types.job_specs import BackendType, ExecutionStatus, Job, JobSchema
 from mindtrace.jobs.utils.schemas import job_from_schema
 
 __all__ = [
     "BackendType",
+    "BatchPublishResult",
     "Consumer",
     "ExecutionStatus",
     "Job",

--- a/mindtrace/jobs/mindtrace/jobs/base/orchestrator_backend.py
+++ b/mindtrace/jobs/mindtrace/jobs/base/orchestrator_backend.py
@@ -57,7 +57,8 @@ class OrchestratorBackend(MindtraceABC):
 
         Backends may override this method with a more efficient implementation.
         Publishing stops after the first failure because earlier jobs may
-        already have been accepted by the backend.
+        already have been accepted by the backend. Backend errors that occur
+        before item publishing begins may be raised by an override.
         """
         result = BatchPublishResult.for_batch_size(len(messages))
         for index, message in enumerate(messages):

--- a/mindtrace/jobs/mindtrace/jobs/base/orchestrator_backend.py
+++ b/mindtrace/jobs/mindtrace/jobs/base/orchestrator_backend.py
@@ -1,10 +1,11 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 import pydantic
 
 from mindtrace.core import MindtraceABC
 from mindtrace.jobs.base.consumer_base import ConsumerBackendBase
+from mindtrace.jobs.types.batch import BatchPublishResult
 
 if TYPE_CHECKING:  # pragma: no cover
     from mindtrace.jobs.consumers.consumer import Consumer
@@ -45,6 +46,30 @@ class OrchestratorBackend(MindtraceABC):
             message: Pydantic model to publish
         """
         raise NotImplementedError
+
+    def publish_batch(
+        self,
+        queue_name: str,
+        messages: Sequence[pydantic.BaseModel],
+        **kwargs,
+    ) -> BatchPublishResult:
+        """Publish an ordered batch using the backend's single-message API.
+
+        Backends may override this method with a more efficient implementation.
+        Publishing stops after the first failure because earlier jobs may
+        already have been accepted by the backend.
+        """
+        result = BatchPublishResult.for_batch_size(len(messages))
+        for index, message in enumerate(messages):
+            try:
+                result.job_ids[index] = self.publish(queue_name, message, **kwargs)
+            except Exception as exc:
+                result.errors[index] = {
+                    "error": type(exc).__name__,
+                    "message": str(exc),
+                }
+                break
+        return result
 
     @abstractmethod
     def clean_queue(self, queue_name: str, **kwargs) -> dict[str, str]:

--- a/mindtrace/jobs/mindtrace/jobs/core/orchestrator.py
+++ b/mindtrace/jobs/mindtrace/jobs/core/orchestrator.py
@@ -85,6 +85,7 @@ class Orchestrator(Mindtrace):
 
         Raises:
             ValueError: If any job is invalid or requires an unregistered schema.
+            Exception: Backend setup errors raised before any item is attempted.
         """
         prepared_jobs = []
         for index, job in enumerate(jobs):

--- a/mindtrace/jobs/mindtrace/jobs/core/orchestrator.py
+++ b/mindtrace/jobs/mindtrace/jobs/core/orchestrator.py
@@ -44,7 +44,7 @@ class Orchestrator(Mindtrace):
             if schema is None:
                 raise ValueError(f"Schema '{queue_name}' not found.")
             return job_from_schema(schema["schema"], job)
-        raise ValueError(f"Invalid job type: {type(job)}, expected Job or TaskSchema.")
+        raise ValueError(f"Invalid job type: {type(job)}, expected Job or BaseModel.")
 
     def publish(self, queue_name: str, job: Job | BaseModel, **kwargs) -> str:
         """Send a job or task input model to the specified queue.

--- a/mindtrace/jobs/mindtrace/jobs/core/orchestrator.py
+++ b/mindtrace/jobs/mindtrace/jobs/core/orchestrator.py
@@ -1,11 +1,12 @@
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
 
 from pydantic import BaseModel
 
 from mindtrace.core import Mindtrace
 from mindtrace.jobs.base.orchestrator_backend import OrchestratorBackend
 from mindtrace.jobs.local.client import LocalClient
+from mindtrace.jobs.types.batch import BatchPublishResult
 from mindtrace.jobs.types.job_specs import Job, JobSchema
 from mindtrace.jobs.utils.schemas import job_from_schema
 
@@ -34,6 +35,17 @@ class Orchestrator(Mindtrace):
         self.backend = backend
         self._schema_mapping: Dict[str, Dict[str, Any]] = {}
 
+    def _prepare_job(self, queue_name: str, job: Job | BaseModel) -> Job:
+        """Validate and normalize a job before sending it to a backend."""
+        if isinstance(job, Job):
+            return job
+        if isinstance(job, BaseModel):
+            schema = self._schema_mapping.get(queue_name, None)
+            if schema is None:
+                raise ValueError(f"Schema '{queue_name}' not found.")
+            return job_from_schema(schema["schema"], job)
+        raise ValueError(f"Invalid job type: {type(job)}, expected Job or TaskSchema.")
+
     def publish(self, queue_name: str, job: Job | BaseModel, **kwargs) -> str:
         """Send a job or task input model to the specified queue.
 
@@ -49,17 +61,39 @@ class Orchestrator(Mindtrace):
         Raises:
             ValueError: If publishing a BaseModel to a queue that has not been registered.
         """
-        if isinstance(job, Job):
-            pass
-        elif isinstance(job, BaseModel):
-            schema = self._schema_mapping.get(queue_name, None)
-            if schema is None:
-                raise ValueError(f"Schema '{queue_name}' not found.")
-            job = job_from_schema(schema["schema"], job)
-        else:
-            raise ValueError(f"Invalid job type: {type(job)}, expected Job or TaskSchema.")
+        return self.backend.publish(queue_name, self._prepare_job(queue_name, job), **kwargs)
 
-        return self.backend.publish(queue_name, job, **kwargs)
+    def publish_batch(
+        self,
+        queue_name: str,
+        jobs: Sequence[Job | BaseModel],
+        **kwargs,
+    ) -> BatchPublishResult:
+        """Send an ordered batch of jobs to the specified queue.
+
+        The complete batch is validated and normalized before the backend is
+        called, preventing a validation error from causing a partially
+        published batch.
+
+        Args:
+            queue_name: Name of the target queue.
+            jobs: Ordered jobs or task input models to publish.
+            **kwargs: Additional parameters passed to the backend.
+
+        Returns:
+            Ordered publication results, including partial-failure details.
+
+        Raises:
+            ValueError: If any job is invalid or requires an unregistered schema.
+        """
+        prepared_jobs = []
+        for index, job in enumerate(jobs):
+            try:
+                prepared_jobs.append(self._prepare_job(queue_name, job))
+            except ValueError as exc:
+                raise ValueError(f"Invalid job at index {index}: {exc}") from exc
+
+        return self.backend.publish_batch(queue_name, prepared_jobs, **kwargs)
 
     def clean_queue(self, queue_name: str, **kwargs) -> None:
         """Clear all messages from specified queue.

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
@@ -322,7 +322,8 @@ class RabbitMQClient(OrchestratorBackend):
         confirms are not enabled, so a returned job ID means ``basic_publish``
         completed without a synchronous error, not that the broker confirmed
         acceptance. Asynchronous broker rejection may surface later and cannot be
-        attributed precisely to an input index.
+        attributed precisely to an input index. Connection and channel setup
+        errors are raised before any item is attempted.
         """
         result = BatchPublishResult.for_batch_size(len(messages))
         if not messages:
@@ -333,24 +334,17 @@ class RabbitMQClient(OrchestratorBackend):
         self.logger.debug(
             f"Publishing RabbitMQ batch of {len(messages)} messages to exchange: {exchange}, routing_key: {routing_key}"
         )
-        try:
-            with self._batch_channel() as channel:
-                for index, message in enumerate(messages):
-                    try:
-                        result.job_ids[index] = self._publish_on_channel(channel, queue_name, message, **kwargs)
-                    except Exception as exc:
-                        self.logger.error(f"Failed to publish RabbitMQ batch item {index}: {exc}")
-                        result.errors[index] = {
-                            "error": type(exc).__name__,
-                            "message": str(exc),
-                        }
-                        break
-        except Exception as exc:
-            self.logger.error(f"Failed to initialize RabbitMQ batch publisher: {exc}")
-            result.setup_error = {
-                "error": type(exc).__name__,
-                "message": str(exc),
-            }
+        with self._batch_channel() as channel:
+            for index, message in enumerate(messages):
+                try:
+                    result.job_ids[index] = self._publish_on_channel(channel, queue_name, message, **kwargs)
+                except Exception as exc:
+                    self.logger.error(f"Failed to publish RabbitMQ batch item {index}: {exc}")
+                    result.errors[index] = {
+                        "error": type(exc).__name__,
+                        "message": str(exc),
+                    }
+                    break
 
         return result
 

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
@@ -293,7 +293,7 @@ class RabbitMQClient(OrchestratorBackend):
         channel = self.create_connection()
         exchange = kwargs.get("exchange", "default")
         routing_key = kwargs.get("routing_key", queue_name)
-        self.logger.info(f"exchange: {exchange}, routing_key: {routing_key}")
+        self.logger.debug(f"exchange: {exchange}, routing_key: {routing_key}")
         try:
             return self._publish_on_channel(channel, queue_name, message, **kwargs)
         except pika.exceptions.UnroutableError as e:

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
@@ -324,17 +324,24 @@ class RabbitMQClient(OrchestratorBackend):
         if not messages:
             return result
 
-        with self._batch_channel() as channel:
-            for index, message in enumerate(messages):
-                try:
-                    result.job_ids[index] = self._publish_on_channel(channel, queue_name, message, **kwargs)
-                except Exception as exc:
-                    self.logger.error(f"Failed to publish RabbitMQ batch item {index}: {exc}")
-                    result.errors[index] = {
-                        "error": type(exc).__name__,
-                        "message": str(exc),
-                    }
-                    break
+        try:
+            with self._batch_channel() as channel:
+                for index, message in enumerate(messages):
+                    try:
+                        result.job_ids[index] = self._publish_on_channel(channel, queue_name, message, **kwargs)
+                    except Exception as exc:
+                        self.logger.error(f"Failed to publish RabbitMQ batch item {index}: {exc}")
+                        result.errors[index] = {
+                            "error": type(exc).__name__,
+                            "message": str(exc),
+                        }
+                        break
+        except Exception as exc:
+            self.logger.error(f"Failed to initialize RabbitMQ batch publisher: {exc}")
+            result.setup_error = {
+                "error": type(exc).__name__,
+                "message": str(exc),
+            }
 
         return result
 

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
@@ -317,8 +317,12 @@ class RabbitMQClient(OrchestratorBackend):
     ) -> BatchPublishResult:
         """Publish a batch using one RabbitMQ connection and channel.
 
-        The operation is not atomic. Publishing stops after the first failure,
-        preserving job IDs for the successfully published prefix.
+        The operation is not atomic. Publishing stops after the first synchronous
+        publish error and preserves job IDs returned before that error. Publisher
+        confirms are not enabled, so a returned job ID means ``basic_publish``
+        completed without a synchronous error, not that the broker confirmed
+        acceptance. Asynchronous broker rejection may surface later and cannot be
+        attributed precisely to an input index.
         """
         result = BatchPublishResult.for_batch_size(len(messages))
         if not messages:

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
@@ -1,5 +1,7 @@
 import json
 import uuid
+from contextlib import contextmanager
+from typing import Iterator, Sequence
 
 import pika
 import pika.exceptions
@@ -11,6 +13,7 @@ from mindtrace.jobs.base.orchestrator_backend import OrchestratorBackend
 from mindtrace.jobs.consumers.consumer import Consumer
 from mindtrace.jobs.rabbitmq.connection import RabbitMQConnection
 from mindtrace.jobs.rabbitmq.consumer_backend import RabbitMQConsumerBackend
+from mindtrace.jobs.types.batch import BatchPublishResult
 
 
 class RabbitMQClient(OrchestratorBackend):
@@ -223,6 +226,59 @@ class RabbitMQClient(OrchestratorBackend):
             self.logger.error(f"Unexpected error: {str(e)}")
             return {"status": "error", "message": f"Unexpected error: {str(e)}"}
 
+    def _publish_on_channel(self, channel, queue_name: str, message: pydantic.BaseModel, **kwargs) -> str:
+        """Publish one message on an existing channel."""
+        job_id = str(uuid.uuid1())
+        exchange = kwargs.get("exchange", "default")
+        routing_key = kwargs.get("routing_key", queue_name)
+        delivery_mode = kwargs.get("delivery_mode", DeliveryMode.Persistent)
+        mandatory = kwargs.get("mandatory", True)
+        priority = kwargs.get("priority", 0)
+        self.logger.info(f"exchange: {exchange}, routing_key: {routing_key}")
+
+        message_dict = message.model_dump()
+        channel.basic_publish(
+            exchange=exchange,
+            routing_key=routing_key,
+            body=json.dumps(message_dict).encode("utf-8"),
+            properties=BasicProperties(
+                content_type="application/json",
+                headers={"job_id": job_id, "routing_key": routing_key},
+                delivery_mode=delivery_mode,
+                priority=priority,
+            ),
+            mandatory=mandatory,
+        )
+        self.logger.debug(
+            f"RabbitMQClient sent message (job_id: {job_id}) with routing key: {routing_key} to exchange: {exchange}"
+        )
+        return job_id
+
+    @contextmanager
+    def _batch_channel(self) -> Iterator:
+        """Open one owned RabbitMQ connection and channel for a batch."""
+        connection = RabbitMQConnection(
+            host=self._host,
+            port=self._port,
+            username=self._username,
+            password=self._password,
+        )
+        channel = None
+        try:
+            connection.connect()
+            channel = connection.get_channel()
+            yield channel
+        finally:
+            if channel is not None and getattr(channel, "is_open", False):
+                try:
+                    channel.close()
+                except Exception as exc:
+                    self.logger.warning(f"Failed to close RabbitMQ batch channel: {exc}")
+            try:
+                connection.close()
+            except Exception as exc:
+                self.logger.warning(f"Failed to close RabbitMQ batch connection: {exc}")
+
     def publish(self, queue_name: str, message: pydantic.BaseModel, **kwargs):
         """Publish a message to the specified exchange using RabbitMQ.
         Args:
@@ -237,34 +293,9 @@ class RabbitMQClient(OrchestratorBackend):
             str: The generated job ID for the message.
         """
         channel = self.create_connection()
-        job_id = str(uuid.uuid1())
         exchange = kwargs.get("exchange", "default")
-        routing_key = kwargs.get("routing_key", queue_name)
-        # durable = kwargs.get("durable", True)
-        delivery_mode = kwargs.get("delivery_mode", DeliveryMode.Persistent)
-        mandatory = kwargs.get("mandatory", True)
-        priority = kwargs.get("priority", 0)
-        self.logger.info(f"exchange: {exchange}, routing_key: {routing_key}")
         try:
-            message_dict = message.model_dump()
-            channel.basic_publish(
-                exchange=exchange,
-                routing_key=routing_key,
-                body=json.dumps(message_dict).encode("utf-8"),
-                properties=BasicProperties(
-                    content_type="application/json",
-                    headers={"job_id": job_id, "routing_key": routing_key},
-                    delivery_mode=delivery_mode,
-                    priority=priority,
-                ),
-                mandatory=mandatory,
-            )
-            self.logger.debug(
-                f"RabbitMQClient sent message (job_id: {job_id}) "
-                f"with routing key: {routing_key} "
-                f"to exchange: {exchange}"
-            )
-            return job_id
+            return self._publish_on_channel(channel, queue_name, message, **kwargs)
         except pika.exceptions.UnroutableError as e:
             self.logger.error("Unroutable Message error: %s \n ", e)
             raise
@@ -277,6 +308,35 @@ class RabbitMQClient(OrchestratorBackend):
         except Exception as e:
             self.logger.error(f"Unexpected error in publish: {e}")
             raise e
+
+    def publish_batch(
+        self,
+        queue_name: str,
+        messages: Sequence[pydantic.BaseModel],
+        **kwargs,
+    ) -> BatchPublishResult:
+        """Publish a batch using one RabbitMQ connection and channel.
+
+        The operation is not atomic. Publishing stops after the first failure,
+        preserving job IDs for the successfully published prefix.
+        """
+        result = BatchPublishResult.for_batch_size(len(messages))
+        if not messages:
+            return result
+
+        with self._batch_channel() as channel:
+            for index, message in enumerate(messages):
+                try:
+                    result.job_ids[index] = self._publish_on_channel(channel, queue_name, message, **kwargs)
+                except Exception as exc:
+                    self.logger.error(f"Failed to publish RabbitMQ batch item {index}: {exc}")
+                    result.errors[index] = {
+                        "error": type(exc).__name__,
+                        "message": str(exc),
+                    }
+                    break
+
+        return result
 
     def clean_queue(self, queue_name: str, **kwargs) -> dict[str, str]:
         """Remove all messages from a queue."""

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
@@ -330,7 +330,7 @@ class RabbitMQClient(OrchestratorBackend):
 
         exchange = kwargs.get("exchange", "default")
         routing_key = kwargs.get("routing_key", queue_name)
-        self.logger.info(
+        self.logger.debug(
             f"Publishing RabbitMQ batch of {len(messages)} messages to exchange: {exchange}, routing_key: {routing_key}"
         )
         try:

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/client.py
@@ -234,8 +234,6 @@ class RabbitMQClient(OrchestratorBackend):
         delivery_mode = kwargs.get("delivery_mode", DeliveryMode.Persistent)
         mandatory = kwargs.get("mandatory", True)
         priority = kwargs.get("priority", 0)
-        self.logger.info(f"exchange: {exchange}, routing_key: {routing_key}")
-
         message_dict = message.model_dump()
         channel.basic_publish(
             exchange=exchange,
@@ -294,6 +292,8 @@ class RabbitMQClient(OrchestratorBackend):
         """
         channel = self.create_connection()
         exchange = kwargs.get("exchange", "default")
+        routing_key = kwargs.get("routing_key", queue_name)
+        self.logger.info(f"exchange: {exchange}, routing_key: {routing_key}")
         try:
             return self._publish_on_channel(channel, queue_name, message, **kwargs)
         except pika.exceptions.UnroutableError as e:
@@ -324,6 +324,11 @@ class RabbitMQClient(OrchestratorBackend):
         if not messages:
             return result
 
+        exchange = kwargs.get("exchange", "default")
+        routing_key = kwargs.get("routing_key", queue_name)
+        self.logger.info(
+            f"Publishing RabbitMQ batch of {len(messages)} messages to exchange: {exchange}, routing_key: {routing_key}"
+        )
         try:
             with self._batch_channel() as channel:
                 for index, message in enumerate(messages):

--- a/mindtrace/jobs/mindtrace/jobs/types/__init__.py
+++ b/mindtrace/jobs/mindtrace/jobs/types/__init__.py
@@ -1,1 +1,3 @@
+from mindtrace.jobs.types.batch import BatchPublishResult
 
+__all__ = ["BatchPublishResult"]

--- a/mindtrace/jobs/mindtrace/jobs/types/batch.py
+++ b/mindtrace/jobs/mindtrace/jobs/types/batch.py
@@ -8,11 +8,13 @@ class BatchPublishResult:
     ``job_ids`` has one entry per input job. Failed and unattempted jobs have
     a value of ``None``. ``errors`` contains details for jobs whose publish was
     attempted and failed; later jobs left unattempted after a failure are not
-    included in ``errors``.
+    included in ``errors``. ``setup_error`` reports a batch-level failure that
+    occurred before any item was attempted.
     """
 
     job_ids: list[str | None]
     errors: dict[int, dict[str, str]] = field(default_factory=dict)
+    setup_error: dict[str, str] | None = None
 
     @classmethod
     def for_batch_size(cls, size: int) -> "BatchPublishResult":
@@ -40,7 +42,7 @@ class BatchPublishResult:
 
     @property
     def failure_count(self) -> int:
-        return len(self.failed_indices)
+        return len(self.failed_indices) + (1 if self.setup_error is not None else 0)
 
     @property
     def unattempted_count(self) -> int:

--- a/mindtrace/jobs/mindtrace/jobs/types/batch.py
+++ b/mindtrace/jobs/mindtrace/jobs/types/batch.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class BatchPublishResult:
+    """Outcome of publishing an ordered batch of jobs.
+
+    ``job_ids`` has one entry per input job. Failed and unattempted jobs have
+    a value of ``None``. ``errors`` contains details for jobs whose publish was
+    attempted and failed; later jobs left unattempted after a failure are not
+    included in ``errors``.
+    """
+
+    job_ids: list[str | None]
+    errors: dict[int, dict[str, str]] = field(default_factory=dict)
+
+    @classmethod
+    def for_batch_size(cls, size: int) -> "BatchPublishResult":
+        """Create an empty result for a batch containing ``size`` jobs."""
+        return cls(job_ids=[None] * size)
+
+    @property
+    def successful_indices(self) -> list[int]:
+        """Indices of jobs published successfully."""
+        return [index for index, job_id in enumerate(self.job_ids) if job_id is not None]
+
+    @property
+    def failed_indices(self) -> list[int]:
+        """Indices of jobs whose publish was attempted and failed."""
+        return list(self.errors)
+
+    @property
+    def unattempted_indices(self) -> list[int]:
+        """Indices not attempted because an earlier publish failed."""
+        return [
+            index
+            for index, job_id in enumerate(self.job_ids)
+            if job_id is None and index not in self.errors
+        ]
+
+    @property
+    def success_count(self) -> int:
+        return len(self.successful_indices)
+
+    @property
+    def failure_count(self) -> int:
+        return len(self.failed_indices)
+
+    @property
+    def unattempted_count(self) -> int:
+        return len(self.unattempted_indices)
+
+    @property
+    def all_succeeded(self) -> bool:
+        return self.failure_count == 0 and self.unattempted_count == 0
+

--- a/mindtrace/jobs/mindtrace/jobs/types/batch.py
+++ b/mindtrace/jobs/mindtrace/jobs/types/batch.py
@@ -8,13 +8,11 @@ class BatchPublishResult:
     ``job_ids`` has one entry per input job. Failed and unattempted jobs have
     a value of ``None``. ``errors`` contains details for jobs whose publish was
     attempted and failed; later jobs left unattempted after a failure are not
-    included in ``errors``. ``setup_error`` reports a batch-level failure that
-    occurred before any item was attempted.
+    included in ``errors``.
     """
 
     job_ids: list[str | None]
     errors: dict[int, dict[str, str]] = field(default_factory=dict)
-    setup_error: dict[str, str] | None = None
 
     @classmethod
     def for_batch_size(cls, size: int) -> "BatchPublishResult":
@@ -42,7 +40,7 @@ class BatchPublishResult:
 
     @property
     def failure_count(self) -> int:
-        return len(self.failed_indices) + (1 if self.setup_error is not None else 0)
+        return len(self.failed_indices)
 
     @property
     def unattempted_count(self) -> int:

--- a/mindtrace/jobs/mindtrace/jobs/types/batch.py
+++ b/mindtrace/jobs/mindtrace/jobs/types/batch.py
@@ -32,11 +32,7 @@ class BatchPublishResult:
     @property
     def unattempted_indices(self) -> list[int]:
         """Indices not attempted because an earlier publish failed."""
-        return [
-            index
-            for index, job_id in enumerate(self.job_ids)
-            if job_id is None and index not in self.errors
-        ]
+        return [index for index, job_id in enumerate(self.job_ids) if job_id is None and index not in self.errors]
 
     @property
     def success_count(self) -> int:
@@ -53,4 +49,3 @@ class BatchPublishResult:
     @property
     def all_succeeded(self) -> bool:
         return self.failure_count == 0 and self.unattempted_count == 0
-

--- a/tests/integration/mindtrace/jobs/test_publish_batch_integration.py
+++ b/tests/integration/mindtrace/jobs/test_publish_batch_integration.py
@@ -1,0 +1,153 @@
+from uuid import uuid4
+
+import pytest
+
+from mindtrace.jobs import Orchestrator
+from mindtrace.jobs.rabbitmq.client import RabbitMQClient
+from mindtrace.jobs.redis.client import RedisClient
+from mindtrace.jobs.types.job_specs import JobSchema
+
+from .conftest import SampleConsumer, SampleJobInput, SampleJobOutput, create_test_job
+
+
+def _queue_name(backend: str) -> str:
+    return f"publish_batch_{backend}_{uuid4().hex}"
+
+
+def _assert_consumed_names(consumer: SampleConsumer, expected_names: list[str]) -> None:
+    assert [job["name"] for job in consumer.processed_jobs] == expected_names
+
+
+@pytest.mark.rabbitmq
+def test_rabbitmq_publish_batch_is_consumable_in_order():
+    client = RabbitMQClient(host="localhost", port=5673, username="user", password="password")
+    orchestrator = Orchestrator(backend=client)
+    queue_name = _queue_name("rabbitmq")
+    orchestrator.register(JobSchema(name=queue_name, input_schema=SampleJobInput, output_schema=SampleJobOutput))
+    consumer = SampleConsumer(queue_name)
+
+    try:
+        jobs = [create_test_job(f"rabbitmq_batch_{index}", queue_name) for index in range(12)]
+        result = orchestrator.publish_batch(queue_name, jobs)
+
+        assert result.all_succeeded is True
+        assert result.successful_indices == list(range(12))
+        assert len(set(result.job_ids)) == 12
+        assert orchestrator.count_queue_messages(queue_name) == 12
+
+        consumer.connect_to_orchestrator(orchestrator, queue_name)
+        consumer.consume(num_messages=12)
+
+        _assert_consumed_names(consumer, [f"rabbitmq_batch_{index}" for index in range(12)])
+        assert orchestrator.count_queue_messages(queue_name) == 0
+    finally:
+        if consumer.consumer_backend is not None:
+            consumer.consumer_backend.connection.close()
+        client.delete_queue(queue_name)
+
+
+@pytest.mark.rabbitmq
+def test_rabbitmq_publish_batch_repeated_and_empty_batches():
+    client = RabbitMQClient(host="localhost", port=5673, username="user", password="password")
+    orchestrator = Orchestrator(backend=client)
+    queue_name = _queue_name("rabbitmq_lifecycle")
+    orchestrator.register(JobSchema(name=queue_name, input_schema=SampleJobInput, output_schema=SampleJobOutput))
+    consumer = SampleConsumer(queue_name)
+
+    try:
+        first = orchestrator.publish_batch(
+            queue_name, [create_test_job(f"first_{index}", queue_name) for index in range(3)]
+        )
+        empty = orchestrator.publish_batch(queue_name, [])
+        second = orchestrator.publish_batch(
+            queue_name, [create_test_job(f"second_{index}", queue_name) for index in range(3)]
+        )
+
+        assert first.all_succeeded is True
+        assert empty.all_succeeded is True
+        assert empty.job_ids == []
+        assert second.all_succeeded is True
+        assert orchestrator.count_queue_messages(queue_name) == 6
+
+        consumer.connect_to_orchestrator(orchestrator, queue_name)
+        consumer.consume(num_messages=6)
+        _assert_consumed_names(
+            consumer,
+            ["first_0", "first_1", "first_2", "second_0", "second_1", "second_2"],
+        )
+    finally:
+        if consumer.consumer_backend is not None:
+            consumer.consumer_backend.connection.close()
+        client.delete_queue(queue_name)
+
+
+@pytest.mark.redis
+def test_redis_publish_batch_fallback_is_consumable_in_order():
+    client = RedisClient(host="localhost", port=6380, db=0)
+    orchestrator = Orchestrator(backend=client)
+    queue_name = _queue_name("redis")
+    orchestrator.register(JobSchema(name=queue_name, input_schema=SampleJobInput, output_schema=SampleJobOutput))
+    consumer = SampleConsumer(queue_name)
+
+    try:
+        jobs = [create_test_job(f"redis_batch_{index}", queue_name) for index in range(8)]
+        result = orchestrator.publish_batch(queue_name, jobs)
+
+        assert result.all_succeeded is True
+        assert result.successful_indices == list(range(8))
+        assert len(set(result.job_ids)) == 8
+        assert orchestrator.count_queue_messages(queue_name) == 8
+
+        consumer.connect_to_orchestrator(orchestrator, queue_name)
+        consumer.consume(num_messages=8)
+
+        _assert_consumed_names(consumer, [f"redis_batch_{index}" for index in range(8)])
+        assert orchestrator.count_queue_messages(queue_name) == 0
+    finally:
+        if consumer.consumer_backend is not None:
+            consumer.consumer_backend.close()
+        client.delete_queue(queue_name)
+        client.close()
+
+
+@pytest.mark.parametrize(
+    ("backend_name", "client"),
+    [
+        pytest.param(
+            "rabbitmq",
+            lambda: RabbitMQClient(host="localhost", port=5673, username="user", password="password"),
+            marks=pytest.mark.rabbitmq,
+        ),
+        pytest.param(
+            "redis",
+            lambda: RedisClient(host="localhost", port=6380, db=0),
+            marks=pytest.mark.redis,
+        ),
+    ],
+)
+def test_publish_batch_converts_registered_inputs_end_to_end(backend_name, client):
+    backend = client()
+    orchestrator = Orchestrator(backend=backend)
+    queue_name = _queue_name(f"{backend_name}_models")
+    orchestrator.register(JobSchema(name=queue_name, input_schema=SampleJobInput, output_schema=SampleJobOutput))
+    consumer = SampleConsumer(queue_name)
+
+    try:
+        inputs = [SampleJobInput(data=f"data_{index}", param1=f"param_{index}") for index in range(4)]
+        result = orchestrator.publish_batch(queue_name, inputs)
+
+        assert result.all_succeeded is True
+        consumer.connect_to_orchestrator(orchestrator, queue_name)
+        consumer.consume(num_messages=4)
+
+        assert [job["payload"]["data"] for job in consumer.processed_jobs] == [f"data_{index}" for index in range(4)]
+        assert [job["payload"]["param1"] for job in consumer.processed_jobs] == [f"param_{index}" for index in range(4)]
+    finally:
+        if consumer.consumer_backend is not None:
+            if backend_name == "rabbitmq":
+                consumer.consumer_backend.connection.close()
+            else:
+                consumer.consumer_backend.close()
+        backend.delete_queue(queue_name)
+        if backend_name == "redis":
+            backend.close()

--- a/tests/unit/mindtrace/jobs/base/test_orchestrator_backend.py
+++ b/tests/unit/mindtrace/jobs/base/test_orchestrator_backend.py
@@ -48,6 +48,49 @@ class TestOrchestratorBackend:
         assert result["queue"] == dlq_name
         assert orchestrator.count_queue_messages(dlq_name) == 1
 
+    def test_publish_batch_default_uses_publish_and_preserves_order(self, mock_orchestrator, test_message):
+        orchestrator = mock_orchestrator()
+        messages = [test_message(data="first"), test_message(data="second")]
+
+        result = orchestrator.publish_batch("test-queue", messages)
+
+        assert result.job_ids == ["message_id", "message_id"]
+        assert result.successful_indices == [0, 1]
+        assert result.all_succeeded is True
+        assert orchestrator.queues["test-queue"] == messages
+
+    def test_publish_batch_default_stops_after_failure(self, mock_orchestrator, test_message, monkeypatch):
+        orchestrator = mock_orchestrator()
+        messages = [test_message(data="first"), test_message(data="second"), test_message(data="third")]
+        original_publish = orchestrator.publish
+        calls = 0
+
+        def fail_second(queue_name, message, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise RuntimeError("publish failed")
+            return original_publish(queue_name, message, **kwargs)
+
+        monkeypatch.setattr(orchestrator, "publish", fail_second)
+
+        result = orchestrator.publish_batch("test-queue", messages, priority=4)
+
+        assert result.job_ids == ["message_id", None, None]
+        assert result.failed_indices == [1]
+        assert result.unattempted_indices == [2]
+        assert result.errors[1] == {"error": "RuntimeError", "message": "publish failed"}
+        assert calls == 2
+
+    def test_publish_batch_default_does_nothing_for_empty_batch(self, mock_orchestrator):
+        orchestrator = mock_orchestrator()
+
+        result = orchestrator.publish_batch("test-queue", [])
+
+        assert result.job_ids == []
+        assert result.all_succeeded is True
+        assert "test-queue" not in orchestrator.queues
+
     def test_abstract_methods(self, mock_consumer_frontend, test_message):
         """Test that abstract methods raise NotImplementedError."""
 

--- a/tests/unit/mindtrace/jobs/core/test_orchestrator.py
+++ b/tests/unit/mindtrace/jobs/core/test_orchestrator.py
@@ -152,7 +152,7 @@ class TestOrchestratorPublish:
         """Test publishing an invalid job type."""
         invalid_job = {"invalid": "job"}
 
-        with pytest.raises(ValueError, match="Invalid job type: <class 'dict'>, expected Job or TaskSchema."):
+        with pytest.raises(ValueError, match="Invalid job type: <class 'dict'>, expected Job or BaseModel."):
             orchestrator.publish("test-queue", invalid_job)
 
     def test_publish_backend_error(self, orchestrator, sample_job, mock_backend):

--- a/tests/unit/mindtrace/jobs/core/test_orchestrator.py
+++ b/tests/unit/mindtrace/jobs/core/test_orchestrator.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from mindtrace.core import TaskSchema, utcnow_iso
 from mindtrace.jobs.core.orchestrator import Orchestrator
 from mindtrace.jobs.local.client import LocalClient
+from mindtrace.jobs.types.batch import BatchPublishResult
 from mindtrace.jobs.types.job_specs import ExecutionStatus, Job, JobSchema
 
 
@@ -45,6 +46,7 @@ def mock_backend():
     """Provide a mock backend for testing."""
     backend = MagicMock()
     backend.publish.return_value = "test-job-id"
+    backend.publish_batch.return_value = BatchPublishResult(job_ids=["batch-job-id"])
     backend.clean_queue.return_value = {"status": "success"}
     backend.delete_queue.return_value = {"status": "success"}
     backend.count_queue_messages.return_value = 5
@@ -159,6 +161,50 @@ class TestOrchestratorPublish:
 
         with pytest.raises(Exception, match="Backend error"):
             orchestrator.publish("test-queue", sample_job)
+
+    def test_publish_batch_jobs_delegates_once(self, orchestrator, sample_job, mock_backend):
+        jobs = [sample_job, sample_job.model_copy(update={"id": str(uuid4())})]
+        expected = BatchPublishResult(job_ids=["job-1", "job-2"])
+        mock_backend.publish_batch.return_value = expected
+
+        result = orchestrator.publish_batch("test-queue", jobs, priority=10)
+
+        assert result is expected
+        mock_backend.publish_batch.assert_called_once_with("test-queue", jobs, priority=10)
+
+    def test_publish_batch_converts_registered_task_models(self, orchestrator, sample_task_schema, mock_backend):
+        schema = MockJobSchema()
+        orchestrator.register(schema)
+        converted_jobs = [MagicMock(), MagicMock()]
+        mock_backend.publish_batch.return_value = BatchPublishResult(job_ids=["job-1", "job-2"])
+
+        with patch("mindtrace.jobs.core.orchestrator.job_from_schema", side_effect=converted_jobs) as convert:
+            result = orchestrator.publish_batch("test-schema", [sample_task_schema, sample_task_schema])
+
+        assert result.job_ids == ["job-1", "job-2"]
+        assert convert.call_count == 2
+        mock_backend.publish_batch.assert_called_once_with("test-schema", converted_jobs)
+
+    def test_publish_batch_validates_every_job_before_backend_call(self, orchestrator, sample_job, mock_backend):
+        with pytest.raises(ValueError, match="Invalid job at index 1"):
+            orchestrator.publish_batch("test-queue", [sample_job, {"invalid": "job"}])
+
+        mock_backend.publish_batch.assert_not_called()
+
+    def test_publish_batch_missing_schema_publishes_nothing(self, orchestrator, sample_task_schema, mock_backend):
+        with pytest.raises(ValueError, match="Invalid job at index 0: Schema 'test-schema' not found"):
+            orchestrator.publish_batch("test-schema", [sample_task_schema])
+
+        mock_backend.publish_batch.assert_not_called()
+
+    def test_publish_batch_empty_delegates_empty_batch(self, orchestrator, mock_backend):
+        expected = BatchPublishResult.for_batch_size(0)
+        mock_backend.publish_batch.return_value = expected
+
+        result = orchestrator.publish_batch("test-queue", [])
+
+        assert result is expected
+        mock_backend.publish_batch.assert_called_once_with("test-queue", [])
 
 
 class TestOrchestratorQueueManagement:

--- a/tests/unit/mindtrace/jobs/core/test_orchestrator.py
+++ b/tests/unit/mindtrace/jobs/core/test_orchestrator.py
@@ -172,6 +172,12 @@ class TestOrchestratorPublish:
         assert result is expected
         mock_backend.publish_batch.assert_called_once_with("test-queue", jobs, priority=10)
 
+    def test_publish_batch_propagates_backend_setup_error(self, orchestrator, sample_job, mock_backend):
+        mock_backend.publish_batch.side_effect = ConnectionError("broker unavailable")
+
+        with pytest.raises(ConnectionError, match="broker unavailable"):
+            orchestrator.publish_batch("test-queue", [sample_job])
+
     def test_publish_batch_converts_registered_task_models(self, orchestrator, sample_task_schema, mock_backend):
         schema = MockJobSchema()
         orchestrator.register(schema)

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py
@@ -194,6 +194,9 @@ def test_publish_batch_uses_one_connection_and_channel():
     assert result.success_count == 2
     assert result.all_succeeded is True
     assert all(isinstance(job_id, str) for job_id in result.job_ids)
+    client.logger.info.assert_called_once_with(
+        "Publishing RabbitMQ batch of 2 messages to exchange: default, routing_key: q"
+    )
     connection_class.assert_called_once_with(host="localhost", port=5671, username="user", password="password")
     connection.connect.assert_called_once_with()
     connection.get_channel.assert_called_once_with()

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py
@@ -194,8 +194,10 @@ def test_publish_batch_uses_one_connection_and_channel():
     assert result.success_count == 2
     assert result.all_succeeded is True
     assert all(isinstance(job_id, str) for job_id in result.job_ids)
-    client.logger.info.assert_called_once_with(
-        "Publishing RabbitMQ batch of 2 messages to exchange: default, routing_key: q"
+    client.logger.debug.assert_any_call("Publishing RabbitMQ batch of 2 messages to exchange: default, routing_key: q")
+    assert (
+        sum(args[0].startswith("Publishing RabbitMQ batch") for args, _kwargs in client.logger.debug.call_args_list)
+        == 1
     )
     connection_class.assert_called_once_with(host="localhost", port=5671, username="user", password="password")
     connection.connect.assert_called_once_with()

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py
@@ -181,6 +181,77 @@ def test_publish_other_exception():
         client.publish("q", dummy)
 
 
+def test_publish_batch_uses_one_connection_and_channel():
+    client = make_client()
+    channel = MagicMock()
+    channel.is_open = True
+    connection = MagicMock()
+    connection.get_channel.return_value = channel
+
+    with patch("mindtrace.jobs.rabbitmq.client.RabbitMQConnection", return_value=connection) as connection_class:
+        result = client.publish_batch("q", [DummyModel(foo="one"), DummyModel(foo="two")], priority=7)
+
+    assert result.success_count == 2
+    assert result.all_succeeded is True
+    assert all(isinstance(job_id, str) for job_id in result.job_ids)
+    connection_class.assert_called_once_with(host="localhost", port=5671, username="user", password="password")
+    connection.connect.assert_called_once_with()
+    connection.get_channel.assert_called_once_with()
+    assert channel.basic_publish.call_count == 2
+    for call in channel.basic_publish.call_args_list:
+        assert call.kwargs["exchange"] == "default"
+        assert call.kwargs["routing_key"] == "q"
+        assert call.kwargs["mandatory"] is True
+        assert call.kwargs["properties"].priority == 7
+        assert call.kwargs["properties"].headers["routing_key"] == "q"
+    channel.close.assert_called_once_with()
+    connection.close.assert_called_once_with()
+
+
+def test_publish_batch_empty_does_not_connect():
+    client = make_client()
+
+    with patch("mindtrace.jobs.rabbitmq.client.RabbitMQConnection") as connection_class:
+        result = client.publish_batch("q", [])
+
+    assert result.job_ids == []
+    assert result.all_succeeded is True
+    connection_class.assert_not_called()
+
+
+def test_publish_batch_reports_partial_failure_and_closes_resources():
+    client = make_client()
+    channel = MagicMock()
+    channel.is_open = True
+    channel.basic_publish.side_effect = [None, RuntimeError("publish failed")]
+    connection = MagicMock()
+    connection.get_channel.return_value = channel
+
+    with patch("mindtrace.jobs.rabbitmq.client.RabbitMQConnection", return_value=connection):
+        result = client.publish_batch("q", [DummyModel(), DummyModel(), DummyModel()])
+
+    assert isinstance(result.job_ids[0], str)
+    assert result.job_ids[1:] == [None, None]
+    assert result.failed_indices == [1]
+    assert result.unattempted_indices == [2]
+    assert result.errors[1] == {"error": "RuntimeError", "message": "publish failed"}
+    assert channel.basic_publish.call_count == 2
+    channel.close.assert_called_once_with()
+    connection.close.assert_called_once_with()
+
+
+def test_publish_batch_closes_connection_when_channel_creation_fails():
+    client = make_client()
+    connection = MagicMock()
+    connection.get_channel.side_effect = RuntimeError("channel failed")
+
+    with patch("mindtrace.jobs.rabbitmq.client.RabbitMQConnection", return_value=connection):
+        with pytest.raises(RuntimeError, match="channel failed"):
+            client.publish_batch("q", [DummyModel()])
+
+    connection.close.assert_called_once_with()
+
+
 def test_clean_queue_success():
     client = make_client()
     client.channel.queue_purge = MagicMock(return_value=None)

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py
@@ -252,6 +252,23 @@ def test_publish_batch_closes_connection_when_channel_creation_fails():
     connection.close.assert_called_once_with()
 
 
+def test_publish_batch_logs_cleanup_failures_without_masking_result():
+    client = make_client()
+    channel = MagicMock()
+    channel.is_open = True
+    channel.close.side_effect = RuntimeError("channel close failed")
+    connection = MagicMock()
+    connection.get_channel.return_value = channel
+    connection.close.side_effect = RuntimeError("connection close failed")
+
+    with patch("mindtrace.jobs.rabbitmq.client.RabbitMQConnection", return_value=connection):
+        result = client.publish_batch("q", [DummyModel()])
+
+    assert result.all_succeeded is True
+    client.logger.warning.assert_any_call("Failed to close RabbitMQ batch channel: channel close failed")
+    client.logger.warning.assert_any_call("Failed to close RabbitMQ batch connection: connection close failed")
+
+
 def test_clean_queue_success():
     client = make_client()
     client.channel.queue_purge = MagicMock(return_value=None)

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py
@@ -240,15 +240,26 @@ def test_publish_batch_reports_partial_failure_and_closes_resources():
     connection.close.assert_called_once_with()
 
 
-def test_publish_batch_closes_connection_when_channel_creation_fails():
+@pytest.mark.parametrize("failure_stage", ["connect", "channel"])
+def test_publish_batch_reports_setup_failure_and_closes_connection(failure_stage):
     client = make_client()
     connection = MagicMock()
-    connection.get_channel.side_effect = RuntimeError("channel failed")
+    if failure_stage == "connect":
+        connection.connect.side_effect = RuntimeError("connect failed")
+    else:
+        connection.get_channel.side_effect = RuntimeError("channel failed")
 
     with patch("mindtrace.jobs.rabbitmq.client.RabbitMQConnection", return_value=connection):
-        with pytest.raises(RuntimeError, match="channel failed"):
-            client.publish_batch("q", [DummyModel()])
+        result = client.publish_batch("q", [DummyModel(), DummyModel()])
 
+    assert result.job_ids == [None, None]
+    assert result.failed_indices == []
+    assert result.unattempted_indices == [0, 1]
+    assert result.failure_count == 1
+    assert result.setup_error == {
+        "error": "RuntimeError",
+        "message": f"{failure_stage} failed",
+    }
     connection.close.assert_called_once_with()
 
 

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py
@@ -246,7 +246,7 @@ def test_publish_batch_reports_partial_failure_and_closes_resources():
 
 
 @pytest.mark.parametrize("failure_stage", ["connect", "channel"])
-def test_publish_batch_reports_setup_failure_and_closes_connection(failure_stage):
+def test_publish_batch_raises_setup_failure_and_closes_connection(failure_stage):
     client = make_client()
     connection = MagicMock()
     if failure_stage == "connect":
@@ -255,16 +255,9 @@ def test_publish_batch_reports_setup_failure_and_closes_connection(failure_stage
         connection.get_channel.side_effect = RuntimeError("channel failed")
 
     with patch("mindtrace.jobs.rabbitmq.client.RabbitMQConnection", return_value=connection):
-        result = client.publish_batch("q", [DummyModel(), DummyModel()])
+        with pytest.raises(RuntimeError, match=f"{failure_stage} failed"):
+            client.publish_batch("q", [DummyModel(), DummyModel()])
 
-    assert result.job_ids == [None, None]
-    assert result.failed_indices == []
-    assert result.unattempted_indices == [0, 1]
-    assert result.failure_count == 1
-    assert result.setup_error == {
-        "error": "RuntimeError",
-        "message": f"{failure_stage} failed",
-    }
     connection.close.assert_called_once_with()
 
 

--- a/tests/unit/mindtrace/jobs/types/test_batch.py
+++ b/tests/unit/mindtrace/jobs/types/test_batch.py
@@ -21,13 +21,3 @@ def test_empty_batch_publish_result_succeeds():
 
     assert result.job_ids == []
     assert result.all_succeeded is True
-
-
-def test_setup_failure_leaves_all_items_unattempted():
-    result = BatchPublishResult.for_batch_size(2)
-    result.setup_error = {"error": "ConnectionError", "message": "broker unavailable"}
-
-    assert result.failed_indices == []
-    assert result.unattempted_indices == [0, 1]
-    assert result.failure_count == 1
-    assert result.all_succeeded is False

--- a/tests/unit/mindtrace/jobs/types/test_batch.py
+++ b/tests/unit/mindtrace/jobs/types/test_batch.py
@@ -21,3 +21,13 @@ def test_empty_batch_publish_result_succeeds():
 
     assert result.job_ids == []
     assert result.all_succeeded is True
+
+
+def test_setup_failure_leaves_all_items_unattempted():
+    result = BatchPublishResult.for_batch_size(2)
+    result.setup_error = {"error": "ConnectionError", "message": "broker unavailable"}
+
+    assert result.failed_indices == []
+    assert result.unattempted_indices == [0, 1]
+    assert result.failure_count == 1
+    assert result.all_succeeded is False

--- a/tests/unit/mindtrace/jobs/types/test_batch.py
+++ b/tests/unit/mindtrace/jobs/types/test_batch.py
@@ -1,0 +1,23 @@
+from mindtrace.jobs import BatchPublishResult
+
+
+def test_batch_publish_result_tracks_success_failure_and_unattempted_items():
+    result = BatchPublishResult(
+        job_ids=["job-1", None, None],
+        errors={1: {"error": "RuntimeError", "message": "publish failed"}},
+    )
+
+    assert result.successful_indices == [0]
+    assert result.failed_indices == [1]
+    assert result.unattempted_indices == [2]
+    assert result.success_count == 1
+    assert result.failure_count == 1
+    assert result.unattempted_count == 1
+    assert result.all_succeeded is False
+
+
+def test_empty_batch_publish_result_succeeds():
+    result = BatchPublishResult.for_batch_size(0)
+
+    assert result.job_ids == []
+    assert result.all_succeeded is True


### PR DESCRIPTION
## Summary

- add `Orchestrator.publish_batch()` with complete preflight validation and schema conversion
- add a backend-neutral `OrchestratorBackend.publish_batch()` fallback for existing and custom backends
- add structured `BatchPublishResult` reporting ordered job IDs, failures, and unattempted items
- optimize RabbitMQ batches to reuse one owned connection and channel
- preserve non-atomic, fail-fast partial progress without replaying already-published messages
- document the public API and failure semantics

Closes #514.

## Behavior

RabbitMQ batch publication uses the same serialization, message properties, routing, and job-ID generation as single-message `publish()`. A non-empty batch owns one connection and channel and closes both on success or failure. Empty batches do not connect.

If an item fails, publication stops. The result retains IDs for the successful prefix, records the attempted failure, and identifies remaining items as unattempted. The batch is not automatically replayed because earlier messages may already be queued.

Redis, local, and custom backends initially use the backend-neutral fallback, which calls their existing `publish()` implementation in order.

## Validation

Ruff formatting and lint:

```bash
uv run ruff format --check mindtrace/jobs tests/unit/mindtrace/jobs tests/integration/mindtrace/jobs
uv run ruff check mindtrace/jobs tests/unit/mindtrace/jobs tests/integration/mindtrace/jobs
```

New unit tests only:

```bash
ds test: \
  tests/unit/mindtrace/jobs/types/test_batch.py \
  tests/unit/mindtrace/jobs/base/test_orchestrator_backend.py \
  tests/unit/mindtrace/jobs/core/test_orchestrator.py \
  tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_client.py \
  -k batch
```

New integration tests only (requires the test Redis and RabbitMQ services):

```bash
ds test: tests/integration/mindtrace/jobs/test_publish_batch_integration.py
```

The full Jobs unit suite passes: `339 passed`. The five new integration tests cover live RabbitMQ publication/consumption and lifecycle behavior, the live Redis fallback, FIFO ordering, queue depth, and registered Pydantic-model conversion on both backends.
