### PR TITLE
feat(cameras): expose color-correction controls for Daheng and Basler backends

### DIFF
--- a/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/basler_camera_backend.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/basler_camera_backend.py
@@ -133,6 +133,7 @@ class BaslerCameraBackend(CameraBackend):
         # Get backend-specific configuration with fallbacks
         pixel_format = backend_kwargs.get("pixel_format")
         buffer_count = backend_kwargs.get("buffer_count")
+        self.color_defaults: bool = bool(backend_kwargs.get("color_defaults", True))
         timeout_ms = backend_kwargs.get("timeout_ms")
 
         if pixel_format is None:
@@ -582,6 +583,11 @@ class BaslerCameraBackend(CameraBackend):
         Node availability is model-dependent; missing attributes and
         insufficient access modes are treated as unavailable.
 
+        Must be called on the camera executor thread (inside a
+        ``_run_blocking`` closure): node attribute access and
+        ``GetAccessMode()`` can be GigE network operations and are subject to
+        the pypylon thread-affinity requirement documented on this class.
+
         Args:
             names: Candidate node names, tried in order
             writable: If True, only accept nodes with RW access
@@ -595,6 +601,29 @@ class BaslerCameraBackend(CameraBackend):
                 continue
             if mode == genicam.RW or (not writable and mode == genicam.RO):
                 return node
+        return None
+
+    @staticmethod
+    def _enum_symbol(node, wanted: str):
+        """Return the node's enum symbol matching *wanted* case-insensitively.
+
+        Different pylon device families spell enum entries differently (e.g.
+        ``sRGB`` vs ``sRgb``); matching against ``GetSymbolics()`` avoids
+        guessing. Must run on the camera executor thread.
+
+        Args:
+            node: A pylon enum node.
+            wanted: Desired symbol, compared case-insensitively.
+
+        Returns:
+            The exact symbol string, or ``None`` when not offered.
+        """
+        try:
+            for symbol in node.GetSymbolics():
+                if str(symbol).lower() == wanted.lower():
+                    return symbol
+        except Exception:
+            pass
         return None
 
     async def _ensure_grabbing(self):
@@ -691,15 +720,26 @@ class BaslerCameraBackend(CameraBackend):
             self.triggermode = "trigger"
 
             # Color-correction defaults: sRGB gamma on, black level 0, for
-            # rendering matched with the Daheng backend (nodes are model-dependent)
+            # rendering matched with the Daheng backend (nodes are
+            # model-dependent; ace2/boost families use BslColorSpace). Gated
+            # by the color_defaults kwarg so tuned deployments are not
+            # clobbered on reconnect; imported config files apply afterwards.
             def _set_color_defaults():
                 try:
-                    node = self._find_node("GammaEnable", writable=True)
-                    if node is not None:
-                        node.SetValue(True)
-                    node = self._find_node("GammaSelector", writable=True)
-                    if node is not None:
-                        node.SetValue("sRGB")
+                    enable_node = self._find_node("GammaEnable", writable=True)
+                    if enable_node is not None:
+                        enable_node.SetValue(True)
+                    selector_node = self._find_node("GammaSelector", writable=True)
+                    if selector_node is not None:
+                        symbol = self._enum_symbol(selector_node, "sRGB")
+                        if symbol is not None:
+                            selector_node.SetValue(symbol)
+                    if enable_node is None and selector_node is None:
+                        colorspace_node = self._find_node("BslColorSpace", writable=True)
+                        if colorspace_node is not None:
+                            symbol = self._enum_symbol(colorspace_node, "srgb")
+                            if symbol is not None:
+                                colorspace_node.SetValue(symbol)
                     node = self._find_node("BlackLevel", writable=True)
                     if node is not None:
                         node.SetValue(0.0)
@@ -710,7 +750,8 @@ class BaslerCameraBackend(CameraBackend):
                 except Exception as color_error:
                     self.logger.warning(f"Could not apply color-correction defaults: {color_error}")
 
-            await self._run_blocking(_set_color_defaults, timeout=self._op_timeout_s)
+            if self.color_defaults:
+                await self._run_blocking(_set_color_defaults, timeout=self._op_timeout_s)
 
             # Configure multicast streaming BEFORE starting grabbing if enabled
             # This is critical for proper multicast setup
@@ -2351,8 +2392,19 @@ class BaslerCameraBackend(CameraBackend):
             raise CameraConnectionError(f"Camera '{self.camera_name}' not initialized")
         assert genicam is not None, "camera is initialized but genicam is not available"
 
+    # ── Color Correction ──
+    #
+    # Thread affinity: every pypylon node operation below (including node
+    # resolution via _find_node) runs inside a _run_blocking closure on the
+    # camera's dedicated executor thread; the event loop thread never touches
+    # the SDK. The camera is opened via _ensure_open(), which already routes
+    # through _run_blocking.
+
     async def get_gamma_enable(self) -> Optional[bool]:
         """Get whether in-camera gamma is enabled.
+
+        Checks ``GammaEnable``, then ``GammaSelector`` (sRGB vs User), then
+        ``BslColorSpace`` (ace2/boost families express sRGB there).
 
         Returns:
             True/False, or None if the camera exposes no gamma node
@@ -2363,17 +2415,24 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("GammaEnable")
-            if node is not None:
-                return bool(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
-            node = self._find_node("GammaSelector")
-            if node is not None:
-                return await self._run_blocking(node.GetValue, timeout=self._op_timeout_s) == "sRGB"
-            self.logger.warning(f"Gamma feature not available on camera '{self.camera_name}'")
-            return None
+            def _get():
+                node = self._find_node("GammaEnable")
+                if node is not None:
+                    return bool(node.GetValue())
+                node = self._find_node("GammaSelector")
+                if node is not None:
+                    return str(node.GetValue()).lower() == "srgb"
+                node = self._find_node("BslColorSpace")
+                if node is not None:
+                    return "srgb" in str(node.GetValue()).lower()
+                return None
+
+            value = await self._run_blocking(_get, timeout=self._op_timeout_s)
+            if value is None:
+                self.logger.warning(f"Gamma feature not available on camera '{self.camera_name}'")
+            return value
         except CameraConnectionError:
             raise
         except Exception as e:
@@ -2383,8 +2442,11 @@ class BaslerCameraBackend(CameraBackend):
     async def set_gamma_enable(self, enabled: bool):
         """Enable or disable in-camera gamma.
 
-        When enabling, the sRGB gamma curve is selected so both supported
-        backends render with matched tone curves.
+        When enabling, the sRGB curve is selected; when disabling, models
+        that only expose ``GammaSelector`` are set to ``User`` and models
+        that express gamma via ``BslColorSpace`` (ace2/boost) are set to the
+        linear/off color space — a disable request is never silently
+        dropped.
 
         Args:
             enabled: True to enable sRGB gamma, False for linear output
@@ -2395,25 +2457,44 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            enable_node = self._find_node("GammaEnable", writable=True)
-            selector_node = self._find_node("GammaSelector", writable=True)
-            if enable_node is None and selector_node is None:
-                raise HardwareOperationError(f"Gamma feature not writable on camera '{self.camera_name}'")
+            def _set():
+                enable_node = self._find_node("GammaEnable", writable=True)
+                selector_node = self._find_node("GammaSelector", writable=True)
+                colorspace_node = self._find_node("BslColorSpace", writable=True)
+                if enable_node is None and selector_node is None and colorspace_node is None:
+                    raise HardwareOperationError(f"Gamma feature not writable on camera '{self.camera_name}'")
 
-            if enable_node is not None:
-                await self._run_blocking(enable_node.SetValue, enabled, timeout=self._op_timeout_s)
-                actual = await self._run_blocking(enable_node.GetValue, timeout=self._op_timeout_s)
-                if bool(actual) != enabled:
-                    raise HardwareOperationError(
-                        f"Failed to set gamma enable for camera '{self.camera_name}'. "
-                        f"Target: {enabled}, Actual: {actual}"
-                    )
-            if enabled and selector_node is not None:
-                await self._run_blocking(selector_node.SetValue, "sRGB", timeout=self._op_timeout_s)
+                if enable_node is not None:
+                    enable_node.SetValue(enabled)
+                    actual = enable_node.GetValue()
+                    if bool(actual) != enabled:
+                        raise HardwareOperationError(
+                            f"Failed to set gamma enable for camera '{self.camera_name}'. "
+                            f"Target: {enabled}, Actual: {actual}"
+                        )
+                if selector_node is not None:
+                    wanted = "sRGB" if enabled else "User"
+                    symbol = self._enum_symbol(selector_node, wanted)
+                    if symbol is not None:
+                        selector_node.SetValue(symbol)
+                    elif enable_node is None:
+                        raise HardwareOperationError(
+                            f"GammaSelector on camera '{self.camera_name}' offers no '{wanted}' entry; "
+                            f"cannot express gamma {'on' if enabled else 'off'}."
+                        )
+                if enable_node is None and selector_node is None and colorspace_node is not None:
+                    wanted = "srgb" if enabled else "off"
+                    symbol = self._enum_symbol(colorspace_node, wanted)
+                    if symbol is None:
+                        raise HardwareOperationError(
+                            f"BslColorSpace on camera '{self.camera_name}' offers no '{wanted}' entry; "
+                            f"cannot express gamma {'on' if enabled else 'off'}."
+                        )
+                    colorspace_node.SetValue(symbol)
 
+            await self._run_blocking(_set, timeout=self._op_timeout_s)
             self.logger.debug(f"Gamma enable set to {enabled} for camera '{self.camera_name}'")
         except (CameraConnectionError, HardwareOperationError):
             raise
@@ -2433,14 +2514,18 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("BlackLevel", "BlackLevelRaw")
-            if node is None:
+            def _get():
+                node = self._find_node("BlackLevel", "BlackLevelRaw")
+                if node is None:
+                    return None
+                return float(node.GetValue())
+
+            value = await self._run_blocking(_get, timeout=self._op_timeout_s)
+            if value is None:
                 self.logger.warning(f"BlackLevel feature not available on camera '{self.camera_name}'")
