### PR TITLE
Add structured DatasetCard support

### DIFF
--- a/mindtrace/datalake/README.md
+++ b/mindtrace/datalake/README.md
@@ -122,12 +122,12 @@ The datalake is evolving from earlier internal versions toward a fuller **V3** c
 `DatasetVersion.description` is the short summary for listings and quick display. `DatasetVersion.metadata`
 remains the place for lightweight operational metadata and query keys. `DatasetVersion.card` is an optional
 `DatasetCard` for richer human-facing documentation that should travel with the immutable dataset version.
+Cards intentionally do not repeat the short summary; renderers should use `DatasetVersion.description` for it.
 
 ```python
 from mindtrace.datalake import DatasetCard, DatasetProvenance, DatasetStatistic, SplitInfo
 
 card = DatasetCard(
-    summary="Binary image classification dataset.",
     task="classification",
     modalities=["image"],
     provenance=DatasetProvenance(

--- a/mindtrace/datalake/README.md
+++ b/mindtrace/datalake/README.md
@@ -119,15 +119,17 @@ The datalake is evolving from earlier internal versions toward a fuller **V3** c
 
 ### Dataset cards
 
-`DatasetVersion.description` is the short summary for listings and quick display. `DatasetVersion.metadata`
-remains the place for lightweight operational metadata and query keys. `DatasetVersion.card` is an optional
-`DatasetCard` for richer human-facing documentation that should travel with the immutable dataset version.
-Cards intentionally do not repeat the short summary; renderers should use `DatasetVersion.description` for it.
+`DatasetVersion.description` is the short summary stored with a version for listings and quick display.
+`DatasetVersion.metadata` remains the place for lightweight operational metadata and query keys.
+`DatasetVersion.card` is an optional, standalone `DatasetCard` for richer human-facing documentation that should
+travel with the immutable dataset version. `DatasetCard.summary` makes the card meaningful when serialized or
+displayed independently; it may intentionally duplicate `DatasetVersion.description`.
 
 ```python
 from mindtrace.datalake import DatasetCard, DatasetProvenance, DatasetStatistic, SplitInfo
 
 card = DatasetCard(
+    summary="Binary image classification dataset.",
     task="classification",
     modalities=["image"],
     provenance=DatasetProvenance(

--- a/mindtrace/datalake/README.md
+++ b/mindtrace/datalake/README.md
@@ -124,13 +124,26 @@ remains the place for lightweight operational metadata and query keys. `DatasetV
 `DatasetCard` for richer human-facing documentation that should travel with the immutable dataset version.
 
 ```python
-from mindtrace.datalake import DatasetCard, SplitInfo
+from mindtrace.datalake import DatasetCard, DatasetProvenance, DatasetStatistic, SplitInfo
 
 card = DatasetCard(
     summary="Binary image classification dataset.",
     task="classification",
     modalities=["image"],
-    splits={"train": SplitInfo(count=1200), "val": SplitInfo(count=200)},
+    provenance=DatasetProvenance(
+        creation_method="Reviewed image importer",
+        included_subsets=["production"],
+        excluded_subsets=["repeated observations"],
+        split_strategy="Deterministic stratification by class",
+        split_seed=42,
+        split_key="source_path",
+    ),
+    splits={
+        "train": SplitInfo(count=1200, percentage=85.7),
+        "val": SplitInfo(count=200, percentage=14.3),
+    },
+    summary_statistics=[DatasetStatistic(name="total_items", value=1400, unit="items")],
+    evaluation_notes=["Evaluate rare classes separately"],
     intended_uses=["Train and validate image classifiers"],
     limitations=["Small validation split"],
     markdown="## Notes\n\nImported from the reviewed production subset.",

--- a/mindtrace/datalake/README.md
+++ b/mindtrace/datalake/README.md
@@ -114,7 +114,35 @@ The datalake is evolving from earlier internal versions toward a fuller **V3** c
 - **StorageRef**, **Asset**
 - **Annotation** schema/set/record model
 - **Datum**, **DatasetVersion**
+- **DatasetCard** (optional structured documentation attached to a dataset version)
 - **DatasetBuilder** (helper for constructing new versions — not the same as a persisted version record)
+
+### Dataset cards
+
+`DatasetVersion.description` is the short summary for listings and quick display. `DatasetVersion.metadata`
+remains the place for lightweight operational metadata and query keys. `DatasetVersion.card` is an optional
+`DatasetCard` for richer human-facing documentation that should travel with the immutable dataset version.
+
+```python
+from mindtrace.datalake import DatasetCard, SplitInfo
+
+card = DatasetCard(
+    summary="Binary image classification dataset.",
+    task="classification",
+    modalities=["image"],
+    splits={"train": SplitInfo(count=1200), "val": SplitInfo(count=200)},
+    intended_uses=["Train and validate image classifiers"],
+    limitations=["Small validation split"],
+    markdown="## Notes\n\nImported from the reviewed production subset.",
+)
+
+datalake.create_dataset_version(
+    dataset_name="demo-images",
+    version="1.0.0",
+    manifest=datum_ids,
+    card=card,
+)
+```
 
 ### Entity relationships (conceptual)
 

--- a/mindtrace/datalake/mindtrace/datalake/__init__.py
+++ b/mindtrace/datalake/mindtrace/datalake/__init__.py
@@ -22,7 +22,7 @@ from .async_datalake import (
     SlowOperationWarning,
     SlowOpsPolicy,
 )
-from .card import AnnotationField, DatasetCard, DatasetSource, SplitInfo
+from .card import AnnotationField, DatasetCard, DatasetProvenance, DatasetSource, DatasetStatistic, SplitInfo
 from .data_vault import AsyncDataVault, DataVault, VaultDataset
 from .data_vault_backends import (
     AsyncDataVaultBackend,
@@ -144,7 +144,9 @@ __all__ = [
     "Collection",
     "CollectionItem",
     "DatasetCard",
+    "DatasetProvenance",
     "DatasetSource",
+    "DatasetStatistic",
     "DatasetSyncBundle",
     "DatasetSyncCommitResult",
     "DatasetSyncImportPlan",

--- a/mindtrace/datalake/mindtrace/datalake/__init__.py
+++ b/mindtrace/datalake/mindtrace/datalake/__init__.py
@@ -22,6 +22,7 @@ from .async_datalake import (
     SlowOperationWarning,
     SlowOpsPolicy,
 )
+from .card import AnnotationField, DatasetCard, DatasetSource, SplitInfo
 from .data_vault import AsyncDataVault, DataVault, VaultDataset
 from .data_vault_backends import (
     AsyncDataVaultBackend,
@@ -95,6 +96,7 @@ from .upload_client import DatalakeDirectUploadClient
 
 __all__ = [
     "Annotation",
+    "AnnotationField",
     "AnnotationVariants",
     "annotation_from_record",
     "BboxAnnotation",
@@ -127,6 +129,7 @@ __all__ = [
     "SlowOperationDisabledError",
     "SlowOperationWarning",
     "SlowOpsPolicy",
+    "SplitInfo",
     "DataVault",
     "DataVaultBackend",
     "DatalakeServiceAsyncDataVaultBackend",
@@ -140,6 +143,8 @@ __all__ = [
     "AsyncDatalake",
     "Collection",
     "CollectionItem",
+    "DatasetCard",
+    "DatasetSource",
     "DatasetSyncBundle",
     "DatasetSyncCommitResult",
     "DatasetSyncImportPlan",

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -2305,8 +2305,6 @@ class AsyncDatalake(Mindtrace):
         for datum_id in manifest:
             await self.get_datum(datum_id)
         card_obj = DatasetCard.model_validate(card) if isinstance(card, dict) else card
-        if description is None and card_obj is not None and card_obj.summary:
-            description = card_obj.summary
         dataset_version = self._build_document(
             DatasetVersion,
             dataset_name=dataset_name,

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -19,6 +19,7 @@ from motor.motor_asyncio import AsyncIOMotorClient
 from mindtrace.core import Mindtrace, as_utc, utcnow
 from mindtrace.database import MongoMindtraceODM
 from mindtrace.database.core.exceptions import DocumentNotFoundError, DuplicateInsertError
+from mindtrace.datalake.card import DatasetCard
 from mindtrace.datalake.pagination_types import (
     CursorEnvelope,
     CursorPage,
@@ -2293,6 +2294,7 @@ class AsyncDatalake(Mindtrace):
         description: str | None = None,
         source_dataset_version_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        card: DatasetCard | dict[str, Any] | None = None,
         created_by: str | None = None,
     ) -> DatasetVersion:
         existing = await self.dataset_version_database.find({"dataset_name": dataset_name, "version": version})
@@ -2302,6 +2304,9 @@ class AsyncDatalake(Mindtrace):
             raise ValueError("Dataset version manifest must not contain duplicate datum ids")
         for datum_id in manifest:
             await self.get_datum(datum_id)
+        card_obj = DatasetCard.model_validate(card) if isinstance(card, dict) else card
+        if description is None and card_obj is not None and card_obj.summary:
+            description = card_obj.summary
         dataset_version = self._build_document(
             DatasetVersion,
             dataset_name=dataset_name,
@@ -2310,6 +2315,7 @@ class AsyncDatalake(Mindtrace):
             manifest=manifest,
             source_dataset_version_id=source_dataset_version_id,
             metadata=metadata or {},
+            card=card_obj,
             created_by=created_by,
         )
         return await self.dataset_version_database.insert(dataset_version)

--- a/mindtrace/datalake/mindtrace/datalake/card.py
+++ b/mindtrace/datalake/mindtrace/datalake/card.py
@@ -74,6 +74,7 @@ class DatasetCard(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: Literal[1] = 1
+    summary: str = ""
     task: str = ""
     modalities: list[str] = Field(default_factory=list)
     sources: list[DatasetSource] = Field(default_factory=list)

--- a/mindtrace/datalake/mindtrace/datalake/card.py
+++ b/mindtrace/datalake/mindtrace/datalake/card.py
@@ -4,11 +4,13 @@ import json
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class DatasetSource(BaseModel):
     """Minimal provenance reference for a dataset card."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     version: str | None = None
@@ -20,12 +22,16 @@ class DatasetSource(BaseModel):
 class SplitInfo(BaseModel):
     """Summary of one dataset split."""
 
-    count: int
+    model_config = ConfigDict(extra="forbid")
+
+    count: int = Field(ge=0)
     description: str = ""
 
 
 class AnnotationField(BaseModel):
     """Summary of an annotation field documented by a dataset card."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     kind: str = ""
@@ -35,6 +41,8 @@ class AnnotationField(BaseModel):
 
 class DatasetCard(BaseModel):
     """Structured documentation for an immutable Datalake dataset version."""
+
+    model_config = ConfigDict(extra="forbid")
 
     summary: str = ""
     task: str = ""

--- a/mindtrace/datalake/mindtrace/datalake/card.py
+++ b/mindtrace/datalake/mindtrace/datalake/card.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 
 class DatasetSource(BaseModel):
@@ -54,7 +54,7 @@ class DatasetCard(BaseModel):
     out_of_scope_uses: list[str] = Field(default_factory=list)
     limitations: list[str] = Field(default_factory=list)
     markdown: str = ""
-    extra: dict[str, Any] = Field(default_factory=dict)
+    extra: dict[str, JsonValue] = Field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the card to a JSON-safe dictionary."""

--- a/mindtrace/datalake/mindtrace/datalake/card.py
+++ b/mindtrace/datalake/mindtrace/datalake/card.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
@@ -19,12 +19,41 @@ class DatasetSource(BaseModel):
     description: str = ""
 
 
+class DatasetStatistic(BaseModel):
+    """Named JSON-safe statistic that generic card renderers can display."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    value: JsonValue
+    unit: str = ""
+    description: str = ""
+
+
+class DatasetProvenance(BaseModel):
+    """Structured provenance and reproduction details for a dataset version."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    creation_method: str = ""
+    included_subsets: list[str] = Field(default_factory=list)
+    excluded_subsets: list[str] = Field(default_factory=list)
+    split_strategy: str = ""
+    split_seed: int | str | None = None
+    split_key: str = ""
+    reproduction_notes: list[str] = Field(default_factory=list)
+
+
 class SplitInfo(BaseModel):
-    """Summary of one dataset split."""
+    """Summary and selection details for one dataset split."""
 
     model_config = ConfigDict(extra="forbid")
 
     count: int = Field(ge=0)
+    percentage: float | None = Field(default=None, ge=0, le=100)
+    source_subsets: list[str] = Field(default_factory=list)
+    selection_criteria: str = ""
+    statistics: list[DatasetStatistic] = Field(default_factory=list)
     description: str = ""
 
 
@@ -44,12 +73,16 @@ class DatasetCard(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    schema_version: Literal[1] = 1
     summary: str = ""
     task: str = ""
     modalities: list[str] = Field(default_factory=list)
     sources: list[DatasetSource] = Field(default_factory=list)
+    provenance: DatasetProvenance | None = None
     splits: dict[str, SplitInfo] = Field(default_factory=dict)
     annotations: list[AnnotationField] = Field(default_factory=list)
+    summary_statistics: list[DatasetStatistic] = Field(default_factory=list)
+    evaluation_notes: list[str] = Field(default_factory=list)
     intended_uses: list[str] = Field(default_factory=list)
     out_of_scope_uses: list[str] = Field(default_factory=list)
     limitations: list[str] = Field(default_factory=list)

--- a/mindtrace/datalake/mindtrace/datalake/card.py
+++ b/mindtrace/datalake/mindtrace/datalake/card.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class DatasetSource(BaseModel):
+    """Minimal provenance reference for a dataset card."""
+
+    name: str
+    version: str | None = None
+    dataset_version_id: str | None = None
+    uri: str | None = None
+    description: str = ""
+
+
+class SplitInfo(BaseModel):
+    """Summary of one dataset split."""
+
+    count: int
+    description: str = ""
+
+
+class AnnotationField(BaseModel):
+    """Summary of an annotation field documented by a dataset card."""
+
+    name: str
+    kind: str = ""
+    labels: list[str] = Field(default_factory=list)
+    description: str = ""
+
+
+class DatasetCard(BaseModel):
+    """Structured documentation for an immutable Datalake dataset version."""
+
+    summary: str = ""
+    task: str = ""
+    modalities: list[str] = Field(default_factory=list)
+    sources: list[DatasetSource] = Field(default_factory=list)
+    splits: dict[str, SplitInfo] = Field(default_factory=dict)
+    annotations: list[AnnotationField] = Field(default_factory=list)
+    intended_uses: list[str] = Field(default_factory=list)
+    out_of_scope_uses: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+    markdown: str = ""
+    extra: dict[str, Any] = Field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the card to a JSON-safe dictionary."""
+        return self.model_dump(mode="json")
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DatasetCard:
+        """Deserialize a card from a dictionary."""
+        return cls.model_validate(data)
+
+    def save_json(self, path: str | Path) -> None:
+        """Save the card as formatted JSON."""
+        destination = Path(path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(
+            json.dumps(self.to_dict(), indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    @classmethod
+    def load_json(cls, path: str | Path) -> DatasetCard:
+        """Load a card from a JSON file."""
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        return cls.from_dict(data)

--- a/mindtrace/datalake/mindtrace/datalake/card.py
+++ b/mindtrace/datalake/mindtrace/datalake/card.py
@@ -74,7 +74,6 @@ class DatasetCard(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: Literal[1] = 1
-    summary: str = ""
     task: str = ""
     modalities: list[str] = Field(default_factory=list)
     sources: list[DatasetSource] = Field(default_factory=list)

--- a/mindtrace/datalake/mindtrace/datalake/data_vault.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault.py
@@ -70,6 +70,7 @@ from mindtrace.datalake.async_datalake import (
     SlowOperationWarning,
     SlowOpsPolicy,
 )
+from mindtrace.datalake.card import DatasetCard
 from mindtrace.datalake.data_vault_backends import (
     _ASYNC_VAULT_METHOD_NAMES,
     _SYNC_VAULT_METHOD_NAMES,
@@ -1268,6 +1269,7 @@ class AsyncDataVault:
         *,
         snapshot_name: str | None = None,
         snapshot_version: str | None = None,
+        card: DatasetCard | dict[str, Any] | None = None,
         persist: bool = True,
         created_by: str | None = None,
     ) -> DatasetVersion | ResolvedDatasetVersion:
@@ -1277,6 +1279,7 @@ class AsyncDataVault:
             persist_snapshot=persist,
             snapshot_name=snapshot_name,
             snapshot_version=snapshot_version,
+            card=card,
             created_by=created_by,
         )
         return resolved.dataset_version if persist else resolved
@@ -1288,6 +1291,7 @@ class AsyncDataVault:
         persist_snapshot: bool = False,
         snapshot_name: str | None = None,
         snapshot_version: str | None = None,
+        card: DatasetCard | dict[str, Any] | None = None,
         created_by: str | None = None,
     ) -> ResolvedDatasetVersion:
         collection = await self._get_dataset_collection(dataset)
@@ -1347,6 +1351,7 @@ class AsyncDataVault:
                         }
                     },
                 ),
+                card=card,
                 created_by=created_by,
             )
             return await self._backend.resolve_dataset_version(dataset_name, version)
@@ -1412,6 +1417,7 @@ class AsyncDataVault:
                         }
                     },
                 ),
+                card=card,
                 created_by=created_by,
             ),
             datums=resolved_datums,
@@ -2354,6 +2360,7 @@ class DataVault:
         *,
         snapshot_name: str | None = None,
         snapshot_version: str | None = None,
+        card: DatasetCard | dict[str, Any] | None = None,
         persist: bool = True,
         created_by: str | None = None,
     ) -> DatasetVersion | ResolvedDatasetVersion:
@@ -2363,6 +2370,7 @@ class DataVault:
             persist_snapshot=persist,
             snapshot_name=snapshot_name,
             snapshot_version=snapshot_version,
+            card=card,
             created_by=created_by,
         )
         return resolved.dataset_version if persist else resolved
@@ -2374,6 +2382,7 @@ class DataVault:
         persist_snapshot: bool = False,
         snapshot_name: str | None = None,
         snapshot_version: str | None = None,
+        card: DatasetCard | dict[str, Any] | None = None,
         created_by: str | None = None,
     ) -> ResolvedDatasetVersion:
         collection = self._get_dataset_collection(dataset)
@@ -2431,6 +2440,7 @@ class DataVault:
                         }
                     },
                 ),
