### PR TITLE
fix(database): preserve model-minted _id through MongoMindtraceODM insert paths

### DIFF
--- a/mindtrace/database/mindtrace/database/backends/mongo_odm.py
+++ b/mindtrace/database/mindtrace/database/backends/mongo_odm.py
@@ -438,13 +438,17 @@ class MongoMindtraceODM[T: MindtraceDocument](MindtraceODM):
         if "_id" in data:
             data.pop("_id")
 
+        # Note: caller-supplied ``id``/``_id`` were stripped above, so ``model_cls(**data)``
+        # gives new-doc semantics. We intentionally do NOT null ``doc.id`` afterward: a model
+        # ``@model_validator`` may derive a deterministic id from other fields.
         doc = self.model_cls(**data)
-        doc.id = None
 
         try:
             if self._motor_routing:
                 raw = self._motor_model_dump(doc)
-                raw.pop("_id", None)
+                # Only strip ``_id`` when the model did not mint one; preserve validator-derived ids.
+                if doc.id is None:
+                    raw.pop("_id", None)
                 if raw.get("id") is None:
                     raw.pop("id", None)
                 result = await self._motor_collection().insert_one(raw)
@@ -481,10 +485,12 @@ class MongoMindtraceODM[T: MindtraceDocument](MindtraceODM):
                 data = obj.model_dump(mode="python", by_alias=True, serialize_as_any=True)
             data.pop("id", None)
             data.pop("_id", None)
+            # Same rationale as insert(): caller ids are stripped above, but a model validator
+            # may mint a deterministic id that must be preserved (don't null doc.id).
             doc = self.model_cls(**data)
-            doc.id = None
             raw = self._motor_model_dump(doc)
-            raw.pop("_id", None)
+            if doc.id is None:
+                raw.pop("_id", None)
             if raw.get("id") is None:
                 raw.pop("id", None)
             raw_docs.append(raw)

--- a/mindtrace/database/mindtrace/database/backends/mongo_odm.py
+++ b/mindtrace/database/mindtrace/database/backends/mongo_odm.py
@@ -438,20 +438,16 @@ class MongoMindtraceODM[T: MindtraceDocument](MindtraceODM):
         if "_id" in data:
             data.pop("_id")
 
-        # Keep a validator-minted instance ObjectId (read via __dict__ — plain doc.id can leak the
-        # class-level ExpressionField on generated Document classes); null anything else.
+        # Caller ids were already stripped above; a model validator may mint a
+        # deterministic id here and it must survive to the write.
         doc = self.model_cls(**data)
-        if not isinstance(doc.__dict__.get("id"), ObjectId):
-            doc.id = None
 
         try:
             if self._motor_routing:
                 raw = self._motor_model_dump(doc)
-                # Strip _id only when the model minted none.
-                if doc.id is None:
-                    raw.pop("_id", None)
-                if raw.get("id") is None:
-                    raw.pop("id", None)
+                for key in ("_id", "id"):
+                    if raw.get(key) is None:
+                        raw.pop(key, None)
                 result = await self._motor_collection().insert_one(raw)
                 inserted = await self._motor_collection().find_one({"_id": result.inserted_id})
                 if inserted is None:
@@ -486,15 +482,12 @@ class MongoMindtraceODM[T: MindtraceDocument](MindtraceODM):
                 data = obj.model_dump(mode="python", by_alias=True, serialize_as_any=True)
             data.pop("id", None)
             data.pop("_id", None)
-            # Same as insert(): keep a validator-minted instance id, null anything else.
+            # Same as insert(): caller ids stripped above; minted ids survive.
             doc = self.model_cls(**data)
-            if not isinstance(doc.__dict__.get("id"), ObjectId):
-                doc.id = None
             raw = self._motor_model_dump(doc)
-            if doc.id is None:
-                raw.pop("_id", None)
-            if raw.get("id") is None:
-                raw.pop("id", None)
+            for key in ("_id", "id"):
+                if raw.get(key) is None:
+                    raw.pop(key, None)
             raw_docs.append(raw)
 
         try:

--- a/mindtrace/database/mindtrace/database/backends/mongo_odm.py
+++ b/mindtrace/database/mindtrace/database/backends/mongo_odm.py
@@ -438,15 +438,16 @@ class MongoMindtraceODM[T: MindtraceDocument](MindtraceODM):
         if "_id" in data:
             data.pop("_id")
 
