### PR TITLE
Index Datum annotation set lookups

### DIFF
--- a/mindtrace/datalake/mindtrace/datalake/types.py
+++ b/mindtrace/datalake/mindtrace/datalake/types.py
@@ -605,6 +605,7 @@ class Datum(DatalakeDocument):
         name = "datalake_datums"
         indexes = [
             "split",
+            "annotation_set_ids",
             [("created_at", -1), ("datum_id", -1)],
             [("split", 1), ("created_at", -1), ("datum_id", -1)],
         ]

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -427,6 +427,11 @@ class TestAsyncDatalakeUnit:
                     f"{key!r} (forward or exact-reverse scan) required by {resource!r} sort {sort_name!r}"
                 )
 
+    def test_datum_annotation_set_lookup_index_is_declared(self):
+        """Annotation record inserts must not scan all Datums to find an AnnotationSet."""
+
+        assert "annotation_set_ids" in Datum.Settings.indexes
+
     @pytest.mark.parametrize(
         ("filter_item", "item", "expected"),
         [


### PR DESCRIPTION
## Summary

This change adds a MongoDB index on `Datum.annotation_set_ids` so annotation-record insertion can find the Datum linked to an AnnotationSet without scanning the entire `datalake_datums` collection.

Fixes #528

## Motivation

A large Datalake importer creates one AnnotationSet per imported Datum and then inserts annotation records into that set. Mindtrace currently backfills asset subjects by looking up the Datum that references the set with `{"annotation_set_ids": annotation_set_id}`.

Without an index, that lookup gets slower as the import grows because MongoDB scans the expanding Datum collection for each annotation insert. During importer development this showed up as throughput falling over the run; with this change, it was confirmed that the full import improved from roughly 2.5-3 hours to roughly 35-40 minutes.

## Implementation

- Added `annotation_set_ids` to `Datum.Settings.indexes`, which lets MongoDB create a multikey index for annotation-set membership lookups.
- Added a focused unit assertion that the Datum model keeps this index declared.

## Validation

- Tested with the parallel importer PR, with a ~4-5x speed improvement observed, notably once the DB fills with many (100k+) Datums.