+                card=card,
                 created_by=created_by,
             )
             return self._backend.resolve_dataset_version(dataset_name, version)
@@ -2496,6 +2506,7 @@ class DataVault:
                         }
                     },
                 ),
+                card=card,
                 created_by=created_by,
             ),
             datums=resolved_datums,

--- a/mindtrace/datalake/mindtrace/datalake/data_vault_backends.py
+++ b/mindtrace/datalake/mindtrace/datalake/data_vault_backends.py
@@ -15,6 +15,7 @@ from typing import Any
 from unittest.mock import Mock as _UnitTestMock
 
 from mindtrace.datalake.async_datalake import AsyncDatalake
+from mindtrace.datalake.card import DatasetCard
 from mindtrace.datalake.datalake import Datalake
 from mindtrace.datalake.pagination_types import CursorPage
 from mindtrace.datalake.service_types import (
@@ -362,6 +363,7 @@ class AsyncDataVaultBackend(ABC):
         description: str | None = None,
         source_dataset_version_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        card: DatasetCard | dict[str, Any] | None = None,
         created_by: str | None = None,
     ) -> DatasetVersion: ...
 
@@ -567,6 +569,7 @@ class DataVaultBackend(ABC):
         description: str | None = None,
         source_dataset_version_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        card: DatasetCard | dict[str, Any] | None = None,
         created_by: str | None = None,
     ) -> DatasetVersion: ...
 
