### PR TITLE
[Jobs Update 3 of 3] Restore RabbitMQ push consumption

### DIFF
--- a/mindtrace/jobs/README.md
+++ b/mindtrace/jobs/README.md
@@ -232,10 +232,25 @@ cancellation is not part of the public consumer API. Finite
 `consume(num_messages=N)` and `consume_until_empty()` continue to use pull
 semantics for exact-count and drain behavior.
 
+Malformed RabbitMQ deliveries are rejected according to the configured
+failure policy. A bare, long-lived `consume()` logs the malformed delivery and
+continues receiving later work. During finite consumption or draining, the
+affected queue is abandoned for the remainder of that call while other queues
+may continue; a later public consume call can try the queue again.
+
+Only delivery-local decoding failures are contained by the push callback.
+Failures while acknowledging or rejecting a delivery, and unexpected channel
+or connection errors, end the current consume operation because the delivery
+settlement and channel state are no longer reliable. Operation-owned resources
+are still cleaned up before the error returns to the caller.
+
 Calling `consumer.stop()` requests graceful shutdown. An in-flight job finishes
 and is acknowledged or rejected before the blocking consume loop exits. The
 stop request is terminal: later consume calls remain stopped until the caller
-explicitly invokes `consumer.reset()`.
+explicitly invokes `consumer.reset()`. If cancellation cannot be scheduled
+because the RabbitMQ connection is already unavailable, `stop()` releases the
+stale operation resources directly; unlike `close()`, it does not permanently
+close the backend.
 RabbitMQ channels and connections close automatically whenever `consume()`
 returns; a later call reconnects.
 

--- a/mindtrace/jobs/README.md
+++ b/mindtrace/jobs/README.md
@@ -232,6 +232,12 @@ explicitly invokes `consumer.reset()`.
 RabbitMQ channels and connections close automatically whenever `consume()`
 returns; a later call reconnects.
 
+An unexpected RabbitMQ connection or channel failure ends the current
+`consume()` operation after its resources are cleaned up. The consumer does
+not reconnect inside a running operation. Callers that need an always-on
+worker must restart `consume()` with their own retry and backoff policy; the
+next call opens a fresh operation-owned connection and channel.
+
 Bare RabbitMQ `consume()` runs `Consumer.run()` synchronously in Pika's
 connection I/O thread. A long-running job therefore pauses other AMQP I/O on
 that connection until the job returns. Workloads whose jobs run for hours or

--- a/mindtrace/jobs/README.md
+++ b/mindtrace/jobs/README.md
@@ -225,6 +225,13 @@ with `REQUEUE` or `DEAD_LETTER` raises `NotImplementedError`; those policies
 require backend-specific retry or dead-letter storage that they do not yet
 provide.
 
+Bare RabbitMQ `consume()` registers every requested queue on one channel and
+uses broker-pushed delivery. `consumer.stop()` stops that whole consumption
+operation and cancels all queue registrations on the channel; per-queue
+cancellation is not part of the public consumer API. Finite
+`consume(num_messages=N)` and `consume_until_empty()` continue to use pull
+semantics for exact-count and drain behavior.
+
 Calling `consumer.stop()` requests graceful shutdown. An in-flight job finishes
 and is acknowledged or rejected before the blocking consume loop exits. The
 stop request is terminal: later consume calls remain stopped until the caller

--- a/mindtrace/jobs/README.md
+++ b/mindtrace/jobs/README.md
@@ -232,6 +232,13 @@ explicitly invokes `consumer.reset()`.
 RabbitMQ channels and connections close automatically whenever `consume()`
 returns; a later call reconnects.
 
+Bare RabbitMQ `consume()` runs `Consumer.run()` synchronously in Pika's
+connection I/O thread. A long-running job therefore pauses other AMQP I/O on
+that connection until the job returns. Workloads whose jobs run for hours or
+days need a separate execution/acknowledgement design before RabbitMQ
+heartbeats can be enabled safely; this consumer does not move job execution to
+a worker thread or process.
+
 `consume(..., block=True)` waits indefinitely until the requested number of
 messages has been attempted, shutdown is requested, or the caller interrupts
 the operation. With `block=False`, consumption returns as soon as no message is

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/connection.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/connection.py
@@ -71,11 +71,15 @@ class RabbitMQConnection(BrokerConnectionBase):
         else:
             return None  # type: ignore
 
-    def add_callback_threadsafe(self, callback: Callable[[], None]) -> None:
-        """Schedule ``callback`` on the BlockingConnection I/O thread."""
+    def add_callback_threadsafe(self, callback: Callable[[], None]) -> bool:
+        """Schedule ``callback`` on the I/O thread, returning whether it was queued."""
         if not self.is_connected():
-            return
-        self.connection.add_callback_threadsafe(callback)
+            return False
+        try:
+            self.connection.add_callback_threadsafe(callback)
+        except exceptions.ConnectionWrongStateError:
+            return False
+        return True
 
     def count_queue_messages(self, queue_name: str, **kwargs) -> int:
         """Get the number of messages in a queue."""

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/connection.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/connection.py
@@ -1,4 +1,5 @@
 import time
+from collections.abc import Callable
 
 import pika.exceptions
 from pika import BlockingConnection, ConnectionParameters, PlainCredentials, exceptions
@@ -69,6 +70,12 @@ class RabbitMQConnection(BrokerConnectionBase):
             return self.connection.channel()
         else:
             return None  # type: ignore