-        # Note: caller-supplied ``id``/``_id`` were stripped above, so ``model_cls(**data)``
-        # gives new-doc semantics. We intentionally do NOT null ``doc.id`` afterward: a model
-        # ``@model_validator`` may derive a deterministic id from other fields.
+        # Keep a validator-minted instance ObjectId (read via __dict__ — plain doc.id can leak the
+        # class-level ExpressionField on generated Document classes); null anything else.
         doc = self.model_cls(**data)
+        if not isinstance(doc.__dict__.get("id"), ObjectId):
+            doc.id = None
 
         try:
             if self._motor_routing:
                 raw = self._motor_model_dump(doc)
-                # Only strip ``_id`` when the model did not mint one; preserve validator-derived ids.
+                # Strip _id only when the model minted none.
                 if doc.id is None:
                     raw.pop("_id", None)
                 if raw.get("id") is None:
@@ -485,9 +486,10 @@ class MongoMindtraceODM[T: MindtraceDocument](MindtraceODM):
                 data = obj.model_dump(mode="python", by_alias=True, serialize_as_any=True)
             data.pop("id", None)
             data.pop("_id", None)
-            # Same rationale as insert(): caller ids are stripped above, but a model validator
-            # may mint a deterministic id that must be preserved (don't null doc.id).
+            # Same as insert(): keep a validator-minted instance id, null anything else.
             doc = self.model_cls(**data)
+            if not isinstance(doc.__dict__.get("id"), ObjectId):
+                doc.id = None
             raw = self._motor_model_dump(doc)
             if doc.id is None:
                 raw.pop("_id", None)

--- a/mindtrace/database/mindtrace/database/backends/unified_odm.py
+++ b/mindtrace/database/mindtrace/database/backends/unified_odm.py
@@ -205,10 +205,16 @@ class UnifiedMindtraceDocument(BaseModel):
             else:
                 annotations[field_name] = processed_type
 
+        # The generated class owns its id field
+        from beanie import PydanticObjectId
+
+        annotations["id"] = Optional[PydanticObjectId]
+
         # Create the class attributes dictionary
         class_dict = {
             "__annotations__": annotations,
             "__module__": cls.__module__,
+            "id": None,
         }
 
         # Add default values to class attributes

--- a/tests/integration/mindtrace/database/test_mongo.py
+++ b/tests/integration/mindtrace/database/test_mongo.py
@@ -1,9 +1,11 @@
+import hashlib
 from typing import Annotated, Optional
 from uuid import uuid4
 
 import pytest
 from beanie import Indexed, PydanticObjectId
-from pydantic import BaseModel
+from bson import ObjectId
+from pydantic import BaseModel, model_validator
 from pymongo import MongoClient
 from pymongo.errors import OperationFailure
 
@@ -45,6 +47,37 @@ class UserCreate(BaseModel):
     name: str
     age: int
     email: str
+
+
+def _derive_id(slug: str) -> ObjectId:
+    """Deterministically derive an ObjectId from a slug (mirrors chiron's convergence pattern)."""
+    return ObjectId(hashlib.sha256(f"test:{slug}".encode()).digest()[:12])
+
+
+class SluggedDoc(MindtraceDocument):
+    """Document whose ``_id`` is minted from ``slug`` by a ``model_validator(mode="before")``.
+
+    Exercises the multi-site fan-in identity convergence: the same slug must always resolve to
+    the same ``_id`` regardless of the insert path (Beanie ``doc.insert()`` vs raw Motor routing).
+    """
+
+    slug: str
+    label: str
+
+    class Settings:
+        name = "slugged_docs"
+        use_cache = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _mint_deterministic_id(cls, data):
+        if isinstance(data, dict):
+            slug = data.get("slug")
+            # Only mint when the caller did not already supply an id (new-doc paths strip ids
+            # before construction, so this fires for every repository-mediated insert).
+            if slug is not None and not data.get("id") and not data.get("_id"):
+                data["id"] = _derive_id(slug)
+        return data
 
 
 @pytest.mark.asyncio
@@ -265,6 +298,86 @@ async def test_initialize_multiple_calls(mongo_backend):
     user = UserCreate(name="Alice", age=30, email="alice@test.com")
     inserted = await mongo_backend.insert(user)
     assert inserted.name == "Alice"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mongo_backend", [SluggedDoc], indirect=True)