@@ -868,6 +871,7 @@ class LocalAsyncDataVaultBackend(AsyncDataVaultBackend):
         description: str | None = None,
         source_dataset_version_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        card: DatasetCard | dict[str, Any] | None = None,
         created_by: str | None = None,
     ) -> DatasetVersion:
         return await self._datalake.create_dataset_version(
@@ -877,6 +881,7 @@ class LocalAsyncDataVaultBackend(AsyncDataVaultBackend):
             description=description,
             source_dataset_version_id=source_dataset_version_id,
             metadata=metadata,
+            card=card,
             created_by=created_by,
         )
 
@@ -1153,6 +1158,7 @@ class LocalDataVaultBackend(DataVaultBackend):
         description: str | None = None,
         source_dataset_version_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        card: DatasetCard | dict[str, Any] | None = None,
         created_by: str | None = None,
     ) -> DatasetVersion:
         return self._datalake.create_dataset_version(
@@ -1162,6 +1168,7 @@ class LocalDataVaultBackend(DataVaultBackend):
             description=description,
             source_dataset_version_id=source_dataset_version_id,
             metadata=metadata,
+            card=card,
             created_by=created_by,
         )
 
@@ -1600,6 +1607,7 @@ class DatalakeServiceAsyncDataVaultBackend(AsyncDataVaultBackend):
         description: str | None = None,
         source_dataset_version_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        card: DatasetCard | dict[str, Any] | None = None,
         created_by: str | None = None,
     ) -> DatasetVersion:
         out = await self._call(
@@ -1611,6 +1619,7 @@ class DatalakeServiceAsyncDataVaultBackend(AsyncDataVaultBackend):
                 description=description,
                 source_dataset_version_id=source_dataset_version_id,
                 metadata=metadata,
+                card=card,
                 created_by=created_by,
             ),
         )
@@ -2003,6 +2012,7 @@ class DatalakeServiceDataVaultBackend(DataVaultBackend):
         description: str | None = None,
         source_dataset_version_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        card: DatasetCard | dict[str, Any] | None = None,
         created_by: str | None = None,
     ) -> DatasetVersion:
         out = self._call(
@@ -2014,6 +2024,7 @@ class DatalakeServiceDataVaultBackend(DataVaultBackend):
                 description=description,
                 source_dataset_version_id=source_dataset_version_id,
                 metadata=metadata,
+                card=card,
                 created_by=created_by,
             ),
         )