+
+    def add_callback_threadsafe(self, callback: Callable[[], None]) -> None:
+        """Schedule ``callback`` on the BlockingConnection I/O thread."""
+        if not self.is_connected():
+            return
+        self.connection.add_callback_threadsafe(callback)
 
     def count_queue_messages(self, queue_name: str, **kwargs) -> int:
         """Get the number of messages in a queue."""

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
@@ -249,7 +249,8 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
     def stop(self) -> None:
         """Request shutdown and wake an active broker-pushed consumer."""
         super().stop()
-        self._request_consumer_stop()
+        if not self._request_consumer_stop():
+            self._close_active_resources()
 
     def _request_consumer_stop(self) -> bool:
         """Schedule cancellation when a push consumer is active."""

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
@@ -51,7 +51,7 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
     def consume(
         self, num_messages: int = 0, *, queues: str | list[str] | None = None, block: bool = True, **kwargs
     ) -> None:
-        """Consume deliveries, waiting indefinitely when ``block`` is true."""
+        """Consume a finite pull batch or run a broker-pushed worker indefinitely."""
         self._ensure_open()
         if isinstance(queues, str):
             queues = [queues]
@@ -65,6 +65,7 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
             channel = self.connection.get_channel()
             with self._active_lock:
                 self._active_channel = channel
+                self._push_consuming = num_messages == 0
             channel.basic_qos(prefetch_count=self.prefetch_count)
             if num_messages > 0:
                 self._consume_finite_messages(channel, num_messages, queues, block=block)
@@ -201,6 +202,7 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
             channel = self.connection.get_channel()
             with self._active_lock:
                 self._active_channel = channel
+                self._push_consuming = False
             channel.basic_qos(prefetch_count=self.prefetch_count)
             while not self.stopped:
                 pending = sum(self.connection.count_queue_messages(queue) for queue in queues)

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
@@ -113,6 +113,8 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
 
         try:
             for queue in queues:
+                if self.stopped:
+                    break
                 channel.basic_consume(
                     queue=queue,
                     on_message_callback=self._on_message,

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
@@ -111,8 +111,6 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
         if self.stopped:
             return
 
-        with self._active_lock:
-            self._push_consuming = True
         try:
             for queue in queues:
                 channel.basic_consume(

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
@@ -129,7 +129,11 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
     def _on_message(self, channel, method, _properties, body) -> None:
         """Decode and process one broker-pushed delivery."""
         self.logger.info("Received message from RabbitMQ.")
-        delivery = self._decode_delivery(channel, method, body)
+        try:
+            delivery = self._decode_delivery(channel, method, body)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            self.logger.error(f"Rejected malformed RabbitMQ delivery: {exc}")
+            return
         self._process_delivery(channel, delivery)
 
     def _decode_delivery(self, channel, method, body) -> RabbitMQDelivery:

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
@@ -46,7 +46,7 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
         self.connection = RabbitMQConnection(host=host, port=port, username=username, password=password)
         self._active_channel = None
         self._active_lock = Lock()
-        self._push_consuming = False
+        self._active_push_channel = None
 
     def consume(
         self, num_messages: int = 0, *, queues: str | list[str] | None = None, block: bool = True, **kwargs
@@ -65,7 +65,7 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
             channel = self.connection.get_channel()
             with self._active_lock:
                 self._active_channel = channel
-                self._push_consuming = num_messages == 0
+                self._active_push_channel = channel if num_messages == 0 else None
             channel.basic_qos(prefetch_count=self.prefetch_count)
             if num_messages > 0:
                 self._consume_finite_messages(channel, num_messages, queues, block=block)
@@ -122,7 +122,8 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
                 channel.start_consuming()
         finally:
             with self._active_lock:
-                self._push_consuming = False
+                if self._active_push_channel is channel:
+                    self._active_push_channel = None
 
     def _on_message(self, channel, method, _properties, body) -> None:
         """Decode and process one broker-pushed delivery."""
@@ -204,7 +205,7 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
             channel = self.connection.get_channel()
             with self._active_lock:
                 self._active_channel = channel
-                self._push_consuming = False
+                self._active_push_channel = None
             channel.basic_qos(prefetch_count=self.prefetch_count)
             while not self.stopped:
                 pending = sum(self.connection.count_queue_messages(queue) for queue in queues)
@@ -251,9 +252,8 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
     def _request_consumer_stop(self) -> bool:
         """Schedule cancellation when a push consumer is active."""
         with self._active_lock:
-            channel = self._active_channel
-            push_consuming = self._push_consuming
-        if channel is None or not push_consuming:
+            channel = self._active_push_channel
+        if channel is None:
             return False
 
         return self.connection.add_callback_threadsafe(lambda: self._stop_consuming(channel))
@@ -269,7 +269,7 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
         with self._active_lock:
             channel = self._active_channel
             self._active_channel = None
-            self._push_consuming = False
+            self._active_push_channel = None
         try:
             if channel is not None and getattr(channel, "is_open", False):
                 channel.close()

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
@@ -258,8 +258,7 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
         if channel is None or not push_consuming:
             return False
 
-        self.connection.add_callback_threadsafe(lambda: self._stop_consuming(channel))
-        return True
+        return self.connection.add_callback_threadsafe(lambda: self._stop_consuming(channel))
 
     @staticmethod
     def _stop_consuming(channel) -> None:

--- a/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
+++ b/mindtrace/jobs/mindtrace/jobs/rabbitmq/consumer_backend.py
@@ -4,6 +4,7 @@ import json
 import time
 import traceback
 from dataclasses import dataclass
+from threading import Lock
 
 from mindtrace.core import ifnone
 from mindtrace.jobs.base.consumer_base import ConsumerBackendBase
@@ -44,6 +45,8 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
         self.queues = [queue_name] if queue_name else []
         self.connection = RabbitMQConnection(host=host, port=port, username=username, password=password)
         self._active_channel = None
+        self._active_lock = Lock()
+        self._push_consuming = False
 
     def consume(
         self, num_messages: int = 0, *, queues: str | list[str] | None = None, block: bool = True, **kwargs
@@ -60,7 +63,8 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
         try:
             self.connection.connect()
             channel = self.connection.get_channel()
-            self._active_channel = channel
+            with self._active_lock:
+                self._active_channel = channel
             channel.basic_qos(prefetch_count=self.prefetch_count)
             if num_messages > 0:
                 self._consume_finite_messages(channel, num_messages, queues, block=block)
@@ -101,23 +105,44 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
                 return
 
     def _consume_infinite_messages(self, channel, queues: list[str]) -> None:
-        """Consume messages until graceful shutdown is requested."""
+        """Register broker-pushed consumers and wait for graceful shutdown."""
         self.logger.info(f"Started consuming messages indefinitely from queues: {queues}.")
-        processed = 0
-        while not self.stopped:
+        if self.stopped:
+            return
+
+        with self._active_lock:
+            self._push_consuming = True
+        try:
             for queue in queues:
-                if self.stopped:
-                    break
-                try:
-                    delivery = self.receive_message(channel, queue, block=True)
-                    if delivery is not None:
-                        processed += 1
-                        self.logger.debug(f"Received message from queue '{queue}': processing message {processed}")
-                        self._process_delivery(channel, delivery)
-                except Exception as exc:
-                    self.logger.error(
-                        f"Error during infinite consumption from {queue}: {exc}\n{traceback.format_exc()}"
-                    )
+                channel.basic_consume(
+                    queue=queue,
+                    on_message_callback=self._on_message,
+                    auto_ack=self.auto_ack,
+                )
+            if not self.stopped:
+                channel.start_consuming()
+        finally:
+            with self._active_lock:
+                self._push_consuming = False
+
+    def _on_message(self, channel, method, _properties, body) -> None:
+        """Decode and process one broker-pushed delivery."""
+        self.logger.info("Received message from RabbitMQ.")
+        delivery = self._decode_delivery(channel, method, body)
+        self._process_delivery(channel, delivery)
+
+    def _decode_delivery(self, channel, method, body) -> RabbitMQDelivery:
+        """Decode a Pika delivery while preserving acknowledgement state."""
+        try:
+            message = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            self._reject_delivery(channel, method.delivery_tag, redelivered=method.redelivered)
+            raise
+        return RabbitMQDelivery(
+            message=message,
+            delivery_tag=method.delivery_tag,
+            redelivered=method.redelivered,
+        )
 
     def _process_delivery(self, channel, delivery: RabbitMQDelivery) -> bool:
         success = self.process_message(delivery.message)
@@ -174,7 +199,8 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
         try:
             self.connection.connect()
             channel = self.connection.get_channel()
-            self._active_channel = channel
+            with self._active_lock:
+                self._active_channel = channel
             channel.basic_qos(prefetch_count=self.prefetch_count)
             while not self.stopped:
                 pending = sum(self.connection.count_queue_messages(queue) for queue in queues)
@@ -195,16 +221,7 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
                 method, _, body = channel.basic_get(queue=queue_name, auto_ack=self.auto_ack)
                 if method:
                     self.logger.info(f"Received message from queue '{queue_name}'.")
-                    try:
-                        message = json.loads(body.decode("utf-8"))
-                    except (UnicodeDecodeError, json.JSONDecodeError):
-                        self._reject_delivery(channel, method.delivery_tag, redelivered=method.redelivered)
-                        raise
-                    return RabbitMQDelivery(
-                        message=message,
-                        delivery_tag=method.delivery_tag,
-                        redelivered=method.redelivered,
-                    )
+                    return self._decode_delivery(channel, method, body)
                 if not block:
                     self.logger.debug(f"No message available in queue '{queue_name}'.")
                     return None
@@ -219,12 +236,37 @@ class RabbitMQConsumerBackend(ConsumerBackendBase):
         if self.closed:
             return
         super().close()
-        self._close_active_resources()
+        if not self._request_consumer_stop():
+            self._close_active_resources()
+
+    def stop(self) -> None:
+        """Request shutdown and wake an active broker-pushed consumer."""
+        super().stop()
+        self._request_consumer_stop()
+
+    def _request_consumer_stop(self) -> bool:
+        """Schedule cancellation when a push consumer is active."""
+        with self._active_lock:
+            channel = self._active_channel
+            push_consuming = self._push_consuming
+        if channel is None or not push_consuming:
+            return False
+
+        self.connection.add_callback_threadsafe(lambda: self._stop_consuming(channel))
+        return True
+
+    @staticmethod
+    def _stop_consuming(channel) -> None:
+        """Stop all consumers registered on an open channel."""
+        if getattr(channel, "is_open", False):
+            channel.stop_consuming()
 
     def _close_active_resources(self) -> None:
         """Release operation-owned resources without closing the backend."""
-        channel = self._active_channel
-        self._active_channel = None
+        with self._active_lock:
+            channel = self._active_channel
+            self._active_channel = None
+            self._push_consuming = False
         try:
             if channel is not None and getattr(channel, "is_open", False):
                 channel.close()

--- a/tests/integration/mindtrace/jobs/test_consumer_ack_integration.py
+++ b/tests/integration/mindtrace/jobs/test_consumer_ack_integration.py
@@ -1,5 +1,4 @@
 import threading
-import time
 import uuid
 
 import pytest
@@ -214,14 +213,11 @@ def test_push_consumer_survives_poison_delivery_and_stops_from_another_thread():
     thread.start()
 
     try:
-        deadline = time.monotonic() + 5
-        while consumer.consumer_backend._active_push_channel is None and time.monotonic() < deadline:
-            time.sleep(0.01)
-        assert consumer.consumer_backend._active_push_channel is not None
-
         client.channel.basic_publish(exchange="default", routing_key=queue, body=b"not-json")
         orchestrator.publish(queue, create_test_job("valid-after-poison", queue))
 
+        # Processing the valid delivery proves that the push consumer is live;
+        # avoid coupling this integration test to backend readiness internals.
         assert processed.wait(timeout=5)
         consumer.stop()
         thread.join(timeout=5)

--- a/tests/integration/mindtrace/jobs/test_consumer_ack_integration.py
+++ b/tests/integration/mindtrace/jobs/test_consumer_ack_integration.py
@@ -1,4 +1,5 @@
 import threading
+import time
 import uuid
 
 import pytest
@@ -175,7 +176,7 @@ def test_stop_waits_for_in_flight_job_before_acknowledging():
     orchestrator.publish(queue, create_test_job("blocking", queue))
     consumer = BlockingConsumer()
     consumer.connect_to_orchestrator(orchestrator, queue)
-    thread = threading.Thread(target=consumer.consume)
+    thread = threading.Thread(target=consumer.consume, daemon=True)
     thread.start()
 
     try:
@@ -192,3 +193,43 @@ def test_stop_waits_for_in_flight_job_before_acknowledging():
         release.set()
         thread.join(timeout=5)
         client.delete_queue(queue)
+
+
+@pytest.mark.rabbitmq
+def test_push_consumer_survives_poison_delivery_and_stops_from_another_thread():
+    processed = threading.Event()
+
+    class SignalingConsumer(Consumer):
+        def run(self, job_dict):
+            processed.set()
+            return {"result": "processed"}
+
+    client = rabbitmq_client()
+    orchestrator = Orchestrator(backend=client)
+    queue = unique_queue("consumer-push")
+    orchestrator.register(JobSchema(name=queue, input_schema=SampleJobInput, output_schema=SampleJobOutput))
+    consumer = SignalingConsumer()
+    consumer.connect_to_orchestrator(orchestrator, queue)
+    thread = threading.Thread(target=consumer.consume, daemon=True)
+    thread.start()
+
+    try:
+        deadline = time.monotonic() + 5
+        while consumer.consumer_backend._active_push_channel is None and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert consumer.consumer_backend._active_push_channel is not None
+
+        client.channel.basic_publish(exchange="default", routing_key=queue, body=b"not-json")
+        orchestrator.publish(queue, create_test_job("valid-after-poison", queue))
+
+        assert processed.wait(timeout=5)
+        consumer.stop()
+        thread.join(timeout=5)
+
+        assert thread.is_alive() is False
+        assert consumer.consumer_backend.connection.is_connected() is False
+    finally:
+        consumer.stop()
+        thread.join(timeout=5)
+        client.delete_queue(queue)
+        client.connection.close()

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_connection.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_connection.py
@@ -87,6 +87,22 @@ class TestRabbitMQConnection:
         rabbitmq_conn.connection = None
         assert rabbitmq_conn.get_channel() is None
 
+    def test_add_callback_threadsafe_forwards_to_connection(self, rabbitmq_conn):
+        mock_conn = MagicMock(is_open=True)
+        callback = MagicMock()
+        rabbitmq_conn.connection = mock_conn
+
+        rabbitmq_conn.add_callback_threadsafe(callback)
+
+        mock_conn.add_callback_threadsafe.assert_called_once_with(callback)
+
+    def test_add_callback_threadsafe_ignores_disconnected_connection(self, rabbitmq_conn):
+        callback = MagicMock()
+
+        rabbitmq_conn.add_callback_threadsafe(callback)
+
+        callback.assert_not_called()
+
     def test_count_queue_messages_success(self, rabbitmq_conn):
         mock_channel = MagicMock()
         mock_result = MagicMock()

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_connection.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_connection.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pika.exceptions import AMQPConnectionError, ChannelClosedByBroker
+from pika.exceptions import AMQPConnectionError, ChannelClosedByBroker, ConnectionWrongStateError
 
 from mindtrace.jobs.rabbitmq.connection import RabbitMQConnection
 
@@ -92,16 +92,25 @@ class TestRabbitMQConnection:
         callback = MagicMock()
         rabbitmq_conn.connection = mock_conn
 
-        rabbitmq_conn.add_callback_threadsafe(callback)
+        scheduled = rabbitmq_conn.add_callback_threadsafe(callback)
 
+        assert scheduled is True
         mock_conn.add_callback_threadsafe.assert_called_once_with(callback)
 
     def test_add_callback_threadsafe_ignores_disconnected_connection(self, rabbitmq_conn):
         callback = MagicMock()
 
-        rabbitmq_conn.add_callback_threadsafe(callback)
+        scheduled = rabbitmq_conn.add_callback_threadsafe(callback)
 
+        assert scheduled is False
         callback.assert_not_called()
+
+    def test_add_callback_threadsafe_handles_connection_closing_race(self, rabbitmq_conn):
+        mock_conn = MagicMock(is_open=True)
+        mock_conn.add_callback_threadsafe.side_effect = ConnectionWrongStateError
+        rabbitmq_conn.connection = mock_conn
+
+        assert rabbitmq_conn.add_callback_threadsafe(MagicMock()) is False
 
     def test_count_queue_messages_success(self, rabbitmq_conn):
         mock_channel = MagicMock()

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
@@ -1,4 +1,3 @@
-import json
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -359,10 +358,24 @@ def test_push_callback_rejects_invalid_json(backend):
     channel = MagicMock()
     method = MagicMock(delivery_tag=42, redelivered=False)
 
-    with pytest.raises(json.JSONDecodeError):
-        backend._on_message(channel, method, MagicMock(), b"not-json")
+    backend._on_message(channel, method, MagicMock(), b"not-json")
 
     channel.basic_nack.assert_called_once_with(delivery_tag=42, requeue=False)
+    backend.logger.error.assert_called_once()
+
+
+def test_push_consumer_continues_after_invalid_json(backend):
+    channel = MagicMock()
+    invalid_method = MagicMock(delivery_tag=41, redelivered=False)
+    valid_method = MagicMock(delivery_tag=42, redelivered=False)
+    backend.process_message = MagicMock(return_value=True)
+
+    backend._on_message(channel, invalid_method, MagicMock(), b"not-json")
+    backend._on_message(channel, valid_method, MagicMock(), b'{"id": 7}')
+
+    backend.process_message.assert_called_once_with({"id": 7})
+    channel.basic_nack.assert_called_once_with(delivery_tag=41, requeue=False)
+    channel.basic_ack.assert_called_once_with(delivery_tag=42)
 
 
 def test_push_callback_error_escapes_consumer(backend):

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
@@ -595,6 +595,23 @@ def test_prior_stop_prevents_push_consumer_registration(backend):
     channel.start_consuming.assert_not_called()
 
 
+def test_stop_during_registration_skips_remaining_queues_and_cleans_up(backend):
+    channel = MagicMock(is_open=True)
+    backend.connection.get_channel.return_value = channel
+    backend.connection.add_callback_threadsafe = MagicMock(return_value=True)
+    backend.connection.close = MagicMock()
+    channel.basic_consume.side_effect = lambda **kwargs: backend.stop()
+
+    backend.consume(num_messages=0, queues=["q1", "q2"])
+
+    channel.basic_consume.assert_called_once_with(
+        queue="q1", on_message_callback=backend._on_message, auto_ack=False
+    )
+    channel.start_consuming.assert_not_called()
+    channel.close.assert_called_once_with()
+    backend.connection.close.assert_called_once_with()
+
+
 def test_stop_schedules_push_consumer_cancellation(backend):
     channel = MagicMock(is_open=True)
     backend.connection.add_callback_threadsafe = MagicMock(return_value=True)

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
@@ -560,7 +560,7 @@ def test_stop_finishes_current_delivery_before_exiting(backend):
     backend.connection.add_callback_threadsafe = MagicMock(return_value=True)
     with backend._active_lock:
         backend._active_channel = channel
-        backend._push_consuming = True
+        backend._active_push_channel = channel
 
     def process_and_stop(message):
         backend.stop()
@@ -600,7 +600,7 @@ def test_stop_schedules_push_consumer_cancellation(backend):
     backend.connection.add_callback_threadsafe = MagicMock(return_value=True)
     with backend._active_lock:
         backend._active_channel = channel
-        backend._push_consuming = True
+        backend._active_push_channel = channel
 
     backend.stop()
 
@@ -618,7 +618,7 @@ def test_close_schedules_active_push_consumer_cancellation(backend):
     backend.connection.close = MagicMock()
     with backend._active_lock:
         backend._active_channel = channel
-        backend._push_consuming = True
+        backend._active_push_channel = channel
 
     backend.close()
 
@@ -635,7 +635,7 @@ def test_close_cleans_stale_resources_when_cancellation_cannot_be_scheduled(back
     backend.connection.close = MagicMock()
     with backend._active_lock:
         backend._active_channel = channel
-        backend._push_consuming = True
+        backend._active_push_channel = channel
 
     backend.close()
 

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock, patch
+import json
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -136,11 +137,16 @@ def test_finite_consume_exits_after_all_queues_fail(backend):
 
 
 def test_consume_infinite_messages_keyboard_interrupt(backend):
-    backend.receive_message = MagicMock(side_effect=[delivery(), KeyboardInterrupt])
-    backend.process_message = MagicMock(return_value=True)
-    backend.logger = MagicMock()
+    channel = MagicMock(is_open=True)
+    channel.start_consuming.side_effect = KeyboardInterrupt
+    backend.connection.get_channel.return_value = channel
+    backend.connection.close = MagicMock()
+
     backend.consume(num_messages=0, queues="q")
+
     backend.logger.info.assert_any_call("Consumption interrupted by user.")
+    channel.close.assert_called_once_with()
+    backend.connection.close.assert_called_once_with()
 
 
 def test_process_message_dict_success(backend, consumer_frontend):
@@ -310,23 +316,74 @@ def test_invalid_json_rejection_honors_ack_policy(backend, auto_ack, policy, exp
         channel.basic_nack.assert_not_called()
 
 
-def test_consume_infinite_messages_exception_handling_with_continue(backend):
-    """Test exception handling in _consume_infinite_messages with continue."""
-    # First call raises a regular exception (caught), second call raises KeyboardInterrupt to break the loop
-    backend.receive_message = MagicMock(side_effect=[Exception("Test exception"), KeyboardInterrupt])
-    backend.logger = MagicMock()
+def test_infinite_consume_registers_all_queues_and_starts_consuming(backend):
+    channel = MagicMock()
 
-    mock_channel = MagicMock()
+    backend._consume_infinite_messages(channel, ["q1", "q2"])
 
-    # Call the infinite consumer directly and break out via KeyboardInterrupt
-    with pytest.raises(KeyboardInterrupt):
-        backend._consume_infinite_messages(mock_channel, ["q"])
+    channel.basic_consume.assert_has_calls(
+        [
+            call(queue="q1", on_message_callback=backend._on_message, auto_ack=False),
+            call(queue="q2", on_message_callback=backend._on_message, auto_ack=False),
+        ]
+    )
+    channel.start_consuming.assert_called_once_with()
+    channel.basic_get.assert_not_called()
 
-    # Verify that the exception was logged by the except block
-    backend.logger.error.assert_called()
-    error_call = backend.logger.error.call_args[0][0]
-    assert "Error during infinite consumption" in error_call
-    assert "Test exception" in error_call
+
+def test_consume_applies_qos_before_registering_push_consumer(backend):
+    channel = backend.connection.get_channel.return_value
+
+    backend.consume(num_messages=0, queues="q")
+
+    qos_index = channel.mock_calls.index(call.basic_qos(prefetch_count=backend.prefetch_count))
+    consume_index = channel.mock_calls.index(
+        call.basic_consume(queue="q", on_message_callback=backend._on_message, auto_ack=False)
+    )
+    start_index = channel.mock_calls.index(call.start_consuming())
+    assert qos_index < consume_index < start_index
+
+
+def test_push_callback_decodes_and_acknowledges_delivery(backend):
+    channel = MagicMock()
+    method = MagicMock(delivery_tag=42, redelivered=False)
+    backend.process_message = MagicMock(return_value=True)
+
+    backend._on_message(channel, method, MagicMock(), b'{"id": 7}')
+
+    backend.process_message.assert_called_once_with({"id": 7})
+    channel.basic_ack.assert_called_once_with(delivery_tag=42)
+
+
+def test_push_callback_rejects_invalid_json(backend):
+    channel = MagicMock()
+    method = MagicMock(delivery_tag=42, redelivered=False)
+
+    with pytest.raises(json.JSONDecodeError):
+        backend._on_message(channel, method, MagicMock(), b"not-json")
+
+    channel.basic_nack.assert_called_once_with(delivery_tag=42, requeue=False)
+
+
+def test_push_callback_error_escapes_consumer(backend):
+    channel = MagicMock()
+    channel.start_consuming.side_effect = RuntimeError("channel failed")
+
+    with pytest.raises(RuntimeError, match="channel failed"):
+        backend._consume_infinite_messages(channel, ["q"])
+
+
+def test_push_consumer_error_closes_operation_resources(backend):
+    channel = MagicMock(is_open=True)
+    channel.start_consuming.side_effect = RuntimeError("channel failed")
+    backend.connection.get_channel.return_value = channel
+    backend.connection.close = MagicMock()
+
+    with pytest.raises(RuntimeError, match="channel failed"):
+        backend.consume(num_messages=0, queues="q")
+
+    channel.close.assert_called_once_with()
+    backend.connection.close.assert_called_once_with()
 
 
 @pytest.mark.parametrize(
@@ -422,6 +479,17 @@ def test_consume_closes_channel_and_connection(backend):
     assert backend.closed is False
 
 
+def test_finite_consume_does_not_register_push_consumer(backend):
+    channel = MagicMock(is_open=True)
+    backend.connection.get_channel.return_value = channel
+    backend.receive_message = MagicMock(return_value=None)
+
+    backend.consume(num_messages=1, queues="q", block=False)
+
+    channel.basic_consume.assert_not_called()
+    channel.start_consuming.assert_not_called()
+
+
 def test_close_is_terminal_and_idempotent(backend):
     channel = MagicMock(is_open=True)
     backend._active_channel = channel
@@ -470,38 +538,97 @@ def test_consume_until_empty_reuses_one_connection_for_full_drain(backend):
     backend.connection.close.assert_called_once_with()
     channel.close.assert_called_once_with()
     assert backend.receive_message.call_count == 2
+    channel.basic_consume.assert_not_called()
+    channel.start_consuming.assert_not_called()
 
 
 def test_stop_finishes_current_delivery_before_exiting(backend):
-    channel = MagicMock()
-    backend.receive_message = MagicMock(return_value=delivery(delivery_tag=42))
+    channel = MagicMock(is_open=True)
+    backend.connection.add_callback_threadsafe = MagicMock()
+    with backend._active_lock:
+        backend._active_channel = channel
 
     def process_and_stop(message):
         backend.stop()
         return True
 
     backend.process_message = MagicMock(side_effect=process_and_stop)
+
+    def deliver_message():
+        backend._on_message(
+            channel,
+            MagicMock(delivery_tag=42, redelivered=False),
+            MagicMock(),
+            b'{"id": 1}',
+        )
+
+    channel.start_consuming.side_effect = deliver_message
 
     backend._consume_infinite_messages(channel, ["q"])
 
     backend.process_message.assert_called_once_with({"id": 1})
     channel.basic_ack.assert_called_once_with(delivery_tag=42)
+    backend.connection.add_callback_threadsafe.assert_called_once()
 
 
-def test_stop_finishes_current_delivery_before_checking_next_queue(backend):
+def test_prior_stop_prevents_push_consumer_registration(backend):
     channel = MagicMock()
-    backend.receive_message = MagicMock(return_value=delivery(delivery_tag=42))
-
-    def process_and_stop(message):
-        backend.stop()
-        return True
-
-    backend.process_message = MagicMock(side_effect=process_and_stop)
+    backend.stop()
 
     backend._consume_infinite_messages(channel, ["q1", "q2"])
 
-    backend.receive_message.assert_called_once_with(channel, "q1", block=True)
-    channel.basic_ack.assert_called_once_with(delivery_tag=42)
+    channel.basic_consume.assert_not_called()
+    channel.start_consuming.assert_not_called()
+
+
+def test_stop_schedules_push_consumer_cancellation(backend):
+    channel = MagicMock(is_open=True)
+    backend.connection.add_callback_threadsafe = MagicMock()
+    with backend._active_lock:
+        backend._active_channel = channel
+        backend._push_consuming = True
+
+    backend.stop()
+
+    assert backend.stopped is True
+    backend.connection.add_callback_threadsafe.assert_called_once()
+    channel.stop_consuming.assert_not_called()
+    callback = backend.connection.add_callback_threadsafe.call_args.args[0]
+    callback()
+    channel.stop_consuming.assert_called_once_with()
+
+
+def test_close_schedules_active_push_consumer_cancellation(backend):
+    channel = MagicMock(is_open=True)
+    backend.connection.add_callback_threadsafe = MagicMock()
+    backend.connection.close = MagicMock()
+    with backend._active_lock:
+        backend._active_channel = channel
+        backend._push_consuming = True
+
+    backend.close()
+
+    assert backend.closed is True
+    assert backend.stopped is True
+    backend.connection.add_callback_threadsafe.assert_called_once()
+    channel.close.assert_not_called()
+    backend.connection.close.assert_not_called()
+
+
+def test_close_during_push_startup_uses_threadsafe_cancellation(backend):
+    channel = MagicMock(is_open=True)
+    backend.connection.get_channel.return_value = channel
+    backend.connection.add_callback_threadsafe = MagicMock()
+
+    def close_during_startup(channel, queues):
+        backend.close()
+
+    backend._consume_infinite_messages = MagicMock(side_effect=close_during_startup)
+
+    backend.consume(num_messages=0, queues="q")
+
+    backend.connection.add_callback_threadsafe.assert_called_once()
+    assert backend.closed is True
 
 
 def test_receive_message_returns_none_when_already_stopped(backend):

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
@@ -557,7 +557,7 @@ def test_consume_until_empty_reuses_one_connection_for_full_drain(backend):
 
 def test_stop_finishes_current_delivery_before_exiting(backend):
     channel = MagicMock(is_open=True)
-    backend.connection.add_callback_threadsafe = MagicMock()
+    backend.connection.add_callback_threadsafe = MagicMock(return_value=True)
     with backend._active_lock:
         backend._active_channel = channel
 
@@ -596,7 +596,7 @@ def test_prior_stop_prevents_push_consumer_registration(backend):
 
 def test_stop_schedules_push_consumer_cancellation(backend):
     channel = MagicMock(is_open=True)
-    backend.connection.add_callback_threadsafe = MagicMock()
+    backend.connection.add_callback_threadsafe = MagicMock(return_value=True)
     with backend._active_lock:
         backend._active_channel = channel
         backend._push_consuming = True
@@ -613,7 +613,7 @@ def test_stop_schedules_push_consumer_cancellation(backend):
 
 def test_close_schedules_active_push_consumer_cancellation(backend):
     channel = MagicMock(is_open=True)
-    backend.connection.add_callback_threadsafe = MagicMock()
+    backend.connection.add_callback_threadsafe = MagicMock(return_value=True)
     backend.connection.close = MagicMock()
     with backend._active_lock:
         backend._active_channel = channel
@@ -628,10 +628,26 @@ def test_close_schedules_active_push_consumer_cancellation(backend):
     backend.connection.close.assert_not_called()
 
 
+def test_close_cleans_stale_resources_when_cancellation_cannot_be_scheduled(backend):
+    channel = MagicMock(is_open=False)
+    backend.connection.add_callback_threadsafe = MagicMock(return_value=False)
+    backend.connection.close = MagicMock()
+    with backend._active_lock:
+        backend._active_channel = channel
+        backend._push_consuming = True
+
+    backend.close()
+
+    assert backend.closed is True
+    backend.connection.add_callback_threadsafe.assert_called_once()
+    backend.connection.close.assert_called_once_with()
+    assert backend._active_channel is None
+
+
 def test_close_during_push_startup_uses_threadsafe_cancellation(backend):
     channel = MagicMock(is_open=True)
     backend.connection.get_channel.return_value = channel
-    backend.connection.add_callback_threadsafe = MagicMock()
+    backend.connection.add_callback_threadsafe = MagicMock(return_value=True)
 
     def close_during_startup(channel, queues):
         backend.close()

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
@@ -189,7 +189,7 @@ def test_consume_until_empty_with_no_queues_returns_without_connecting(backend):
 def test_consume_until_empty_keyboard_interrupt_closes_resources(backend):
     channel = MagicMock(is_open=True)
     backend.connection.get_channel.return_value = channel
-    backend.connection.count_queue_messages.side_effect = KeyboardInterrupt
+    backend.connection.count_queue_messages = MagicMock(side_effect=KeyboardInterrupt)
     backend.connection.close = MagicMock()
 
     backend.consume_until_empty(queues="q")

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
@@ -560,6 +560,7 @@ def test_stop_finishes_current_delivery_before_exiting(backend):
     backend.connection.add_callback_threadsafe = MagicMock(return_value=True)
     with backend._active_lock:
         backend._active_channel = channel
+        backend._push_consuming = True
 
     def process_and_stop(message):
         backend.stop()

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
@@ -378,6 +378,21 @@ def test_push_consumer_continues_after_invalid_json(backend):
     channel.basic_ack.assert_called_once_with(delivery_tag=42)
 
 
+def test_push_consumer_continues_after_job_failure(backend):
+    channel = MagicMock()
+    failed_method = MagicMock(delivery_tag=41, redelivered=False)
+    successful_method = MagicMock(delivery_tag=42, redelivered=False)
+    backend.failure_policy = ConsumerFailurePolicy.REQUEUE
+    backend.process_message = MagicMock(side_effect=[False, True])
+
+    backend._on_message(channel, failed_method, MagicMock(), b'{"id": 1}')
+    backend._on_message(channel, successful_method, MagicMock(), b'{"id": 2}')
+
+    assert backend.process_message.call_args_list == [call({"id": 1}), call({"id": 2})]
+    channel.basic_nack.assert_called_once_with(delivery_tag=41, requeue=True)
+    channel.basic_ack.assert_called_once_with(delivery_tag=42)
+
+
 def test_push_callback_error_escapes_consumer(backend):
     channel = MagicMock()
     channel.start_consuming.side_effect = RuntimeError("channel failed")

--- a/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
+++ b/tests/unit/mindtrace/jobs/rabbitmq/test_rabbitmq_consumer_backend.py
@@ -644,6 +644,23 @@ def test_stop_schedules_push_consumer_cancellation(backend):
     channel.stop_consuming.assert_called_once_with()
 
 
+def test_stop_cleans_stale_resources_when_cancellation_cannot_be_scheduled(backend):
+    channel = MagicMock(is_open=False)
+    backend.connection.add_callback_threadsafe = MagicMock(return_value=False)
+    backend.connection.close = MagicMock()
+    with backend._active_lock:
+        backend._active_channel = channel
+        backend._active_push_channel = channel
+
+    backend.stop()
+
+    assert backend.stopped is True
+    assert backend.closed is False
+    backend.connection.add_callback_threadsafe.assert_called_once()
+    backend.connection.close.assert_called_once_with()
+    assert backend._active_channel is None
+
+
 def test_close_schedules_active_push_consumer_cancellation(backend):
     channel = MagicMock(is_open=True)
     backend.connection.add_callback_threadsafe = MagicMock(return_value=True)


### PR DESCRIPTION
## Summary

- restore broker-pushed RabbitMQ delivery for bare indefinite `consume()` using `basic_consume` and `start_consuming`
- keep finite consumption and queue draining on the existing `basic_get` paths
- preserve delivery decoding and acknowledgement/failure policies across push and pull modes
- reject malformed push deliveries without terminating an otherwise healthy worker
- make `stop()` and `close()` cancel active push consumers through Pika thread-safe callbacks, with stale-resource cleanup when cancellation cannot be scheduled
- retain operation-owned channel and connection cleanup

## Testing

- expanded unit coverage for multi-queue registration, QoS ordering, callback decoding and rejection, poison-message and job-failure resilience, acknowledgement policies, stop/close cancellation, disconnected/startup races, interrupt/error cleanup, and unchanged finite/drain behavior
- added a bounded live-RabbitMQ integration test covering poison-message recovery and cross-thread shutdown
- startup, disconnection, failed scheduling, and registration races are covered by unit tests rather than the live integration test
- unit tests pass with 100% coverage: `403 passed in 13.28s`
- integration tests pass: `57 passed in 22.22s`

## Operational semantics

- all queues registered by one bare `consume()` call share a channel and are stopped together
- malformed push deliveries are rejected and skipped; finite/drain calls abandon the affected queue for the remainder of that call
- acknowledgement, rejection, channel, or connection failures end the current operation rather than being swallowed
- connection/channel failure ends the current operation; callers own retry/backoff around a later `consume()` call
- job execution remains synchronous on Pika's I/O thread

## Scope

This PR intentionally does not enable heartbeats, add automatic reconnection, or move long-running jobs off the Pika I/O thread. Those concerns require separate lifecycle and job-execution design.

Closes #517.