+async def test_model_minted_id_survives_insert_beanie_path(mongo_backend):
+    """A validator-derived ``_id`` must be persisted (Beanie ``doc.insert()`` path).
+
+    The first backend for a model class is the one that runs ``init_beanie``, so this insert
+    goes through ``await doc.insert()`` rather than raw Motor routing.
+    """
+    assert mongo_backend._motor_routing is False  # first backend => Beanie insert path
+
+    expected = _derive_id("acme-plant")
+    inserted = await mongo_backend.insert(SluggedDoc(slug="acme-plant", label="Acme Plant"))
+    assert inserted.id == expected
+
+    # Round-trip: assert the *persisted* _id equals the derived value, not just the returned object.
+    raw = await mongo_backend.client["test_db"]["slugged_docs"].find_one({"slug": "acme-plant"})
+    assert raw is not None
+    assert raw["_id"] == expected
+
+    fetched = await mongo_backend.get(str(expected))
+    assert fetched.label == "Acme Plant"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mongo_backend", [SluggedDoc], indirect=True)
+async def test_model_minted_id_survives_insert_motor_path(mongo_backend):
+    """A validator-derived ``_id`` must be persisted through the raw Motor routing path too.
+
+    A second backend for an already-initialized model class routes through raw Motor writes
+    (``insert_one``) instead of Beanie; this covers the ``raw.pop("_id", ...)`` branch of the fix.
+    """
+    # ``mongo_backend`` already registered SluggedDoc, so a second backend routes via Motor.
+    motor_backend = MongoMindtraceODM(SluggedDoc, "mongodb://localhost:27018", "test_db")
+    await motor_backend.initialize()
+    assert motor_backend._motor_routing is True
+
+    expected = _derive_id("beta-plant")
+    inserted = await motor_backend.insert(SluggedDoc(slug="beta-plant", label="Beta Plant"))
+    assert inserted.id == expected
+
+    raw = await motor_backend.client["test_db"]["slugged_docs"].find_one({"slug": "beta-plant"})
+    assert raw is not None
+    assert raw["_id"] == expected
+
+    motor_backend.client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mongo_backend", [UserDoc], indirect=True)
+async def test_new_doc_semantics_strips_caller_supplied_id(mongo_backend):
+    """For a model WITHOUT an id-minting validator, a caller-supplied id is discarded.
+
+    ``insert()`` must preserve "new document" semantics: caller ids are stripped and Mongo
+    generates a fresh ObjectId.
+    """
+    caller_id = ObjectId()
+    inserted = await mongo_backend.insert(
+        {"id": caller_id, "name": "Alice", "age": 30, "email": "alice@newdoc.test"}
+    )
+
+    # A fresh random id was minted; the caller-supplied id did not survive.
+    assert inserted.id is not None
+    assert ObjectId(str(inserted.id)) != caller_id
+
+    raw = await mongo_backend.client["test_db"]["users"].find_one({"email": "alice@newdoc.test"})
+    assert raw is not None
+    assert raw["_id"] != caller_id
+    assert raw["_id"] == ObjectId(str(inserted.id))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mongo_backend", [SluggedDoc], indirect=True)
+async def test_duplicate_derived_id_raises_duplicate_insert_error(mongo_backend):
+    """Inserting the same slug twice collides on the deterministic ``_id`` => DuplicateInsertError."""
+    await mongo_backend.insert(SluggedDoc(slug="gamma-plant", label="Gamma Plant"))
+
+    with pytest.raises(DuplicateInsertError):
+        await mongo_backend.insert(SluggedDoc(slug="gamma-plant", label="Gamma Plant (dupe)"))
 
 
 def test_mongo_backend_find_iter_sync_streams_with_real_mongo():