--- a/mindtrace/datalake/mindtrace/datalake/service_types.py
+++ b/mindtrace/datalake/mindtrace/datalake/service_types.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from mindtrace.core import TaskSchema
+from mindtrace.datalake.card import DatasetCard
 from mindtrace.datalake.pagination_types import (
     CursorPage,
     DatasetViewPage,
@@ -709,6 +710,7 @@ class CreateDatasetVersionInput(BaseModel):
     description: str | None = None
     source_dataset_version_id: str | None = None
     metadata: dict[str, Any] | None = None
+    card: DatasetCard | None = None
     created_by: str | None = None
 
 

--- a/mindtrace/datalake/mindtrace/datalake/types.py
+++ b/mindtrace/datalake/mindtrace/datalake/types.py
@@ -11,6 +11,7 @@ from pymongo import IndexModel
 
 from mindtrace.core import utcnow
 from mindtrace.database import MindtraceDocument
+from mindtrace.datalake.card import DatasetCard
 
 AnnotationTaskType = Literal["classification", "detection", "segmentation", "keypoint", "other"]
 AnnotationKind = Literal[
@@ -624,6 +625,7 @@ class DatasetVersion(DatalakeDocument):
     manifest: list[str] = Field(default_factory=list)
     source_dataset_version_id: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    card: DatasetCard | None = None
     created_at: datetime = Field(default_factory=utcnow)
     created_by: str | None = None
 

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -19,7 +19,7 @@ from export_test_utils import (
 
 from mindtrace.core import utcnow
 from mindtrace.database.core.exceptions import DocumentNotFoundError, DuplicateInsertError
-from mindtrace.datalake import AsyncDatalake
+from mindtrace.datalake import AsyncDatalake, DatasetCard
 from mindtrace.datalake.async_datalake import (
     PAGINATION_RESOURCE_MODELS,
     PAGINATION_SORT_SPECS,
@@ -1747,6 +1747,27 @@ class TestAsyncDatalakeUnit:
         mock_odm.find.return_value = [existing]
         with pytest.raises(ValueError):
             await async_datalake.create_dataset_version(dataset_name="demo", version="0.1.0", manifest=[])
+
+    @pytest.mark.asyncio
+    async def test_create_dataset_version_accepts_card(self, async_datalake, mock_odm):
+        mock_odm.find.return_value = []
+        async_datalake.get_datum = AsyncMock(return_value=Datum(asset_refs={"image": "asset_1"}))
+
+        created = await async_datalake.create_dataset_version(
+            dataset_name="demo",
+            version="0.1.0",
+            manifest=["datum_1"],
+            card={
+                "summary": "Demo card",
+                "task": "classification",
+                "splits": {"train": {"count": 1}},
+            },
+        )
+
+        assert created.description == "Demo card"
+        assert isinstance(created.card, DatasetCard)
+        assert created.card.task == "classification"
+        assert created.card.splits["train"].count == 1
 
     @pytest.mark.asyncio
     async def test_create_dataset_version_rejects_duplicate_manifest_ids(self, async_datalake, mock_odm):

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -1758,7 +1758,6 @@ class TestAsyncDatalakeUnit:
             version="0.1.0",
             manifest=["datum_1"],
             card={
-                "summary": "Demo card",
                 "task": "classification",
                 "splits": {"train": {"count": 1}},
             },

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -1758,6 +1758,7 @@ class TestAsyncDatalakeUnit:
             version="0.1.0",
             manifest=["datum_1"],
             card={
+                "summary": "Demo card",
                 "task": "classification",
                 "splits": {"train": {"count": 1}},
             },
@@ -1765,6 +1766,7 @@ class TestAsyncDatalakeUnit:
 
         assert created.description is None
         assert isinstance(created.card, DatasetCard)
+        assert created.card.summary == "Demo card"
         assert created.card.task == "classification"
         assert created.card.splits["train"].count == 1
 

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -1769,6 +1769,46 @@ class TestAsyncDatalakeUnit:
         assert created.card.splits["train"].count == 1
 
     @pytest.mark.asyncio
+    async def test_dataset_version_card_persists_and_reconstructs_from_database(self, async_datalake):
+        stored: dict[str, str] = {}
+        database = MagicMock()
+
+        async def insert(document):
+            stored["document"] = document.model_dump_json()
+            return DatasetVersion.model_validate_json(stored["document"])
+
+        async def find(_filters):
+            if "document" not in stored:
+                return []
+            return [DatasetVersion.model_validate_json(stored["document"])]
+
+        database.insert = AsyncMock(side_effect=insert)
+        database.find = AsyncMock(side_effect=find)
+        async_datalake.dataset_version_database = database
+        async_datalake.get_datum = AsyncMock(return_value=Datum(asset_refs={"image": "asset_1"}))
+
+        created = await async_datalake.create_dataset_version(
+            dataset_name="demo",
+            version="0.1.0",
+            manifest=["datum_1"],
+            card={
+                "task": "classification",
+                "provenance": {
+                    "creation_method": "Reviewed importer",
+                    "split_strategy": "Deterministic stratification",
+                    "split_key": "source_path",
+                },
+                "splits": {"train": {"count": 1}},
+            },
+        )
+        loaded = await async_datalake.get_dataset_version("demo", "0.1.0")
+
+        assert isinstance(created.card, DatasetCard)
+        assert isinstance(loaded.card, DatasetCard)
+        assert loaded.card == created.card
+        assert loaded.card.provenance.split_key == "source_path"
+
+    @pytest.mark.asyncio
     async def test_create_dataset_version_rejects_duplicate_manifest_ids(self, async_datalake, mock_odm):
         mock_odm.find.return_value = []
 

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -1764,7 +1764,7 @@ class TestAsyncDatalakeUnit:
             },
         )
 
-        assert created.description == "Demo card"
+        assert created.description is None
         assert isinstance(created.card, DatasetCard)
         assert created.card.task == "classification"
         assert created.card.splits["train"].count == 1

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -2055,7 +2055,7 @@ async def test_async_data_vault_eager_dataset_methods_obey_slow_ops_policy_warn(
 
 
 def test_sync_data_vault_freeze_dataset_persists_snapshot():
-    card = DatasetCard(summary="Training snapshot")
+    card = DatasetCard(task="classification")
     collection = Collection(name="training", collection_id="collection_1")
     item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1", split="train")
     asset = Asset(
@@ -2124,7 +2124,7 @@ def test_sync_data_vault_freeze_dataset_persists_snapshot():
 
 @pytest.mark.asyncio
 async def test_async_data_vault_freeze_dataset_persists_snapshot():
-    card = DatasetCard(summary="Training snapshot")
+    card = DatasetCard(task="classification")
     collection = Collection(name="training", collection_id="collection_1")
     item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1", split="train")
     asset = Asset(
@@ -2185,7 +2185,7 @@ async def test_async_data_vault_freeze_dataset_persists_snapshot():
 
 
 def test_sync_data_vault_freeze_dataset_attaches_card_to_non_persisted_snapshot():
-    card = DatasetCard(summary="In-memory snapshot")
+    card = DatasetCard(task="classification")
     collection = Collection(name="training", collection_id="collection_1")
     datalake = Mock()
     datalake.list_collections = Mock(return_value=[collection])
@@ -2851,7 +2851,7 @@ async def test_async_data_vault_import_dataset_version_skips_empty_datums_and_no
 
 
 def test_sync_data_vault_freeze_dataset_returns_dataset_version_when_persisting():
-    card = DatasetCard(summary="Training snapshot")
+    card = DatasetCard(task="classification")
     resolved = ResolvedDatasetVersion(
         dataset_version=DatasetVersion(dataset_name="training", version="1.2.3"), datums=[]
     )
@@ -2866,7 +2866,7 @@ def test_sync_data_vault_freeze_dataset_returns_dataset_version_when_persisting(
 
 @pytest.mark.asyncio
 async def test_async_data_vault_freeze_dataset_returns_resolved_snapshot_when_not_persisting():
-    card = DatasetCard(summary="Training snapshot")
+    card = DatasetCard(task="classification")
     resolved = ResolvedDatasetVersion(
         dataset_version=DatasetVersion(dataset_name="training", version="1.2.3"), datums=[]
     )

--- a/tests/unit/mindtrace/datalake/test_data_vault.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault.py
@@ -13,7 +13,7 @@ from urllib3.util import parse_url
 
 from mindtrace.core import CoreConfig
 from mindtrace.database.core.exceptions import DocumentNotFoundError
-from mindtrace.datalake import AsyncDatalake, DatalakeService
+from mindtrace.datalake import AsyncDatalake, DatalakeService, DatasetCard
 from mindtrace.datalake.annotations import BboxAnnotation, ClassificationAnnotation, PolygonAnnotation
 from mindtrace.datalake.async_datalake import SlowOperationDisabledError, SlowOperationWarning, SlowOpsPolicy
 from mindtrace.datalake.data_vault import (
@@ -2055,6 +2055,7 @@ async def test_async_data_vault_eager_dataset_methods_obey_slow_ops_policy_warn(
 
 
 def test_sync_data_vault_freeze_dataset_persists_snapshot():
+    card = DatasetCard(summary="Training snapshot")
     collection = Collection(name="training", collection_id="collection_1")
     item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1", split="train")
     asset = Asset(
@@ -2102,7 +2103,9 @@ def test_sync_data_vault_freeze_dataset_persists_snapshot():
     datalake.create_dataset_version = Mock(return_value=DatasetVersion(dataset_name="training", version="1.2.3"))
     datalake.resolve_dataset_version = Mock(return_value=resolved)
 
-    snapshot = DataVault(datalake)._freeze_dataset("training", persist_snapshot=True, snapshot_version="1.2.3")
+    snapshot = DataVault(datalake)._freeze_dataset(
+        "training", persist_snapshot=True, snapshot_version="1.2.3", card=card
+    )
 
     assert snapshot == resolved
     datalake.create_datum.assert_called_once()
@@ -2112,6 +2115,7 @@ def test_sync_data_vault_freeze_dataset_persists_snapshot():
     assert datalake.create_dataset_version.call_args.kwargs["dataset_name"] == "training"
     assert datalake.create_dataset_version.call_args.kwargs["version"] == "1.2.3"
     assert datalake.create_dataset_version.call_args.kwargs["manifest"] == ["datum_1"]
+    assert datalake.create_dataset_version.call_args.kwargs["card"] == card
     assert (
         datalake.create_dataset_version.call_args.kwargs["metadata"]["mindtrace"]["data_vault"]["source_dataset_id"]
         == "collection_1"
@@ -2120,6 +2124,7 @@ def test_sync_data_vault_freeze_dataset_persists_snapshot():
 
 @pytest.mark.asyncio
 async def test_async_data_vault_freeze_dataset_persists_snapshot():
+    card = DatasetCard(summary="Training snapshot")
     collection = Collection(name="training", collection_id="collection_1")
     item = CollectionItem(collection_id="collection_1", asset_id="asset_1", collection_item_id="ci_1", split="train")
     asset = Asset(
@@ -2168,7 +2173,7 @@ async def test_async_data_vault_freeze_dataset_persists_snapshot():
     datalake.resolve_dataset_version = AsyncMock(return_value=resolved)
 
     snapshot = await AsyncDataVault(datalake)._freeze_dataset(
-        "training", persist_snapshot=True, snapshot_version="1.2.3"
+        "training", persist_snapshot=True, snapshot_version="1.2.3", card=card
     )
 
     assert snapshot == resolved
@@ -2176,6 +2181,19 @@ async def test_async_data_vault_freeze_dataset_persists_snapshot():
     datalake.create_annotation_set.assert_awaited_once()
     datalake.add_annotation_records.assert_awaited_once()
     datalake.create_dataset_version.assert_awaited_once()
+    assert datalake.create_dataset_version.await_args.kwargs["card"] == card
+
+
+def test_sync_data_vault_freeze_dataset_attaches_card_to_non_persisted_snapshot():
+    card = DatasetCard(summary="In-memory snapshot")
+    collection = Collection(name="training", collection_id="collection_1")
+    datalake = Mock()
+    datalake.list_collections = Mock(return_value=[collection])
+    datalake.list_collection_items = Mock(return_value=[])
+
+    snapshot = DataVault(datalake)._freeze_dataset("training", card=card)
+
+    assert snapshot.dataset_version.card == card
 
 
 @pytest.mark.asyncio
@@ -2833,30 +2851,32 @@ async def test_async_data_vault_import_dataset_version_skips_empty_datums_and_no
 
 
 def test_sync_data_vault_freeze_dataset_returns_dataset_version_when_persisting():
+    card = DatasetCard(summary="Training snapshot")
     resolved = ResolvedDatasetVersion(
         dataset_version=DatasetVersion(dataset_name="training", version="1.2.3"), datums=[]
     )
     vault = object.__new__(DataVault)
     vault._freeze_dataset = Mock(return_value=resolved)
 
-    result = vault.freeze_dataset("training", persist=True, snapshot_version="1.2.3")
+    result = vault.freeze_dataset("training", persist=True, snapshot_version="1.2.3", card=card)
 
     assert result == resolved.dataset_version
-    vault._freeze_dataset.assert_called_once()
+    assert vault._freeze_dataset.call_args.kwargs["card"] == card
 
 
 @pytest.mark.asyncio
 async def test_async_data_vault_freeze_dataset_returns_resolved_snapshot_when_not_persisting():
+    card = DatasetCard(summary="Training snapshot")
     resolved = ResolvedDatasetVersion(
         dataset_version=DatasetVersion(dataset_name="training", version="1.2.3"), datums=[]
     )
     vault = object.__new__(AsyncDataVault)
     vault._freeze_dataset = AsyncMock(return_value=resolved)
 
-    result = await vault.freeze_dataset("training", persist=False, snapshot_version="1.2.3")
+    result = await vault.freeze_dataset("training", persist=False, snapshot_version="1.2.3", card=card)
 
     assert result == resolved
-    vault._freeze_dataset.assert_awaited_once()
+    assert vault._freeze_dataset.await_args.kwargs["card"] == card
 
 
 # --- Normalization and alias-indexing behavior (``data_vault`` + backends) ---

--- a/tests/unit/mindtrace/datalake/test_data_vault_backends.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault_backends.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from urllib3.util.url import parse_url
 
+from mindtrace.datalake import DatasetCard
 from mindtrace.datalake.data_vault import _normalize_async_backend, _normalize_sync_backend
 from mindtrace.datalake.data_vault_backends import (
     DatalakeServiceAsyncDataVaultBackend,
@@ -1078,7 +1079,8 @@ async def test_datalake_service_async_backend_dataset_methods():
 async def test_datalake_service_async_backend_snapshot_methods():
     collection = Collection(name="training", collection_id="collection_1")
     datum = Datum(datum_id="datum_1", asset_refs={"image": "asset_1"})
-    dataset_version = DatasetVersion(dataset_name="training", version="1.0.0")
+    card = DatasetCard(summary="Training snapshot", splits={"train": {"count": 1}})
+    dataset_version = DatasetVersion(dataset_name="training", version="1.0.0", card=card)
     resolved = ResolvedDatasetVersion(dataset_version=dataset_version, datums=[])
     cm = Mock()
     cm.acollections_update = AsyncMock(return_value=CollectionOutput(collection=collection))
@@ -1092,20 +1094,22 @@ async def test_datalake_service_async_backend_snapshot_methods():
 
     assert await backend.update_collection("collection_1", status="archived") == collection
     assert await backend.create_datum(asset_refs={"image": "asset_1"}, split="train") == datum
-    assert (
-        await backend.create_dataset_version(
-            dataset_name="training",
-            version="1.0.0",
-            manifest=["datum_1"],
-            description="snapshot",
-        )
-        == dataset_version
+    created = await backend.create_dataset_version(
+        dataset_name="training",
+        version="1.0.0",
+        manifest=["datum_1"],
+        description="snapshot",
+        card=card.to_dict(),
     )
+    assert created == dataset_version
+    assert created.card == card
     assert await backend.resolve_dataset_version("training", "1.0.0") == resolved
 
     assert isinstance(cm.acollections_update.await_args.args[0], UpdateCollectionInput)
     assert isinstance(cm.adatums_create.await_args.args[0], CreateDatumInput)
-    assert isinstance(cm.adataset_versions_create.await_args.args[0], CreateDatasetVersionInput)
+    create_input = cm.adataset_versions_create.await_args.args[0]
+    assert isinstance(create_input, CreateDatasetVersionInput)
+    assert create_input.card == card
     assert isinstance(cm.adataset_versions_resolve.await_args.args[0], GetDatasetVersionInput)
 
 

--- a/tests/unit/mindtrace/datalake/test_data_vault_backends.py
+++ b/tests/unit/mindtrace/datalake/test_data_vault_backends.py
@@ -1079,7 +1079,7 @@ async def test_datalake_service_async_backend_dataset_methods():
 async def test_datalake_service_async_backend_snapshot_methods():
     collection = Collection(name="training", collection_id="collection_1")
     datum = Datum(datum_id="datum_1", asset_refs={"image": "asset_1"})
-    card = DatasetCard(summary="Training snapshot", splits={"train": {"count": 1}})
+    card = DatasetCard(task="classification", splits={"train": {"count": 1}})
     dataset_version = DatasetVersion(dataset_name="training", version="1.0.0", card=card)
     resolved = ResolvedDatasetVersion(dataset_version=dataset_version, datums=[])
     cm = Mock()

--- a/tests/unit/mindtrace/datalake/test_datalake_service.py
+++ b/tests/unit/mindtrace/datalake/test_datalake_service.py
@@ -1335,7 +1335,7 @@ SERVICE_CASES = [
             description="unit dataset",
             source_dataset_version_id=None,
             metadata={"source": "unit"},
-            card=DatasetCard(task="classification", splits={"train": {"count": 1}}),
+            card=DatasetCard(summary="Unit dataset card", task="classification", splits={"train": {"count": 1}}),
             created_by="tester",
         ),
         "datalake_method": "create_dataset_version",
@@ -1351,7 +1351,7 @@ SERVICE_CASES = [
             description="unit dataset",
             source_dataset_version_id=None,
             metadata={"source": "unit"},
-            card=DatasetCard(task="classification", splits={"train": {"count": 1}}),
+            card=DatasetCard(summary="Unit dataset card", task="classification", splits={"train": {"count": 1}}),
             created_by="tester",
         ).model_dump(),
     },
@@ -1939,7 +1939,7 @@ async def test_service_view_dataset_version_page_translates_invalid_cursor(servi
 
 @pytest.mark.asyncio
 async def test_service_export_dataset_version_uses_sync_manager(service, datalake_objects):
-    card = DatasetCard(task="classification", splits={"train": {"count": 1}})
+    card = DatasetCard(summary="Demo export card", task="classification", splits={"train": {"count": 1}})
     dataset_version = datalake_objects.dataset_version.model_copy(update={"card": card})
     bundle = DatasetSyncBundle(dataset_version=dataset_version)
     with patch.object(SERVICE_MODULE, "DatasetSyncManager") as manager_cls:
@@ -1953,6 +1953,7 @@ async def test_service_export_dataset_version_uses_sync_manager(service, datalak
     restored = DatasetSyncBundleOutput.model_validate_json(result.model_dump_json())
     assert isinstance(restored.bundle.dataset_version.card, DatasetCard)
     assert restored.bundle.dataset_version.card == card
+    assert restored.bundle.dataset_version.card.summary == "Demo export card"
     manager.export_dataset_version.assert_awaited_once_with("demo", "1.0")
 
 

--- a/tests/unit/mindtrace/datalake/test_datalake_service.py
+++ b/tests/unit/mindtrace/datalake/test_datalake_service.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 
 from mindtrace.database.core.exceptions import DocumentNotFoundError, DocumentTooLargeError
+from mindtrace.datalake import DatasetCard
 from mindtrace.datalake.async_datalake import AsyncDatalake, SlowOperationDisabledError, SlowOpsPolicy
 from mindtrace.datalake.pagination_types import (
     CursorPage,
@@ -1334,6 +1335,7 @@ SERVICE_CASES = [
             description="unit dataset",
             source_dataset_version_id=None,
             metadata={"source": "unit"},
+            card=DatasetCard(task="classification", splits={"train": {"count": 1}}),
             created_by="tester",
         ),
         "datalake_method": "create_dataset_version",
@@ -1349,6 +1351,7 @@ SERVICE_CASES = [
             description="unit dataset",
             source_dataset_version_id=None,
             metadata={"source": "unit"},
+            card=DatasetCard(task="classification", splits={"train": {"count": 1}}),
             created_by="tester",
         ).model_dump(),
     },
@@ -1936,7 +1939,9 @@ async def test_service_view_dataset_version_page_translates_invalid_cursor(servi
 
 @pytest.mark.asyncio
 async def test_service_export_dataset_version_uses_sync_manager(service, datalake_objects):
-    bundle = DatasetSyncBundle(dataset_version=datalake_objects.dataset_version)
+    card = DatasetCard(task="classification", splits={"train": {"count": 1}})
+    dataset_version = datalake_objects.dataset_version.model_copy(update={"card": card})
+    bundle = DatasetSyncBundle(dataset_version=dataset_version)
     with patch.object(SERVICE_MODULE, "DatasetSyncManager") as manager_cls:
         manager = manager_cls.return_value
         manager.export_dataset_version = AsyncMock(return_value=bundle)
@@ -1945,6 +1950,9 @@ async def test_service_export_dataset_version_uses_sync_manager(service, datalak
 
     assert isinstance(result, DatasetSyncBundleOutput)
     assert result.bundle == bundle
+    restored = DatasetSyncBundleOutput.model_validate_json(result.model_dump_json())
+    assert isinstance(restored.bundle.dataset_version.card, DatasetCard)
+    assert restored.bundle.dataset_version.card == card
     manager.export_dataset_version.assert_awaited_once_with("demo", "1.0")
 
 

--- a/tests/unit/mindtrace/datalake/test_datalake_types.py
+++ b/tests/unit/mindtrace/datalake/test_datalake_types.py
@@ -1,3 +1,4 @@
+from mindtrace.datalake import DatasetCard
 from mindtrace.datalake.types import (
     AnnotationLabelDefinition,
     AnnotationRecord,
@@ -77,6 +78,20 @@ def test_main_type_str_methods_are_readable():
     assert str(dataset_version) == "DatasetVersion(dataset=demo, version=0.1.0, datums=1)"
     assert str(resolved_datum) == f"ResolvedDatum(datum_id={datum.datum_id}, assets=1, annotation_sets=1)"
     assert str(resolved_dataset) == "ResolvedDatasetVersion(dataset=demo, version=0.1.0, datums=1)"
+
+
+def test_dataset_version_accepts_optional_card():
+    without_card = DatasetVersion(dataset_name="demo", version="0.1.0")
+    with_card = DatasetVersion(
+        dataset_name="demo",
+        version="0.2.0",
+        card={"summary": "Demo dataset", "splits": {"train": {"count": 5}}},
+    )
+
+    assert without_card.card is None
+    assert isinstance(with_card.card, DatasetCard)
+    assert with_card.card.summary == "Demo dataset"
+    assert with_card.card.splits["train"].count == 5
 
 
 def test_annotation_schema_and_label_definition_defaults():

--- a/tests/unit/mindtrace/datalake/test_datalake_types.py
+++ b/tests/unit/mindtrace/datalake/test_datalake_types.py
@@ -85,11 +85,12 @@ def test_dataset_version_accepts_optional_card():
     with_card = DatasetVersion(
         dataset_name="demo",
         version="0.2.0",
-        card={"task": "classification", "splits": {"train": {"count": 5}}},
+        card={"summary": "Demo dataset", "task": "classification", "splits": {"train": {"count": 5}}},
     )
 
     assert without_card.card is None
     assert isinstance(with_card.card, DatasetCard)
+    assert with_card.card.summary == "Demo dataset"
     assert with_card.card.task == "classification"
     assert with_card.card.splits["train"].count == 5
 

--- a/tests/unit/mindtrace/datalake/test_datalake_types.py
+++ b/tests/unit/mindtrace/datalake/test_datalake_types.py
@@ -85,12 +85,12 @@ def test_dataset_version_accepts_optional_card():
     with_card = DatasetVersion(
         dataset_name="demo",
         version="0.2.0",
-        card={"summary": "Demo dataset", "splits": {"train": {"count": 5}}},
+        card={"task": "classification", "splits": {"train": {"count": 5}}},
     )
 
     assert without_card.card is None
     assert isinstance(with_card.card, DatasetCard)
-    assert with_card.card.summary == "Demo dataset"
+    assert with_card.card.task == "classification"
     assert with_card.card.splits["train"].count == 5
 
 

--- a/tests/unit/mindtrace/datalake/test_dataset_card.py
+++ b/tests/unit/mindtrace/datalake/test_dataset_card.py
@@ -68,3 +68,8 @@ def test_dataset_card_rejects_unknown_fields(payload):
 def test_split_info_rejects_negative_count():
     with pytest.raises(ValidationError):
         SplitInfo(count=-1)
+
+
+def test_dataset_card_rejects_non_json_extra_value():
+    with pytest.raises(ValidationError):
+        DatasetCard(extra={"unsupported": object()})

--- a/tests/unit/mindtrace/datalake/test_dataset_card.py
+++ b/tests/unit/mindtrace/datalake/test_dataset_card.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import json
 
+import pytest
+from pydantic import ValidationError
+
 from mindtrace.datalake import AnnotationField, DatasetCard, DatasetSource, SplitInfo
 from mindtrace.datalake.service_types import CreateDatasetVersionInput
 
@@ -48,3 +51,20 @@ def test_create_dataset_version_input_accepts_card_dict():
 
     assert isinstance(payload.card, DatasetCard)
     assert payload.card.summary == "Demo dataset"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"intended_use": ["Train classifiers"]},
+        {"sources": [{"name": "source", "unknown": "value"}]},
+    ],
+)
+def test_dataset_card_rejects_unknown_fields(payload):
+    with pytest.raises(ValidationError):
+        DatasetCard.model_validate(payload)
+
+
+def test_split_info_rejects_negative_count():
+    with pytest.raises(ValidationError):
+        SplitInfo(count=-1)

--- a/tests/unit/mindtrace/datalake/test_dataset_card.py
+++ b/tests/unit/mindtrace/datalake/test_dataset_card.py
@@ -18,7 +18,6 @@ from mindtrace.datalake.service_types import CreateDatasetVersionInput
 
 def test_dataset_card_to_dict_roundtrip():
     card = DatasetCard(
-        summary="Image classification dataset.",
         task="classification",
         modalities=["image"],
         sources=[DatasetSource(name="source-dataset", version="1.0.0", dataset_version_id="dataset_version_1")],
@@ -62,12 +61,12 @@ def test_dataset_card_to_dict_roundtrip():
 
 
 def test_dataset_card_save_and_load_json(tmp_path):
-    card = DatasetCard(summary="Demo dataset", splits={"test": {"count": 3}})
+    card = DatasetCard(task="classification", splits={"test": {"count": 3}})
     path = tmp_path / "nested" / "card.json"
 
     card.save_json(path)
 
-    assert json.loads(path.read_text(encoding="utf-8"))["summary"] == "Demo dataset"
+    assert json.loads(path.read_text(encoding="utf-8"))["task"] == "classification"
     assert DatasetCard.load_json(path) == card
 
 
@@ -76,11 +75,11 @@ def test_create_dataset_version_input_accepts_card_dict():
         dataset_name="demo",
         version="0.1.0",
         manifest=[],
-        card={"summary": "Demo dataset"},
+        card={"task": "classification"},
     )
 
     assert isinstance(payload.card, DatasetCard)
-    assert payload.card.summary == "Demo dataset"
+    assert payload.card.task == "classification"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/mindtrace/datalake/test_dataset_card.py
+++ b/tests/unit/mindtrace/datalake/test_dataset_card.py
@@ -5,7 +5,14 @@ import json
 import pytest
 from pydantic import ValidationError
 
-from mindtrace.datalake import AnnotationField, DatasetCard, DatasetSource, SplitInfo
+from mindtrace.datalake import (
+    AnnotationField,
+    DatasetCard,
+    DatasetProvenance,
+    DatasetSource,
+    DatasetStatistic,
+    SplitInfo,
+)
 from mindtrace.datalake.service_types import CreateDatasetVersionInput
 
 
@@ -15,8 +22,28 @@ def test_dataset_card_to_dict_roundtrip():
         task="classification",
         modalities=["image"],
         sources=[DatasetSource(name="source-dataset", version="1.0.0", dataset_version_id="dataset_version_1")],
-        splits={"train": SplitInfo(count=10), "val": SplitInfo(count=2, description="held-out validation")},
+        provenance=DatasetProvenance(
+            creation_method="Reviewed importer",
+            included_subsets=["production"],
+            excluded_subsets=["repeated-observations"],
+            split_strategy="Deterministic stratification by class",
+            split_seed=42,
+            split_key="source_path",
+            reproduction_notes=["Rare classes are allocated before the majority class"],
+        ),
+        splits={
+            "train": SplitInfo(
+                count=10,
+                percentage=83.33,
+                source_subsets=["production"],
+                selection_criteria="Training allocation",
+                statistics=[DatasetStatistic(name="defective", value=4, unit="items")],
+            ),
+            "val": SplitInfo(count=2, description="held-out validation"),
+        },
         annotations=[AnnotationField(name="defect_type", kind="classification", labels=["healthy", "defective"])],
+        summary_statistics=[DatasetStatistic(name="total_items", value=12, unit="items")],
+        evaluation_notes=["Validate rare classes separately"],
         intended_uses=["Train defect classifiers"],
         out_of_scope_uses=["General consumer photography"],
         limitations=["Small validation split"],
@@ -27,7 +54,10 @@ def test_dataset_card_to_dict_roundtrip():
     restored = DatasetCard.from_dict(card.to_dict())
 
     assert restored == card
+    assert restored.schema_version == 1
+    assert restored.provenance.split_key == "source_path"
     assert restored.splits["train"].count == 10
+    assert restored.splits["train"].statistics[0].value == 4
     assert restored.annotations[0].labels == ["healthy", "defective"]
 
 
@@ -73,3 +103,8 @@ def test_split_info_rejects_negative_count():
 def test_dataset_card_rejects_non_json_extra_value():
     with pytest.raises(ValidationError):
         DatasetCard(extra={"unsupported": object()})
+
+
+def test_dataset_card_rejects_unknown_schema_version():
+    with pytest.raises(ValidationError):
+        DatasetCard(schema_version=2)

--- a/tests/unit/mindtrace/datalake/test_dataset_card.py
+++ b/tests/unit/mindtrace/datalake/test_dataset_card.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+
+from mindtrace.datalake import AnnotationField, DatasetCard, DatasetSource, SplitInfo
+from mindtrace.datalake.service_types import CreateDatasetVersionInput
+
+
+def test_dataset_card_to_dict_roundtrip():
+    card = DatasetCard(
+        summary="Image classification dataset.",
+        task="classification",
+        modalities=["image"],
+        sources=[DatasetSource(name="source-dataset", version="1.0.0", dataset_version_id="dataset_version_1")],
+        splits={"train": SplitInfo(count=10), "val": SplitInfo(count=2, description="held-out validation")},
+        annotations=[AnnotationField(name="defect_type", kind="classification", labels=["healthy", "defective"])],
+        intended_uses=["Train defect classifiers"],
+        out_of_scope_uses=["General consumer photography"],
+        limitations=["Small validation split"],
+        markdown="## Notes\n\n| split | count |\n| --- | ---: |\n| train | 10 |",
+        extra={"importer": "unit"},
+    )
+
+    restored = DatasetCard.from_dict(card.to_dict())
+
+    assert restored == card
+    assert restored.splits["train"].count == 10
+    assert restored.annotations[0].labels == ["healthy", "defective"]
+
+
+def test_dataset_card_save_and_load_json(tmp_path):
+    card = DatasetCard(summary="Demo dataset", splits={"test": {"count": 3}})
+    path = tmp_path / "nested" / "card.json"
+
+    card.save_json(path)
+
+    assert json.loads(path.read_text(encoding="utf-8"))["summary"] == "Demo dataset"
+    assert DatasetCard.load_json(path) == card
+
+
+def test_create_dataset_version_input_accepts_card_dict():
+    payload = CreateDatasetVersionInput(
+        dataset_name="demo",
+        version="0.1.0",
+        manifest=[],
+        card={"summary": "Demo dataset"},
+    )
+
+    assert isinstance(payload.card, DatasetCard)
+    assert payload.card.summary == "Demo dataset"

--- a/tests/unit/mindtrace/datalake/test_dataset_card.py
+++ b/tests/unit/mindtrace/datalake/test_dataset_card.py
@@ -18,6 +18,7 @@ from mindtrace.datalake.service_types import CreateDatasetVersionInput
 
 def test_dataset_card_to_dict_roundtrip():
     card = DatasetCard(
+        summary="Image classification dataset.",
         task="classification",
         modalities=["image"],
         sources=[DatasetSource(name="source-dataset", version="1.0.0", dataset_version_id="dataset_version_1")],
@@ -61,12 +62,12 @@ def test_dataset_card_to_dict_roundtrip():
 
 
 def test_dataset_card_save_and_load_json(tmp_path):
-    card = DatasetCard(task="classification", splits={"test": {"count": 3}})
+    card = DatasetCard(summary="Demo dataset", task="classification", splits={"test": {"count": 3}})
     path = tmp_path / "nested" / "card.json"
 
     card.save_json(path)
 
-    assert json.loads(path.read_text(encoding="utf-8"))["task"] == "classification"
+    assert json.loads(path.read_text(encoding="utf-8"))["summary"] == "Demo dataset"
     assert DatasetCard.load_json(path) == card
 
 
@@ -75,10 +76,11 @@ def test_create_dataset_version_input_accepts_card_dict():
         dataset_name="demo",
         version="0.1.0",
         manifest=[],
-        card={"task": "classification"},
+        card={"summary": "Demo dataset", "task": "classification"},
     )
 
     assert isinstance(payload.card, DatasetCard)
+    assert payload.card.summary == "Demo dataset"
     assert payload.card.task == "classification"
 
 

--- a/tests/unit/mindtrace/datalake/test_sync.py
+++ b/tests/unit/mindtrace/datalake/test_sync.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 
 from mindtrace.database.core.exceptions import DocumentNotFoundError, DuplicateInsertError
+from mindtrace.datalake import DatasetCard
 from mindtrace.datalake.sync import (
     DatasetSyncManager,
     _apply_mount_map_to_storage_ref,
@@ -101,6 +102,7 @@ def sync_objects():
         version="1.0.0",
         manifest=[datum.datum_id],
         metadata={"dataset": True},
+        card=DatasetCard(summary="Demo sync dataset", splits={"train": {"count": 1}}),
     )
     return SimpleNamespace(
         storage_ref=storage_ref,
@@ -463,6 +465,7 @@ class TestDatasetSyncManager:
         inserted_dataset_version = target_datalake.dataset_version_database.insert.await_args.args[0]
         assert inserted_dataset_version.metadata["origin"]["entity_id"] == "dataset_version_1"
         assert inserted_dataset_version.metadata["origin"]["dataset_name"] == "demo"
+        assert inserted_dataset_version.card == sync_objects.dataset_version.card
 
     @pytest.mark.asyncio
     async def test_commit_import_transfers_payloads_with_bounded_concurrency(

--- a/tests/unit/mindtrace/datalake/test_sync.py
+++ b/tests/unit/mindtrace/datalake/test_sync.py
@@ -102,7 +102,7 @@ def sync_objects():
         version="1.0.0",
         manifest=[datum.datum_id],
         metadata={"dataset": True},
-        card=DatasetCard(summary="Demo sync dataset", splits={"train": {"count": 1}}),
+        card=DatasetCard(task="classification", splits={"train": {"count": 1}}),
     )
     return SimpleNamespace(
         storage_ref=storage_ref,

--- a/tests/unit/mindtrace/datalake/test_sync_types.py
+++ b/tests/unit/mindtrace/datalake/test_sync_types.py
@@ -1,5 +1,6 @@
 import pytest
 
+from mindtrace.datalake import DatasetCard, DatasetProvenance
 from mindtrace.datalake.sync_types import (
     DatasetSyncBundle,
     DatasetSyncCommitResult,
@@ -9,6 +10,26 @@ from mindtrace.datalake.sync_types import (
     ObjectPayloadDescriptor,
 )
 from mindtrace.datalake.types import AnnotationRecord, AnnotationSet, Asset, DatasetVersion, Datum, StorageRef
+
+
+def test_dataset_sync_bundle_json_roundtrip_preserves_typed_card():
+    card = DatasetCard(
+        task="classification",
+        provenance=DatasetProvenance(
+            creation_method="Reviewed importer",
+            split_strategy="Deterministic stratification",
+            split_seed=42,
+            split_key="source_path",
+        ),
+        splits={"train": {"count": 10, "percentage": 80}, "val": {"count": 2, "percentage": 20}},
+    )
+    bundle = DatasetSyncBundle(dataset_version=DatasetVersion(dataset_name="demo", version="1.0.0", card=card))
+
+    restored = DatasetSyncBundle.model_validate_json(bundle.model_dump_json())
+
+    assert isinstance(restored.dataset_version.card, DatasetCard)
+    assert restored.dataset_version.card == card
+    assert restored.dataset_version.card.provenance.split_key == "source_path"
 
 
 def test_sync_type_defaults_and_nested_models():

--- a/tests/unit/mindtrace/datalake/test_sync_types.py
+++ b/tests/unit/mindtrace/datalake/test_sync_types.py
@@ -14,6 +14,7 @@ from mindtrace.datalake.types import AnnotationRecord, AnnotationSet, Asset, Dat
 
 def test_dataset_sync_bundle_json_roundtrip_preserves_typed_card():
     card = DatasetCard(
+        summary="Demo sync dataset",
         task="classification",
         provenance=DatasetProvenance(
             creation_method="Reviewed importer",
@@ -29,6 +30,7 @@ def test_dataset_sync_bundle_json_roundtrip_preserves_typed_card():
 
     assert isinstance(restored.dataset_version.card, DatasetCard)
     assert restored.dataset_version.card == card
+    assert restored.dataset_version.card.summary == "Demo sync dataset"
     assert restored.dataset_version.card.provenance.split_key == "source_path"
 
 


### PR DESCRIPTION
## Summary

This change adds a public, versioned, standalone `DatasetCard` for documenting an immutable Datalake dataset version. Cards capture a human-readable summary, task and modality information, typed provenance and reproduction details, split summaries and statistics, annotation fields, evaluation notes, intended and out-of-scope uses, limitations, free-form Markdown, and JSON-safe extension metadata.

Cards can be serialized to dictionaries or JSON, attached when a dataset version is created or frozen from a DataVault dataset, retrieved as typed objects, and preserved through dataset sync/export/import flows.

Fixes #532

## Motivation

`DatasetVersion.description` provides a short summary stored with a version for listings and quick display, while `DatasetVersion.metadata` is appropriate for lightweight operational metadata and query keys. `DatasetCard.summary` makes a card meaningful when serialized or displayed independently and may intentionally duplicate the version description.

Without a first-class card, importers and dataset producers must invent incompatible metadata structures, and downstream tools cannot reliably render provenance, split details, annotation semantics, intended uses, or known limitations. A typed `DatasetCard` gives dataset documentation a stable public contract while keeping cards optional for backward compatibility.

## Implementation

- Added schema-versioned `DatasetCard` models for a standalone summary, sources, provenance/reproduction details, splits, statistics, and annotation fields, with strict validation and dictionary/JSON persistence helpers.
- Constrained the extension `extra` field to JSON-safe values so invalid transport or persistence payloads fail during validation.
- Added an optional `card` field to `DatasetVersion` and accepted cards through local, DataVault freeze, and service-backed dataset-version creation paths.
- Preserved typed cards through database reconstruction and dataset sync/export/import serialization boundaries.
- Exported the card types from `mindtrace.datalake` and documented how cards relate to `DatasetVersion.description` and `DatasetVersion.metadata`.

## Usage

Create a standalone card and attach it when adding a dataset version to a Datalake:

```python
from mindtrace.datalake import (
    AnnotationField,
    DatasetCard,
    DatasetProvenance,
    DatasetStatistic,
    SplitInfo,
)

card = DatasetCard(
    summary="Reviewed images for binary defect classification.",
    task="classification",
    modalities=["image"],
    provenance=DatasetProvenance(
        creation_method="Reviewed image importer",
        included_subsets=["production"],
        excluded_subsets=["repeated observations"],
        split_strategy="Deterministic stratification by class",
        split_seed=42,
        split_key="source_path",
    ),
    splits={
        "train": SplitInfo(count=1_200, percentage=85.7),
        "val": SplitInfo(count=200, percentage=14.3),
    },
    annotations=[
        AnnotationField(
            name="defect_type",
            kind="classification",
            labels=["healthy", "defective"],
        )
    ],
    summary_statistics=[DatasetStatistic(name="total_items", value=1_400, unit="items")],
    evaluation_notes=["Evaluate rare classes separately"],
    intended_uses=["Train and validate binary image classifiers"],
    out_of_scope_uses=["Unreviewed safety-critical decisions"],
    limitations=["The validation split is smaller than the training split"],
    markdown="## Notes\n\nAll samples were reviewed before inclusion.",
)

dataset_version = datalake.create_dataset_version(
    dataset_name="reviewed-images",
    version="1.0.0",
    manifest=datum_ids,
    description="Reviewed binary classification dataset",
    card=card,
)

assert dataset_version.card == card
```

## Validation

Run the focused card unit tests with:

```bash
uv run pytest \
  tests/unit/mindtrace/datalake/test_dataset_card.py \
  tests/unit/mindtrace/datalake/test_datalake_types.py::test_dataset_version_accepts_optional_card \
  tests/unit/mindtrace/datalake/test_async_datalake.py::TestAsyncDatalakeUnit::test_create_dataset_version_accepts_card \
  tests/unit/mindtrace/datalake/test_async_datalake.py::TestAsyncDatalakeUnit::test_dataset_version_card_persists_and_reconstructs_from_database \
  tests/unit/mindtrace/datalake/test_data_vault.py::test_sync_data_vault_freeze_dataset_persists_snapshot \
  tests/unit/mindtrace/datalake/test_data_vault.py::test_async_data_vault_freeze_dataset_persists_snapshot \
  tests/unit/mindtrace/datalake/test_data_vault.py::test_sync_data_vault_freeze_dataset_attaches_card_to_non_persisted_snapshot \
  tests/unit/mindtrace/datalake/test_data_vault_backends.py::test_datalake_service_async_backend_snapshot_methods \
  tests/unit/mindtrace/datalake/test_sync_types.py::test_dataset_sync_bundle_json_roundtrip_preserves_typed_card \
  'tests/unit/mindtrace/datalake/test_datalake_service.py::test_service_methods_map_requests_to_async_datalake[create_dataset_version]' \
  tests/unit/mindtrace/datalake/test_datalake_service.py::test_service_export_dataset_version_uses_sync_manager \
  tests/unit/mindtrace/datalake/test_sync.py::TestDatasetSyncManager::test_commit_import_transfers_and_inserts_entities
```

The original focused card tests passed before the review updates. Per request, unit tests were not rerun during the review pass. Ruff formatting and lint checks passed for every touched Python file before each review-fix commit.