-                return None
-            return float(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+            return value
         except CameraConnectionError:
             raise
         except Exception as e:
@@ -2459,19 +2544,20 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("BlackLevel", writable=True)
-            if node is not None:
-                await self._run_blocking(node.SetValue, float(level), timeout=self._op_timeout_s)
-            else:
+            def _set():
+                node = self._find_node("BlackLevel", writable=True)
+                if node is not None:
+                    node.SetValue(float(level))
+                    return
                 # Older acA GigE models expose the integer raw node instead
                 node = self._find_node("BlackLevelRaw", writable=True)
                 if node is None:
                     raise HardwareOperationError(f"BlackLevel feature not writable on camera '{self.camera_name}'")
-                await self._run_blocking(node.SetValue, int(round(level)), timeout=self._op_timeout_s)
+                node.SetValue(int(round(level)))
 
+            await self._run_blocking(_set, timeout=self._op_timeout_s)
             self.logger.debug(f"Black level set to {level} for camera '{self.camera_name}'")
         except (CameraConnectionError, HardwareOperationError):
             raise
@@ -2491,14 +2577,18 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("ColorTransformationEnable")
-            if node is None:
+            def _get():
+                node = self._find_node("ColorTransformationEnable")
+                if node is None:
+                    return None
+                return bool(node.GetValue())
+
+            value = await self._run_blocking(_get, timeout=self._op_timeout_s)
+            if value is None:
                 self.logger.warning(f"ColorTransformation feature not available on camera '{self.camera_name}'")
-                return None
-            return bool(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+            return value
         except CameraConnectionError:
             raise
         except Exception as e:
@@ -2517,13 +2607,17 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("ColorTransformationEnable", writable=True)
-            if node is None:
-                raise HardwareOperationError(f"ColorTransformation feature not writable on camera '{self.camera_name}'")
-            await self._run_blocking(node.SetValue, enabled, timeout=self._op_timeout_s)
+            def _set():
+                node = self._find_node("ColorTransformationEnable", writable=True)
+                if node is None:
+                    raise HardwareOperationError(
+                        f"ColorTransformation feature not writable on camera '{self.camera_name}'"
+                    )
+                node.SetValue(enabled)
+
+            await self._run_blocking(_set, timeout=self._op_timeout_s)
             self.logger.debug(f"Color transformation set to {enabled} for camera '{self.camera_name}'")
         except (CameraConnectionError, HardwareOperationError):
             raise
@@ -2543,14 +2637,18 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("LightSourcePreset")
-            if node is None:
+            def _get():
+                node = self._find_node("LightSourcePreset")
+                if node is None:
+                    return None
+                return str(node.GetValue())
+
+            value = await self._run_blocking(_get, timeout=self._op_timeout_s)
+            if value is None:
                 self.logger.warning(f"LightSourcePreset feature not available on camera '{self.camera_name}'")
-                return None
-            return str(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+            return value
         except CameraConnectionError:
             raise
         except Exception as e:
@@ -2570,24 +2668,33 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("LightSourcePreset", writable=True)
-            if node is None:
-                raise HardwareOperationError(f"LightSourcePreset feature not writable on camera '{self.camera_name}'")
+            def _set():
+                # Validation outcome is returned (not raised) because
+                # _run_blocking wraps closure exceptions in
+                # HardwareOperationError, which would mask the
+                # CameraConfigurationError contract for invalid presets.
+                node = self._find_node("LightSourcePreset", writable=True)
+                if node is None:
+                    raise HardwareOperationError(
+                        f"LightSourcePreset feature not writable on camera '{self.camera_name}'"
+                    )
+                try:
+                    valid_presets = list(node.GetSymbolics())
+                except Exception:
+                    valid_presets = None
+                if valid_presets is not None and preset not in valid_presets:
+                    return valid_presets
+                node.SetValue(preset)
+                return None
 
-            try:
-                valid_presets = list(node.GetSymbolics())
-            except Exception:
-                valid_presets = None
-            if valid_presets is not None and preset not in valid_presets:
+            invalid_presets = await self._run_blocking(_set, timeout=self._op_timeout_s)
+            if invalid_presets is not None:
                 raise CameraConfigurationError(
                     f"Invalid light source preset '{preset}' for camera '{self.camera_name}'. "
-                    f"Available presets: {valid_presets}"
+                    f"Available presets: {invalid_presets}"
                 )
-
-            await self._run_blocking(node.SetValue, preset, timeout=self._op_timeout_s)
             self.logger.debug(f"Light source preset set to '{preset}' for camera '{self.camera_name}'")
         except (CameraConnectionError, CameraConfigurationError, HardwareOperationError):
             raise
@@ -2607,23 +2714,23 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
-
-            selector = self._find_node("BalanceRatioSelector", writable=True)
-            ratio = self._find_node("BalanceRatio", "BalanceRatioAbs")
-            if selector is None or ratio is None:
-                self.logger.warning(f"BalanceRatio feature not available on camera '{self.camera_name}'")
-                return None
+            await self._ensure_open()
 
             def _get():
+                selector = self._find_node("BalanceRatioSelector", writable=True)
+                ratio = self._find_node("BalanceRatio", "BalanceRatioAbs")
+                if selector is None or ratio is None:
+                    return None
                 ratios = {}
                 for channel in ("Red", "Green", "Blue"):
                     selector.SetValue(channel)
                     ratios[channel.lower()] = float(ratio.GetValue())
                 return ratios
 
-            return await self._run_blocking(_get, timeout=self._op_timeout_s)
+            value = await self._run_blocking(_get, timeout=self._op_timeout_s)
+            if value is None:
+                self.logger.warning(f"BalanceRatio feature not available on camera '{self.camera_name}'")
+            return value
         except CameraConnectionError:
             raise
         except Exception as e:
@@ -2649,15 +2756,13 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
-
-            selector = self._find_node("BalanceRatioSelector", writable=True)
-            ratio = self._find_node("BalanceRatio", "BalanceRatioAbs", writable=True)
-            if selector is None or ratio is None:
-                raise HardwareOperationError(f"BalanceRatio feature not writable on camera '{self.camera_name}'")
+            await self._ensure_open()
 
             def _set():
+                selector = self._find_node("BalanceRatioSelector", writable=True)
+                ratio = self._find_node("BalanceRatio", "BalanceRatioAbs", writable=True)
+                if selector is None or ratio is None:
+                    raise HardwareOperationError(f"BalanceRatio feature not writable on camera '{self.camera_name}'")
                 for channel, value in (("Red", red), ("Green", green), ("Blue", blue)):
                     if value is not None:
                         selector.SetValue(channel)
@@ -2683,14 +2788,18 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("BslContrast", "Contrast")
-            if node is None:
+            def _get():
+                node = self._find_node("BslContrast", "Contrast")
+                if node is None:
+                    return None
+                return float(node.GetValue())
+
+            value = await self._run_blocking(_get, timeout=self._op_timeout_s)
+            if value is None:
                 self.logger.warning(f"Contrast feature not available on camera '{self.camera_name}'")
-                return None
-            return float(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+            return value
         except CameraConnectionError:
             raise
         except Exception as e:
@@ -2709,13 +2818,15 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("BslContrast", "Contrast", writable=True)
-            if node is None:
-                raise HardwareOperationError(f"Contrast feature not writable on camera '{self.camera_name}'")
-            await self._run_blocking(node.SetValue, float(value), timeout=self._op_timeout_s)
+            def _set():
+                node = self._find_node("BslContrast", "Contrast", writable=True)
+                if node is None:
+                    raise HardwareOperationError(f"Contrast feature not writable on camera '{self.camera_name}'")
+                node.SetValue(float(value))
+
+            await self._run_blocking(_set, timeout=self._op_timeout_s)
             self.logger.debug(f"Contrast set to {value} for camera '{self.camera_name}'")
         except (CameraConnectionError, HardwareOperationError):
             raise
@@ -2735,14 +2846,18 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("SharpnessEnhancement", "BslSharpnessEnhancement")
-            if node is None:
+            def _get():
+                node = self._find_node("SharpnessEnhancement", "BslSharpnessEnhancement")
+                if node is None:
+                    return None
+                return float(node.GetValue())
+
+            value = await self._run_blocking(_get, timeout=self._op_timeout_s)
+            if value is None:
                 self.logger.warning(f"Sharpness feature not available on camera '{self.camera_name}'")
-                return None
-            return float(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+            return value
         except CameraConnectionError:
             raise
         except Exception as e:
@@ -2761,13 +2876,15 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("SharpnessEnhancement", "BslSharpnessEnhancement", writable=True)
-            if node is None:
-                raise HardwareOperationError(f"Sharpness feature not writable on camera '{self.camera_name}'")
-            await self._run_blocking(node.SetValue, float(value), timeout=self._op_timeout_s)
+            def _set():
+                node = self._find_node("SharpnessEnhancement", "BslSharpnessEnhancement", writable=True)
+                if node is None:
+                    raise HardwareOperationError(f"Sharpness feature not writable on camera '{self.camera_name}'")
+                node.SetValue(float(value))
+
+            await self._run_blocking(_set, timeout=self._op_timeout_s)
             self.logger.debug(f"Sharpness set to {value} for camera '{self.camera_name}'")
         except (CameraConnectionError, HardwareOperationError):
             raise
@@ -2787,14 +2904,18 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("BslSaturation", "BslSaturationValue")
-            if node is None:
+            def _get():
+                node = self._find_node("BslSaturation", "BslSaturationValue")
+                if node is None:
+                    return None
+                return float(node.GetValue())
+
+            value = await self._run_blocking(_get, timeout=self._op_timeout_s)
+            if value is None:
                 self.logger.warning(f"Saturation feature not available on camera '{self.camera_name}'")
-                return None
-            return float(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+            return value
         except CameraConnectionError:
             raise
         except Exception as e:
@@ -2813,13 +2934,15 @@ class BaslerCameraBackend(CameraBackend):
         """
         self._require_initialized()
         try:
-            if not self.camera.IsOpen():
-                self.camera.Open()
+            await self._ensure_open()
 
-            node = self._find_node("BslSaturation", "BslSaturationValue", writable=True)
-            if node is None:
-                raise HardwareOperationError(f"Saturation feature not writable on camera '{self.camera_name}'")
-            await self._run_blocking(node.SetValue, float(value), timeout=self._op_timeout_s)
+            def _set():
+                node = self._find_node("BslSaturation", "BslSaturationValue", writable=True)
+                if node is None:
+                    raise HardwareOperationError(f"Saturation feature not writable on camera '{self.camera_name}'")
+                node.SetValue(float(value))
+
+            await self._run_blocking(_set, timeout=self._op_timeout_s)
             self.logger.debug(f"Saturation set to {value} for camera '{self.camera_name}'")
         except (CameraConnectionError, HardwareOperationError):
             raise

--- a/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/basler_camera_backend.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/basler_camera_backend.py
@@ -2522,9 +2522,7 @@ class BaslerCameraBackend(CameraBackend):
 
             node = self._find_node("ColorTransformationEnable", writable=True)
             if node is None:
-                raise HardwareOperationError(
-                    f"ColorTransformation feature not writable on camera '{self.camera_name}'"
-                )
+                raise HardwareOperationError(f"ColorTransformation feature not writable on camera '{self.camera_name}'")
             await self._run_blocking(node.SetValue, enabled, timeout=self._op_timeout_s)
             self.logger.debug(f"Color transformation set to {enabled} for camera '{self.camera_name}'")
         except (CameraConnectionError, HardwareOperationError):

--- a/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/basler_camera_backend.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/basler_camera_backend.py
@@ -576,6 +576,27 @@ class BaslerCameraBackend(CameraBackend):
         except Exception as e:
             raise CameraConnectionError(f"Failed to ensure camera '{self.camera_name}' is open: {e}") from e
 
+    def _find_node(self, *names: str, writable: bool = False):
+        """Return the first available camera node from names, or None.
+
+        Node availability is model-dependent; missing attributes and
+        insufficient access modes are treated as unavailable.
+
+        Args:
+            names: Candidate node names, tried in order
+            writable: If True, only accept nodes with RW access
+        """
+        assert genicam is not None, "genicam is not available"
+        for name in names:
+            try:
+                node = getattr(self.camera, name)
+                mode = node.GetAccessMode()
+            except Exception:
+                continue
+            if mode == genicam.RW or (not writable and mode == genicam.RO):
+                return node
+        return None
+
     async def _ensure_grabbing(self):
         """Ensure camera is grabbing images.
 
@@ -668,6 +689,28 @@ class BaslerCameraBackend(CameraBackend):
 
             await self._run_blocking(_set_trigger_mode, timeout=self._op_timeout_s)
             self.triggermode = "trigger"
+
+            # Color-correction defaults: sRGB gamma on, black level 0, for
+            # rendering matched with the Daheng backend (nodes are model-dependent)
+            def _set_color_defaults():
+                try:
+                    node = self._find_node("GammaEnable", writable=True)
+                    if node is not None:
+                        node.SetValue(True)
+                    node = self._find_node("GammaSelector", writable=True)
+                    if node is not None:
+                        node.SetValue("sRGB")
+                    node = self._find_node("BlackLevel", writable=True)
+                    if node is not None:
+                        node.SetValue(0.0)
+                    else:
+                        node = self._find_node("BlackLevelRaw", writable=True)
+                        if node is not None:
+                            node.SetValue(0)
+                except Exception as color_error:
+                    self.logger.warning(f"Could not apply color-correction defaults: {color_error}")
+
+            await self._run_blocking(_set_color_defaults, timeout=self._op_timeout_s)
 
             # Configure multicast streaming BEFORE starting grabbing if enabled
             # This is critical for proper multicast setup
@@ -2301,6 +2344,490 @@ class BaslerCameraBackend(CameraBackend):
         except Exception as e:
             self.logger.error(f"Error setting white balance for camera '{self.camera_name}': {str(e)}")
             raise HardwareOperationError(f"Failed to set white balance: {str(e)}")
+
+    def _require_initialized(self):
+        """Raise unless the camera is initialized and the SDK is loaded."""
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' not initialized")
+        assert genicam is not None, "camera is initialized but genicam is not available"
+
+    async def get_gamma_enable(self) -> Optional[bool]:
+        """Get whether in-camera gamma is enabled.
+
+        Returns:
+            True/False, or None if the camera exposes no gamma node
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If gamma retrieval fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("GammaEnable")
+            if node is not None:
+                return bool(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+            node = self._find_node("GammaSelector")
+            if node is not None:
+                return await self._run_blocking(node.GetValue, timeout=self._op_timeout_s) == "sRGB"
+            self.logger.warning(f"Gamma feature not available on camera '{self.camera_name}'")
+            return None
+        except CameraConnectionError:
+            raise
+        except Exception as e:
+            self.logger.error(f"Error getting gamma enable for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to get gamma enable: {str(e)}")
+
+    async def set_gamma_enable(self, enabled: bool):
+        """Enable or disable in-camera gamma.
+
+        When enabling, the sRGB gamma curve is selected so both supported
+        backends render with matched tone curves.
+
+        Args:
+            enabled: True to enable sRGB gamma, False for linear output
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If no gamma node is writable or setting fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            enable_node = self._find_node("GammaEnable", writable=True)
+            selector_node = self._find_node("GammaSelector", writable=True)
+            if enable_node is None and selector_node is None:
+                raise HardwareOperationError(f"Gamma feature not writable on camera '{self.camera_name}'")
+
+            if enable_node is not None:
+                await self._run_blocking(enable_node.SetValue, enabled, timeout=self._op_timeout_s)
+                actual = await self._run_blocking(enable_node.GetValue, timeout=self._op_timeout_s)
+                if bool(actual) != enabled:
+                    raise HardwareOperationError(
+                        f"Failed to set gamma enable for camera '{self.camera_name}'. "
+                        f"Target: {enabled}, Actual: {actual}"
+                    )
+            if enabled and selector_node is not None:
+                await self._run_blocking(selector_node.SetValue, "sRGB", timeout=self._op_timeout_s)
+
+            self.logger.debug(f"Gamma enable set to {enabled} for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
+        except Exception as e:
+            self.logger.error(f"Error setting gamma enable for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to set gamma enable: {str(e)}")
+
+    async def get_black_level(self) -> Optional[float]:
+        """Get the current black level.
+
+        Returns:
+            Black level in camera units, or None if unavailable
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If black level retrieval fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("BlackLevel", "BlackLevelRaw")
+            if node is None:
+                self.logger.warning(f"BlackLevel feature not available on camera '{self.camera_name}'")
+                return None
+            return float(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+        except CameraConnectionError:
+            raise
+        except Exception as e:
+            self.logger.error(f"Error getting black level for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to get black level: {str(e)}")
+
+    async def set_black_level(self, level: float):
+        """Set the black level (shadow floor).
+
+        Args:
+            level: Black level value in camera units
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If no black level node is writable or setting fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("BlackLevel", writable=True)
+            if node is not None:
+                await self._run_blocking(node.SetValue, float(level), timeout=self._op_timeout_s)
+            else:
+                # Older acA GigE models expose the integer raw node instead
+                node = self._find_node("BlackLevelRaw", writable=True)
+                if node is None:
+                    raise HardwareOperationError(f"BlackLevel feature not writable on camera '{self.camera_name}'")
+                await self._run_blocking(node.SetValue, int(round(level)), timeout=self._op_timeout_s)
+
+            self.logger.debug(f"Black level set to {level} for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
+        except Exception as e:
+            self.logger.error(f"Error setting black level for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to set black level: {str(e)}")
+
+    async def get_color_transformation(self) -> Optional[bool]:
+        """Get whether the color transformation matrix is enabled.
+
+        Returns:
+            True/False, or None if unavailable
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If retrieval fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("ColorTransformationEnable")
+            if node is None:
+                self.logger.warning(f"ColorTransformation feature not available on camera '{self.camera_name}'")
+                return None
+            return bool(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+        except CameraConnectionError:
+            raise
+        except Exception as e:
+            self.logger.error(f"Error getting color transformation for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to get color transformation: {str(e)}")
+
+    async def set_color_transformation(self, enabled: bool):
+        """Enable or disable the color transformation matrix.
+
+        Args:
+            enabled: True to enable, False to disable
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If the node is not writable or setting fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("ColorTransformationEnable", writable=True)
+            if node is None:
+                raise HardwareOperationError(
+                    f"ColorTransformation feature not writable on camera '{self.camera_name}'"
+                )
+            await self._run_blocking(node.SetValue, enabled, timeout=self._op_timeout_s)
+            self.logger.debug(f"Color transformation set to {enabled} for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
+        except Exception as e:
+            self.logger.error(f"Error setting color transformation for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to set color transformation: {str(e)}")
+
+    async def get_light_source_preset(self) -> Optional[str]:
+        """Get the current light source preset.
+
+        Returns:
+            Preset name, or None if unavailable
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If retrieval fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("LightSourcePreset")
+            if node is None:
+                self.logger.warning(f"LightSourcePreset feature not available on camera '{self.camera_name}'")
+                return None
+            return str(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+        except CameraConnectionError:
+            raise
+        except Exception as e:
+            self.logger.error(f"Error getting light source preset for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to get light source preset: {str(e)}")
+
+    async def set_light_source_preset(self, preset: str):
+        """Set the light source preset (color-temperature preset).
+
+        Args:
+            preset: Preset name, e.g. "Off", "Daylight5000K", "Tungsten2800K"
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            CameraConfigurationError: If the preset is not supported by the camera
+            HardwareOperationError: If the node is not writable or setting fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("LightSourcePreset", writable=True)
+            if node is None:
+                raise HardwareOperationError(f"LightSourcePreset feature not writable on camera '{self.camera_name}'")
+
+            try:
+                valid_presets = list(node.GetSymbolics())
+            except Exception:
+                valid_presets = None
+            if valid_presets is not None and preset not in valid_presets:
+                raise CameraConfigurationError(
+                    f"Invalid light source preset '{preset}' for camera '{self.camera_name}'. "
+                    f"Available presets: {valid_presets}"
+                )
+
+            await self._run_blocking(node.SetValue, preset, timeout=self._op_timeout_s)
+            self.logger.debug(f"Light source preset set to '{preset}' for camera '{self.camera_name}'")
+        except (CameraConnectionError, CameraConfigurationError, HardwareOperationError):
+            raise
+        except Exception as e:
+            self.logger.error(f"Error setting light source preset for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to set light source preset: {str(e)}")
+
+    async def get_balance_ratios(self) -> Optional[Dict[str, float]]:
+        """Get the current R/G/B white balance ratios.
+
+        Returns:
+            Dict with 'red', 'green', 'blue' ratio values, or None if unavailable
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If retrieval fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            selector = self._find_node("BalanceRatioSelector", writable=True)
+            ratio = self._find_node("BalanceRatio", "BalanceRatioAbs")
+            if selector is None or ratio is None:
+                self.logger.warning(f"BalanceRatio feature not available on camera '{self.camera_name}'")
+                return None
+
+            def _get():
+                ratios = {}
+                for channel in ("Red", "Green", "Blue"):
+                    selector.SetValue(channel)
+                    ratios[channel.lower()] = float(ratio.GetValue())
+                return ratios
+
+            return await self._run_blocking(_get, timeout=self._op_timeout_s)
+        except CameraConnectionError:
+            raise
+        except Exception as e:
+            self.logger.error(f"Error getting balance ratios for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to get balance ratios: {str(e)}")
+
+    async def set_balance_ratios(
+        self, red: Optional[float] = None, green: Optional[float] = None, blue: Optional[float] = None
+    ):
+        """Set R/G/B white balance ratios (manual color cast correction).
+
+        Only channels passed as non-None are written. Most models require
+        BalanceWhiteAuto to be "Off" for the ratios to be writable.
+
+        Args:
+            red: Red channel ratio
+            green: Green channel ratio
+            blue: Blue channel ratio
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If the nodes are not writable or setting fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            selector = self._find_node("BalanceRatioSelector", writable=True)
+            ratio = self._find_node("BalanceRatio", "BalanceRatioAbs", writable=True)
+            if selector is None or ratio is None:
+                raise HardwareOperationError(f"BalanceRatio feature not writable on camera '{self.camera_name}'")
+
+            def _set():
+                for channel, value in (("Red", red), ("Green", green), ("Blue", blue)):
+                    if value is not None:
+                        selector.SetValue(channel)
+                        ratio.SetValue(float(value))
+
+            await self._run_blocking(_set, timeout=self._op_timeout_s)
+            self.logger.debug(f"Balance ratios set (R={red}, G={green}, B={blue}) for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
+        except Exception as e:
+            self.logger.error(f"Error setting balance ratios for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to set balance ratios: {str(e)}")
+
+    async def get_contrast(self) -> Optional[float]:
+        """Get the current contrast value.
+
+        Returns:
+            Contrast value, or None if unavailable (common on acA models)
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If retrieval fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("BslContrast", "Contrast")
+            if node is None:
+                self.logger.warning(f"Contrast feature not available on camera '{self.camera_name}'")
+                return None
+            return float(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+        except CameraConnectionError:
+            raise
+        except Exception as e:
+            self.logger.error(f"Error getting contrast for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to get contrast: {str(e)}")
+
+    async def set_contrast(self, value: float):
+        """Set the contrast value.
+
+        Args:
+            value: Contrast value in camera units
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If no contrast node is writable or setting fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("BslContrast", "Contrast", writable=True)
+            if node is None:
+                raise HardwareOperationError(f"Contrast feature not writable on camera '{self.camera_name}'")
+            await self._run_blocking(node.SetValue, float(value), timeout=self._op_timeout_s)
+            self.logger.debug(f"Contrast set to {value} for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
+        except Exception as e:
+            self.logger.error(f"Error setting contrast for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to set contrast: {str(e)}")
+
+    async def get_sharpness(self) -> Optional[float]:
+        """Get the current sharpness enhancement value.
+
+        Returns:
+            Sharpness value, or None if unavailable
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If retrieval fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("SharpnessEnhancement", "BslSharpnessEnhancement")
+            if node is None:
+                self.logger.warning(f"Sharpness feature not available on camera '{self.camera_name}'")
+                return None
+            return float(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+        except CameraConnectionError:
+            raise
+        except Exception as e:
+            self.logger.error(f"Error getting sharpness for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to get sharpness: {str(e)}")
+
+    async def set_sharpness(self, value: float):
+        """Set the sharpness enhancement value.
+
+        Args:
+            value: Sharpness value in camera units
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If no sharpness node is writable or setting fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("SharpnessEnhancement", "BslSharpnessEnhancement", writable=True)
+            if node is None:
+                raise HardwareOperationError(f"Sharpness feature not writable on camera '{self.camera_name}'")
+            await self._run_blocking(node.SetValue, float(value), timeout=self._op_timeout_s)
+            self.logger.debug(f"Sharpness set to {value} for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
+        except Exception as e:
+            self.logger.error(f"Error setting sharpness for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to set sharpness: {str(e)}")
+
+    async def get_saturation(self) -> Optional[float]:
+        """Get the current color saturation value.
+
+        Returns:
+            Saturation value, or None if unavailable
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If retrieval fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("BslSaturation", "BslSaturationValue")
+            if node is None:
+                self.logger.warning(f"Saturation feature not available on camera '{self.camera_name}'")
+                return None
+            return float(await self._run_blocking(node.GetValue, timeout=self._op_timeout_s))
+        except CameraConnectionError:
+            raise
+        except Exception as e:
+            self.logger.error(f"Error getting saturation for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to get saturation: {str(e)}")
+
+    async def set_saturation(self, value: float):
+        """Set the color saturation value.
+
+        Args:
+            value: Saturation value in camera units
+
+        Raises:
+            CameraConnectionError: If camera is not initialized
+            HardwareOperationError: If no saturation node is writable or setting fails
+        """
+        self._require_initialized()
+        try:
+            if not self.camera.IsOpen():
+                self.camera.Open()
+
+            node = self._find_node("BslSaturation", "BslSaturationValue", writable=True)
+            if node is None:
+                raise HardwareOperationError(f"Saturation feature not writable on camera '{self.camera_name}'")
+            await self._run_blocking(node.SetValue, float(value), timeout=self._op_timeout_s)
+            self.logger.debug(f"Saturation set to {value} for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
+        except Exception as e:
+            self.logger.error(f"Error setting saturation for camera '{self.camera_name}': {str(e)}")
+            raise HardwareOperationError(f"Failed to set saturation: {str(e)}")
 
     async def get_trigger_modes(self) -> List[str]:
         """Get available trigger modes for Basler cameras.

--- a/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/mock_basler_camera_backend.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/backends/basler/mock_basler_camera_backend.py
@@ -136,6 +136,14 @@ class MockBaslerCameraBackend(CameraBackend):
         self.gain = 1.0
         self.roi = {"x": 0, "y": 0, "width": 1920, "height": 1080}
         self.white_balance_mode = "off"
+        self.gamma_enable = True
+        self.black_level = 0.0
+        self.color_transformation = False
+        self.light_source_preset = "Off"
+        self.balance_ratios = {"red": 1.0, "green": 1.0, "blue": 1.0}
+        self.contrast = 0.0
+        self.sharpness = 1.0
+        self.saturation = 1.0
         self.triggermode = self.camera_config.cameras.trigger_mode
         self.image_counter = 0
 
@@ -674,6 +682,83 @@ class MockBaslerCameraBackend(CameraBackend):
         # Simulate async operation
         await self._sleep(0.001)
         return ["off", "once", "continuous"]
+
+    async def get_gamma_enable(self) -> bool:
+        """Get current gamma enable state."""
+        return self.gamma_enable
+
+    async def set_gamma_enable(self, enabled: bool):
+        """Enable or disable in-camera gamma."""
+        self.gamma_enable = bool(enabled)
+        self.logger.debug(f"Gamma enable set to {enabled} for mock camera '{self.camera_name}'")
+
+    async def get_black_level(self) -> float:
+        """Get current black level."""
+        return self.black_level
+
+    async def set_black_level(self, level: float):
+        """Set black level."""
+        self.black_level = float(level)
+        self.logger.debug(f"Black level set to {level} for mock camera '{self.camera_name}'")
+
+    async def get_color_transformation(self) -> bool:
+        """Get current color transformation enable state."""
+        return self.color_transformation
+
+    async def set_color_transformation(self, enabled: bool):
+        """Enable or disable color transformation."""
+        self.color_transformation = bool(enabled)
+        self.logger.debug(f"Color transformation set to {enabled} for mock camera '{self.camera_name}'")
+
+    async def get_light_source_preset(self) -> str:
+        """Get current light source preset."""
+        return self.light_source_preset
+
+    async def set_light_source_preset(self, preset: str):
+        """Set light source preset."""
+        self.light_source_preset = preset
+        self.logger.debug(f"Light source preset set to '{preset}' for mock camera '{self.camera_name}'")
+
+    async def get_balance_ratios(self) -> Dict[str, float]:
+        """Get current R/G/B balance ratios."""
+        return self.balance_ratios.copy()
+
+    async def set_balance_ratios(self, red: float = None, green: float = None, blue: float = None):
+        """Set R/G/B balance ratios."""
+        if red is not None:
+            self.balance_ratios["red"] = float(red)
+        if green is not None:
+            self.balance_ratios["green"] = float(green)
+        if blue is not None:
+            self.balance_ratios["blue"] = float(blue)
+        self.logger.debug(f"Balance ratios set (R={red}, G={green}, B={blue}) for mock camera '{self.camera_name}'")
+
+    async def get_contrast(self) -> float:
+        """Get current contrast value."""
+        return self.contrast
+
+    async def set_contrast(self, value: float):
+        """Set contrast value."""
+        self.contrast = float(value)
+        self.logger.debug(f"Contrast set to {value} for mock camera '{self.camera_name}'")
+
+    async def get_sharpness(self) -> float:
+        """Get current sharpness value."""
+        return self.sharpness
+
+    async def set_sharpness(self, value: float):
+        """Set sharpness value."""
+        self.sharpness = float(value)
+        self.logger.debug(f"Sharpness set to {value} for mock camera '{self.camera_name}'")
+
+    async def get_saturation(self) -> float:
+        """Get current saturation value."""
+        return self.saturation
+
+    async def set_saturation(self, value: float):
+        """Set saturation value."""
+        self.saturation = float(value)
+        self.logger.debug(f"Saturation set to {value} for mock camera '{self.camera_name}'")
 
     async def get_pixel_format_range(self) -> List[str]:
         """Get available pixel formats.

--- a/mindtrace/hardware/mindtrace/hardware/cameras/backends/daheng/daheng_camera_backend.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/backends/daheng/daheng_camera_backend.py
@@ -104,6 +104,11 @@ class DahengCameraBackend(CameraBackend):
                 - pixel_format: Default pixel format (uses config default if None)
                 - buffer_count: Number of frame buffers (uses config default if None)
                 - timeout_ms: Capture timeout in milliseconds (uses config default if None)
+                - color_defaults: Apply the sRGB-gamma / black-level-0 color
+                  defaults on connect (default True). Set False for
+                  deployments that tune color at runtime and must not have
+                  values reset on reconnect; imported config files are
+                  applied after the defaults either way.
 
         Raises:
             SDKNotAvailableError: If gxipy SDK is not available
@@ -126,6 +131,7 @@ class DahengCameraBackend(CameraBackend):
         pixel_format = backend_kwargs.get("pixel_format")
         buffer_count = backend_kwargs.get("buffer_count")
         timeout_ms = backend_kwargs.get("timeout_ms")
+        self.color_defaults: bool = bool(backend_kwargs.get("color_defaults", True))
 
         if pixel_format is None:
             pixel_format = getattr(self.camera_config, "pixel_format", "BGR8")
@@ -357,19 +363,23 @@ class DahengCameraBackend(CameraBackend):
                     cam.AcquisitionMode.set(gx.GxAcquisitionModeEntry.CONTINUOUS)
 
                 # Color-correction defaults: sRGB gamma on, black level 0, for
-                # rendering matched with the Basler backend (nodes are model-dependent)
-                try:
-                    if cam.GammaMode.is_implemented():
-                        cam.GammaMode.set(0)  # 0 = sRGB
-                    if cam.GammaEnable.is_implemented():
-                        cam.GammaEnable.set(True)
-                except Exception as e:
-                    self.logger.debug(f"Gamma defaults not applied for camera '{self.camera_name}': {e}")
-                try:
-                    if cam.BlackLevel.is_implemented():
-                        cam.BlackLevel.set(0.0)
-                except Exception as e:
-                    self.logger.debug(f"Black level default not applied for camera '{self.camera_name}': {e}")
+                # rendering matched with the Basler backend (nodes are
+                # model-dependent). Gated by the color_defaults kwarg so tuned
+                # deployments are not clobbered on reconnect; an imported
+                # config file (applied after this) also restores tuned values.
+                if self.color_defaults:
+                    try:
+                        if cam.GammaMode.is_implemented():
+                            cam.GammaMode.set(0)  # 0 = sRGB
+                        if cam.GammaEnable.is_implemented():
+                            cam.GammaEnable.set(True)
+                    except Exception as e:
+                        self.logger.debug(f"Gamma defaults not applied for camera '{self.camera_name}': {e}")
+                    try:
+                        if cam.BlackLevel.is_implemented():
+                            cam.BlackLevel.set(0.0)
+                    except Exception as e:
+                        self.logger.debug(f"Black level default not applied for camera '{self.camera_name}': {e}")
 
                 # Start streaming
                 cam.stream_on()
@@ -908,168 +918,268 @@ class DahengCameraBackend(CameraBackend):
         """
         return ["off", "once", "continuous"]
 
-    # ── Color Transformation ──
+    # ── Color Correction ──
+    #
+    # Contract (mirrors the Basler backend):
+    # * Getters return ``None`` when the camera does not implement the feature
+    #   (never a fabricated default) and raise ``HardwareOperationError`` on
+    #   real read failures.
+    # * Setters raise ``HardwareOperationError`` when the feature is
+    #   unsupported or the write fails, and ``CameraConfigurationError`` for
+    #   invalid values.
 
-    async def get_color_transformation(self) -> bool:
-        """Get current color transformation enable state."""
+    def _color_feature(self, name: str):
+        """Return an implemented gxipy feature by name, or ``None``.
+
+        Must be called from the camera executor thread (inside a
+        ``_run_blocking`` closure).
+
+        Args:
+            name: gxipy feature attribute name (e.g. ``"GammaEnable"``).
+
+        Returns:
+            The feature object when present and implemented, else ``None``.
+        """
+        feature = getattr(self.camera, name, None)
+        if feature is None:
+            return None
+        try:
+            if not feature.is_implemented():
+                return None
+        except Exception:
+            return None
+        return feature
+
+    async def get_color_transformation(self) -> Optional[bool]:
+        """Get the color transformation enable state.
+
+        Returns:
+            True/False, or ``None`` when the camera has no color
+            transformation node.
+
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If reading the feature fails.
+        """
         if not self.initialized or self.camera is None:
             raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _get():
+            feature = self._color_feature("ColorTransformationEnable")
+            if feature is None:
+                return None
+            return bool(feature.get())
+
         try:
-
-            def _get():
-                cam = self.camera
-                if cam.ColorTransformationEnable.is_implemented():
-                    return cam.ColorTransformationEnable.get()
-                return False
-
             return await self._run_blocking(_get)
         except Exception as e:
-            self.logger.warning(f"Color transformation not available for camera '{self.camera_name}': {e}")
-            return False
+            raise HardwareOperationError(
+                f"Failed to read color transformation for camera '{self.camera_name}': {e}"
+            ) from e
 
     async def set_color_transformation(self, enabled: bool):
         """Enable or disable color transformation.
 
         Args:
-            enabled: True to enable, False to disable
+            enabled: True to enable, False to disable.
+
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If the feature is unsupported or the
+                write fails.
         """
         if not self.initialized or self.camera is None:
             raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _set():
+            feature = self._color_feature("ColorTransformationEnable")
+            if feature is None:
+                raise HardwareOperationError(f"Color transformation is not supported by camera '{self.camera_name}'")
+            feature.set(enabled)
+
         try:
-
-            def _set():
-                cam = self.camera
-                if cam.ColorTransformationEnable.is_implemented():
-                    cam.ColorTransformationEnable.set(enabled)
-                    pass
-
             await self._run_blocking(_set)
-            self.logger.info(f"Color transformation set to {enabled} for camera '{self.camera_name}'")
+            self.logger.debug(f"Color transformation set to {enabled} for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
         except Exception as e:
-            self.logger.warning(f"Failed to set color transformation for camera '{self.camera_name}': {e}")
+            raise HardwareOperationError(
+                f"Failed to set color transformation for camera '{self.camera_name}': {e}"
+            ) from e
 
     # ── Light Source Preset ──
 
-    async def get_light_source_preset(self) -> str:
-        """Get current light source preset."""
-        if not self.initialized or self.camera is None:
-            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
-        try:
+    _LIGHT_SOURCE_PRESETS: Dict[str, int] = {
+        "OFF": 0,
+        "CUSTOM": 1,
+        "DAYLIGHT_6500K": 2,
+        "DAYLIGHT_5000K": 3,
+        "COOL_WHITE_FLUORESCENCE": 4,
+        "INCA": 5,
+    }
 
-            def _get():
-                cam = self.camera
-                if cam.LightSourcePreset.is_implemented():
-                    _val, desc = cam.LightSourcePreset.get()
-                    return desc
-                return "OFF"
+    async def get_light_source_preset(self) -> Optional[str]:
+        """Get the current light source preset.
 
-            return await self._run_blocking(_get)
-        except Exception as e:
-            self.logger.warning(f"Light source preset not available for camera '{self.camera_name}': {e}")
-            return "OFF"
+        Returns:
+            Preset description string, or ``None`` when the camera has no
+            light source preset node.
 
-    async def set_light_source_preset(self, preset: str):
-        """Set light source preset.
-
-        Args:
-            preset: One of 'OFF', 'CUSTOM', 'DAYLIGHT_6500K', 'DAYLIGHT_5000K',
-                    'COOL_WHITE_FLUORESCENCE', 'INCA'
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If reading the feature fails.
         """
         if not self.initialized or self.camera is None:
             raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
-        preset_map = {
-            "OFF": 0,
-            "CUSTOM": 1,
-            "DAYLIGHT_6500K": 2,
-            "DAYLIGHT_5000K": 3,
-            "COOL_WHITE_FLUORESCENCE": 4,
-            "INCA": 5,
-        }
-        value = preset_map.get(preset.upper(), 0)
+
+        def _get():
+            feature = self._color_feature("LightSourcePreset")
+            if feature is None:
+                return None
+            _val, desc = feature.get()
+            return desc
+
         try:
+            return await self._run_blocking(_get)
+        except Exception as e:
+            raise HardwareOperationError(
+                f"Failed to read light source preset for camera '{self.camera_name}': {e}"
+            ) from e
 
-            def _set():
-                cam = self.camera
-                if cam.LightSourcePreset.is_implemented():
-                    cam.LightSourcePreset.set(value)
+    async def set_light_source_preset(self, preset: str):
+        """Set the light source preset.
 
+        Args:
+            preset: One of 'OFF', 'CUSTOM', 'DAYLIGHT_6500K',
+                'DAYLIGHT_5000K', 'COOL_WHITE_FLUORESCENCE', 'INCA'
+                (case-insensitive).
+
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            CameraConfigurationError: If *preset* is not a known preset.
+            HardwareOperationError: If the feature is unsupported or the
+                write fails.
+        """
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        key = preset.upper()
+        if key not in self._LIGHT_SOURCE_PRESETS:
+            raise CameraConfigurationError(
+                f"Invalid light source preset '{preset}' for camera '{self.camera_name}'. "
+                f"Available presets: {sorted(self._LIGHT_SOURCE_PRESETS)}"
+            )
+        value = self._LIGHT_SOURCE_PRESETS[key]
+
+        def _set():
+            feature = self._color_feature("LightSourcePreset")
+            if feature is None:
+                raise HardwareOperationError(f"Light source preset is not supported by camera '{self.camera_name}'")
+            feature.set(value)
+
+        try:
             await self._run_blocking(_set)
             self.logger.debug(f"Light source preset set to '{preset}' for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
         except Exception as e:
-            self.logger.warning(f"Failed to set light source preset for camera '{self.camera_name}': {e}")
+            raise HardwareOperationError(
+                f"Failed to set light source preset for camera '{self.camera_name}': {e}"
+            ) from e
 
     # ── Balance Ratio (R/G/B) ──
 
-    async def get_balance_ratios(self) -> Dict[str, float]:
-        """Get current R/G/B balance ratios.
+    async def get_balance_ratios(self) -> Optional[Dict[str, float]]:
+        """Get the current R/G/B balance ratios.
 
         Returns:
-            Dict with 'red', 'green', 'blue' ratio values
+            Dict with 'red', 'green', 'blue' ratio values, or ``None`` when
+            the camera has no balance ratio nodes.
+
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If reading the ratios fails.
         """
         if not self.initialized or self.camera is None:
             raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _get():
+            selector = self._color_feature("BalanceRatioSelector")
+            ratio = self._color_feature("BalanceRatio")
+            if selector is None or ratio is None:
+                return None
+            ratios = {}
+            for channel, index in (("red", 0), ("green", 1), ("blue", 2)):
+                selector.set(index)
+                ratios[channel] = float(ratio.get())
+            return ratios
+
         try:
-
-            def _get():
-                cam = self.camera
-                ratios = {}
-                for channel, selector in [("red", 0), ("green", 1), ("blue", 2)]:
-                    cam.BalanceRatioSelector.set(selector)
-                    ratios[channel] = cam.BalanceRatio.get()
-                return ratios
-
             return await self._run_blocking(_get)
         except Exception as e:
-            self.logger.warning(f"Balance ratios not available for camera '{self.camera_name}': {e}")
-            return {"red": 1.0, "green": 1.0, "blue": 1.0}
+            raise HardwareOperationError(f"Failed to read balance ratios for camera '{self.camera_name}': {e}") from e
 
     async def set_balance_ratios(self, red: float = None, green: float = None, blue: float = None):
         """Set R/G/B balance ratios.
 
+        Only channels passed as non-None are written.
+
         Args:
-            red: Red channel ratio
-            green: Green channel ratio
-            blue: Blue channel ratio
+            red: Red channel ratio.
+            green: Green channel ratio.
+            blue: Blue channel ratio.
+
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If the feature is unsupported or the
+                write fails.
         """
         if not self.initialized or self.camera is None:
             raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _set():
+            selector = self._color_feature("BalanceRatioSelector")
+            ratio = self._color_feature("BalanceRatio")
+            if selector is None or ratio is None:
+                raise HardwareOperationError(f"Balance ratios are not supported by camera '{self.camera_name}'")
+            for channel_value, index in ((red, 0), (green, 1), (blue, 2)):
+                if channel_value is not None:
+                    selector.set(index)
+                    ratio.set(channel_value)
+
         try:
-
-            def _set():
-                cam = self.camera
-                if red is not None:
-                    cam.BalanceRatioSelector.set(0)
-                    cam.BalanceRatio.set(red)
-                if green is not None:
-                    cam.BalanceRatioSelector.set(1)
-                    cam.BalanceRatio.set(green)
-                if blue is not None:
-                    cam.BalanceRatioSelector.set(2)
-                    cam.BalanceRatio.set(blue)
-
             await self._run_blocking(_set)
             self.logger.debug(f"Balance ratios set (R={red}, G={green}, B={blue}) for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
         except Exception as e:
-            self.logger.warning(f"Failed to set balance ratios for camera '{self.camera_name}': {e}")
+            raise HardwareOperationError(f"Failed to set balance ratios for camera '{self.camera_name}': {e}") from e
 
     # ── Gamma ──
 
-    async def get_gamma_enable(self) -> bool:
-        """Get current gamma enable state."""
+    async def get_gamma_enable(self) -> Optional[bool]:
+        """Get the gamma enable state.
+
+        Returns:
+            True/False, or ``None`` when the camera has no gamma node.
+
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If reading the feature fails.
+        """
         if not self.initialized or self.camera is None:
             raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _get():
+            feature = self._color_feature("GammaEnable")
+            if feature is None:
+                return None
+            return bool(feature.get())
+
         try:
-
-            def _get():
-                cam = self.camera
-                if cam.GammaEnable.is_implemented():
-                    return bool(cam.GammaEnable.get())
-                return False
-
             return await self._run_blocking(_get)
         except Exception as e:
-            self.logger.warning(f"Gamma not available for camera '{self.camera_name}': {e}")
-            return False
+            raise HardwareOperationError(f"Failed to read gamma enable for camera '{self.camera_name}': {e}") from e
 
     async def set_gamma_enable(self, enabled: bool):
         """Enable or disable in-camera gamma.
@@ -1078,183 +1188,255 @@ class DahengCameraBackend(CameraBackend):
         backends render with matched tone curves.
 
         Args:
-            enabled: True to enable sRGB gamma, False for linear output
+            enabled: True to enable sRGB gamma, False for linear output.
+
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If the feature is unsupported or the
+                write fails.
         """
         if not self.initialized or self.camera is None:
             raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _set():
+            feature = self._color_feature("GammaEnable")
+            if feature is None:
+                raise HardwareOperationError(f"Gamma is not supported by camera '{self.camera_name}'")
+            if enabled:
+                mode = self._color_feature("GammaMode")
+                if mode is not None:
+                    mode.set(0)  # 0 = sRGB
+            feature.set(enabled)
+
         try:
-
-            def _set():
-                cam = self.camera
-                if enabled and cam.GammaMode.is_implemented():
-                    cam.GammaMode.set(0)  # 0 = sRGB
-                if cam.GammaEnable.is_implemented():
-                    cam.GammaEnable.set(enabled)
-
             await self._run_blocking(_set)
             self.logger.debug(f"Gamma enable set to {enabled} for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
         except Exception as e:
-            self.logger.warning(f"Failed to set gamma enable for camera '{self.camera_name}': {e}")
+            raise HardwareOperationError(f"Failed to set gamma enable for camera '{self.camera_name}': {e}") from e
 
     # ── Black Level ──
 
-    async def get_black_level(self) -> float:
-        """Get current black level."""
-        if not self.initialized or self.camera is None:
-            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
-        try:
+    async def get_black_level(self) -> Optional[float]:
+        """Get the current black level.
 
-            def _get():
-                cam = self.camera
-                if cam.BlackLevel.is_implemented():
-                    return float(cam.BlackLevel.get())
-                return 0.0
+        Returns:
+            Black level in camera units, or ``None`` when unsupported.
 
-            return await self._run_blocking(_get)
-        except Exception as e:
-            self.logger.warning(f"Black level not available for camera '{self.camera_name}': {e}")
-            return 0.0
-
-    async def set_black_level(self, level: float):
-        """Set black level (shadow floor).
-
-        Args:
-            level: Black level value in camera units
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If reading the feature fails.
         """
         if not self.initialized or self.camera is None:
             raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _get():
+            feature = self._color_feature("BlackLevel")
+            if feature is None:
+                return None
+            return float(feature.get())
+
         try:
+            return await self._run_blocking(_get)
+        except Exception as e:
+            raise HardwareOperationError(f"Failed to read black level for camera '{self.camera_name}': {e}") from e
 
-            def _set():
-                cam = self.camera
-                if cam.BlackLevel.is_implemented():
-                    cam.BlackLevel.set(level)
+    async def set_black_level(self, level: float):
+        """Set the black level (shadow floor).
 
+        Args:
+            level: Black level value in camera units.
+
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If the feature is unsupported or the
+                write fails.
+        """
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _set():
+            feature = self._color_feature("BlackLevel")
+            if feature is None:
+                raise HardwareOperationError(f"Black level is not supported by camera '{self.camera_name}'")
+            feature.set(level)
+
+        try:
             await self._run_blocking(_set)
             self.logger.debug(f"Black level set to {level} for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
         except Exception as e:
-            self.logger.warning(f"Failed to set black level for camera '{self.camera_name}': {e}")
+            raise HardwareOperationError(f"Failed to set black level for camera '{self.camera_name}': {e}") from e
 
     # ── Contrast ──
 
-    async def get_contrast(self) -> int:
-        """Get current contrast parameter."""
-        if not self.initialized or self.camera is None:
-            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
-        try:
+    async def get_contrast(self) -> Optional[int]:
+        """Get the current contrast parameter.
 
-            def _get():
-                cam = self.camera
-                if cam.ContrastParam.is_implemented():
-                    return int(cam.ContrastParam.get())
-                return 0
+        Returns:
+            Contrast value, or ``None`` when unsupported.
 
-            return await self._run_blocking(_get)
-        except Exception as e:
-            self.logger.warning(f"Contrast not available for camera '{self.camera_name}': {e}")
-            return 0
-
-    async def set_contrast(self, value: int):
-        """Set contrast parameter.
-
-        Args:
-            value: Contrast value in camera units
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If reading the feature fails.
         """
         if not self.initialized or self.camera is None:
             raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _get():
+            feature = self._color_feature("ContrastParam")
+            if feature is None:
+                return None
+            return int(feature.get())
+
         try:
+            return await self._run_blocking(_get)
+        except Exception as e:
+            raise HardwareOperationError(f"Failed to read contrast for camera '{self.camera_name}': {e}") from e
 
-            def _set():
-                cam = self.camera
-                if cam.ContrastParam.is_implemented():
-                    cam.ContrastParam.set(int(value))
+    async def set_contrast(self, value: int):
+        """Set the contrast parameter.
 
+        Args:
+            value: Contrast value in camera units.
+
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If the feature is unsupported or the
+                write fails.
+        """
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _set():
+            feature = self._color_feature("ContrastParam")
+            if feature is None:
+                raise HardwareOperationError(f"Contrast is not supported by camera '{self.camera_name}'")
+            feature.set(int(value))
+
+        try:
             await self._run_blocking(_set)
             self.logger.debug(f"Contrast set to {value} for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
         except Exception as e:
-            self.logger.warning(f"Failed to set contrast for camera '{self.camera_name}': {e}")
+            raise HardwareOperationError(f"Failed to set contrast for camera '{self.camera_name}': {e}") from e
 
     # ── Sharpness ──
 
-    async def get_sharpness(self) -> float:
-        """Get current sharpness value."""
-        if not self.initialized or self.camera is None:
-            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
-        try:
+    async def get_sharpness(self) -> Optional[float]:
+        """Get the current sharpness value.
 
-            def _get():
-                cam = self.camera
-                if cam.Sharpness.is_implemented():
-                    return float(cam.Sharpness.get())
-                return 0.0
+        Returns:
+            Sharpness value, or ``None`` when unsupported.
 
-            return await self._run_blocking(_get)
-        except Exception as e:
-            self.logger.warning(f"Sharpness not available for camera '{self.camera_name}': {e}")
-            return 0.0
-
-    async def set_sharpness(self, value: float):
-        """Set sharpness (edge enhancement) value.
-
-        Args:
-            value: Sharpness value in camera units
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If reading the feature fails.
         """
         if not self.initialized or self.camera is None:
             raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _get():
+            feature = self._color_feature("Sharpness")
+            if feature is None:
+                return None
+            return float(feature.get())
+
         try:
+            return await self._run_blocking(_get)
+        except Exception as e:
+            raise HardwareOperationError(f"Failed to read sharpness for camera '{self.camera_name}': {e}") from e
 
-            def _set():
-                cam = self.camera
-                if cam.SharpnessMode.is_implemented():
-                    cam.SharpnessMode.set(1)  # 1 = ON
-                if cam.Sharpness.is_implemented():
-                    cam.Sharpness.set(value)
+    async def set_sharpness(self, value: float):
+        """Set the sharpness (edge enhancement) value.
 
+        Args:
+            value: Sharpness value in camera units.
+
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If the feature is unsupported or the
+                write fails.
+        """
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _set():
+            feature = self._color_feature("Sharpness")
+            if feature is None:
+                raise HardwareOperationError(f"Sharpness is not supported by camera '{self.camera_name}'")
+            mode = self._color_feature("SharpnessMode")
+            if mode is not None:
+                mode.set(1)  # 1 = ON
+            feature.set(value)
+
+        try:
             await self._run_blocking(_set)
             self.logger.debug(f"Sharpness set to {value} for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
         except Exception as e:
-            self.logger.warning(f"Failed to set sharpness for camera '{self.camera_name}': {e}")
+            raise HardwareOperationError(f"Failed to set sharpness for camera '{self.camera_name}': {e}") from e
 
     # ── Saturation ──
 
-    async def get_saturation(self) -> int:
-        """Get current saturation value."""
-        if not self.initialized or self.camera is None:
-            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
-        try:
+    async def get_saturation(self) -> Optional[int]:
+        """Get the current saturation value.
 
-            def _get():
-                cam = self.camera
-                if cam.Saturation.is_implemented():
-                    return int(cam.Saturation.get())
-                return 0
+        Returns:
+            Saturation value, or ``None`` when unsupported.
 
-            return await self._run_blocking(_get)
-        except Exception as e:
-            self.logger.warning(f"Saturation not available for camera '{self.camera_name}': {e}")
-            return 0
-
-    async def set_saturation(self, value: int):
-        """Set color saturation value.
-
-        Args:
-            value: Saturation value in camera units
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If reading the feature fails.
         """
         if not self.initialized or self.camera is None:
             raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _get():
+            feature = self._color_feature("Saturation")
+            if feature is None:
+                return None
+            return int(feature.get())
+
         try:
+            return await self._run_blocking(_get)
+        except Exception as e:
+            raise HardwareOperationError(f"Failed to read saturation for camera '{self.camera_name}': {e}") from e
 
-            def _set():
-                cam = self.camera
-                if cam.SaturationMode.is_implemented():
-                    cam.SaturationMode.set(1)  # 1 = ON
-                if cam.Saturation.is_implemented():
-                    cam.Saturation.set(int(value))
+    async def set_saturation(self, value: int):
+        """Set the color saturation value.
 
+        Args:
+            value: Saturation value in camera units.
+
+        Raises:
+            CameraConnectionError: If the camera is not initialized.
+            HardwareOperationError: If the feature is unsupported or the
+                write fails.
+        """
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+
+        def _set():
+            feature = self._color_feature("Saturation")
+            if feature is None:
+                raise HardwareOperationError(f"Saturation is not supported by camera '{self.camera_name}'")
+            mode = self._color_feature("SaturationMode")
+            if mode is not None:
+                mode.set(1)  # 1 = ON
+            feature.set(int(value))
+
+        try:
             await self._run_blocking(_set)
             self.logger.debug(f"Saturation set to {value} for camera '{self.camera_name}'")
+        except (CameraConnectionError, HardwareOperationError):
+            raise
         except Exception as e:
-            self.logger.warning(f"Failed to set saturation for camera '{self.camera_name}': {e}")
+            raise HardwareOperationError(f"Failed to set saturation for camera '{self.camera_name}': {e}") from e
 
     # ── User Set (Save/Load/Default) ──
 
@@ -1481,6 +1663,34 @@ class DahengCameraBackend(CameraBackend):
             if "white_balance" in config_data:
                 await self.set_auto_wb_once(config_data["white_balance"])
 
+            # Color-correction settings: applied individually and tolerantly
+            # so a config exported from a better-equipped camera still loads.
+            color_setters = {
+                "gamma_enable": self.set_gamma_enable,
+                "black_level": self.set_black_level,
+                "color_transformation": self.set_color_transformation,
+                "light_source_preset": self.set_light_source_preset,
+                "contrast": self.set_contrast,
+                "sharpness": self.set_sharpness,
+                "saturation": self.set_saturation,
+            }
+            for key, setter in color_setters.items():
+                if key in config_data:
+                    try:
+                        await setter(config_data[key])
+                    except HardwareOperationError as e:
+                        self.logger.warning(f"Could not apply '{key}' from config for camera '{self.camera_name}': {e}")
+            if "balance_ratios" in config_data:
+                ratios = config_data["balance_ratios"] or {}
+                try:
+                    await self.set_balance_ratios(
+                        red=ratios.get("red"), green=ratios.get("green"), blue=ratios.get("blue")
+                    )
+                except HardwareOperationError as e:
+                    self.logger.warning(
+                        f"Could not apply 'balance_ratios' from config for camera '{self.camera_name}': {e}"
+                    )
+
             self.logger.debug(f"Configuration imported from '{config_path}' for camera '{self.camera_name}'")
         except CameraConfigurationError:
             raise
@@ -1509,6 +1719,27 @@ class DahengCameraBackend(CameraBackend):
                 "retrieve_retry_count": self.retrieve_retry_count,
                 "timeout_ms": self.timeout_ms,
             }
+
+            # Color-correction settings: exported only when the camera
+            # supports them (getters return None for unsupported features).
+            color_getters = {
+                "gamma_enable": self.get_gamma_enable,
+                "black_level": self.get_black_level,
+                "color_transformation": self.get_color_transformation,
+                "light_source_preset": self.get_light_source_preset,
+                "balance_ratios": self.get_balance_ratios,
+                "contrast": self.get_contrast,
+                "sharpness": self.get_sharpness,
+                "saturation": self.get_saturation,
+            }
+            for key, getter in color_getters.items():
+                try:
+                    value = await getter()
+                except Exception as e:
+                    self.logger.warning(f"Skipping '{key}' in config export for camera '{self.camera_name}': {e}")
+                    continue
+                if value is not None:
+                    config_data[key] = value
 
             os.makedirs(os.path.dirname(config_path), exist_ok=True)
 

--- a/mindtrace/hardware/mindtrace/hardware/cameras/backends/daheng/daheng_camera_backend.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/backends/daheng/daheng_camera_backend.py
@@ -356,6 +356,21 @@ class DahengCameraBackend(CameraBackend):
                 if cam.AcquisitionMode.is_implemented():
                     cam.AcquisitionMode.set(gx.GxAcquisitionModeEntry.CONTINUOUS)
 
+                # Color-correction defaults: sRGB gamma on, black level 0, for
+                # rendering matched with the Basler backend (nodes are model-dependent)
+                try:
+                    if cam.GammaMode.is_implemented():
+                        cam.GammaMode.set(0)  # 0 = sRGB
+                    if cam.GammaEnable.is_implemented():
+                        cam.GammaEnable.set(True)
+                except Exception as e:
+                    self.logger.debug(f"Gamma defaults not applied for camera '{self.camera_name}': {e}")
+                try:
+                    if cam.BlackLevel.is_implemented():
+                        cam.BlackLevel.set(0.0)
+                except Exception as e:
+                    self.logger.debug(f"Black level default not applied for camera '{self.camera_name}': {e}")
+
                 # Start streaming
                 cam.stream_on()
 
@@ -1036,6 +1051,210 @@ class DahengCameraBackend(CameraBackend):
             self.logger.debug(f"Balance ratios set (R={red}, G={green}, B={blue}) for camera '{self.camera_name}'")
         except Exception as e:
             self.logger.warning(f"Failed to set balance ratios for camera '{self.camera_name}': {e}")
+
+    # ── Gamma ──
+
+    async def get_gamma_enable(self) -> bool:
+        """Get current gamma enable state."""
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+        try:
+
+            def _get():
+                cam = self.camera
+                if cam.GammaEnable.is_implemented():
+                    return bool(cam.GammaEnable.get())
+                return False
+
+            return await self._run_blocking(_get)
+        except Exception as e:
+            self.logger.warning(f"Gamma not available for camera '{self.camera_name}': {e}")
+            return False
+
+    async def set_gamma_enable(self, enabled: bool):
+        """Enable or disable in-camera gamma.
+
+        When enabling, the sRGB gamma curve is selected so both supported
+        backends render with matched tone curves.
+
+        Args:
+            enabled: True to enable sRGB gamma, False for linear output
+        """
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+        try:
+
+            def _set():
+                cam = self.camera
+                if enabled and cam.GammaMode.is_implemented():
+                    cam.GammaMode.set(0)  # 0 = sRGB
+                if cam.GammaEnable.is_implemented():
+                    cam.GammaEnable.set(enabled)
+
+            await self._run_blocking(_set)
+            self.logger.debug(f"Gamma enable set to {enabled} for camera '{self.camera_name}'")
+        except Exception as e:
+            self.logger.warning(f"Failed to set gamma enable for camera '{self.camera_name}': {e}")
+
+    # ── Black Level ──
+
+    async def get_black_level(self) -> float:
+        """Get current black level."""
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+        try:
+
+            def _get():
+                cam = self.camera
+                if cam.BlackLevel.is_implemented():
+                    return float(cam.BlackLevel.get())
+                return 0.0
+
+            return await self._run_blocking(_get)
+        except Exception as e:
+            self.logger.warning(f"Black level not available for camera '{self.camera_name}': {e}")
+            return 0.0
+
+    async def set_black_level(self, level: float):
+        """Set black level (shadow floor).
+
+        Args:
+            level: Black level value in camera units
+        """
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+        try:
+
+            def _set():
+                cam = self.camera
+                if cam.BlackLevel.is_implemented():
+                    cam.BlackLevel.set(level)
+
+            await self._run_blocking(_set)
+            self.logger.debug(f"Black level set to {level} for camera '{self.camera_name}'")
+        except Exception as e:
+            self.logger.warning(f"Failed to set black level for camera '{self.camera_name}': {e}")
+
+    # ── Contrast ──
+
+    async def get_contrast(self) -> int:
+        """Get current contrast parameter."""
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+        try:
+
+            def _get():
+                cam = self.camera
+                if cam.ContrastParam.is_implemented():
+                    return int(cam.ContrastParam.get())
+                return 0
+
+            return await self._run_blocking(_get)
+        except Exception as e:
+            self.logger.warning(f"Contrast not available for camera '{self.camera_name}': {e}")
+            return 0
+
+    async def set_contrast(self, value: int):
+        """Set contrast parameter.
+
+        Args:
+            value: Contrast value in camera units
+        """
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+        try:
+
+            def _set():
+                cam = self.camera
+                if cam.ContrastParam.is_implemented():
+                    cam.ContrastParam.set(int(value))
+
+            await self._run_blocking(_set)
+            self.logger.debug(f"Contrast set to {value} for camera '{self.camera_name}'")
+        except Exception as e:
+            self.logger.warning(f"Failed to set contrast for camera '{self.camera_name}': {e}")
+
+    # ── Sharpness ──
+
+    async def get_sharpness(self) -> float:
+        """Get current sharpness value."""
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+        try:
+
+            def _get():
+                cam = self.camera
+                if cam.Sharpness.is_implemented():
+                    return float(cam.Sharpness.get())
+                return 0.0
+
+            return await self._run_blocking(_get)
+        except Exception as e:
+            self.logger.warning(f"Sharpness not available for camera '{self.camera_name}': {e}")
+            return 0.0
+
+    async def set_sharpness(self, value: float):
+        """Set sharpness (edge enhancement) value.
+
+        Args:
+            value: Sharpness value in camera units
+        """
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+        try:
+
+            def _set():
+                cam = self.camera
+                if cam.SharpnessMode.is_implemented():
+                    cam.SharpnessMode.set(1)  # 1 = ON
+                if cam.Sharpness.is_implemented():
+                    cam.Sharpness.set(value)
+
+            await self._run_blocking(_set)
+            self.logger.debug(f"Sharpness set to {value} for camera '{self.camera_name}'")
+        except Exception as e:
+            self.logger.warning(f"Failed to set sharpness for camera '{self.camera_name}': {e}")
+
+    # ── Saturation ──
+
+    async def get_saturation(self) -> int:
+        """Get current saturation value."""
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+        try:
+
+            def _get():
+                cam = self.camera
+                if cam.Saturation.is_implemented():
+                    return int(cam.Saturation.get())
+                return 0
+
+            return await self._run_blocking(_get)
+        except Exception as e:
+            self.logger.warning(f"Saturation not available for camera '{self.camera_name}': {e}")
+            return 0
+
+    async def set_saturation(self, value: int):
+        """Set color saturation value.
+
+        Args:
+            value: Saturation value in camera units
+        """
+        if not self.initialized or self.camera is None:
+            raise CameraConnectionError(f"Camera '{self.camera_name}' is not initialized")
+        try:
+
+            def _set():
+                cam = self.camera
+                if cam.SaturationMode.is_implemented():
+                    cam.SaturationMode.set(1)  # 1 = ON
+                if cam.Saturation.is_implemented():
+                    cam.Saturation.set(int(value))
+
+            await self._run_blocking(_set)
+            self.logger.debug(f"Saturation set to {value} for camera '{self.camera_name}'")
+        except Exception as e:
+            self.logger.warning(f"Failed to set saturation for camera '{self.camera_name}': {e}")
 
     # ── User Set (Save/Load/Default) ──
 

--- a/mindtrace/hardware/mindtrace/hardware/cameras/backends/daheng/mock_daheng_camera_backend.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/backends/daheng/mock_daheng_camera_backend.py
@@ -124,6 +124,14 @@ class MockDahengCameraBackend(CameraBackend):
         self.gain = 1.0
         self.roi = {"x": 0, "y": 0, "width": 1920, "height": 1080}
         self.white_balance_mode = "off"
+        self.gamma_enable = True
+        self.black_level = 0.0
+        self.color_transformation = False
+        self.light_source_preset = "OFF"
+        self.balance_ratios = {"red": 1.0, "green": 1.0, "blue": 1.0}
+        self.contrast = 0
+        self.sharpness = 0.0
+        self.saturation = 64
         self.triggermode = self.camera_config.cameras.trigger_mode
         self.image_counter = 0
         self._streaming = False
@@ -489,6 +497,83 @@ class MockDahengCameraBackend(CameraBackend):
         """Get available white balance modes."""
         await self._sleep(0.001)
         return ["off", "once", "continuous"]
+
+    async def get_gamma_enable(self) -> bool:
+        """Get current gamma enable state."""
+        return self.gamma_enable
+
+    async def set_gamma_enable(self, enabled: bool):
+        """Enable or disable in-camera gamma."""
+        self.gamma_enable = bool(enabled)
+        self.logger.debug(f"Gamma enable set to {enabled} for mock camera '{self.camera_name}'")
+
+    async def get_black_level(self) -> float:
+        """Get current black level."""
+        return self.black_level
+
+    async def set_black_level(self, level: float):
+        """Set black level."""
+        self.black_level = float(level)
+        self.logger.debug(f"Black level set to {level} for mock camera '{self.camera_name}'")
+
+    async def get_color_transformation(self) -> bool:
+        """Get current color transformation enable state."""
+        return self.color_transformation
+
+    async def set_color_transformation(self, enabled: bool):
+        """Enable or disable color transformation."""
+        self.color_transformation = bool(enabled)
+        self.logger.debug(f"Color transformation set to {enabled} for mock camera '{self.camera_name}'")
+
+    async def get_light_source_preset(self) -> str:
+        """Get current light source preset."""
+        return self.light_source_preset
+
+    async def set_light_source_preset(self, preset: str):
+        """Set light source preset."""
+        self.light_source_preset = preset
+        self.logger.debug(f"Light source preset set to '{preset}' for mock camera '{self.camera_name}'")
+
+    async def get_balance_ratios(self) -> Dict[str, float]:
+        """Get current R/G/B balance ratios."""
+        return self.balance_ratios.copy()
+
+    async def set_balance_ratios(self, red: float = None, green: float = None, blue: float = None):
+        """Set R/G/B balance ratios."""
+        if red is not None:
+            self.balance_ratios["red"] = float(red)
+        if green is not None:
+            self.balance_ratios["green"] = float(green)
+        if blue is not None:
+            self.balance_ratios["blue"] = float(blue)
+        self.logger.debug(f"Balance ratios set (R={red}, G={green}, B={blue}) for mock camera '{self.camera_name}'")
+
+    async def get_contrast(self) -> int:
+        """Get current contrast value."""
+        return self.contrast
+
+    async def set_contrast(self, value: int):
+        """Set contrast value."""
+        self.contrast = int(value)
+        self.logger.debug(f"Contrast set to {value} for mock camera '{self.camera_name}'")
+
+    async def get_sharpness(self) -> float:
+        """Get current sharpness value."""
+        return self.sharpness
+
+    async def set_sharpness(self, value: float):
+        """Set sharpness value."""
+        self.sharpness = float(value)
+        self.logger.debug(f"Sharpness set to {value} for mock camera '{self.camera_name}'")
+
+    async def get_saturation(self) -> int:
+        """Get current saturation value."""
+        return self.saturation
+
+    async def set_saturation(self, value: int):
+        """Set saturation value."""
+        self.saturation = int(value)
+        self.logger.debug(f"Saturation set to {value} for mock camera '{self.camera_name}'")
 
     async def get_pixel_format_range(self) -> List[str]:
         """Get available pixel formats."""

--- a/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/core/async_camera.py
@@ -303,7 +303,10 @@ class AsyncCamera(Mindtrace):
 
         Args:
             **settings: Supported keys include exposure, gain, roi=(x, y, w, h), trigger_mode,
-                pixel_format, white_balance, image_enhancement, capture_timeout, optical_power.
+                pixel_format, white_balance, image_enhancement, capture_timeout, optical_power,
+                gamma_enable, black_level, color_transformation, light_source_preset,
+                balance_ratios={"red": r, "green": g, "blue": b}, contrast, sharpness, saturation.
+                Color-correction keys are skipped when the backend does not implement them.
 
         Raises:
             CameraConfigurationError: If a provided value is invalid for the backend.
@@ -329,6 +332,34 @@ class AsyncCamera(Mindtrace):
                 await self._backend.set_auto_wb_once(settings["white_balance"])
             if "image_enhancement" in settings:
                 self._backend.set_image_quality_enhancement(settings["image_enhancement"])
+            # Color-correction settings (model/backend-dependent; skipped when unsupported)
+            color_setters = {
+                "gamma_enable": "set_gamma_enable",
+                "black_level": "set_black_level",
+                "color_transformation": "set_color_transformation",
+                "light_source_preset": "set_light_source_preset",
+                "contrast": "set_contrast",
+                "sharpness": "set_sharpness",
+                "saturation": "set_saturation",
+            }
+            for key, method_name in color_setters.items():
+                if key in settings:
+                    setter = getattr(self._backend, method_name, None)
+                    if setter is None:
+                        self.logger.warning(
+                            f"Backend for camera '{self._full_name}' does not support '{key}'; skipping"
+                        )
+                    else:
+                        await setter(settings[key])
+            if "balance_ratios" in settings:
+                setter = getattr(self._backend, "set_balance_ratios", None)
+                if setter is None:
+                    self.logger.warning(
+                        f"Backend for camera '{self._full_name}' does not support 'balance_ratios'; skipping"
+                    )
+                else:
+                    ratios = settings["balance_ratios"] or {}
+                    await setter(red=ratios.get("red"), green=ratios.get("green"), blue=ratios.get("blue"))
             # Handle both "capture_timeout" and "timeout_ms" for backwards compatibility
             if "capture_timeout" in settings:
                 await self._backend.set_capture_timeout(settings["capture_timeout"])
@@ -979,6 +1010,88 @@ class AsyncCamera(Mindtrace):
         """Get available white balance modes (backend-specific method)."""
         async with self._lock:
             return await self._backend.get_wb_range()
+
+    async def get_gamma_enable(self) -> Optional[bool]:
+        """Get gamma enable state (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.get_gamma_enable()
+
+    async def set_gamma_enable(self, enabled: bool):
+        """Enable or disable in-camera sRGB gamma (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.set_gamma_enable(enabled)
+
+    async def get_black_level(self) -> Optional[float]:
+        """Get black level (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.get_black_level()
+
+    async def set_black_level(self, level: float):
+        """Set black level (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.set_black_level(level)
+
+    async def get_color_transformation(self) -> Optional[bool]:
+        """Get color transformation enable state (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.get_color_transformation()
+
+    async def set_color_transformation(self, enabled: bool):
+        """Enable or disable color transformation (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.set_color_transformation(enabled)
+
+    async def get_light_source_preset(self) -> Optional[str]:
+        """Get light source preset (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.get_light_source_preset()
+
+    async def set_light_source_preset(self, preset: str):
+        """Set light source preset (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.set_light_source_preset(preset)
+
+    async def get_balance_ratios(self) -> Optional[Dict[str, float]]:
+        """Get R/G/B balance ratios (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.get_balance_ratios()
+
+    async def set_balance_ratios(
+        self, red: Optional[float] = None, green: Optional[float] = None, blue: Optional[float] = None
+    ):
+        """Set R/G/B balance ratios (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.set_balance_ratios(red=red, green=green, blue=blue)
+
+    async def get_contrast(self) -> Optional[float]:
+        """Get contrast value (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.get_contrast()
+
+    async def set_contrast(self, value: Union[int, float]):
+        """Set contrast value (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.set_contrast(value)
+
+    async def get_sharpness(self) -> Optional[float]:
+        """Get sharpness value (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.get_sharpness()
+
+    async def set_sharpness(self, value: Union[int, float]):
+        """Set sharpness value (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.set_sharpness(value)
+
+    async def get_saturation(self) -> Optional[float]:
+        """Get saturation value (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.get_saturation()
+
+    async def set_saturation(self, value: Union[int, float]):
+        """Set saturation value (backend-specific method)."""
+        async with self._lock:
+            return await self._backend.set_saturation(value)
 
     async def export_config(self, config_path: str):
         """Export camera configuration (backend-specific method)."""

--- a/mindtrace/hardware/mindtrace/hardware/cameras/core/camera.py
+++ b/mindtrace/hardware/mindtrace/hardware/cameras/core/camera.py
@@ -164,7 +164,8 @@ class Camera(Mindtrace):
 
         Args:
             **settings: Supported keys include exposure, gain, roi=(x, y, w, h), trigger_mode, pixel_format,
-                white_balance, image_enhancement.
+                white_balance, image_enhancement, gamma_enable, black_level, color_transformation,
+                light_source_preset, balance_ratios, contrast, sharpness, saturation.
 
         Raises:
             CameraConfigurationError: If a provided value is invalid for the backend.

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/models/responses.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/models/responses.py
@@ -140,6 +140,14 @@ class CameraConfiguration(BaseModel):
     packet_size: Optional[int] = None
     inter_packet_delay: Optional[float] = None
     optical_power: Optional[float] = None
+    gamma_enable: Optional[bool] = None
+    black_level: Optional[float] = None
+    color_transformation: Optional[bool] = None
+    light_source_preset: Optional[str] = None
+    balance_ratios: Optional[Dict[str, float]] = None
+    contrast: Optional[float] = None
+    sharpness: Optional[float] = None
+    saturation: Optional[float] = None
 
 
 # Liquid Lens

--- a/mindtrace/hardware/mindtrace/hardware/services/cameras/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/cameras/service.py
@@ -912,6 +912,47 @@ class CameraManagerService(Service):
             except Exception:
                 inter_packet_delay = None
 
+            # Color-correction settings (backend/model-dependent)
+            try:
+                gamma_enable = await camera_proxy.get_gamma_enable()
+            except Exception:
+                gamma_enable = None
+
+            try:
+                black_level = await camera_proxy.get_black_level()
+            except Exception:
+                black_level = None
+
+            try:
+                color_transformation = await camera_proxy.get_color_transformation()
+            except Exception:
+                color_transformation = None
+
+            try:
+                light_source_preset = await camera_proxy.get_light_source_preset()
+            except Exception:
+                light_source_preset = None
+
+            try:
+                balance_ratios = await camera_proxy.get_balance_ratios()
+            except Exception:
+                balance_ratios = None
+
+            try:
+                contrast = await camera_proxy.get_contrast()
+            except Exception:
+                contrast = None
+
+            try:
+                sharpness = await camera_proxy.get_sharpness()
+            except Exception:
+                sharpness = None
+
+            try:
+                saturation = await camera_proxy.get_saturation()
+            except Exception:
+                saturation = None
+
             config = CameraConfiguration(
                 exposure_time=exposure_time,
                 gain=gain,
@@ -924,6 +965,14 @@ class CameraManagerService(Service):
                 bandwidth_limit=bandwidth_limit,
                 packet_size=packet_size,
                 inter_packet_delay=inter_packet_delay,
+                gamma_enable=gamma_enable,
+                black_level=black_level,
+                color_transformation=color_transformation,
+                light_source_preset=light_source_preset,
+                balance_ratios=balance_ratios,
+                contrast=contrast,
+                sharpness=sharpness,
+                saturation=saturation,
             )
 
             return CameraConfigurationResponse(

--- a/tests/unit/mindtrace/hardware/cameras/backends/basler/test_basler_camera_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/basler/test_basler_camera_backend.py
@@ -132,6 +132,20 @@ class MockPylonCamera:
         self._offset_x_param = MockParameter(0, min_val=0, max_val=1920, camera_attr="offset_x", camera_obj=self)
         self._offset_y_param = MockParameter(0, min_val=0, max_val=1080, camera_attr="offset_y", camera_obj=self)
 
+        # Color-correction parameters (BslContrast/Contrast intentionally absent
+        # to exercise the unsupported-node path)
+        self._gamma_enable_param = MockParameter(False)
+        self._gamma_selector_param = MockEnumParameter("User", ["User", "sRGB"])
+        self._black_level_param = MockParameter(4.0, min_val=0.0, max_val=255.0)
+        self._color_transformation_enable_param = MockParameter(False)
+        self._light_source_preset_param = MockEnumParameter(
+            "Off", ["Off", "Daylight5000K", "Daylight6500K", "Tungsten2800K"]
+        )
+        self._balance_ratio_selector_param = MockEnumParameter("Red", ["Red", "Green", "Blue"])
+        self._balance_ratio_param = MockBalanceRatioParameter(self._balance_ratio_selector_param)
+        self._sharpness_enhancement_param = MockParameter(1.0, min_val=0.0, max_val=3.98)
+        self._bsl_saturation_param = MockParameter(1.0, min_val=0.0, max_val=2.0)
+
     def Attach(self, device_info):
         self.device_info = device_info
 
@@ -238,6 +252,42 @@ class MockPylonCamera:
     def OffsetY(self):
         return self._offset_y_param
 
+    @property
+    def GammaEnable(self):
+        return self._gamma_enable_param
+
+    @property
+    def GammaSelector(self):
+        return self._gamma_selector_param
+
+    @property
+    def BlackLevel(self):
+        return self._black_level_param
+
+    @property
+    def ColorTransformationEnable(self):
+        return self._color_transformation_enable_param
+
+    @property
+    def LightSourcePreset(self):
+        return self._light_source_preset_param
+
+    @property
+    def BalanceRatioSelector(self):
+        return self._balance_ratio_selector_param
+
+    @property
+    def BalanceRatio(self):
+        return self._balance_ratio_param
+
+    @property
+    def SharpnessEnhancement(self):
+        return self._sharpness_enhancement_param
+
+    @property
+    def BslSaturation(self):
+        return self._bsl_saturation_param
+
 
 class MockParameter:
     """Mock parameter for camera settings."""
@@ -322,6 +372,22 @@ class MockEnumParameter:
     def GetEntries(self):
         """Get available entries for enumeration parameters."""
         return self.valid_values
+
+
+class MockBalanceRatioParameter(MockParameter):
+    """Mock balance ratio parameter with per-channel storage driven by a selector."""
+
+    def __init__(self, selector):
+        super().__init__(1.0, min_val=0.0, max_val=15.98)
+        self._selector = selector
+        self._values = {"Red": 1.0, "Green": 1.0, "Blue": 1.0}
+
+    def GetValue(self):
+        return self._values[self._selector.GetValue()]
+
+    def SetValue(self, value):
+        super().SetValue(value)
+        self._values[self._selector.GetValue()] = value
 
 
 class MockGrabResult:
@@ -987,6 +1053,99 @@ class TestBaslerCameraBackendWhiteBalance:
         # Setting should raise when not writable
         with pytest.raises(HardwareOperationError):
             await basler_camera.set_auto_wb_once("once")
+
+
+class TestBaslerColorCorrection:
+    """Test color-correction functionality."""
+
+    @pytest.mark.asyncio
+    async def test_set_gamma_enable_selects_srgb(self, basler_camera):
+        """Test enabling gamma selects the sRGB curve and round-trips."""
+        await basler_camera.initialize()
+
+        await basler_camera.set_gamma_enable(True)
+        assert basler_camera.camera.GammaEnable.GetValue() is True
+        assert basler_camera.camera.GammaSelector.GetValue() == "sRGB"
+        assert await basler_camera.get_gamma_enable() is True
+
+        await basler_camera.set_gamma_enable(False)
+        assert await basler_camera.get_gamma_enable() is False
+
+    @pytest.mark.asyncio
+    async def test_black_level_set_and_get(self, basler_camera):
+        """Test black level control."""
+        await basler_camera.initialize()
+
+        await basler_camera.set_black_level(8.0)
+        assert await basler_camera.get_black_level() == 8.0
+
+    @pytest.mark.asyncio
+    async def test_color_transformation_set_and_get(self, basler_camera):
+        """Test color transformation enable control."""
+        await basler_camera.initialize()
+
+        await basler_camera.set_color_transformation(True)
+        assert await basler_camera.get_color_transformation() is True
+
+    @pytest.mark.asyncio
+    async def test_balance_ratios_partial_set_and_get(self, basler_camera):
+        """Test setting a subset of balance ratios leaves other channels untouched."""
+        await basler_camera.initialize()
+
+        await basler_camera.set_balance_ratios(red=1.2, blue=1.4)
+        ratios = await basler_camera.get_balance_ratios()
+        assert ratios == {"red": 1.2, "green": 1.0, "blue": 1.4}
+
+    @pytest.mark.asyncio
+    async def test_light_source_preset_set_and_get(self, basler_camera):
+        """Test light source preset control."""
+        await basler_camera.initialize()
+
+        await basler_camera.set_light_source_preset("Daylight5000K")
+        assert await basler_camera.get_light_source_preset() == "Daylight5000K"
+
+    @pytest.mark.asyncio
+    async def test_light_source_preset_invalid_raises(self, basler_camera):
+        """Test invalid light source preset raises a configuration error."""
+        await basler_camera.initialize()
+
+        with pytest.raises(CameraConfigurationError, match="Invalid light source preset"):
+            await basler_camera.set_light_source_preset("NotAPreset")
+
+    @pytest.mark.asyncio
+    async def test_sharpness_and_saturation_set_and_get(self, basler_camera):
+        """Test sharpness and saturation controls."""
+        await basler_camera.initialize()
+
+        await basler_camera.set_sharpness(2.5)
+        assert await basler_camera.get_sharpness() == 2.5
+
+        await basler_camera.set_saturation(1.5)
+        assert await basler_camera.get_saturation() == 1.5
+
+    @pytest.mark.asyncio
+    async def test_set_contrast_unsupported_raises(self, basler_camera):
+        """Test contrast setter raises when the camera has no contrast node."""
+        await basler_camera.initialize()
+
+        with pytest.raises(HardwareOperationError, match="Contrast feature not writable"):
+            await basler_camera.set_contrast(1.0)
+        assert await basler_camera.get_contrast() is None
+
+    @pytest.mark.asyncio
+    async def test_color_method_requires_initialization(self, basler_camera):
+        """Test color methods raise when the camera is not initialized."""
+        with pytest.raises(CameraConnectionError, match="not initialized"):
+            await basler_camera.set_gamma_enable(True)
+
+    @pytest.mark.asyncio
+    async def test_configure_camera_applies_color_defaults(self, basler_camera):
+        """Test connect applies sRGB gamma and zero black level defaults."""
+        await basler_camera.initialize()
+
+        assert basler_camera.camera.GammaEnable.GetValue() is True
+        assert basler_camera.camera.GammaSelector.GetValue() == "sRGB"
+        assert basler_camera.camera.BlackLevel.GetValue() == 0.0
 
 
 class TestBaslerCameraBackendRangeQueries:

--- a/tests/unit/mindtrace/hardware/cameras/backends/basler/test_basler_camera_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/basler/test_basler_camera_backend.py
@@ -143,6 +143,7 @@ class MockPylonCamera:
         )
         self._balance_ratio_selector_param = MockEnumParameter("Red", ["Red", "Green", "Blue"])
         self._balance_ratio_param = MockBalanceRatioParameter(self._balance_ratio_selector_param)
+        self._bsl_color_space_param = MockEnumParameter("Off", ["Off", "sRGB"])
         self._sharpness_enhancement_param = MockParameter(1.0, min_val=0.0, max_val=3.98)
         self._bsl_saturation_param = MockParameter(1.0, min_val=0.0, max_val=2.0)
 
@@ -279,6 +280,10 @@ class MockPylonCamera:
     @property
     def BalanceRatio(self):
         return self._balance_ratio_param
+
+    @property
+    def BslColorSpace(self):
+        return self._bsl_color_space_param
 
     @property
     def SharpnessEnhancement(self):
@@ -1137,6 +1142,48 @@ class TestBaslerColorCorrection:
         """Test color methods raise when the camera is not initialized."""
         with pytest.raises(CameraConnectionError, match="not initialized"):
             await basler_camera.set_gamma_enable(True)
+
+    @pytest.mark.asyncio
+    async def test_disable_gamma_on_selector_only_model(self, basler_camera, monkeypatch):
+        """Disabling gamma must write GammaSelector=User when no GammaEnable exists."""
+        await basler_camera.initialize()
+        monkeypatch.setattr(basler_camera.camera.GammaEnable, "GetAccessMode", lambda: "NA")
+
+        await basler_camera.set_gamma_enable(False)
+        assert basler_camera.camera.GammaSelector.GetValue() == "User"
+        assert await basler_camera.get_gamma_enable() is False
+
+        await basler_camera.set_gamma_enable(True)
+        assert basler_camera.camera.GammaSelector.GetValue() == "sRGB"
+        assert await basler_camera.get_gamma_enable() is True
+
+    @pytest.mark.asyncio
+    async def test_gamma_via_bsl_color_space(self, basler_camera, monkeypatch):
+        """ace2/boost-style models express sRGB through BslColorSpace."""
+        await basler_camera.initialize()
+        monkeypatch.setattr(basler_camera.camera.GammaEnable, "GetAccessMode", lambda: "NA")
+        monkeypatch.setattr(basler_camera.camera.GammaSelector, "GetAccessMode", lambda: "NA")
+
+        await basler_camera.set_gamma_enable(True)
+        assert basler_camera.camera.BslColorSpace.GetValue() == "sRGB"
+        assert await basler_camera.get_gamma_enable() is True
+
+        await basler_camera.set_gamma_enable(False)
+        assert basler_camera.camera.BslColorSpace.GetValue() == "Off"
+        assert await basler_camera.get_gamma_enable() is False
+
+    @pytest.mark.asyncio
+    async def test_color_defaults_can_be_disabled(self, mock_pypylon):
+        """color_defaults=False must leave camera color state untouched on connect."""
+        from mindtrace.hardware.cameras.backends.basler.basler_camera_backend import BaslerCameraBackend
+
+        camera = BaslerCameraBackend(camera_name="Camera_12345670", color_defaults=False)
+        await camera.initialize()
+        try:
+            assert camera.camera.GammaEnable.GetValue() is False  # factory state preserved
+            assert camera.camera.BlackLevel.GetValue() == 4.0
+        finally:
+            await camera.close()
 
     @pytest.mark.asyncio
     async def test_configure_camera_applies_color_defaults(self, basler_camera):

--- a/tests/unit/mindtrace/hardware/cameras/backends/daheng/test_daheng_camera_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/daheng/test_daheng_camera_backend.py
@@ -82,6 +82,14 @@ class MockDahengDevice:
         self.AcquisitionMode = MockGxFeature(0)
         self.PixelFormat = MockGxFeature("BGR8")
         self.BalanceWhiteAuto = MockGxFeature(0)
+        self.GammaEnable = MockGxFeature(False)
+        self.GammaMode = MockGxFeature(1)
+        self.BlackLevel = MockGxFeature(4.0, 0.0, 255.0)
+        self.ContrastParam = MockGxFeature(0, -50, 100)
+        self.Sharpness = MockGxFeature(0.0, 0.0, 3.0)
+        self.SharpnessMode = MockGxFeature(0)
+        self.Saturation = MockGxFeature(64, 0, 128)
+        self.SaturationMode = MockGxFeature(0)
         self.OffsetX = MockGxFeature(0, 0, width)
         self.OffsetY = MockGxFeature(0, 0, height)
         self.Width = MockGxFeature(width, 1, width)
@@ -459,6 +467,74 @@ class TestDahengConfiguration:
         """Test setting negative capture timeout."""
         with pytest.raises(ValueError):
             await initialized_daheng.set_capture_timeout(-1)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Color Correction Tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestDahengColorCorrection:
+    """Test DahengCameraBackend color-correction controls."""
+
+    @pytest.mark.asyncio
+    async def test_gamma_enable_set_and_get(self, initialized_daheng):
+        """Test enabling gamma selects the sRGB curve and round-trips."""
+        await initialized_daheng.set_gamma_enable(True)
+        assert initialized_daheng.camera.GammaEnable._value is True
+        assert initialized_daheng.camera.GammaMode._value == 0
+        assert await initialized_daheng.get_gamma_enable() is True
+
+        await initialized_daheng.set_gamma_enable(False)
+        assert await initialized_daheng.get_gamma_enable() is False
+
+    @pytest.mark.asyncio
+    async def test_black_level_set_and_get(self, initialized_daheng):
+        """Test black level control."""
+        await initialized_daheng.set_black_level(8.0)
+        assert await initialized_daheng.get_black_level() == 8.0
+
+    @pytest.mark.asyncio
+    async def test_contrast_set_and_get(self, initialized_daheng):
+        """Test contrast control."""
+        await initialized_daheng.set_contrast(25)
+        assert await initialized_daheng.get_contrast() == 25
+
+    @pytest.mark.asyncio
+    async def test_sharpness_enables_mode_and_sets_value(self, initialized_daheng):
+        """Test sharpness control turns sharpness mode on."""
+        await initialized_daheng.set_sharpness(2.5)
+        assert initialized_daheng.camera.SharpnessMode._value == 1
+        assert await initialized_daheng.get_sharpness() == 2.5
+
+    @pytest.mark.asyncio
+    async def test_saturation_set_and_get(self, initialized_daheng):
+        """Test saturation control turns saturation mode on."""
+        await initialized_daheng.set_saturation(100)
+        assert initialized_daheng.camera.SaturationMode._value == 1
+        assert await initialized_daheng.get_saturation() == 100
+
+    @pytest.mark.asyncio
+    async def test_setter_noop_when_feature_not_implemented(self, initialized_daheng):
+        """Test setters are silent no-ops when the camera lacks the node."""
+        initialized_daheng.camera.GammaEnable._implemented = False
+        initialized_daheng.camera.GammaEnable._value = False
+        await initialized_daheng.set_gamma_enable(True)
+        assert initialized_daheng.camera.GammaEnable._value is False
+        assert await initialized_daheng.get_gamma_enable() is False
+
+    @pytest.mark.asyncio
+    async def test_color_method_requires_initialization(self, daheng_camera):
+        """Test color methods raise when the camera is not initialized."""
+        with pytest.raises(CameraConnectionError):
+            await daheng_camera.set_gamma_enable(True)
+
+    @pytest.mark.asyncio
+    async def test_configure_camera_applies_color_defaults(self, initialized_daheng):
+        """Test connect applies sRGB gamma and zero black level defaults."""
+        assert initialized_daheng.camera.GammaEnable._value is True
+        assert initialized_daheng.camera.GammaMode._value == 0
+        assert initialized_daheng.camera.BlackLevel._value == 0.0
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/unit/mindtrace/hardware/cameras/backends/daheng/test_daheng_camera_backend.py
+++ b/tests/unit/mindtrace/hardware/cameras/backends/daheng/test_daheng_camera_backend.py
@@ -16,6 +16,7 @@ from mindtrace.hardware.core.exceptions import (
     CameraConnectionError,
     CameraInitializationError,
     CameraNotFoundError,
+    HardwareOperationError,
     SDKNotAvailableError,
 )
 
@@ -55,6 +56,37 @@ class MockGxFeature:
         pass
 
 
+class MockGxEnumFeature(MockGxFeature):
+    """gxipy enum feature whose get() returns a (value, description) tuple."""
+
+    DESCRIPTIONS = {
+        0: "OFF",
+        1: "CUSTOM",
+        2: "DAYLIGHT_6500K",
+        3: "DAYLIGHT_5000K",
+        4: "COOL_WHITE_FLUORESCENCE",
+        5: "INCA",
+    }
+
+    def get(self):
+        return self._value, self.DESCRIPTIONS.get(self._value, "OFF")
+
+
+class MockGxBalanceRatioFeature(MockGxFeature):
+    """gxipy balance ratio with per-channel storage driven by the selector."""
+
+    def __init__(self, selector: MockGxFeature):
+        super().__init__(1.0, 0.0, 10.0)
+        self._selector = selector
+        self._values = {0: 1.0, 1: 1.0, 2: 1.0}
+
+    def get(self):
+        return self._values[self._selector._value]
+
+    def set(self, value):
+        self._values[self._selector._value] = value
+
+
 class MockDataStream:
     """Mock gxipy data stream."""
 
@@ -84,6 +116,10 @@ class MockDahengDevice:
         self.BalanceWhiteAuto = MockGxFeature(0)
         self.GammaEnable = MockGxFeature(False)
         self.GammaMode = MockGxFeature(1)
+        self.ColorTransformationEnable = MockGxFeature(False)
+        self.LightSourcePreset = MockGxEnumFeature(0)
+        self.BalanceRatioSelector = MockGxFeature(0)
+        self.BalanceRatio = MockGxBalanceRatioFeature(self.BalanceRatioSelector)
         self.BlackLevel = MockGxFeature(4.0, 0.0, 255.0)
         self.ContrastParam = MockGxFeature(0, -50, 100)
         self.Sharpness = MockGxFeature(0.0, 0.0, 3.0)
@@ -515,13 +551,72 @@ class TestDahengColorCorrection:
         assert await initialized_daheng.get_saturation() == 100
 
     @pytest.mark.asyncio
-    async def test_setter_noop_when_feature_not_implemented(self, initialized_daheng):
-        """Test setters are silent no-ops when the camera lacks the node."""
+    async def test_setter_raises_when_feature_not_implemented(self, initialized_daheng):
+        """Test setters raise HardwareOperationError when the camera lacks the node."""
         initialized_daheng.camera.GammaEnable._implemented = False
-        initialized_daheng.camera.GammaEnable._value = False
+        with pytest.raises(HardwareOperationError, match="not supported"):
+            await initialized_daheng.set_gamma_enable(True)
+
+    @pytest.mark.asyncio
+    async def test_getter_returns_none_when_feature_not_implemented(self, initialized_daheng):
+        """Test getters return None (not a fabricated default) when unsupported."""
+        initialized_daheng.camera.GammaEnable._implemented = False
+        assert await initialized_daheng.get_gamma_enable() is None
+        initialized_daheng.camera.BalanceRatio._implemented = False
+        assert await initialized_daheng.get_balance_ratios() is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_light_source_preset_raises(self, initialized_daheng):
+        """Test unknown presets raise instead of silently mapping to OFF."""
+        with pytest.raises(CameraConfigurationError, match="Invalid light source preset"):
+            await initialized_daheng.set_light_source_preset("DAYLIGHT_650K")
+
+    @pytest.mark.asyncio
+    async def test_light_source_preset_round_trip(self, initialized_daheng):
+        """Test preset set/get round-trips through the enum feature."""
+        await initialized_daheng.set_light_source_preset("DAYLIGHT_5000K")
+        assert await initialized_daheng.get_light_source_preset() == "DAYLIGHT_5000K"
+
+    @pytest.mark.asyncio
+    async def test_balance_ratios_unsupported_raises(self, initialized_daheng):
+        """Test balance ratio setter raises when the camera lacks the nodes."""
+        initialized_daheng.camera.BalanceRatioSelector._implemented = False
+        with pytest.raises(HardwareOperationError, match="not supported"):
+            await initialized_daheng.set_balance_ratios(red=1.2)
+
+    @pytest.mark.asyncio
+    async def test_color_defaults_can_be_disabled(self, mock_gxipy):
+        """Test color_defaults=False leaves camera color state untouched on connect."""
+        from mindtrace.hardware.cameras.backends.daheng.daheng_camera_backend import DahengCameraBackend
+
+        camera = DahengCameraBackend("DH000001", color_defaults=False)
+        await camera.initialize()
+        try:
+            assert camera.camera.GammaEnable._value is False  # factory state preserved
+            assert camera.camera.BlackLevel._value == 4.0
+        finally:
+            await camera.close()
+
+    @pytest.mark.asyncio
+    async def test_config_export_import_round_trips_color_settings(self, initialized_daheng, tmp_path):
+        """Test the new color keys survive an export/import cycle."""
         await initialized_daheng.set_gamma_enable(True)
-        assert initialized_daheng.camera.GammaEnable._value is False
-        assert await initialized_daheng.get_gamma_enable() is False
+        await initialized_daheng.set_black_level(6.0)
+        await initialized_daheng.set_balance_ratios(red=1.2, green=1.0, blue=1.4)
+        await initialized_daheng.set_light_source_preset("DAYLIGHT_5000K")
+
+        config_path = str(tmp_path / "cam.json")
+        await initialized_daheng.export_config(config_path)
+
+        # Perturb, then restore from the exported file.
+        await initialized_daheng.set_black_level(0.0)
+        await initialized_daheng.set_gamma_enable(False)
+        await initialized_daheng.import_config(config_path)
+
+        assert await initialized_daheng.get_gamma_enable() is True
+        assert await initialized_daheng.get_black_level() == 6.0
+        assert await initialized_daheng.get_balance_ratios() == {"red": 1.2, "green": 1.0, "blue": 1.4}
+        assert await initialized_daheng.get_light_source_preset() == "DAYLIGHT_5000K"
 
     @pytest.mark.asyncio
     async def test_color_method_requires_initialization(self, daheng_camera):

--- a/tests/unit/mindtrace/hardware/cameras/core/test_async_camera.py
+++ b/tests/unit/mindtrace/hardware/cameras/core/test_async_camera.py
@@ -101,6 +101,77 @@ async def test_async_camera_configure_all_settings(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_async_camera_configure_color_settings():
+    manager = AsyncCameraManager(include_mocks=True)
+    try:
+        name = [n for n in AsyncCameraManager.discover(include_mocks=True) if n.startswith("MockBasler:")][0]
+        cam = await manager.open(name)
+
+        # Record what each color setter receives
+        backend = cam.backend
+        recorded = {}
+
+        def _recorder(key):
+            async def _set(value):
+                recorded[key] = value
+
+            return _set
+
+        for key in ("gamma_enable", "black_level", "color_transformation", "light_source_preset",
+                    "contrast", "sharpness", "saturation"):
+            setattr(backend, f"set_{key}", _recorder(key))
+
+        async def _set_balance_ratios(red=None, green=None, blue=None):
+            recorded["balance_ratios"] = {"red": red, "green": green, "blue": blue}
+
+        backend.set_balance_ratios = _set_balance_ratios  # type: ignore[attr-defined]
+
+        await cam.configure(
+            gamma_enable=True,
+            black_level=0.0,
+            color_transformation=True,
+            light_source_preset="Daylight5000K",
+            balance_ratios={"red": 1.2, "blue": 1.4},
+            contrast=1.1,
+            sharpness=1.5,
+            saturation=1.0,
+        )
+
+        assert recorded["gamma_enable"] is True
+        assert recorded["black_level"] == 0.0
+        assert recorded["color_transformation"] is True
+        assert recorded["light_source_preset"] == "Daylight5000K"
+        assert recorded["balance_ratios"] == {"red": 1.2, "green": None, "blue": 1.4}
+        assert recorded["contrast"] == 1.1
+        assert recorded["sharpness"] == 1.5
+        assert recorded["saturation"] == 1.0
+    finally:
+        await manager.close(None)
+
+
+@pytest.mark.asyncio
+async def test_async_camera_configure_skips_unsupported_color_settings():
+    manager = AsyncCameraManager(include_mocks=True)
+    try:
+        name = [n for n in AsyncCameraManager.discover(include_mocks=True) if n.startswith("MockBasler:")][0]
+        cam = await manager.open(name)
+
+        # A backend without any color setters must be skipped, not crash
+        class _BareBackend:
+            pass
+
+        original_backend = cam._backend
+        try:
+            cam._backend = _BareBackend()
+            result = await cam.configure(gamma_enable=True, balance_ratios={"red": 1.0})
+            assert result is True
+        finally:
+            cam._backend = original_backend
+    finally:
+        await manager.close(None)
+
+
+@pytest.mark.asyncio
 async def test_async_camera_capture_retries_then_success(monkeypatch):
     manager = AsyncCameraManager(include_mocks=True)
     try:

--- a/tests/unit/mindtrace/hardware/cameras/core/test_async_camera.py
+++ b/tests/unit/mindtrace/hardware/cameras/core/test_async_camera.py
@@ -117,8 +117,15 @@ async def test_async_camera_configure_color_settings():
 
             return _set
 
-        for key in ("gamma_enable", "black_level", "color_transformation", "light_source_preset",
-                    "contrast", "sharpness", "saturation"):
+        for key in (
+            "gamma_enable",
+            "black_level",
+            "color_transformation",
+            "light_source_preset",
+            "contrast",
+            "sharpness",
+            "saturation",
+        ):
             setattr(backend, f"set_{key}", _recorder(key))
 
         async def _set_balance_ratios(red=None, green=None, blue=None):

--- a/tests/unit/mindtrace/hardware/mocks/mock_pypylon.py
+++ b/tests/unit/mindtrace/hardware/mocks/mock_pypylon.py
@@ -206,6 +206,11 @@ def create_fake_pypylon():
                 "BalanceRatio": Parameter(1.0, 0.0, 10.0),
                 "BlackLevel": Parameter(0.0, 0.0, 100.0),
                 "Gamma": Parameter(1.0, 0.0, 2.0),
+                "GammaEnable": Parameter(False),
+                "GammaSelector": EnumParameter("User", ["User", "sRGB"]),
+                "ColorTransformationEnable": Parameter(False),
+                "SharpnessEnhancement": Parameter(1.0, 0.0, 3.98),
+                "BslSaturation": Parameter(1.0, 0.0, 2.0),
                 "LightSourcePreset": EnumParameter("Off", ["Off", "Daylight5000K", "Tungsten2800K"]),
             }
 
@@ -441,6 +446,11 @@ def create_fake_pypylon():
     genicam.TimeoutException = TimeoutException
     genicam.RuntimeException = RuntimeException
     genicam.AccessException = AccessException
+
+    # Access mode constants
+    genicam.RW = "RW"
+    genicam.RO = "RO"
+    genicam.WO = "WO"
 
     # Assign sub-modules
     pypylon.pylon = pylon

--- a/tests/unit/mindtrace/hardware/services/cameras/test_hardware_services_cameras_service.py
+++ b/tests/unit/mindtrace/hardware/services/cameras/test_hardware_services_cameras_service.py
@@ -588,6 +588,14 @@ class TestCameraManagerServiceBusinessLogic:
         mock_camera.get_bandwidth_limit.return_value = 800.0
         mock_camera.get_packet_size.side_effect = RuntimeError("no packet")
         mock_camera.get_inter_packet_delay.return_value = 100
+        mock_camera.get_gamma_enable.return_value = True
+        mock_camera.get_black_level.return_value = 0.0
+        mock_camera.get_color_transformation.side_effect = RuntimeError("no color transform")
+        mock_camera.get_light_source_preset.return_value = "Daylight5000K"
+        mock_camera.get_balance_ratios.return_value = {"red": 1.0, "green": 1.0, "blue": 1.0}
+        mock_camera.get_contrast.side_effect = RuntimeError("no contrast")
+        mock_camera.get_sharpness.return_value = 1.5
+        mock_camera.get_saturation.side_effect = RuntimeError("no saturation")
         mock_manager.open = AsyncMock(return_value=mock_camera)
 
         response = await service.get_camera_configuration(CameraQueryRequest(camera="MockBasler:Camera1"))
@@ -603,6 +611,14 @@ class TestCameraManagerServiceBusinessLogic:
         assert response.data.bandwidth_limit == 800.0
         assert response.data.packet_size is None
         assert response.data.inter_packet_delay == 100
+        assert response.data.gamma_enable is True
+        assert response.data.black_level == 0.0
+        assert response.data.color_transformation is None
+        assert response.data.light_source_preset == "Daylight5000K"
+        assert response.data.balance_ratios == {"red": 1.0, "green": 1.0, "blue": 1.0}
+        assert response.data.contrast is None
+        assert response.data.sharpness == 1.5
+        assert response.data.saturation is None
 
     @pytest.mark.asyncio
     async def test_import_and_export_camera_config_delegate_to_proxy(self, service_with_mock_manager):


### PR DESCRIPTION
## Problem

The Daheng and Basler cameras render the same part differently: Daheng images look dark and glossy on metal while Basler images look matte. The root cause is the in-camera gamma curve — Basler ships with sRGB gamma enabled while Daheng ships linear (gamma disabled, black level 4.0), so shadows crush and speculars clip on Daheng. Beyond that, none of the color/tone knobs (gamma, black level, white balance ratios, light source preset, color transformation, contrast, sharpness, saturation) were reachable through `/cameras/configure`, so rendering could not be matched or tuned per deployment.

## What changed

- **Daheng backend**: new guarded get/set methods for `gamma_enable` (selects the sRGB curve when enabling), `black_level`, `contrast`, `sharpness` and `saturation`. On connect the backend now enables sRGB gamma and sets black level to 0 so rendering matches the Basler default out of the box.
- **Basler backend**: new `_find_node` helper for model-dependent GenICam node resolution, plus get/set methods for all eight color knobs (`gamma_enable`, `black_level`, `color_transformation`, `light_source_preset`, `balance_ratios`, `contrast`, `sharpness`, `saturation`). Getters return `None` when a node is absent; setters raise `HardwareOperationError`. Same sRGB gamma / black level 0 defaults on connect.
- **Core**: `AsyncCamera.configure()` dispatches the eight new keys to any backend that implements the matching setter and skips (with a warning) backends that do not, so OpenCV/GenICam backends are unaffected. Matching delegation getters/setters were added to `AsyncCamera`, and the mock Daheng/Basler backends implement the knobs in memory.
- **Service**: `CameraConfiguration` gained the eight optional fields and `get_camera_configuration` queries them, so values applied via `POST /cameras/configure` can be read back via the config-get endpoint.

Note: enabling sRGB gamma by default changes Daheng rendering for existing users — images become brighter/matte with recovered shadow detail. This is intentional to match the two backends; the knob is exposed for anyone who needs linear output (`{"properties": {"gamma_enable": false}}`).

## Testing

- 20 new unit tests: Daheng color controls and connect defaults (mocked gxipy), Basler color controls including the unsupported-node path (mocked pypylon), and `configure()` dispatch incl. skipping backends without color support.
- Updated the service configuration test for the new fields.
- Full hardware unit suite passes locally: `uv run pytest tests/unit/mindtrace/hardware/` — 2238 passed, 14 skipped.
- `ruff check` and `ruff format --check` are clean on all changed files.
- End-to-end sanity check through `AsyncCameraManager` with a mock camera: configured all eight knobs via `configure()` and read every value back correctly.