--- a/tests/integration/mindtrace/database/test_mongo.py
+++ b/tests/integration/mindtrace/database/test_mongo.py
@@ -356,9 +356,7 @@ async def test_new_doc_semantics_strips_caller_supplied_id(mongo_backend):
     generates a fresh ObjectId.
     """
     caller_id = ObjectId()
-    inserted = await mongo_backend.insert(
-        {"id": caller_id, "name": "Alice", "age": 30, "email": "alice@newdoc.test"}
-    )
+    inserted = await mongo_backend.insert({"id": caller_id, "name": "Alice", "age": 30, "email": "alice@newdoc.test"})
 
     # A fresh random id was minted; the caller-supplied id did not survive.
     assert inserted.id is not None

--- a/tests/integration/mindtrace/database/test_mongo.py
+++ b/tests/integration/mindtrace/database/test_mongo.py
@@ -49,34 +49,34 @@ class UserCreate(BaseModel):
     email: str
 
 
-def _derive_id(slug: str) -> ObjectId:
-    """Deterministically derive an ObjectId from a slug (mirrors chiron's convergence pattern)."""
-    return ObjectId(hashlib.sha256(f"test:{slug}".encode()).digest()[:12])
+def _derive_id(key: str) -> ObjectId:
+    """Deterministically derive an ObjectId from a natural key."""
+    return ObjectId(hashlib.sha256(f"test:{key}".encode()).digest()[:12])
 
 
-class SluggedDoc(MindtraceDocument):
-    """Document whose ``_id`` is minted from ``slug`` by a ``model_validator(mode="before")``.
+class DerivedIdDoc(MindtraceDocument):
+    """Document whose ``_id`` is minted from a natural key by a ``model_validator(mode="before")``.
 
-    Exercises the multi-site fan-in identity convergence: the same slug must always resolve to
-    the same ``_id`` regardless of the insert path (Beanie ``doc.insert()`` vs raw Motor routing).
+    A validator-minted id is the model's identity; the backend must persist it
+    verbatim instead of re-minting a random one.
     """
 
-    slug: str
+    key: str
     label: str
 
     class Settings:
-        name = "slugged_docs"
+        name = "derived_id_docs"
         use_cache = False
 
     @model_validator(mode="before")
     @classmethod
     def _mint_deterministic_id(cls, data):
         if isinstance(data, dict):
-            slug = data.get("slug")
+            key = data.get("key")
             # Only mint when the caller did not already supply an id (new-doc paths strip ids
             # before construction, so this fires for every repository-mediated insert).
-            if slug is not None and not data.get("id") and not data.get("_id"):
-                data["id"] = _derive_id(slug)
+            if key is not None and not data.get("id") and not data.get("_id"):
+                data["id"] = _derive_id(key)
         return data
 
 
@@ -301,7 +301,7 @@ async def test_initialize_multiple_calls(mongo_backend):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("mongo_backend", [SluggedDoc], indirect=True)
+@pytest.mark.parametrize("mongo_backend", [DerivedIdDoc], indirect=True)
 async def test_model_minted_id_survives_insert_beanie_path(mongo_backend):
     """A validator-derived ``_id`` must be persisted (Beanie ``doc.insert()`` path).
 
@@ -310,37 +310,37 @@ async def test_model_minted_id_survives_insert_beanie_path(mongo_backend):
     """
     assert mongo_backend._motor_routing is False  # first backend => Beanie insert path
 
-    expected = _derive_id("acme-plant")
-    inserted = await mongo_backend.insert(SluggedDoc(slug="acme-plant", label="Acme Plant"))
+    expected = _derive_id("alpha")
+    inserted = await mongo_backend.insert(DerivedIdDoc(key="alpha", label="Alpha"))
     assert inserted.id == expected
 
     # Round-trip: assert the *persisted* _id equals the derived value, not just the returned object.
-    raw = await mongo_backend.client["test_db"]["slugged_docs"].find_one({"slug": "acme-plant"})
+    raw = await mongo_backend.client["test_db"]["derived_id_docs"].find_one({"key": "alpha"})
     assert raw is not None
     assert raw["_id"] == expected
 
     fetched = await mongo_backend.get(str(expected))
-    assert fetched.label == "Acme Plant"
+    assert fetched.label == "Alpha"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("mongo_backend", [SluggedDoc], indirect=True)
+@pytest.mark.parametrize("mongo_backend", [DerivedIdDoc], indirect=True)
 async def test_model_minted_id_survives_insert_motor_path(mongo_backend):
     """A validator-derived ``_id`` must be persisted through the raw Motor routing path too.
 
     A second backend for an already-initialized model class routes through raw Motor writes
     (``insert_one``) instead of Beanie; this covers the ``raw.pop("_id", ...)`` branch of the fix.
     """
-    # ``mongo_backend`` already registered SluggedDoc, so a second backend routes via Motor.
-    motor_backend = MongoMindtraceODM(SluggedDoc, "mongodb://localhost:27018", "test_db")
+    # ``mongo_backend`` already registered DerivedIdDoc, so a second backend routes via Motor.
+    motor_backend = MongoMindtraceODM(DerivedIdDoc, "mongodb://localhost:27018", "test_db")
     await motor_backend.initialize()
     assert motor_backend._motor_routing is True
 
-    expected = _derive_id("beta-plant")
-    inserted = await motor_backend.insert(SluggedDoc(slug="beta-plant", label="Beta Plant"))
+    expected = _derive_id("beta")
+    inserted = await motor_backend.insert(DerivedIdDoc(key="beta", label="Beta"))
     assert inserted.id == expected
 
-    raw = await motor_backend.client["test_db"]["slugged_docs"].find_one({"slug": "beta-plant"})
+    raw = await motor_backend.client["test_db"]["derived_id_docs"].find_one({"key": "beta"})
     assert raw is not None
     assert raw["_id"] == expected
 
@@ -369,13 +369,13 @@ async def test_new_doc_semantics_strips_caller_supplied_id(mongo_backend):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("mongo_backend", [SluggedDoc], indirect=True)
+@pytest.mark.parametrize("mongo_backend", [DerivedIdDoc], indirect=True)
 async def test_duplicate_derived_id_raises_duplicate_insert_error(mongo_backend):
-    """Inserting the same slug twice collides on the deterministic ``_id`` => DuplicateInsertError."""
-    await mongo_backend.insert(SluggedDoc(slug="gamma-plant", label="Gamma Plant"))
+    """Inserting the same natural key twice collides on the deterministic ``_id`` => DuplicateInsertError."""
+    await mongo_backend.insert(DerivedIdDoc(key="gamma", label="Gamma"))
 
     with pytest.raises(DuplicateInsertError):
-        await mongo_backend.insert(SluggedDoc(slug="gamma-plant", label="Gamma Plant (dupe)"))
+        await mongo_backend.insert(DerivedIdDoc(key="gamma", label="Gamma (dupe)"))
 
 
 def test_mongo_backend_find_iter_sync_streams_with_real_mongo():

--- a/tests/unit/mindtrace/database/test_mongo_unit.py
+++ b/tests/unit/mindtrace/database/test_mongo_unit.py
@@ -1,4 +1,5 @@
 import builtins
+import hashlib
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -6,6 +7,7 @@ import pytest
 from beanie import Document as BeanieDocument
 from bson import ObjectId
 from pydantic import BaseModel, Field, field_validator
+from pydantic import model_validator as pydantic_model_validator
 
 from mindtrace.database import MindtraceDocument
 
@@ -1673,3 +1675,61 @@ def test_close_releases_lazy_sync_client(mock_mongo_connection):
     backend.close()
     sync_stub.close.assert_called_once()
     assert backend._sync_client is None
+
+
+class SluggedUnitDoc(BaseModel):
+    """Plain Pydantic doc (MotorDoc convention) whose id is minted by a model
+    validator, deterministically from ``slug``. Exercises the motor-routing
+    fallback dump path (``model_dump(by_alias=True)`` emits ``_id``)."""
+
+    model_config = {"populate_by_name": True, "arbitrary_types_allowed": True}
+
+    slug: str
+    id: Optional[ObjectId] = Field(default=None, alias="_id")
+
+    @pydantic_model_validator(mode="before")
+    @classmethod
+    def _derive_id(cls, values):
+        if isinstance(values, dict) and not (values.get("id") or values.get("_id")):
+            slug = values.get("slug")
+            if isinstance(slug, str) and slug:
+                values["id"] = ObjectId(hashlib.sha256(f"unit:{slug}".encode()).digest()[:12])
+        return values
+
+    class Settings:
+        name = "slugged_unit_docs"
+
+
+@pytest.mark.asyncio
+async def test_insert_motor_path_preserves_model_minted_id(mock_mongo_connection):
+    """``insert()`` must not strip a validator-minted ``_id`` (motor-routing path).
+
+    Regression guard for the ``doc.id = None`` removal: deterministic ids minted
+    by a ``model_validator`` have to reach ``insert_one`` intact, while models
+    without such a validator still get new-doc semantics (Mongo mints the id).
+    """
+    from mindtrace.database.backends.mongo_odm import MongoMindtraceODM
+
+    backend = MongoMindtraceODM(SluggedUnitDoc, "mongodb://localhost:27017", "test_db")
+    backend._is_initialized = True
+    backend._motor_routing = True
+
+    captured = {}
+
+    async def fake_insert_one(raw):
+        captured["raw"] = dict(raw)
+        return MagicMock(inserted_id=raw["_id"])
+
+    async def fake_find_one(query):
+        return dict(captured["raw"])
+
+    fake_collection = MagicMock()
+    fake_collection.insert_one = fake_insert_one
+    fake_collection.find_one = fake_find_one
+    backend._motor_collection = MagicMock(return_value=fake_collection)
+
+    derived = ObjectId(hashlib.sha256(b"unit:alpha").digest()[:12])
+    out = await backend.insert(SluggedUnitDoc(slug="alpha"))
+
+    assert captured["raw"]["_id"] == derived
+    assert out.id == derived

--- a/tests/unit/mindtrace/database/test_mongo_unit.py
+++ b/tests/unit/mindtrace/database/test_mongo_unit.py
@@ -1677,27 +1677,27 @@ def test_close_releases_lazy_sync_client(mock_mongo_connection):
     assert backend._sync_client is None
 
 
-class SluggedUnitDoc(BaseModel):
+class DerivedIdUnitDoc(BaseModel):
     """Plain Pydantic doc (MotorDoc convention) whose id is minted by a model
-    validator, deterministically from ``slug``. Exercises the motor-routing
+    validator, deterministically from a natural key. Exercises the motor-routing
     fallback dump path (``model_dump(by_alias=True)`` emits ``_id``)."""
 
     model_config = {"populate_by_name": True, "arbitrary_types_allowed": True}
 
-    slug: str
+    key: str
     id: Optional[ObjectId] = Field(default=None, alias="_id")
 
     @pydantic_model_validator(mode="before")
     @classmethod
     def _derive_id(cls, values):
         if isinstance(values, dict) and not (values.get("id") or values.get("_id")):
-            slug = values.get("slug")
-            if isinstance(slug, str) and slug:
-                values["id"] = ObjectId(hashlib.sha256(f"unit:{slug}".encode()).digest()[:12])
+            key = values.get("key")
+            if isinstance(key, str) and key:
+                values["id"] = ObjectId(hashlib.sha256(f"unit:{key}".encode()).digest()[:12])
         return values
 
     class Settings:
-        name = "slugged_unit_docs"
+        name = "derived_id_unit_docs"
 
 
 @pytest.mark.asyncio
@@ -1710,7 +1710,7 @@ async def test_insert_motor_path_preserves_model_minted_id(mock_mongo_connection
     """
     from mindtrace.database.backends.mongo_odm import MongoMindtraceODM
 
-    backend = MongoMindtraceODM(SluggedUnitDoc, "mongodb://localhost:27017", "test_db")
+    backend = MongoMindtraceODM(DerivedIdUnitDoc, "mongodb://localhost:27017", "test_db")
     backend._is_initialized = True
     backend._motor_routing = True
 
@@ -1729,7 +1729,7 @@ async def test_insert_motor_path_preserves_model_minted_id(mock_mongo_connection
     backend._motor_collection = MagicMock(return_value=fake_collection)
 
     derived = ObjectId(hashlib.sha256(b"unit:alpha").digest()[:12])
-    out = await backend.insert(SluggedUnitDoc(slug="alpha"))
+    out = await backend.insert(DerivedIdUnitDoc(key="alpha"))
 
     assert captured["raw"]["_id"] == derived
     assert out.id == derived


### PR DESCRIPTION
### why
- insert() (and insert_many()) strip caller-supplied id/_id for new-doc semantics, reconstruct the doc at which point a model_validator(mode="before") may legitimately mint a deterministic id and then null it with doc.id = None, forcing a random ObjectId. Result: repository/API inserts got random ids while direct doc.insert() callers kept derived ids 

### How

- Removed doc.id = None in insert() and insert_many(). Caller-supplied ids are still stripped by the pops above, so new-doc semantics are unchanged


### tested

- 4 new integration tests (live Mongo, tests/integration/.../test_mongo.py): validator-minted id round-trips to the persisted _id on both the Beanie path and the motor-routing path; caller-supplied id on a validator-less model is still stripped (fresh random _id); duplicate derived id → DuplicateInsertError.
- new unit test (test_mongo_unit.py, MotorDoc convention): real insert() against a fake motor collection asserts the derived _id reaches insert_one intact — guards the fix without docker.
- Suites: database unit 70 passed, mongo integration 16 passed (full mongo suite 103).