### PR TITLE
hardware/plcs: typed tag results, dual channel comm, recovery for transport

### DIFF
--- a/mindtrace/hardware/README.md
+++ b/mindtrace/hardware/README.md
@@ -506,14 +506,33 @@ async def plc_operations():
     await manager.register_plc("Line1", "192.168.1.100", plc_type="logix")
     await manager.connect_plc("Line1")
 
-    # Read/write operations
-    values = await manager.read_tags("Line1", ["Motor_Speed", "Status"])
-    await manager.write_tag("Line1", "Command", True)
+    # Read/write operations return one TagResult per tag
+    results = await manager.read_tag("Line1", ["Motor_Speed", "Status"])
+    if results["Motor_Speed"].ok:
+        speed = results["Motor_Speed"].value
+    else:
+        kind = results["Motor_Speed"].error.kind  # missing_tag / type_mismatch / encode / transport
+
+    await manager.write_tag("Line1", [("Command", True)])
 
     await manager.cleanup()
 
 asyncio.run(plc_operations())
 ```
+
+### Transport behaviour
+
+Reads and writes are serialized on separate channels (a read driver and a write
+driver per PLC), each recovering on its own:
+
+- Transport-class failures retry up to `MINDTRACE_HW_PLC_RETRY_COUNT` times,
+  reconnecting only that channel between attempts, then raise
+  `PLCCommunicationError` with `attempts=N`.
+- The delay between attempts is a flat `MINDTRACE_HW_PLC_RETRY_DELAY`; a failed
+  reconnect is logged, not fatal. No circuit breaker, no escalating backoff.
+- Malformed requests (`PLCTagReadError` / `PLCTagWriteError`) are never retried.
+- Per-tag failures are never retried or laundered — they come back as
+  `TagResult.error`.
 
 ### Service Layer
 

--- a/mindtrace/hardware/README.md
+++ b/mindtrace/hardware/README.md
@@ -531,8 +531,12 @@ driver per PLC), each recovering on its own:
 - The delay between attempts is a flat `MINDTRACE_HW_PLC_RETRY_DELAY`; a failed
   reconnect is logged, not fatal. No circuit breaker, no escalating backoff.
 - Malformed requests (`PLCTagReadError` / `PLCTagWriteError`) are never retried.
-- Per-tag failures are never retried or laundered — they come back as
-  `TagResult.error`.
+- A returned result map contains only **address verdicts** (`missing_tag` /
+  `type_mismatch` / `encode` / `unknown`) — stable answers a retry cannot
+  change, never retried, never laundered. Link trouble never appears in a
+  returned map: any transport-kind entry escalates into the retry loop and,
+  if it survives the budget, the raised `PLCCommunicationError` (partial map
+  attached as `.results`).
 
 ### Service Layer
 

--- a/mindtrace/hardware/README.md
+++ b/mindtrace/hardware/README.md
@@ -503,7 +503,7 @@ from mindtrace.hardware import PLCManager
 
 async def plc_operations():
     manager = PLCManager()
-    await manager.register_plc("Line1", "192.168.1.100", plc_type="logix")
+    await manager.register_plc("Line1", "AllenBradley", "192.168.1.100", plc_type="logix")
     await manager.connect_plc("Line1")
 
     # Read/write operations return one TagResult per tag
@@ -511,7 +511,7 @@ async def plc_operations():
     if results["Motor_Speed"].ok:
         speed = results["Motor_Speed"].value
     else:
-        kind = results["Motor_Speed"].error.kind  # missing_tag / type_mismatch / encode / transport
+        kind = results["Motor_Speed"].error.kind  # missing_tag / type_mismatch / encode / transient / unknown
 
     await manager.write_tag("Line1", [("Command", True)])
 
@@ -523,20 +523,26 @@ asyncio.run(plc_operations())
 ### Transport behaviour
 
 Reads and writes are serialized on separate channels (a read driver and a write
-driver per PLC), each recovering on its own:
+driver per PLC). One attempt per call, no retry — re-issuing is the caller's
+job (a poll loop's next tick is the retry):
 
-- Transport-class failures retry up to `MINDTRACE_HW_PLC_RETRY_COUNT` times,
-  reconnecting only that channel between attempts, then raise
-  `PLCCommunicationError` with `attempts=N`.
-- The delay between attempts is a flat `MINDTRACE_HW_PLC_RETRY_DELAY`; a failed
-  reconnect is logged, not fatal. No circuit breaker, no escalating backoff.
-- Malformed requests (`PLCTagReadError` / `PLCTagWriteError`) are never retried.
+- Any failed exchange — wire death, timeout, garbled reply, or a delivered
+  reply carrying session-dead statuses — closes its channel and raises typed
+  (`PLCTimeoutError`, a `PLCCommunicationError` subclass, when the failure was
+  a timeout). The channel reopens automatically at the next call's entry.
+  Only a delivered, parsed reply keeps the session.
+- Malformed requests (`PLCTagReadError` / `PLCTagWriteError`) are rejected
+  before the wire; the session is untouched.
 - A returned result map contains only **address verdicts** (`missing_tag` /
-  `type_mismatch` / `encode` / `unknown`) — stable answers a retry cannot
-  change, never retried, never laundered. Link trouble never appears in a
-  returned map: any transport-kind entry escalates into the retry loop and,
-  if it survives the budget, the raised `PLCCommunicationError` (partial map
-  attached as `.results`).
+  `type_mismatch` / `encode` / `transient` / `unknown`). `transient` means the
+  controller answered but that exchange misbehaved — re-asking is reasonable;
+  the others are stable answers retrying cannot change. Link trouble never
+  appears in a returned map.
+- `MINDTRACE_HW_PLC_READ_TIMEOUT` / `WRITE_TIMEOUT` bound each channel's
+  handshake and exchanges (they are the socket deadline);
+  `MINDTRACE_HW_PLC_CONNECTION_TIMEOUT` bounds auto-detection probes.
+- `is_connected()` reports the lifecycle state (`connect()` succeeded,
+  `disconnect()` not called) — a channel healing itself does not flip it.
 
 ### Service Layer
 

--- a/mindtrace/hardware/mindtrace/hardware/__init__.py
+++ b/mindtrace/hardware/mindtrace/hardware/__init__.py
@@ -39,7 +39,7 @@ Usage:
     async with PLCManager() as plc_manager:
         await plc_manager.register_plc("PLC1", "AllenBradley", "192.168.1.100")
         await plc_manager.connect_plc("PLC1")
-        values = await plc_manager.read_tag("PLC1", ["Tag1", "Tag2"])
+        results = await plc_manager.read_tag("PLC1", ["Tag1", "Tag2"])
 
     # Sensor operations (direct manager)
     async with SensorManager() as sensor_manager:
@@ -81,6 +81,10 @@ def __getattr__(name):
         from mindtrace.hardware.plcs.plc_manager import PLCManager
 
         return PLCManager
+    elif name in {"TagError", "TagErrorKind", "TagResult"}:
+        from mindtrace.hardware.plcs.types import TagError, TagErrorKind, TagResult
+
+        return {"TagError": TagError, "TagErrorKind": TagErrorKind, "TagResult": TagResult}[name]
     elif name == "SensorManager":
         from .sensors.core.manager import SensorManager
 
@@ -111,6 +115,9 @@ def __getattr__(name):
 __all__ = [
     "CameraManager",
     "PLCManager",
+    "TagError",
+    "TagErrorKind",
+    "TagResult",
     "SensorManager",
     "HomographyCalibrator",
     "CalibrationData",

--- a/mindtrace/hardware/mindtrace/hardware/core/config.py
+++ b/mindtrace/hardware/mindtrace/hardware/core/config.py
@@ -405,7 +405,6 @@ class PLCSettings:
         connection_timeout: PLC connection timeout in seconds
         read_timeout: Tag read operation timeout in seconds
         write_timeout: Tag write operation timeout in seconds
-        retry_count: Number of retry attempts for PLC operations
         retry_delay: Delay between retry attempts in seconds
         max_concurrent_connections: Maximum number of concurrent PLC connections
         keep_alive_interval: Keep-alive ping interval in seconds
@@ -417,7 +416,6 @@ class PLCSettings:
     connection_timeout: float = 10.0
     read_timeout: float = 5.0
     write_timeout: float = 5.0
-    retry_count: int = 3
     retry_delay: float = 1.0
     max_concurrent_connections: int = 10
     keep_alive_interval: float = 30.0
@@ -881,12 +879,6 @@ class HardwareConfigManager(Mindtrace):
         if env_val := os.getenv("MINDTRACE_HW_PLC_WRITE_TIMEOUT"):
             try:
                 self._config.plcs.write_timeout = float(env_val)
-            except ValueError:
-                pass  # Keep default value on invalid input
-
-        if env_val := os.getenv("MINDTRACE_HW_PLC_RETRY_COUNT"):
-            try:
-                self._config.plcs.retry_count = int(env_val)
             except ValueError:
                 pass  # Keep default value on invalid input
 

--- a/mindtrace/hardware/mindtrace/hardware/core/config.py
+++ b/mindtrace/hardware/mindtrace/hardware/core/config.py
@@ -405,7 +405,7 @@ class PLCSettings:
         connection_timeout: PLC connection timeout in seconds
         read_timeout: Tag read operation timeout in seconds
         write_timeout: Tag write operation timeout in seconds
-        retry_delay: Delay between retry attempts in seconds
+        retry_delay: Settle delay between close and reopen inside reconnect()
         max_concurrent_connections: Maximum number of concurrent PLC connections
         keep_alive_interval: Keep-alive ping interval in seconds
         reconnect_attempts: Number of reconnection attempts

--- a/mindtrace/hardware/mindtrace/hardware/core/exceptions.py
+++ b/mindtrace/hardware/mindtrace/hardware/core/exceptions.py
@@ -22,7 +22,7 @@ Exception Hierarchy:
     │   ├── PLCConnectionError
     │   ├── PLCInitializationError
     │   ├── PLCCommunicationError
-    │   ├── PLCTimeoutError
+    │   │   └── PLCTimeoutError
     │   ├── PLCConfigurationError
     │   └── PLCTagError (tag-specific base)
     │       ├── PLCTagNotFoundError
@@ -172,8 +172,10 @@ class PLCTagWriteError(PLCTagError):
     pass
 
 
-class PLCTimeoutError(PLCError):
-    """Raised when PLC operation times out."""
+class PLCTimeoutError(PLCCommunicationError):
+    """The exchange outlived its timeout knob: communication-class (the channel
+    closes and reopens at the next call), distinguishable for callers that
+    want to treat slowness differently from breakage."""
 
     pass
 

--- a/mindtrace/hardware/mindtrace/hardware/plcs/__init__.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/__init__.py
@@ -5,7 +5,11 @@ with support for discovery, registration, and batch operations.
 """
 
 from mindtrace.hardware.plcs.plc_manager import PLCManager
+from mindtrace.hardware.plcs.types import TagError, TagErrorKind, TagResult
 
 __all__ = [
     "PLCManager",
+    "TagError",
+    "TagErrorKind",
+    "TagResult",
 ]

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
@@ -20,6 +20,7 @@ from mindtrace.hardware.core.exceptions import (
     PLCTagNotFoundError,
     PLCTagReadError,
     PLCTagWriteError,
+    PLCTimeoutError,
     SDKNotAvailableError,
 )
 from mindtrace.hardware.plcs.backends.base import BasePLC
@@ -31,10 +32,8 @@ try:
 
     PYCOMM3_AVAILABLE = True
     PYCOMM3_ERRORS: Tuple[type, ...] = (CommError, DataError, RequestError, ResponseError)
-    # CommError,  pycomm3's own wire/session verdict
-    PYCOMM3_WIRE_ERRORS: Tuple[type, ...] = (CommError, OSError)
-    # Reply-level trouble - garbled or refused replies. keep session.
-    PYCOMM3_REPLY_ERRORS: Tuple[type, ...] = (DataError, ResponseError)
+    # Anything raised from INSIDE an exchange closes the channel.
+    PYCOMM3_EXCHANGE_ERRORS: Tuple[type, ...] = (CommError, DataError, ResponseError, OSError)
     PYCOMM3_TAG_ERRORS: Tuple[type, ...] = (DataError, RequestError, ResponseError)
 except ImportError:
     PYCOMM3_AVAILABLE = False
@@ -42,20 +41,8 @@ except ImportError:
     SLCDriver = None
     CIPDriver = None
     PYCOMM3_ERRORS = ()
-    PYCOMM3_WIRE_ERRORS = (OSError,)
-    PYCOMM3_REPLY_ERRORS = ()
+    PYCOMM3_EXCHANGE_ERRORS = (OSError,)
     PYCOMM3_TAG_ERRORS = ()
-
-
-def _chain_has_timeout(error) -> bool:
-    """socket.timeout IS TimeoutError; differentiate from socket errors."""
-    seen: set = set()
-    while error is not None and id(error) not in seen:
-        if isinstance(error, TimeoutError):
-            return True
-        seen.add(id(error))
-        error = error.__cause__ or error.__context__
-    return False
 
 
 class AllenBradleyPLC(BasePLC):
@@ -290,12 +277,16 @@ class AllenBradleyPLC(BasePLC):
     def _channel_timeout(self, channel: str) -> float:
         return self.read_timeout if channel == "read" else self.write_timeout
 
+    async def _bounded(self, channel: str, call: Any, *args: Any, **kwargs: Any) -> Any:
+        """Bounds the calls on a channel with a timeout."""
+        return await asyncio.wait_for(asyncio.to_thread(call, *args, **kwargs), self._channel_timeout(channel))
+
     async def _open_driver(self, channel: str) -> Any:
         """Construct and open ONE driver for the resolved plc_type; raises if it will not open.
 
-        Two-phase socket timeout: ``connection_timeout`` bounds the open itself,
-        then the channel's read/write timeout takes over — the configured knobs
-        are what actually bound how long a call can fence its channel.
+        ``connection_timeout`` is the driver's socket deadline: it bounds the
+        open handshake and backstops the data phase, whose real bound is
+        ``_bounded``'s per-channel knob.
 
         Uses the family ``connect()`` resolved — an entry reopen must not
         re-detect and drift ``driver_type`` while the other channel's driver
@@ -315,7 +306,6 @@ class AllenBradleyPLC(BasePLC):
         if not opened:
             await self._close_driver(driver, "new")
             raise PLCConnectionError(f"Failed to open a driver to Allen Bradley PLC at {self.ip_address}")
-        driver.socket_timeout = self._channel_timeout(channel)
         self.driver_type = driver_name
         return driver
 
@@ -366,11 +356,8 @@ class AllenBradleyPLC(BasePLC):
         return closed
 
     async def is_connected(self) -> bool:
-        """Connected means BOTH channels' drivers are open."""
-        try:
-            return self._driver_open(self._read_driver) and self._driver_open(self._write_driver)
-        except Exception:
-            return False
+        """connected means in the lifecycle state of connect() succeeded, disconnect() was not called."""
+        return self._read_driver is not None and self._write_driver is not None
 
     async def _read_tags(self, addresses: List[str]) -> Dict[str, TagResult]:
         """Read on the read channel; per-tag errors are classified, not logged away."""
@@ -380,7 +367,7 @@ class AllenBradleyPLC(BasePLC):
 
         try:
             if self.driver_type == "LogixDriver":
-                results = await asyncio.to_thread(driver.read, *addresses)
+                results = await self._bounded("read", driver.read, *addresses)
                 tags = results if isinstance(results, list) else [results]
                 if len(tags) != len(addresses):
                     raise PLCTagReadError(
@@ -396,14 +383,16 @@ class AllenBradleyPLC(BasePLC):
 
         except PLCTagReadError:
             raise
-        except PYCOMM3_WIRE_ERRORS as e:
-            if not _chain_has_timeout(e):  # busy is not dead; the caller decides patience
-                await self._close_driver(driver, "read")
-            raise PLCCommunicationError(f"Read failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
-        except PYCOMM3_REPLY_ERRORS as e:
+        except TimeoutError as e:
+            await self._close_driver(driver, "read")
+            raise PLCTimeoutError(
+                f"Read timed out after {self.read_timeout}s on Allen Bradley PLC at {self.ip_address}"
+            ) from e
+        except PYCOMM3_EXCHANGE_ERRORS as e:
+            await self._close_driver(driver, "read")
             raise PLCCommunicationError(f"Read failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
         except PYCOMM3_ERRORS as e:
-            # What's left is RequestError — a malformed request; the session is fine.
+            # What's left is RequestError, hit before the exchange.
             raise PLCTagReadError(f"Driver rejected the read on Allen Bradley PLC at {self.ip_address}: {e}") from e
         except Exception as e:
             raise PLCTagReadError(f"Unexpected read failure on Allen Bradley PLC at {self.ip_address}: {e}") from e
@@ -415,7 +404,7 @@ class AllenBradleyPLC(BasePLC):
         """One SLC data-file read; only per-tag driver errors stay per-tag — a
         CommError is a whole-call failure and propagates to ``_read_tags``."""
         try:
-            return tag_to_result(await asyncio.to_thread(driver.read, address))
+            return tag_to_result(await self._bounded("read", driver.read, address))
         except PYCOMM3_TAG_ERRORS as e:
             return TagResult(error=classify_tag_error(e))
 
@@ -423,11 +412,12 @@ class AllenBradleyPLC(BasePLC):
         """One generic-CIP read, dispatched on the address form."""
         try:
             if address.startswith("Identity") or address == "DeviceInfo":
-                return TagResult(value=await asyncio.to_thread(driver.list_identity, self.ip_address))
+                return TagResult(value=await self._bounded("read", driver.list_identity, self.ip_address))
 
             if address.startswith("Assembly"):
                 instance = int(address.split(":")[-1]) if ":" in address else 1
-                result = await asyncio.to_thread(
+                result = await self._bounded(
+                    "read",
                     driver.generic_message,
                     service=0x0E,  # Get_Attribute_Single
                     class_code=0x04,  # Assembly Object
@@ -439,10 +429,11 @@ class AllenBradleyPLC(BasePLC):
 
             if address.startswith("Module"):
                 slot = int(address.split(":")[-1]) if ":" in address else 0
-                return TagResult(value=await asyncio.to_thread(driver.get_module_info, slot))
+                return TagResult(value=await self._bounded("read", driver.get_module_info, slot))
 
             if address.startswith("Connection"):
-                result = await asyncio.to_thread(
+                result = await self._bounded(
+                    "read",
                     driver.generic_message,
                     service=0x01,  # Get_Attributes_All
                     class_code=0x06,  # Connection Manager Object
@@ -456,7 +447,8 @@ class AllenBradleyPLC(BasePLC):
                 class_code = int(parts[0], 16) if parts[0].startswith("0x") else int(parts[0])
                 instance = int(parts[1])
                 attribute = int(parts[2])
-                result = await asyncio.to_thread(
+                result = await self._bounded(
+                    "read",
                     driver.generic_message,
                     service=0x0E,  # Get_Attribute_Single
                     class_code=class_code,
@@ -466,7 +458,7 @@ class AllenBradleyPLC(BasePLC):
                 )
                 return tag_to_result(result)
 
-            return tag_to_result(await asyncio.to_thread(driver.read, address))
+            return tag_to_result(await self._bounded("read", driver.read, address))
         except PYCOMM3_TAG_ERRORS as e:
             return TagResult(error=classify_tag_error(e))
 
@@ -478,7 +470,7 @@ class AllenBradleyPLC(BasePLC):
 
         try:
             if self.driver_type == "LogixDriver":
-                results = await asyncio.to_thread(driver.write, *writes)
+                results = await self._bounded("write", driver.write, *writes)
                 tags = results if isinstance(results, list) else [results]
                 if len(tags) != len(writes):
                     raise PLCTagWriteError(
@@ -496,14 +488,16 @@ class AllenBradleyPLC(BasePLC):
 
         except PLCTagWriteError:
             raise
-        except PYCOMM3_WIRE_ERRORS as e:
-            if not _chain_has_timeout(e):
-                await self._close_driver(driver, "write")
-            raise PLCCommunicationError(f"Write failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
-        except PYCOMM3_REPLY_ERRORS as e:
+        except TimeoutError as e:
+            await self._close_driver(driver, "write")
+            raise PLCTimeoutError(
+                f"Write timed out after {self.write_timeout}s on Allen Bradley PLC at {self.ip_address}"
+            ) from e
+        except PYCOMM3_EXCHANGE_ERRORS as e:
+            await self._close_driver(driver, "write")
             raise PLCCommunicationError(f"Write failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
         except PYCOMM3_ERRORS as e:
-            # RequestError: a malformed request; the session is fine.
+            # RequestError: raised before anything hit the wire; the session is untouched.
             raise PLCTagWriteError(f"Driver rejected the write on Allen Bradley PLC at {self.ip_address}: {e}") from e
         except Exception as e:
             raise PLCTagWriteError(f"Unexpected write failure on Allen Bradley PLC at {self.ip_address}: {e}") from e
@@ -515,7 +509,7 @@ class AllenBradleyPLC(BasePLC):
         """One SLC data-file write; only per-tag driver errors stay per-tag — a
         CommError is a whole-call failure and propagates to ``_write_tags``."""
         try:
-            result = await asyncio.to_thread(driver.write, (address, value))
+            result = await self._bounded("write", driver.write, (address, value))
             return tag_to_result(result, value_on_success=value, use_tag_value=False)
         except PYCOMM3_TAG_ERRORS as e:
             return TagResult(error=classify_tag_error(e))
@@ -525,7 +519,8 @@ class AllenBradleyPLC(BasePLC):
         try:
             if address.startswith("Assembly"):
                 instance = int(address.split(":")[-1]) if ":" in address else 1
-                result = await asyncio.to_thread(
+                result = await self._bounded(
+                    "write",
                     driver.generic_message,
                     service=0x10,  # Set_Attribute_Single
                     class_code=0x04,  # Assembly Object
@@ -538,7 +533,8 @@ class AllenBradleyPLC(BasePLC):
 
             if address.startswith("Parameter"):
                 instance = int(address.split(":")[-1]) if ":" in address else 1
-                result = await asyncio.to_thread(
+                result = await self._bounded(
+                    "write",
                     driver.generic_message,
                     service=0x10,  # Set_Attribute_Single
                     class_code=0x0F,  # Parameter Object
@@ -554,7 +550,8 @@ class AllenBradleyPLC(BasePLC):
                 class_code = int(parts[0], 16) if parts[0].startswith("0x") else int(parts[0])
                 instance = int(parts[1])
                 attribute = int(parts[2])
-                result = await asyncio.to_thread(
+                result = await self._bounded(
+                    "write",
                     driver.generic_message,
                     service=0x10,  # Set_Attribute_Single
                     class_code=class_code,
@@ -565,7 +562,7 @@ class AllenBradleyPLC(BasePLC):
                 )
                 return tag_to_result(result, value_on_success=value, use_tag_value=False)
 
-            result = await asyncio.to_thread(driver.write, (address, value))
+            result = await self._bounded("write", driver.write, (address, value))
             return tag_to_result(result, value_on_success=value, use_tag_value=False)
         except PYCOMM3_TAG_ERRORS as e:
             return TagResult(error=classify_tag_error(e))
@@ -907,6 +904,10 @@ class AllenBradleyPLC(BasePLC):
                 "driver_type": self.driver_type,
                 "plc_type": self.plc_type,
                 "connected": await self.is_connected(),
+                # Diagnostics: a False here with connected=True is a channel
+                # awaiting its entry reopen, not a disconnection.
+                "read_channel_open": self._driver_open(self._read_driver),
+                "write_channel_open": self._driver_open(self._write_driver),
             }
 
             if self.driver_type == "LogixDriver":

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
@@ -119,6 +119,9 @@ class AllenBradleyPLC(BasePLC):
 
         self.plc_type = plc_type or "auto"
         self.driver_type = None
+        # Resolved once per connect(); reopens reuse it so a re-detection cannot
+        # drift the two channels onto different driver families.
+        self._driver_family: Optional[str] = None
         self._read_driver: Any = None
         self._write_driver: Any = None
         self._tags_cache: Optional[List[str]] = None
@@ -261,6 +264,8 @@ class AllenBradleyPLC(BasePLC):
             self._write_driver = None
             self.plc = None
 
+        self._driver_family = await self._resolve_plc_type()
+
         try:
             self._read_driver = await self._open_driver("read")
         except Exception as e:
@@ -291,8 +296,12 @@ class AllenBradleyPLC(BasePLC):
         Two-phase socket timeout: ``connection_timeout`` bounds the open itself,
         then the channel's read/write timeout takes over — the configured knobs
         are what actually bound how long a call can fence its channel.
+
+        Uses the family ``connect()`` resolved — an entry reopen must not
+        re-detect and drift ``driver_type`` while the other channel's driver
+        is still live.
         """
-        driver_class, driver_name = self._driver_class(await self._resolve_plc_type())
+        driver_class, driver_name = self._driver_class(self._driver_family)
 
         driver = await asyncio.to_thread(driver_class, self.ip_address)
         driver.socket_timeout = self.connection_timeout

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
@@ -10,6 +10,7 @@ share a socket.
 
 import asyncio
 import time
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
 from mindtrace.hardware.core.exceptions import (
@@ -48,6 +49,23 @@ except ImportError:
     PYCOMM3_ERRORS = ()
     PYCOMM3_EXCHANGE_ERRORS = (OSError,)
     PYCOMM3_TAG_ERRORS = ()
+
+
+# Stand-in for a driver whose worker thread never returned: the real one must
+# never be called into again; ``connected`` False makes the next entry open fresh.
+_ABANDONED_DRIVER = SimpleNamespace(connected=False, close=lambda: None)
+
+
+def _chain_has_timeout(error: Any) -> bool:
+    """LABEL selector only - policy is identical (the channel closes either way);
+    this just picks PLCTimeoutError over PLCCommunicationError for the caller."""
+    seen: set = set()
+    while error is not None and id(error) not in seen:
+        if isinstance(error, TimeoutError):
+            return True
+        seen.add(id(error))
+        error = error.__cause__ or error.__context__
+    return False
 
 
 class AllenBradleyPLC(BasePLC):
@@ -204,6 +222,7 @@ class AllenBradleyPLC(BasePLC):
         # Try LogixDriver first (most common)
         try:
             test_plc = await asyncio.to_thread(LogixDriver, self.ip_address)
+            test_plc.socket_timeout = self.connection_timeout
             connection_result = await asyncio.to_thread(test_plc.open)
             if connection_result:
                 await asyncio.to_thread(test_plc.close)
@@ -215,6 +234,7 @@ class AllenBradleyPLC(BasePLC):
         # Try SLCDriver
         try:
             test_plc = await asyncio.to_thread(SLCDriver, self.ip_address)
+            test_plc.socket_timeout = self.connection_timeout
             connection_result = await asyncio.to_thread(test_plc.open)
             if connection_result:
                 await asyncio.to_thread(test_plc.close)
@@ -283,15 +303,25 @@ class AllenBradleyPLC(BasePLC):
         return self.read_timeout if channel == "read" else self.write_timeout
 
     async def _bounded(self, channel: str, call: Any, *args: Any, **kwargs: Any) -> Any:
-        """Bounds the calls on a channel with a timeout."""
-        return await asyncio.wait_for(asyncio.to_thread(call, *args, **kwargs), self._channel_timeout(channel))
+        """One driver call under a generous BACKSTOP bound.
+
+        The channel's socket deadline (set at open) is the real timeout, firing
+        on the thread that owns the driver; this outer bound only trips when
+        that deadline malfunctions (a dripping reply, a blocked send). The
+        worker thread is then still inside the driver, so expiry must ABANDON
+        the channel - swap the driver out untouched - never close it.
+        """
+        return await asyncio.wait_for(
+            asyncio.to_thread(call, *args, **kwargs), self._channel_timeout(channel) * 1.5 + 1.0
+        )
 
     async def _open_driver(self, channel: str) -> Any:
         """Construct and open ONE driver for the resolved plc_type; raises if it will not open.
 
-        ``connection_timeout`` is the driver's socket deadline: it bounds the
-        open handshake and backstops the data phase, whose real bound is
-        ``_bounded``'s per-channel knob.
+        The channel's read/write knob is the driver's socket deadline - pycomm3
+        applies it once, at open() - so it bounds this channel's handshake AND
+        every exchange, and timeouts surface on the thread that owns the driver.
+        ``connection_timeout`` bounds the discovery probes only.
 
         Uses the family ``connect()`` resolved — an entry reopen must not
         re-detect and drift ``driver_type`` while the other channel's driver
@@ -300,7 +330,7 @@ class AllenBradleyPLC(BasePLC):
         driver_class, driver_name = self._driver_class(self._driver_family)
 
         driver = await asyncio.to_thread(driver_class, self.ip_address)
-        driver.socket_timeout = self.connection_timeout
+        driver.socket_timeout = self._channel_timeout(channel)
         try:
             opened = await asyncio.to_thread(driver.open)
         except Exception:
@@ -389,12 +419,22 @@ class AllenBradleyPLC(BasePLC):
         except PLCTagReadError:
             raise
         except TimeoutError as e:
-            await self._close_driver(driver, "read")
+            # Backstop expiry: the worker thread is STILL inside the driver.
+            self._read_driver = _ABANDONED_DRIVER
             raise PLCTimeoutError(
-                f"Read timed out after {self.read_timeout}s on Allen Bradley PLC at {self.ip_address}"
+                f"Read gave no reply within the backstop on Allen Bradley PLC at {self.ip_address}"
             ) from e
+        except asyncio.CancelledError:
+            # Caller cancelled mid-exchange: same live-thread situation.
+            self._read_driver = _ABANDONED_DRIVER
+            raise
         except PYCOMM3_EXCHANGE_ERRORS as e:
+            # The thread finished (it raised), so closing is single-threaded and safe.
             await self._close_driver(driver, "read")
+            if _chain_has_timeout(e):
+                raise PLCTimeoutError(
+                    f"Read timed out after {self.read_timeout}s on Allen Bradley PLC at {self.ip_address}"
+                ) from e
             raise PLCCommunicationError(f"Read failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
         except PYCOMM3_ERRORS as e:
             # What's left is RequestError, hit before the exchange.
@@ -494,12 +534,19 @@ class AllenBradleyPLC(BasePLC):
         except PLCTagWriteError:
             raise
         except TimeoutError as e:
-            await self._close_driver(driver, "write")
+            self._write_driver = _ABANDONED_DRIVER
             raise PLCTimeoutError(
-                f"Write timed out after {self.write_timeout}s on Allen Bradley PLC at {self.ip_address}"
+                f"Write gave no reply within the backstop on Allen Bradley PLC at {self.ip_address}"
             ) from e
+        except asyncio.CancelledError:
+            self._write_driver = _ABANDONED_DRIVER
+            raise
         except PYCOMM3_EXCHANGE_ERRORS as e:
             await self._close_driver(driver, "write")
+            if _chain_has_timeout(e):
+                raise PLCTimeoutError(
+                    f"Write timed out after {self.write_timeout}s on Allen Bradley PLC at {self.ip_address}"
+                ) from e
             raise PLCCommunicationError(f"Write failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
         except PYCOMM3_ERRORS as e:
             # RequestError: raised before anything hit the wire; the session is untouched.

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
@@ -363,6 +363,16 @@ class AllenBradleyPLC(BasePLC):
             return False
         return not getattr(driver, "connected", False)
 
+    async def _close_and_raise(self, driver: Any, channel: str, what: str, e: BaseException) -> None:
+        """A failed exchange: close the channel (the stream is suspect) and raise
+        typed — ``PLCTimeoutError`` when the cause chain says timeout."""
+        await self._close_driver(driver, channel)
+        if _chain_has_timeout(e):
+            raise PLCTimeoutError(
+                f"{what} timed out after {self._channel_timeout(channel)}s on Allen Bradley PLC at {self.ip_address}"
+            ) from e
+        raise PLCCommunicationError(f"{what} failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
+
     async def _raise_if_session_dead(self, driver: Any, channel: str, results: Dict[str, TagResult]) -> None:
         """Session-dead statuses in a delivered reply close the channel and raise."""
         dead = session_dead_addresses(results)
@@ -430,21 +440,18 @@ class AllenBradleyPLC(BasePLC):
         except TimeoutError as e:
             # Backstop expiry: the worker thread is STILL inside the driver.
             self._read_driver = _ABANDONED_DRIVER
+            self.plc = _ABANDONED_DRIVER  # the alias must not keep the driver alive
             raise PLCTimeoutError(
                 f"Read gave no reply within the backstop on Allen Bradley PLC at {self.ip_address}"
             ) from e
         except asyncio.CancelledError:
             # Caller cancelled mid-exchange: same live-thread situation.
             self._read_driver = _ABANDONED_DRIVER
+            self.plc = _ABANDONED_DRIVER
             raise
         except PYCOMM3_EXCHANGE_ERRORS as e:
             # The thread finished (it raised), so closing is single-threaded and safe.
-            await self._close_driver(driver, "read")
-            if _chain_has_timeout(e):
-                raise PLCTimeoutError(
-                    f"Read timed out after {self.read_timeout}s on Allen Bradley PLC at {self.ip_address}"
-                ) from e
-            raise PLCCommunicationError(f"Read failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
+            await self._close_and_raise(driver, "read", "Read", e)
         except PYCOMM3_ERRORS as e:
             # What's left is RequestError, hit before the exchange.
             raise PLCTagReadError(f"Driver rejected the read on Allen Bradley PLC at {self.ip_address}: {e}") from e
@@ -568,12 +575,7 @@ class AllenBradleyPLC(BasePLC):
             self._write_driver = _ABANDONED_DRIVER
             raise
         except PYCOMM3_EXCHANGE_ERRORS as e:
-            await self._close_driver(driver, "write")
-            if _chain_has_timeout(e):
-                raise PLCTimeoutError(
-                    f"Write timed out after {self.write_timeout}s on Allen Bradley PLC at {self.ip_address}"
-                ) from e
-            raise PLCCommunicationError(f"Write failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
+            await self._close_and_raise(driver, "write", "Write", e)
         except PYCOMM3_ERRORS as e:
             # RequestError: raised before anything hit the wire; the session is untouched.
             raise PLCTagWriteError(f"Driver rejected the write on Allen Bradley PLC at {self.ip_address}: {e}") from e
@@ -835,10 +837,7 @@ class AllenBradleyPLC(BasePLC):
                                     if module_info:
                                         self._tags_cache.append(f"Module:{slot}")
                             except (CommError, OSError) as e:
-                                await self._close_driver(driver, "read")
-                                raise PLCCommunicationError(
-                                    f"Tag discovery failed on Allen Bradley PLC at {self.ip_address}: {e}"
-                                ) from e
+                                await self._close_and_raise(driver, "read", "Tag discovery", e)
                             except Exception:
                                 pass  # an empty slot answers with an error reply
 
@@ -901,19 +900,15 @@ class AllenBradleyPLC(BasePLC):
                         self.logger.debug("Successfully retrieved object list from device")
 
                 except (CommError, OSError) as e:
-                    await self._close_driver(driver, "read")
-                    raise PLCCommunicationError(
-                        f"Tag discovery failed on Allen Bradley PLC at {self.ip_address}: {e}"
-                    ) from e
+                    await self._close_and_raise(driver, "read", "Tag discovery", e)
                 except Exception as e:
                     self.logger.debug(f"Could not retrieve object list: {e}")
 
             self._cache_timestamp = current_time
             return self._tags_cache
 
-        except PLCTagError:
-            # Already a clear, intentional error (e.g. empty tag-list upload) —
-            # don't re-wrap it.
+        except (PLCTagError, PLCCommunicationError):
+            # Already a clear, intentional error — don't re-wrap it.
             raise
         except Exception as e:
             self.logger.error(f"Failed to get tags: {e}")
@@ -1029,11 +1024,7 @@ class AllenBradleyPLC(BasePLC):
                         pass
 
                 except PYCOMM3_EXCHANGE_ERRORS as e:
-                    # A failed exchange on the channel driver: the stream is suspect.
-                    await self._close_driver(driver, "read")
-                    raise PLCCommunicationError(
-                        f"PLC info read failed on Allen Bradley PLC at {self.ip_address}: {e}"
-                    ) from e
+                    await self._close_and_raise(driver, "read", "PLC info read", e)
                 except Exception as e:
                     self.logger.warning(f"Could not get detailed Logix PLC info: {e}")
 
@@ -1060,9 +1051,13 @@ class AllenBradleyPLC(BasePLC):
                             module_info = await asyncio.to_thread(driver.get_module_info, 0)
                             if module_info:
                                 info["module_info"] = module_info
+                        except PYCOMM3_EXCHANGE_ERRORS as e:
+                            await self._close_and_raise(driver, "read", "PLC info read", e)
                         except Exception:
                             pass
 
+                except PLCCommunicationError:
+                    raise
                 except Exception as e:
                     self.logger.warning(f"Could not get CIP device info: {e}")
 
@@ -1078,6 +1073,8 @@ class AllenBradleyPLC(BasePLC):
 
             return info
 
+        except PLCCommunicationError:
+            raise
         except Exception as e:
             self.logger.error(f"Failed to get PLC info: {e}")
             return {
@@ -1085,7 +1082,6 @@ class AllenBradleyPLC(BasePLC):
                 "ip_address": self.ip_address,
                 "driver_type": self.driver_type,
                 "plc_type": self.plc_type,
-                "connected": False,
                 "error": str(e),
             }
 

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
@@ -3,11 +3,14 @@ Allen Bradley PLC implementation using pycomm3.
 
 Provides communication interface for Allen Bradley PLCs and other Ethernet/IP devices
 using CIPDriver, LogixDriver, and SLCDriver from pycomm3 library.
+
+Connecting opens one EtherNet/IP session per channel, so reads and writes never
+share a socket.
 """
 
 import asyncio
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 from mindtrace.hardware.core.exceptions import (
     PLCCommunicationError,
@@ -20,17 +23,24 @@ from mindtrace.hardware.core.exceptions import (
     SDKNotAvailableError,
 )
 from mindtrace.hardware.plcs.backends.base import BasePLC
+from mindtrace.hardware.plcs.types import TagResult, classify_tag_error, tag_to_result
 
 try:
-    from pycomm3 import CIPDriver, LogixDriver, SLCDriver, Tag  # type; ignore
+    from pycomm3 import CIPDriver, LogixDriver, SLCDriver
+    from pycomm3.exceptions import CommError, DataError, RequestError, ResponseError
 
     PYCOMM3_AVAILABLE = True
+    PYCOMM3_ERRORS: Tuple[type, ...] = (CommError, DataError, RequestError, ResponseError)
+    PYCOMM3_TRANSPORT_ERRORS: Tuple[type, ...] = (CommError, DataError, ResponseError, OSError)
+    PYCOMM3_TAG_ERRORS: Tuple[type, ...] = (DataError, RequestError, ResponseError)
 except ImportError:
     PYCOMM3_AVAILABLE = False
     LogixDriver = None
     SLCDriver = None
     CIPDriver = None
-    Tag = None
+    PYCOMM3_ERRORS = ()
+    PYCOMM3_TRANSPORT_ERRORS = (OSError,)
+    PYCOMM3_TAG_ERRORS = ()
 
 
 class AllenBradleyPLC(BasePLC):
@@ -43,9 +53,10 @@ class AllenBradleyPLC(BasePLC):
     - Generic Ethernet/IP devices (CIPDriver)
 
     Attributes:
-        plc: pycomm3 driver instance (LogixDriver, SLCDriver, or CIPDriver)
+        plc: alias of the read driver (downstream code reads ``plc.tags``)
         driver_type: Type of driver being used
         plc_type: Type of PLC (auto-detected or specified)
+        _read_driver / _write_driver: the per-channel drivers
         _tags_cache: Cached list of available tags
         _cache_timestamp: Timestamp of last tag cache update
         _cache_ttl: Time-to-live for tag cache in seconds
@@ -96,6 +107,8 @@ class AllenBradleyPLC(BasePLC):
 
         self.plc_type = plc_type or "auto"
         self.driver_type = None
+        self._read_driver: Any = None
+        self._write_driver: Any = None
         self._tags_cache: Optional[List[str]] = None
         self._cache_timestamp: float = 0
         self._cache_ttl: float = 300  # 5 minutes
@@ -103,6 +116,41 @@ class AllenBradleyPLC(BasePLC):
         self.logger.info(
             f"Allen Bradley PLC initialized: plc_type={self.plc_type}, pycomm3_available={PYCOMM3_AVAILABLE}"
         )
+
+    def _driver_class(self, plc_type: Optional[str] = None):
+        """Driver class for a resolved plc_type, plus its reported name."""
+        resolved = plc_type or self.plc_type
+        if resolved == "logix":
+            return LogixDriver, "LogixDriver"
+        if resolved == "slc":
+            return SLCDriver, "SLCDriver"
+        return CIPDriver, "CIPDriver"
+
+    async def _resolve_plc_type(self) -> str:
+        """The driver family to use now, latching it only when detection was sure.
+
+        A None from ``_detect_plc_type`` means nothing answered — indistinguishable
+        from a controller that is merely down, so ``plc_type`` stays ``"auto"``
+        rather than pinning CIPDriver to a ControlLogix for the life of the process.
+        """
+        if self.plc_type != "auto":
+            return self.plc_type
+        detected = await self._detect_plc_type()
+        if detected is None:
+            return "cip"
+        self.plc_type = detected
+        return detected
+
+    @staticmethod
+    def _driver_open(driver: Any) -> bool:
+        return bool(driver is not None and getattr(driver, "connected", False))
+
+    def _driver_for(self, channel: str) -> Any:
+        """This channel's open driver, or PLCCommunicationError. Never reconnects implicitly."""
+        driver = self._read_driver if channel == "read" else self._write_driver
+        if not self._driver_open(driver):
+            raise PLCCommunicationError(f"Not connected to Allen Bradley PLC at {self.ip_address} ({channel} channel)")
+        return driver
 
     async def initialize(self) -> Tuple[bool, Any, Any]:
         """
@@ -122,12 +170,13 @@ class AllenBradleyPLC(BasePLC):
             self.logger.error(f"PLC initialization failed: {e}")
             raise PLCInitializationError(f"Failed to initialize Allen Bradley PLC: {e}")
 
-    async def _detect_plc_type(self) -> str:
+    async def _detect_plc_type(self) -> Optional[str]:
         """
         Auto-detect PLC type by attempting connections with different drivers.
 
         Returns:
-            Detected PLC type ('logix', 'slc', or 'cip')
+            Detected PLC type ('logix', 'slc', or 'cip'), or None when nothing
+            at the address answered — the caller must not latch a type then.
         """
         self.logger.info(f"Auto-detecting PLC type for {self.ip_address}")
 
@@ -153,389 +202,331 @@ class AllenBradleyPLC(BasePLC):
         except Exception as e:
             self.logger.debug(f"SLCDriver detection failed: {e}")
 
-        # Fall back to CIPDriver for generic Ethernet/IP devices
+        # Neither driver opened: a generic Ethernet/IP device and an unreachable
+        # controller look identical here. A unicast ListIdentity separates them —
+        # silence means nobody is home, so do not pin CIPDriver to a PLC that is
+        # merely down.
+        try:
+            answered = bool(await asyncio.to_thread(CIPDriver.list_identity, self.ip_address))
+        except Exception as e:
+            self.logger.debug(f"CIP identity probe failed: {e}")
+            answered = False
+
+        if not answered:
+            self.logger.warning(f"Nothing answered at {self.ip_address}; PLC type stays undetected")
+            return None
+
         self.logger.info("Using CIPDriver for generic Ethernet/IP device")
         return "cip"
 
-    async def connect(self) -> bool:
-        """
-        Establish connection to the Allen Bradley PLC.
+    async def _connect(self) -> bool:
+        """Open both channels' drivers. Raises PLCConnectionError if either fails.
 
-        Returns:
-            True if connection successful, False otherwise
+        A single attempt; channel recovery goes through ``_reconnect_channel``. Both
+        drivers are constructed before either opens, so a half-open device is
+        reported as such rather than looking like a plain connect failure.
         """
         self.logger.info(f"Connecting to Allen Bradley PLC at {self.ip_address}")
 
-        # Determine driver type
-        if self.plc_type == "auto":
-            detected_type = await self._detect_plc_type()
-            self.plc_type = detected_type
+        # Close what a previous connect opened: the controller caps attached
+        # sessions and keeps counting orphans until they time out.
+        if self._read_driver is not None or self._write_driver is not None:
+            await self._close_drivers()
+            self._read_driver = None
+            self._write_driver = None
+            self.plc = None
 
-        for attempt in range(self.retry_count):
-            try:
-                # Create appropriate driver
-                if self.plc_type == "logix":
-                    self.plc = await asyncio.to_thread(LogixDriver, self.ip_address)
-                    self.driver_type = "LogixDriver"
-                elif self.plc_type == "slc":
-                    self.plc = await asyncio.to_thread(SLCDriver, self.ip_address)
-                    self.driver_type = "SLCDriver"
-                else:  # cip or fallback
-                    self.plc = await asyncio.to_thread(CIPDriver, self.ip_address)
-                    self.driver_type = "CIPDriver"
-
-                # Attempt connection
-                connection_result = await asyncio.to_thread(self.plc.open)
-
-                if connection_result:
-                    self.logger.info(f"Successfully connected to Allen Bradley PLC using {self.driver_type}")
-                    return True
-                else:
-                    raise PLCConnectionError("Connection attempt returned False")
-
-            except Exception as e:
-                self.logger.warning(f"Connection attempt {attempt + 1} failed: {e}")
-                if attempt < self.retry_count - 1:
-                    self.logger.info(f"Retrying in {self.retry_delay} seconds...")
-                    await asyncio.sleep(self.retry_delay)
-                else:
-                    self.logger.error(f"Failed to connect to Allen Bradley PLC after {self.retry_count} attempts")
-                    raise PLCConnectionError(
-                        f"Failed to connect to Allen Bradley PLC at {self.ip_address} after {self.retry_count} attempts"
-                    )
-
-    async def disconnect(self) -> bool:
-        """
-        Disconnect from the Allen Bradley PLC.
-
-        Returns:
-            True if disconnection successful, False otherwise
-        """
-        if self.plc is not None:
-            try:
-                await asyncio.to_thread(self.plc.close)
-                if not self.plc.connected:
-                    self.logger.info(f"Disconnected from Allen Bradley PLC at {self.ip_address}")
-                    self.initialized = False
-                    return True
-                else:
-                    return False
-            except Exception as e:
-                self.logger.error(f"Error during disconnection: {e}")
-                return False
-        return True
-
-    async def is_connected(self) -> bool:
-        """
-        Check if Allen Bradley PLC is currently connected.
-
-        Returns:
-            True if connected, False otherwise
-        """
-        if not self.plc:
-            return False
+        driver_class, driver_name = self._driver_class(await self._resolve_plc_type())
 
         try:
-            return self.plc.connected
+            self._read_driver = await asyncio.to_thread(driver_class, self.ip_address)
+            self._write_driver = await asyncio.to_thread(driver_class, self.ip_address)
+            # `plc` stays the READ driver: downstream code reads plc.tags.
+            self.plc = self._read_driver
+            self.driver_type = driver_name
+
+            read_open = await asyncio.to_thread(self._read_driver.open)
+            write_open = await asyncio.to_thread(self._write_driver.open)
+        except Exception as e:
+            await self._close_drivers()
+            raise PLCConnectionError(f"Failed to connect to Allen Bradley PLC at {self.ip_address}: {e}") from e
+
+        if not (read_open and write_open):
+            await self._close_drivers()
+            raise PLCConnectionError(
+                f"Failed to open both channels to Allen Bradley PLC at {self.ip_address} "
+                f"(read={bool(read_open)}, write={bool(write_open)})"
+            )
+
+        self.logger.info(f"Connected to Allen Bradley PLC using {self.driver_type} (read + write channels)")
+        return True
+
+    async def _open_driver(self) -> Any:
+        """Construct and open ONE driver for the resolved plc_type; raises if it will not open."""
+        driver_class, driver_name = self._driver_class(await self._resolve_plc_type())
+
+        driver = await asyncio.to_thread(driver_class, self.ip_address)
+        try:
+            opened = await asyncio.to_thread(driver.open)
+        except Exception:
+            # A raising open() leaves an orphan driver the controller keeps counting
+            # against its session cap until it times out.
+            await self._close_driver(driver, "new")
+            raise
+        if not opened:
+            await self._close_driver(driver, "new")
+            raise PLCConnectionError(f"Failed to open a driver to Allen Bradley PLC at {self.ip_address}")
+        self.driver_type = driver_name
+        return driver
+
+    async def _close_driver(self, driver: Any, label: str) -> bool:
+        """Close one driver; ``label`` names it in the log ("read"/"write"/"new")."""
+        if driver is None:
+            return True
+        try:
+            await asyncio.to_thread(driver.close)
+        except Exception as e:
+            self.logger.error(f"Error closing the {label} Allen Bradley driver: {e}")
+            return False
+        return not getattr(driver, "connected", False)
+
+    async def _reconnect_channel(self, channel: str) -> bool:
+        """Rebuild ONE channel's driver; the other channel's socket is untouched.
+
+        Runs under that channel's lock: never call the public ``reconnect`` /
+        ``connect``, which take both locks and would deadlock.
+        """
+        attribute = "_read_driver" if channel == "read" else "_write_driver"
+
+        await self._close_driver(getattr(self, attribute), channel)
+        setattr(self, attribute, None)
+        if channel == "read":
+            self.plc = None
+
+        await asyncio.sleep(self.retry_delay)  # let the controller drop the old driver
+
+        driver = await self._open_driver()
+        setattr(self, attribute, driver)
+        if channel == "read":
+            # `plc` follows the read driver: downstream code reads plc.tags.
+            self.plc = driver
+        self.logger.info(f"Reopened the {channel} channel to Allen Bradley PLC at {self.ip_address}")
+        return True
+
+    async def _close_drivers(self) -> bool:
+        """Close both channels' drivers; True only if both are actually closed."""
+        closed = True
+        for channel, driver in (("read", self._read_driver), ("write", self._write_driver)):
+            closed = await self._close_driver(driver, channel) and closed
+        return closed
+
+    async def _disconnect(self) -> bool:
+        """Close both channels' drivers."""
+        if self._read_driver is None and self._write_driver is None:
+            return True
+
+        closed = await self._close_drivers()
+        if closed:
+            self.logger.info(f"Disconnected from Allen Bradley PLC at {self.ip_address}")
+            self.initialized = False
+        return closed
+
+    async def is_connected(self) -> bool:
+        """Connected means BOTH channels' drivers are open."""
+        try:
+            return self._driver_open(self._read_driver) and self._driver_open(self._write_driver)
         except Exception:
             return False
 
-    async def read_tag(self, tags: Union[str, List[str]]) -> Dict[str, Any]:
-        """
-        Read values from Allen Bradley PLC tags.
-
-        Args:
-            tags: Single tag name or list of tag names
-
-        Returns:
-            Dictionary mapping tag names to their values
-
-        Raises:
-            PLCTagReadError: If tag reading fails
-        """
-        if not await self.is_connected():
-            if not await self.reconnect():
-                raise PLCCommunicationError(f"Not connected to Allen Bradley PLC at {self.ip_address}")
+    async def _read_tags(self, addresses: List[str]) -> Dict[str, TagResult]:
+        """Read on the read channel; per-tag errors are classified, not logged away."""
+        driver = self._driver_for("read")
+        if not addresses:
+            return {}
 
         try:
-            if isinstance(tags, str):
-                tag_list = [tags]
-            else:
-                tag_list = tags
-
-            # Read tags based on driver type
             if self.driver_type == "LogixDriver":
-                # LogixDriver supports multiple tag reading
-                if len(tag_list) == 1:
-                    result = await asyncio.to_thread(self.plc.read, tag_list[0])
-                    results = [result] if not isinstance(result, list) else result
-                else:
-                    results = await asyncio.to_thread(self.plc.read, *tag_list)
-                    results = results if isinstance(results, list) else [results]
+                results = await asyncio.to_thread(driver.read, *addresses)
+                tags = results if isinstance(results, list) else [results]
+                if len(tags) != len(addresses):
+                    raise PLCTagReadError(
+                        f"Allen Bradley PLC at {self.ip_address} returned {len(tags)} results "
+                        f"for {len(addresses)} requested tags"
+                    )
+                return {address: tag_to_result(tag) for address, tag in zip(addresses, tags)}
 
-            elif self.driver_type == "SLCDriver":
-                # SLCDriver reads data files with enhanced support
-                results = []
-                for tag in tag_list:
-                    try:
-                        # SLCDriver supports various data file formats
-                        result = await asyncio.to_thread(self.plc.read, tag)
-                        results.append(result)
-                    except Exception as e:
-                        self.logger.warning(f"Failed to read SLC tag {tag}: {e}")
-                        # Create error result
-                        error_result = type("ErrorResult", (), {"error": str(e), "value": None})()
-                        results.append(error_result)
+            if self.driver_type == "SLCDriver":
+                # SLC data-file reads are not batchable; one request per address.
+                return {address: await self._slc_read_one(driver, address) for address in addresses}
 
-            else:  # CIPDriver - Enhanced implementation using proper generic messaging
-                # CIPDriver for generic CIP objects and services using official API
-                results = []
-                for tag in tag_list:
-                    try:
-                        # Enhanced CIP implementation using proper generic_message() calls
-                        if tag.startswith("Identity") or tag == "DeviceInfo":
-                            # Read device identity object using proper method
-                            try:
-                                result = await asyncio.to_thread(self.plc.list_identity, self.ip_address)
-                                results.append(type("CIPResult", (), {"value": result, "error": None})())
-                            except Exception as e:
-                                results.append(type("CIPResult", (), {"value": None, "error": str(e)})())
+            return {address: await self._cip_read_one(driver, address) for address in addresses}
 
-                        elif tag.startswith("Assembly"):
-                            # Read assembly object using generic_message with proper service codes
-                            assembly_id = int(tag.split(":")[-1]) if ":" in tag else 1
-                            try:
-                                # Use generic_message with proper CIP service codes
-                                result = await asyncio.to_thread(
-                                    self.plc.generic_message,
-                                    service=0x0E,  # Get_Attribute_Single service
-                                    class_code=0x04,  # Assembly Object class
-                                    instance=assembly_id,
-                                    attribute=3,  # Data attribute
-                                    name=f"read_assembly_{assembly_id}",
-                                )
-                                value = result.value if hasattr(result, "value") else result
-                                results.append(type("CIPResult", (), {"value": value, "error": None})())
-                            except Exception as e:
-                                results.append(type("CIPResult", (), {"value": None, "error": str(e)})())
-
-                        elif tag.startswith("Module"):
-                            # Read module information for rack-based devices
-                            slot = int(tag.split(":")[-1]) if ":" in tag else 0
-                            try:
-                                result = await asyncio.to_thread(self.plc.get_module_info, slot)
-                                results.append(type("CIPResult", (), {"value": result, "error": None})())
-                            except Exception as e:
-                                results.append(type("CIPResult", (), {"value": None, "error": str(e)})())
-
-                        elif tag.startswith("Connection"):
-                            # Read connection object status using generic messaging
-                            try:
-                                result = await asyncio.to_thread(
-                                    self.plc.generic_message,
-                                    service=0x01,  # Get_Attributes_All service
-                                    class_code=0x06,  # Connection Manager Object
-                                    instance=1,
-                                    name="read_connection_status",
-                                )
-                                value = result.value if hasattr(result, "value") else result
-                                results.append(type("CIPResult", (), {"value": value, "error": None})())
-                            except Exception as e:
-                                results.append(type("CIPResult", (), {"value": None, "error": str(e)})())
-
-                        else:
-                            # Generic CIP object read using proper format parsing
-                            try:
-                                # Parse tag format: Class:Instance:Attribute or use generic_message
-                                parts = tag.split(":")
-                                if len(parts) >= 3:
-                                    class_code = int(parts[0], 16) if parts[0].startswith("0x") else int(parts[0])
-                                    instance = int(parts[1])
-                                    attribute = int(parts[2])
-
-                                    result = await asyncio.to_thread(
-                                        self.plc.generic_message,
-                                        service=0x0E,  # Get_Attribute_Single
-                                        class_code=class_code,
-                                        instance=instance,
-                                        attribute=attribute,
-                                        name=f"read_cip_{class_code}_{instance}_{attribute}",
-                                    )
-                                    value = result.value if hasattr(result, "value") else result
-                                    results.append(type("CIPResult", (), {"value": value, "error": None})())
-                                else:
-                                    # Try direct read for simple tags
-                                    result = await asyncio.to_thread(self.plc.read, tag)
-                                    results.append(result)
-                            except Exception as e:
-                                self.logger.warning(f"CIP read failed for {tag}: {e}")
-                                results.append(type("CIPResult", (), {"value": None, "error": str(e)})())
-                    except Exception as e:
-                        self.logger.error(f"Failed to read CIP tag {tag}: {e}")
-                        results.append(type("CIPResult", (), {"value": None, "error": str(e)})())
-
-            # Convert results to dictionary
-            tag_values = {}
-            for i, tag_result in enumerate(results):
-                tag_name = tag_list[i] if i < len(tag_list) else f"tag_{i}"
-
-                if tag_result is None:
-                    tag_values[tag_name] = None
-                elif hasattr(tag_result, "error") and tag_result.error:
-                    self.logger.warning(f"Error reading tag {tag_name}: {tag_result.error}")
-                    tag_values[tag_name] = None
-                elif hasattr(tag_result, "value"):
-                    tag_values[tag_name] = tag_result.value
-                else:
-                    tag_values[tag_name] = tag_result
-
-            return tag_values
-
+        except PLCTagReadError:
+            raise
+        except PYCOMM3_TRANSPORT_ERRORS as e:
+            # Retryable: the caller's recovery loop reconnects the read channel.
+            raise PLCCommunicationError(f"Read failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
+        except PYCOMM3_ERRORS as e:
+            # What's left is RequestError — a malformed request no retry can fix.
+            raise PLCTagReadError(f"Driver rejected the read on Allen Bradley PLC at {self.ip_address}: {e}") from e
         except Exception as e:
-            self.logger.error(f"Failed to read tags: {e}")
-            raise PLCTagReadError(f"Failed to read tags from Allen Bradley PLC: {e}")
+            raise PLCTagReadError(f"Unexpected read failure on Allen Bradley PLC at {self.ip_address}: {e}") from e
 
-    async def write_tag(self, tags: Union[Tuple[str, Any], List[Tuple[str, Any]]]) -> Dict[str, bool]:
-        """
-        Write values to Allen Bradley PLC tags.
+    async def _slc_read_one(self, driver: Any, address: str) -> TagResult:
+        """One SLC data-file read; only per-tag driver errors stay per-tag — a
+        CommError is a whole-call failure and propagates to ``_read_tags``."""
+        try:
+            return tag_to_result(await asyncio.to_thread(driver.read, address))
+        except PYCOMM3_TAG_ERRORS as e:
+            return TagResult(error=classify_tag_error(e))
 
-        Args:
-            tags: Single (tag_name, value) tuple or list of tuples
+    async def _cip_read_one(self, driver: Any, address: str) -> TagResult:
+        """One generic-CIP read, dispatched on the address form."""
+        try:
+            if address.startswith("Identity") or address == "DeviceInfo":
+                return TagResult(value=await asyncio.to_thread(driver.list_identity, self.ip_address))
 
-        Returns:
-            Dictionary mapping tag names to write success status
+            if address.startswith("Assembly"):
+                instance = int(address.split(":")[-1]) if ":" in address else 1
+                result = await asyncio.to_thread(
+                    driver.generic_message,
+                    service=0x0E,  # Get_Attribute_Single
+                    class_code=0x04,  # Assembly Object
+                    instance=instance,
+                    attribute=3,  # Data
+                    name=f"read_assembly_{instance}",
+                )
+                return tag_to_result(result)
 
-        Raises:
-            PLCTagWriteError: If tag writing fails
-        """
-        if not await self.is_connected():
-            if not await self.reconnect():
-                raise PLCCommunicationError(f"Not connected to Allen Bradley PLC at {self.ip_address}")
+            if address.startswith("Module"):
+                slot = int(address.split(":")[-1]) if ":" in address else 0
+                return TagResult(value=await asyncio.to_thread(driver.get_module_info, slot))
+
+            if address.startswith("Connection"):
+                result = await asyncio.to_thread(
+                    driver.generic_message,
+                    service=0x01,  # Get_Attributes_All
+                    class_code=0x06,  # Connection Manager Object
+                    instance=1,
+                    name="read_connection_status",
+                )
+                return tag_to_result(result)
+
+            parts = address.split(":")
+            if len(parts) >= 3:
+                class_code = int(parts[0], 16) if parts[0].startswith("0x") else int(parts[0])
+                instance = int(parts[1])
+                attribute = int(parts[2])
+                result = await asyncio.to_thread(
+                    driver.generic_message,
+                    service=0x0E,  # Get_Attribute_Single
+                    class_code=class_code,
+                    instance=instance,
+                    attribute=attribute,
+                    name=f"read_cip_{class_code}_{instance}_{attribute}",
+                )
+                return tag_to_result(result)
+
+            return tag_to_result(await asyncio.to_thread(driver.read, address))
+        except PYCOMM3_TAG_ERRORS as e:
+            return TagResult(error=classify_tag_error(e))
+
+    async def _write_tags(self, writes: List[Tuple[str, Any]]) -> Dict[str, TagResult]:
+        """Write on the write channel; per-tag errors are classified, not laundered to False."""
+        driver = self._driver_for("write")
+        if not writes:
+            return {}
 
         try:
-            if isinstance(tags, tuple):
-                tag_list = [tags]
-            else:
-                tag_list = tags
-
-            # Write tags based on driver type
             if self.driver_type == "LogixDriver":
-                # LogixDriver supports multiple tag writing
-                if len(tag_list) == 1:
-                    result = await asyncio.to_thread(self.plc.write, tag_list[0])
-                    results = [result] if not isinstance(result, list) else result
-                else:
-                    results = await asyncio.to_thread(self.plc.write, *tag_list)
-                    results = results if isinstance(results, list) else [results]
+                results = await asyncio.to_thread(driver.write, *writes)
+                tags = results if isinstance(results, list) else [results]
+                if len(tags) != len(writes):
+                    raise PLCTagWriteError(
+                        f"Allen Bradley PLC at {self.ip_address} returned {len(tags)} results "
+                        f"for {len(writes)} requested writes"
+                    )
+                return {
+                    address: tag_to_result(tag, value_on_success=value, use_tag_value=False)
+                    for (address, value), tag in zip(writes, tags)
+                }
 
-            elif self.driver_type == "SLCDriver":
-                # Enhanced SLCDriver writes with better error handling
-                results = []
-                for tag_name, value in tag_list:
-                    try:
-                        # SLCDriver supports various data file formats
-                        result = await asyncio.to_thread(self.plc.write, (tag_name, value))
-                        results.append(result)
-                    except Exception as e:
-                        self.logger.warning(f"Failed to write SLC tag {tag_name}: {e}")
-                        results.append(False)
+            if self.driver_type == "SLCDriver":
+                return {address: await self._slc_write_one(driver, address, value) for address, value in writes}
 
-            else:  # CIPDriver - Enhanced implementation using proper generic messaging
-                # Enhanced CIP implementation for writing using official API
-                results = []
-                for tag_name, value in tag_list:
-                    try:
-                        # Enhanced CIP implementation using proper generic_message() calls
-                        if tag_name.startswith("Assembly"):
-                            # Write to assembly object using generic_message with proper service codes
-                            assembly_id = int(tag_name.split(":")[-1]) if ":" in tag_name else 1
-                            try:
-                                result = await asyncio.to_thread(
-                                    self.plc.generic_message,
-                                    service=0x10,  # Set_Attribute_Single service
-                                    class_code=0x04,  # Assembly Object class
-                                    instance=assembly_id,
-                                    attribute=3,  # Data attribute
-                                    data=value,
-                                    name=f"write_assembly_{assembly_id}",
-                                )
-                                success = not (hasattr(result, "error") and result.error)
-                                results.append(success)
-                            except Exception as e:
-                                self.logger.warning(f"CIP assembly write failed for {tag_name}: {e}")
-                                results.append(False)
+            return {address: await self._cip_write_one(driver, address, value) for address, value in writes}
 
-                        elif tag_name.startswith("Parameter"):
-                            # Write to parameter object (for drives) using generic messaging
-                            param_id = int(tag_name.split(":")[-1]) if ":" in tag_name else 1
-                            try:
-                                result = await asyncio.to_thread(
-                                    self.plc.generic_message,
-                                    service=0x10,  # Set_Attribute_Single service
-                                    class_code=0x0F,  # Parameter Object class
-                                    instance=param_id,
-                                    attribute=1,  # Parameter value attribute
-                                    data=value,
-                                    name=f"write_parameter_{param_id}",
-                                )
-                                success = not (hasattr(result, "error") and result.error)
-                                results.append(success)
-                            except Exception as e:
-                                self.logger.warning(f"CIP parameter write failed for {tag_name}: {e}")
-                                results.append(False)
-
-                        else:
-                            # Generic CIP object write using proper format parsing
-                            try:
-                                # Parse tag format: Class:Instance:Attribute
-                                parts = tag_name.split(":")
-                                if len(parts) >= 3:
-                                    class_code = int(parts[0], 16) if parts[0].startswith("0x") else int(parts[0])
-                                    instance = int(parts[1])
-                                    attribute = int(parts[2])
-
-                                    result = await asyncio.to_thread(
-                                        self.plc.generic_message,
-                                        service=0x10,  # Set_Attribute_Single
-                                        class_code=class_code,
-                                        instance=instance,
-                                        attribute=attribute,
-                                        data=value,
-                                        name=f"write_cip_{class_code}_{instance}_{attribute}",
-                                    )
-                                    success = not (hasattr(result, "error") and result.error)
-                                    results.append(success)
-                                else:
-                                    # Try direct write for simple tags
-                                    result = await asyncio.to_thread(self.plc.write, (tag_name, value))
-                                    results.append(True if result else False)
-                            except Exception as e:
-                                self.logger.warning(f"CIP write failed for {tag_name}: {e}")
-                                results.append(False)
-                    except Exception as e:
-                        self.logger.error(f"Failed to write CIP tag {tag_name}: {e}")
-                        results.append(False)
-
-            # Convert results to dictionary
-            write_status = {}
-            for i, tag_result in enumerate(results):
-                tag_name = tag_list[i][0] if i < len(tag_list) else f"tag_{i}"
-
-                if tag_result is False:
-                    write_status[tag_name] = False
-                elif hasattr(tag_result, "error") and tag_result.error:
-                    self.logger.warning(f"Error writing tag {tag_name}: {tag_result.error}")
-                    write_status[tag_name] = False
-                else:
-                    write_status[tag_name] = True
-
-            return write_status
-
+        except PLCTagWriteError:
+            raise
+        except PYCOMM3_TRANSPORT_ERRORS as e:
+            # Retryable: the caller's recovery loop reconnects the write channel.
+            raise PLCCommunicationError(f"Write failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
+        except PYCOMM3_ERRORS as e:
+            # RequestError: a malformed request no retry can fix.
+            raise PLCTagWriteError(f"Driver rejected the write on Allen Bradley PLC at {self.ip_address}: {e}") from e
         except Exception as e:
-            self.logger.error(f"Failed to write tags: {e}")
-            raise PLCTagWriteError(f"Failed to write tags to Allen Bradley PLC: {e}")
+            raise PLCTagWriteError(f"Unexpected write failure on Allen Bradley PLC at {self.ip_address}: {e}") from e
 
-    async def get_all_tags(self) -> List[str]:
+    async def _slc_write_one(self, driver: Any, address: str, value: Any) -> TagResult:
+        """One SLC data-file write; only per-tag driver errors stay per-tag — a
+        CommError is a whole-call failure and propagates to ``_write_tags``."""
+        try:
+            result = await asyncio.to_thread(driver.write, (address, value))
+            return tag_to_result(result, value_on_success=value, use_tag_value=False)
+        except PYCOMM3_TAG_ERRORS as e:
+            return TagResult(error=classify_tag_error(e))
+
+    async def _cip_write_one(self, driver: Any, address: str, value: Any) -> TagResult:
+        """One generic-CIP write, dispatched on the address form."""
+        try:
+            if address.startswith("Assembly"):
+                instance = int(address.split(":")[-1]) if ":" in address else 1
+                result = await asyncio.to_thread(
+                    driver.generic_message,
+                    service=0x10,  # Set_Attribute_Single
+                    class_code=0x04,  # Assembly Object
+                    instance=instance,
+                    attribute=3,  # Data
+                    data=value,
+                    name=f"write_assembly_{instance}",
+                )
+                return tag_to_result(result, value_on_success=value, use_tag_value=False)
+
+            if address.startswith("Parameter"):
+                instance = int(address.split(":")[-1]) if ":" in address else 1
+                result = await asyncio.to_thread(
+                    driver.generic_message,
+                    service=0x10,  # Set_Attribute_Single
+                    class_code=0x0F,  # Parameter Object
+                    instance=instance,
+                    attribute=1,  # Parameter value
+                    data=value,
+                    name=f"write_parameter_{instance}",
+                )
+                return tag_to_result(result, value_on_success=value, use_tag_value=False)
+
+            parts = address.split(":")
+            if len(parts) >= 3:
+                class_code = int(parts[0], 16) if parts[0].startswith("0x") else int(parts[0])
+                instance = int(parts[1])
+                attribute = int(parts[2])
+                result = await asyncio.to_thread(
+                    driver.generic_message,
+                    service=0x10,  # Set_Attribute_Single
+                    class_code=class_code,
+                    instance=instance,
+                    attribute=attribute,
+                    data=value,
+                    name=f"write_cip_{class_code}_{instance}_{attribute}",
+                )
+                return tag_to_result(result, value_on_success=value, use_tag_value=False)
+
+            result = await asyncio.to_thread(driver.write, (address, value))
+            return tag_to_result(result, value_on_success=value, use_tag_value=False)
+        except PYCOMM3_TAG_ERRORS as e:
+            return TagResult(error=classify_tag_error(e))
+
+    async def _get_all_tags(self) -> List[str]:
         """
         Get list of all available tags on the Allen Bradley PLC.
 
@@ -548,14 +539,12 @@ class AllenBradleyPLC(BasePLC):
         if self._tags_cache is not None and current_time - self._cache_timestamp < self._cache_ttl:
             return self._tags_cache
 
-        if not await self.is_connected():
-            if not await self.reconnect():
-                raise PLCCommunicationError(f"Not connected to Allen Bradley PLC at {self.ip_address}")
+        driver = self._driver_for("read")
 
         try:
             if self.driver_type == "LogixDriver":
                 # LogixDriver has built-in tag list functionality
-                tags_dict = await asyncio.to_thread(lambda: self.plc.tags)
+                tags_dict = await asyncio.to_thread(lambda: driver.tags)
                 if not tags_dict:
                     # We're connected, but the controller tag list came back
                     # empty/None — for a Logix controller that means the upload
@@ -716,7 +705,7 @@ class AllenBradleyPLC(BasePLC):
                             # Try to discover module information for rack-based devices
                             try:
                                 for slot in range(0, 8):  # Check first 8 slots
-                                    module_info = await asyncio.to_thread(self.plc.get_module_info, slot)
+                                    module_info = await asyncio.to_thread(driver.get_module_info, slot)
                                     if module_info:
                                         self._tags_cache.append(f"Module:{slot}")
                             except Exception:
@@ -767,7 +756,7 @@ class AllenBradleyPLC(BasePLC):
                 try:
                     # Attempt to get object list from Message Router (if supported)
                     object_list_result = await asyncio.to_thread(
-                        self.plc.generic_message,
+                        driver.generic_message,
                         service=0x0E,  # Get_Attribute_Single
                         class_code=0x02,  # Message Router Object
                         instance=1,
@@ -794,7 +783,7 @@ class AllenBradleyPLC(BasePLC):
             self.logger.error(f"Failed to get tags: {e}")
             raise PLCTagError(f"Failed to get tags from Allen Bradley PLC: {e}")
 
-    async def get_tag_info(self, tag_name: str) -> Dict[str, Any]:
+    async def _get_tag_info(self, tag_name: str) -> Dict[str, Any]:
         """
         Get detailed information about a specific tag.
 
@@ -804,13 +793,11 @@ class AllenBradleyPLC(BasePLC):
         Returns:
             Dictionary with tag information (type, description, etc.)
         """
-        if not await self.is_connected():
-            if not await self.reconnect():
-                raise PLCCommunicationError(f"Not connected to Allen Bradley PLC at {self.ip_address}")
+        driver = self._driver_for("read")
 
         try:
             if self.driver_type == "LogixDriver":
-                tags_dict = await asyncio.to_thread(lambda: self.plc.tags)
+                tags_dict = await asyncio.to_thread(lambda: driver.tags)
                 if not tags_dict:
                     # Connected, but the controller tag list is empty/None — the
                     # upload failed. We CANNOT conclude the tag is absent; raising
@@ -860,16 +847,14 @@ class AllenBradleyPLC(BasePLC):
             self.logger.error(f"Failed to get tag info: {e}")
             raise PLCTagError(f"Failed to get tag info from Allen Bradley PLC: {e}")
 
-    async def get_plc_info(self) -> Dict[str, Any]:
+    async def _get_plc_info(self) -> Dict[str, Any]:
         """
         Get detailed information about the connected PLC using proper pycomm3 methods.
 
         Returns:
             Dictionary with PLC information
         """
-        if not await self.is_connected():
-            if not await self.reconnect():
-                raise PLCCommunicationError(f"Not connected to Allen Bradley PLC at {self.ip_address}")
+        driver = self._driver_for("read")
 
         try:
             info = {
@@ -883,7 +868,7 @@ class AllenBradleyPLC(BasePLC):
             if self.driver_type == "LogixDriver":
                 # LogixDriver provides detailed PLC information via get_plc_info()
                 try:
-                    plc_info = await asyncio.to_thread(self.plc.get_plc_info)
+                    plc_info = await asyncio.to_thread(driver.get_plc_info)
                     info.update(
                         {
                             "product_name": getattr(plc_info, "product_name", "Unknown"),
@@ -896,7 +881,7 @@ class AllenBradleyPLC(BasePLC):
 
                     # Try to get program name using generic messaging (as shown in docs)
                     try:
-                        program_name = await asyncio.to_thread(self.plc.get_plc_name)
+                        program_name = await asyncio.to_thread(driver.get_plc_name)
                         info["program_name"] = program_name
                     except Exception:
                         pass
@@ -924,7 +909,7 @@ class AllenBradleyPLC(BasePLC):
 
                         # Try to get additional module information for rack-based devices
                         try:
-                            module_info = await asyncio.to_thread(self.plc.get_module_info, 0)
+                            module_info = await asyncio.to_thread(driver.get_module_info, 0)
                             if module_info:
                                 info["module_info"] = module_info
                         except Exception:

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
@@ -23,7 +23,7 @@ from mindtrace.hardware.core.exceptions import (
     SDKNotAvailableError,
 )
 from mindtrace.hardware.plcs.backends.base import BasePLC
-from mindtrace.hardware.plcs.types import TagResult, classify_tag_error, tag_to_result
+from mindtrace.hardware.plcs.types import TagResult, classify_tag_error, session_dead_addresses, tag_to_result
 
 try:
     from pycomm3 import CIPDriver, LogixDriver, SLCDriver
@@ -31,7 +31,10 @@ try:
 
     PYCOMM3_AVAILABLE = True
     PYCOMM3_ERRORS: Tuple[type, ...] = (CommError, DataError, RequestError, ResponseError)
-    PYCOMM3_TRANSPORT_ERRORS: Tuple[type, ...] = (CommError, DataError, ResponseError, OSError)
+    # CommError,  pycomm3's own wire/session verdict
+    PYCOMM3_WIRE_ERRORS: Tuple[type, ...] = (CommError, OSError)
+    # Reply-level trouble - garbled or refused replies. keep session.
+    PYCOMM3_REPLY_ERRORS: Tuple[type, ...] = (DataError, ResponseError)
     PYCOMM3_TAG_ERRORS: Tuple[type, ...] = (DataError, RequestError, ResponseError)
 except ImportError:
     PYCOMM3_AVAILABLE = False
@@ -39,8 +42,20 @@ except ImportError:
     SLCDriver = None
     CIPDriver = None
     PYCOMM3_ERRORS = ()
-    PYCOMM3_TRANSPORT_ERRORS = (OSError,)
+    PYCOMM3_WIRE_ERRORS = (OSError,)
+    PYCOMM3_REPLY_ERRORS = ()
     PYCOMM3_TAG_ERRORS = ()
+
+
+def _chain_has_timeout(error) -> bool:
+    """socket.timeout IS TimeoutError; differentiate from socket errors."""
+    seen: set = set()
+    while error is not None and id(error) not in seen:
+        if isinstance(error, TimeoutError):
+            return True
+        seen.add(id(error))
+        error = error.__cause__ or error.__context__
+    return False
 
 
 class AllenBradleyPLC(BasePLC):
@@ -71,7 +86,6 @@ class AllenBradleyPLC(BasePLC):
         connection_timeout: Optional[float] = None,
         read_timeout: Optional[float] = None,
         write_timeout: Optional[float] = None,
-        retry_count: Optional[int] = None,
         retry_delay: Optional[float] = None,
     ):
         """
@@ -85,7 +99,6 @@ class AllenBradleyPLC(BasePLC):
             connection_timeout: Connection timeout in seconds
             read_timeout: Tag read timeout in seconds
             write_timeout: Tag write timeout in seconds
-            retry_count: Number of retry attempts
             retry_delay: Delay between retries in seconds
 
         Raises:
@@ -101,7 +114,6 @@ class AllenBradleyPLC(BasePLC):
             connection_timeout=connection_timeout,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
-            retry_count=retry_count,
             retry_delay=retry_delay,
         )
 
@@ -145,11 +157,25 @@ class AllenBradleyPLC(BasePLC):
     def _driver_open(driver: Any) -> bool:
         return bool(driver is not None and getattr(driver, "connected", False))
 
-    def _driver_for(self, channel: str) -> Any:
-        """This channel's open driver, or PLCCommunicationError. Never reconnects implicitly."""
-        driver = self._read_driver if channel == "read" else self._write_driver
+    async def _driver_for(self, channel: str) -> Any:
+        """This channel's driver: reopen one that died; never open a never-connected one."""
+        attribute = "_read_driver" if channel == "read" else "_write_driver"
+        driver = getattr(self, attribute)
+        if driver is None:
+            raise PLCConnectionError(
+                f"The {channel} channel to Allen Bradley PLC at {self.ip_address} was never opened - call connect()"
+            )
         if not self._driver_open(driver):
-            raise PLCCommunicationError(f"Not connected to Allen Bradley PLC at {self.ip_address} ({channel} channel)")
+            try:
+                driver = await self._open_driver(channel)
+            except Exception as error:
+                raise PLCCommunicationError(
+                    f"Could not reopen the {channel} channel to Allen Bradley PLC at {self.ip_address}: {error}"
+                ) from error
+            setattr(self, attribute, driver)
+            if channel == "read":
+                self.plc = driver  # downstream code reads plc.tags off the read driver
+            self.logger.info(f"Reopened the {channel} channel to Allen Bradley PLC at {self.ip_address}")
         return driver
 
     async def initialize(self) -> Tuple[bool, Any, Any]:
@@ -220,11 +246,10 @@ class AllenBradleyPLC(BasePLC):
         return "cip"
 
     async def _connect(self) -> bool:
-        """Open both channels' drivers. Raises PLCConnectionError if either fails.
+        """Open both channels' drivers via ``_open_driver``. Raises PLCConnectionError.
 
-        A single attempt; channel recovery goes through ``_reconnect_channel``. Both
-        drivers are constructed before either opens, so a half-open device is
-        reported as such rather than looking like a plain connect failure.
+        A single attempt. A device that only grants one session fails on the
+        write channel with the read side already open - the error says so.
         """
         self.logger.info(f"Connecting to Allen Bradley PLC at {self.ip_address}")
 
@@ -236,36 +261,41 @@ class AllenBradleyPLC(BasePLC):
             self._write_driver = None
             self.plc = None
 
-        driver_class, driver_name = self._driver_class(await self._resolve_plc_type())
+        try:
+            self._read_driver = await self._open_driver("read")
+        except Exception as e:
+            raise PLCConnectionError(f"Failed to connect to Allen Bradley PLC at {self.ip_address}: {e}") from e
+        # `plc` stays the READ driver: downstream code reads plc.tags.
+        self.plc = self._read_driver
 
         try:
-            self._read_driver = await asyncio.to_thread(driver_class, self.ip_address)
-            self._write_driver = await asyncio.to_thread(driver_class, self.ip_address)
-            # `plc` stays the READ driver: downstream code reads plc.tags.
-            self.plc = self._read_driver
-            self.driver_type = driver_name
-
-            read_open = await asyncio.to_thread(self._read_driver.open)
-            write_open = await asyncio.to_thread(self._write_driver.open)
+            self._write_driver = await self._open_driver("write")
         except Exception as e:
-            await self._close_drivers()
-            raise PLCConnectionError(f"Failed to connect to Allen Bradley PLC at {self.ip_address}: {e}") from e
-
-        if not (read_open and write_open):
-            await self._close_drivers()
+            await self._close_driver(self._read_driver, "read")
+            self._read_driver = None
+            self.plc = None
             raise PLCConnectionError(
-                f"Failed to open both channels to Allen Bradley PLC at {self.ip_address} "
-                f"(read={bool(read_open)}, write={bool(write_open)})"
-            )
+                f"Failed to connect to Allen Bradley PLC at {self.ip_address}: "
+                f"the read channel opened but the write channel did not: {e}"
+            ) from e
 
         self.logger.info(f"Connected to Allen Bradley PLC using {self.driver_type} (read + write channels)")
         return True
 
-    async def _open_driver(self) -> Any:
-        """Construct and open ONE driver for the resolved plc_type; raises if it will not open."""
+    def _channel_timeout(self, channel: str) -> float:
+        return self.read_timeout if channel == "read" else self.write_timeout
+
+    async def _open_driver(self, channel: str) -> Any:
+        """Construct and open ONE driver for the resolved plc_type; raises if it will not open.
+
+        Two-phase socket timeout: ``connection_timeout`` bounds the open itself,
+        then the channel's read/write timeout takes over — the configured knobs
+        are what actually bound how long a call can fence its channel.
+        """
         driver_class, driver_name = self._driver_class(await self._resolve_plc_type())
 
         driver = await asyncio.to_thread(driver_class, self.ip_address)
+        driver.socket_timeout = self.connection_timeout
         try:
             opened = await asyncio.to_thread(driver.open)
         except Exception:
@@ -276,6 +306,7 @@ class AllenBradleyPLC(BasePLC):
         if not opened:
             await self._close_driver(driver, "new")
             raise PLCConnectionError(f"Failed to open a driver to Allen Bradley PLC at {self.ip_address}")
+        driver.socket_timeout = self._channel_timeout(channel)
         self.driver_type = driver_name
         return driver
 
@@ -290,28 +321,19 @@ class AllenBradleyPLC(BasePLC):
             return False
         return not getattr(driver, "connected", False)
 
-    async def _reconnect_channel(self, channel: str) -> bool:
-        """Rebuild ONE channel's driver; the other channel's socket is untouched.
-
-        Runs under that channel's lock: never call the public ``reconnect`` /
-        ``connect``, which take both locks and would deadlock.
-        """
-        attribute = "_read_driver" if channel == "read" else "_write_driver"
-
-        await self._close_driver(getattr(self, attribute), channel)
-        setattr(self, attribute, None)
-        if channel == "read":
-            self.plc = None
-
-        await asyncio.sleep(self.retry_delay)  # let the controller drop the old driver
-
-        driver = await self._open_driver()
-        setattr(self, attribute, driver)
-        if channel == "read":
-            # `plc` follows the read driver: downstream code reads plc.tags.
-            self.plc = driver
-        self.logger.info(f"Reopened the {channel} channel to Allen Bradley PLC at {self.ip_address}")
-        return True
+    async def _raise_if_session_dead(self, driver: Any, channel: str, results: Dict[str, TagResult]) -> None:
+        """Session-dead statuses in a delivered reply close the channel and raise."""
+        dead = session_dead_addresses(results)
+        if not dead:
+            return
+        first = results[dead[0]].error.message
+        self.logger.warning(
+            f"{self.plc_name} {channel} channel: session-dead statuses on {len(dead)}/{len(results)} tags ({first})"
+        )
+        await self._close_driver(driver, channel)
+        raise PLCCommunicationError(
+            f"{self.plc_name} {channel} channel failed on {len(dead)}/{len(results)} tags: {first}"
+        )
 
     async def _close_drivers(self) -> bool:
         """Close both channels' drivers; True only if both are actually closed."""
@@ -321,12 +343,15 @@ class AllenBradleyPLC(BasePLC):
         return closed
 
     async def _disconnect(self) -> bool:
-        """Close both channels' drivers."""
+        """Close both channels' drivers and forget them."""
         if self._read_driver is None and self._write_driver is None:
             return True
 
         closed = await self._close_drivers()
         if closed:
+            self._read_driver = None
+            self._write_driver = None
+            self.plc = None
             self.logger.info(f"Disconnected from Allen Bradley PLC at {self.ip_address}")
             self.initialized = False
         return closed
@@ -340,7 +365,7 @@ class AllenBradleyPLC(BasePLC):
 
     async def _read_tags(self, addresses: List[str]) -> Dict[str, TagResult]:
         """Read on the read channel; per-tag errors are classified, not logged away."""
-        driver = self._driver_for("read")
+        driver = await self._driver_for("read")
         if not addresses:
             return {}
 
@@ -353,24 +378,29 @@ class AllenBradleyPLC(BasePLC):
                         f"Allen Bradley PLC at {self.ip_address} returned {len(tags)} results "
                         f"for {len(addresses)} requested tags"
                     )
-                return {address: tag_to_result(tag) for address, tag in zip(addresses, tags)}
-
-            if self.driver_type == "SLCDriver":
+                results = {address: tag_to_result(tag) for address, tag in zip(addresses, tags)}
+            elif self.driver_type == "SLCDriver":
                 # SLC data-file reads are not batchable; one request per address.
-                return {address: await self._slc_read_one(driver, address) for address in addresses}
-
-            return {address: await self._cip_read_one(driver, address) for address in addresses}
+                results = {address: await self._slc_read_one(driver, address) for address in addresses}
+            else:
+                results = {address: await self._cip_read_one(driver, address) for address in addresses}
 
         except PLCTagReadError:
             raise
-        except PYCOMM3_TRANSPORT_ERRORS as e:
-            # Retryable: the caller's recovery loop reconnects the read channel.
+        except PYCOMM3_WIRE_ERRORS as e:
+            if not _chain_has_timeout(e):  # busy is not dead; the caller decides patience
+                await self._close_driver(driver, "read")
+            raise PLCCommunicationError(f"Read failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
+        except PYCOMM3_REPLY_ERRORS as e:
             raise PLCCommunicationError(f"Read failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
         except PYCOMM3_ERRORS as e:
-            # What's left is RequestError — a malformed request no retry can fix.
+            # What's left is RequestError — a malformed request; the session is fine.
             raise PLCTagReadError(f"Driver rejected the read on Allen Bradley PLC at {self.ip_address}: {e}") from e
         except Exception as e:
             raise PLCTagReadError(f"Unexpected read failure on Allen Bradley PLC at {self.ip_address}: {e}") from e
+
+        await self._raise_if_session_dead(driver, "read", results)
+        return results
 
     async def _slc_read_one(self, driver: Any, address: str) -> TagResult:
         """One SLC data-file read; only per-tag driver errors stay per-tag — a
@@ -433,7 +463,7 @@ class AllenBradleyPLC(BasePLC):
 
     async def _write_tags(self, writes: List[Tuple[str, Any]]) -> Dict[str, TagResult]:
         """Write on the write channel; per-tag errors are classified, not laundered to False."""
-        driver = self._driver_for("write")
+        driver = await self._driver_for("write")
         if not writes:
             return {}
 
@@ -446,26 +476,31 @@ class AllenBradleyPLC(BasePLC):
                         f"Allen Bradley PLC at {self.ip_address} returned {len(tags)} results "
                         f"for {len(writes)} requested writes"
                     )
-                return {
+                results_map = {
                     address: tag_to_result(tag, value_on_success=value, use_tag_value=False)
                     for (address, value), tag in zip(writes, tags)
                 }
-
-            if self.driver_type == "SLCDriver":
-                return {address: await self._slc_write_one(driver, address, value) for address, value in writes}
-
-            return {address: await self._cip_write_one(driver, address, value) for address, value in writes}
+            elif self.driver_type == "SLCDriver":
+                results_map = {address: await self._slc_write_one(driver, address, value) for address, value in writes}
+            else:
+                results_map = {address: await self._cip_write_one(driver, address, value) for address, value in writes}
 
         except PLCTagWriteError:
             raise
-        except PYCOMM3_TRANSPORT_ERRORS as e:
-            # Retryable: the caller's recovery loop reconnects the write channel.
+        except PYCOMM3_WIRE_ERRORS as e:
+            if not _chain_has_timeout(e):
+                await self._close_driver(driver, "write")
+            raise PLCCommunicationError(f"Write failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
+        except PYCOMM3_REPLY_ERRORS as e:
             raise PLCCommunicationError(f"Write failed on Allen Bradley PLC at {self.ip_address}: {e}") from e
         except PYCOMM3_ERRORS as e:
-            # RequestError: a malformed request no retry can fix.
+            # RequestError: a malformed request; the session is fine.
             raise PLCTagWriteError(f"Driver rejected the write on Allen Bradley PLC at {self.ip_address}: {e}") from e
         except Exception as e:
             raise PLCTagWriteError(f"Unexpected write failure on Allen Bradley PLC at {self.ip_address}: {e}") from e
+
+        await self._raise_if_session_dead(driver, "write", results_map)
+        return results_map
 
     async def _slc_write_one(self, driver: Any, address: str, value: Any) -> TagResult:
         """One SLC data-file write; only per-tag driver errors stay per-tag — a
@@ -539,7 +574,7 @@ class AllenBradleyPLC(BasePLC):
         if self._tags_cache is not None and current_time - self._cache_timestamp < self._cache_ttl:
             return self._tags_cache
 
-        driver = self._driver_for("read")
+        driver = await self._driver_for("read")
 
         try:
             if self.driver_type == "LogixDriver":
@@ -793,7 +828,7 @@ class AllenBradleyPLC(BasePLC):
         Returns:
             Dictionary with tag information (type, description, etc.)
         """
-        driver = self._driver_for("read")
+        driver = await self._driver_for("read")
 
         try:
             if self.driver_type == "LogixDriver":
@@ -854,7 +889,7 @@ class AllenBradleyPLC(BasePLC):
         Returns:
             Dictionary with PLC information
         """
-        driver = self._driver_for("read")
+        driver = await self._driver_for("read")
 
         try:
             info = {
@@ -1170,7 +1205,7 @@ class AllenBradleyPLC(BasePLC):
                 "SLC data file mapping with bit-level access",
                 "Logix tag enumeration and data type detection",
                 "PLC information retrieval and device identification",
-                "Connection management with automatic retry logic",
+                "Explicit connect lifecycle; a channel closed on proof reopens at the next call",
                 "Async/await support for non-blocking operations",
                 "Caching system for improved performance",
                 "Device-specific object discovery",

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
@@ -23,8 +23,13 @@ from mindtrace.hardware.core.exceptions import (
     PLCTimeoutError,
     SDKNotAvailableError,
 )
+from mindtrace.hardware.plcs.backends.allen_bradley.error_text import (
+    classify_tag_error,
+    session_dead_addresses,
+    tag_to_result,
+)
 from mindtrace.hardware.plcs.backends.base import BasePLC
-from mindtrace.hardware.plcs.types import TagResult, classify_tag_error, session_dead_addresses, tag_to_result
+from mindtrace.hardware.plcs.types import TagResult
 
 try:
     from pycomm3 import CIPDriver, LogixDriver, SLCDriver

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/allen_bradley_plc.py
@@ -30,7 +30,7 @@ from mindtrace.hardware.plcs.backends.allen_bradley.error_text import (
     tag_to_result,
 )
 from mindtrace.hardware.plcs.backends.base import BasePLC
-from mindtrace.hardware.plcs.types import TagResult
+from mindtrace.hardware.plcs.types import TagError, TagErrorKind, TagResult
 
 try:
     from pycomm3 import CIPDriver, LogixDriver, SLCDriver
@@ -40,7 +40,8 @@ try:
     PYCOMM3_ERRORS: Tuple[type, ...] = (CommError, DataError, RequestError, ResponseError)
     # Anything raised from INSIDE an exchange closes the channel.
     PYCOMM3_EXCHANGE_ERRORS: Tuple[type, ...] = (CommError, DataError, ResponseError, OSError)
-    PYCOMM3_TAG_ERRORS: Tuple[type, ...] = (DataError, RequestError, ResponseError)
+    # RequestError is pre-wire: the one raised class the unbatched paths keep per-tag.
+    PYCOMM3_TAG_ERRORS: Tuple[type, ...] = (RequestError,)
 except ImportError:
     PYCOMM3_AVAILABLE = False
     LogixDriver = None
@@ -49,6 +50,13 @@ except ImportError:
     PYCOMM3_ERRORS = ()
     PYCOMM3_EXCHANGE_ERRORS = (OSError,)
     PYCOMM3_TAG_ERRORS = ()
+
+
+def _unsupported_cip_address(address: str) -> TagResult:
+    """CIPDriver has no tag database; only the known address forms can be served."""
+    return TagResult(
+        error=TagError(kind=TagErrorKind.missing_tag, message=f"Unsupported CIP address form: {address!r}")
+    )
 
 
 # Stand-in for a driver whose worker thread never returned: the real one must
@@ -377,17 +385,17 @@ class AllenBradleyPLC(BasePLC):
         return closed
 
     async def _disconnect(self) -> bool:
-        """Close both channels' drivers and forget them."""
+        """Close both channels' drivers and forget them — unconditionally:
+        pycomm3's close() resets its own state before raising."""
         if self._read_driver is None and self._write_driver is None:
             return True
 
         closed = await self._close_drivers()
-        if closed:
-            self._read_driver = None
-            self._write_driver = None
-            self.plc = None
-            self.logger.info(f"Disconnected from Allen Bradley PLC at {self.ip_address}")
-            self.initialized = False
+        self._read_driver = None
+        self._write_driver = None
+        self.plc = None
+        self.initialized = False
+        self.logger.info(f"Disconnected from Allen Bradley PLC at {self.ip_address}")
         return closed
 
     async def is_connected(self) -> bool:
@@ -405,6 +413,7 @@ class AllenBradleyPLC(BasePLC):
                 results = await self._bounded("read", driver.read, *addresses)
                 tags = results if isinstance(results, list) else [results]
                 if len(tags) != len(addresses):
+                    await self._close_driver(driver, "read")
                     raise PLCTagReadError(
                         f"Allen Bradley PLC at {self.ip_address} returned {len(tags)} results "
                         f"for {len(addresses)} requested tags"
@@ -446,8 +455,9 @@ class AllenBradleyPLC(BasePLC):
         return results
 
     async def _slc_read_one(self, driver: Any, address: str) -> TagResult:
-        """One SLC data-file read; only per-tag driver errors stay per-tag — a
-        CommError is a whole-call failure and propagates to ``_read_tags``."""
+        """One SLC data-file read; pre-wire ``RequestError`` stays per-tag,
+        any other raised class is TREATED as an aborted exchange and propagates
+        to the ladder."""
         try:
             return tag_to_result(await self._bounded("read", driver.read, address))
         except PYCOMM3_TAG_ERRORS as e:
@@ -457,10 +467,18 @@ class AllenBradleyPLC(BasePLC):
         """One generic-CIP read, dispatched on the address form."""
         try:
             if address.startswith("Identity") or address == "DeviceInfo":
-                return TagResult(value=await self._bounded("read", driver.list_identity, self.ip_address))
+                # list_identity opens its own throwaway connection; its failures
+                # are never evidence about the channel.
+                try:
+                    return TagResult(value=await asyncio.to_thread(driver.list_identity, self.ip_address))
+                except Exception as e:
+                    return TagResult(error=TagError(kind=TagErrorKind.unknown, message=f"identity probe failed: {e}"))
 
             if address.startswith("Assembly"):
-                instance = int(address.split(":")[-1]) if ":" in address else 1
+                try:
+                    instance = int(address.split(":")[-1]) if ":" in address else 1
+                except ValueError:
+                    return _unsupported_cip_address(address)
                 result = await self._bounded(
                     "read",
                     driver.generic_message,
@@ -473,7 +491,10 @@ class AllenBradleyPLC(BasePLC):
                 return tag_to_result(result)
 
             if address.startswith("Module"):
-                slot = int(address.split(":")[-1]) if ":" in address else 0
+                try:
+                    slot = int(address.split(":")[-1]) if ":" in address else 0
+                except ValueError:
+                    return _unsupported_cip_address(address)
                 return TagResult(value=await self._bounded("read", driver.get_module_info, slot))
 
             if address.startswith("Connection"):
@@ -489,9 +510,12 @@ class AllenBradleyPLC(BasePLC):
 
             parts = address.split(":")
             if len(parts) >= 3:
-                class_code = int(parts[0], 16) if parts[0].startswith("0x") else int(parts[0])
-                instance = int(parts[1])
-                attribute = int(parts[2])
+                try:
+                    class_code = int(parts[0], 16) if parts[0].startswith("0x") else int(parts[0])
+                    instance = int(parts[1])
+                    attribute = int(parts[2])
+                except ValueError:
+                    return _unsupported_cip_address(address)
                 result = await self._bounded(
                     "read",
                     driver.generic_message,
@@ -503,7 +527,8 @@ class AllenBradleyPLC(BasePLC):
                 )
                 return tag_to_result(result)
 
-            return tag_to_result(await self._bounded("read", driver.read, address))
+            # CIPDriver has no read(); anything else is an unservable address.
+            return _unsupported_cip_address(address)
         except PYCOMM3_TAG_ERRORS as e:
             return TagResult(error=classify_tag_error(e))
 
@@ -518,6 +543,7 @@ class AllenBradleyPLC(BasePLC):
                 results = await self._bounded("write", driver.write, *writes)
                 tags = results if isinstance(results, list) else [results]
                 if len(tags) != len(writes):
+                    await self._close_driver(driver, "write")
                     raise PLCTagWriteError(
                         f"Allen Bradley PLC at {self.ip_address} returned {len(tags)} results "
                         f"for {len(writes)} requested writes"
@@ -558,8 +584,7 @@ class AllenBradleyPLC(BasePLC):
         return results_map
 
     async def _slc_write_one(self, driver: Any, address: str, value: Any) -> TagResult:
-        """One SLC data-file write; only per-tag driver errors stay per-tag — a
-        CommError is a whole-call failure and propagates to ``_write_tags``."""
+        """One SLC data-file write; same per-tag rule as ``_slc_read_one``."""
         try:
             result = await self._bounded("write", driver.write, (address, value))
             return tag_to_result(result, value_on_success=value, use_tag_value=False)
@@ -570,7 +595,10 @@ class AllenBradleyPLC(BasePLC):
         """One generic-CIP write, dispatched on the address form."""
         try:
             if address.startswith("Assembly"):
-                instance = int(address.split(":")[-1]) if ":" in address else 1
+                try:
+                    instance = int(address.split(":")[-1]) if ":" in address else 1
+                except ValueError:
+                    return _unsupported_cip_address(address)
                 result = await self._bounded(
                     "write",
                     driver.generic_message,
@@ -584,7 +612,10 @@ class AllenBradleyPLC(BasePLC):
                 return tag_to_result(result, value_on_success=value, use_tag_value=False)
 
             if address.startswith("Parameter"):
-                instance = int(address.split(":")[-1]) if ":" in address else 1
+                try:
+                    instance = int(address.split(":")[-1]) if ":" in address else 1
+                except ValueError:
+                    return _unsupported_cip_address(address)
                 result = await self._bounded(
                     "write",
                     driver.generic_message,
@@ -599,9 +630,12 @@ class AllenBradleyPLC(BasePLC):
 
             parts = address.split(":")
             if len(parts) >= 3:
-                class_code = int(parts[0], 16) if parts[0].startswith("0x") else int(parts[0])
-                instance = int(parts[1])
-                attribute = int(parts[2])
+                try:
+                    class_code = int(parts[0], 16) if parts[0].startswith("0x") else int(parts[0])
+                    instance = int(parts[1])
+                    attribute = int(parts[2])
+                except ValueError:
+                    return _unsupported_cip_address(address)
                 result = await self._bounded(
                     "write",
                     driver.generic_message,
@@ -614,8 +648,7 @@ class AllenBradleyPLC(BasePLC):
                 )
                 return tag_to_result(result, value_on_success=value, use_tag_value=False)
 
-            result = await self._bounded("write", driver.write, (address, value))
-            return tag_to_result(result, value_on_success=value, use_tag_value=False)
+            return _unsupported_cip_address(address)
         except PYCOMM3_TAG_ERRORS as e:
             return TagResult(error=classify_tag_error(e))
 
@@ -801,8 +834,13 @@ class AllenBradleyPLC(BasePLC):
                                     module_info = await asyncio.to_thread(driver.get_module_info, slot)
                                     if module_info:
                                         self._tags_cache.append(f"Module:{slot}")
+                            except (CommError, OSError) as e:
+                                await self._close_driver(driver, "read")
+                                raise PLCCommunicationError(
+                                    f"Tag discovery failed on Allen Bradley PLC at {self.ip_address}: {e}"
+                                ) from e
                             except Exception:
-                                pass
+                                pass  # an empty slot answers with an error reply
 
                         # PLC-specific tags (ControlLogix, CompactLogix via CIP)
                         elif product_type == "Programmable Logic Controller":
@@ -862,6 +900,11 @@ class AllenBradleyPLC(BasePLC):
                         # This would require parsing the CIP object list format
                         self.logger.debug("Successfully retrieved object list from device")
 
+                except (CommError, OSError) as e:
+                    await self._close_driver(driver, "read")
+                    raise PLCCommunicationError(
+                        f"Tag discovery failed on Allen Bradley PLC at {self.ip_address}: {e}"
+                    ) from e
                 except Exception as e:
                     self.logger.debug(f"Could not retrieve object list: {e}")
 
@@ -980,9 +1023,17 @@ class AllenBradleyPLC(BasePLC):
                     try:
                         program_name = await asyncio.to_thread(driver.get_plc_name)
                         info["program_name"] = program_name
+                    except PYCOMM3_EXCHANGE_ERRORS:
+                        raise
                     except Exception:
                         pass
 
+                except PYCOMM3_EXCHANGE_ERRORS as e:
+                    # A failed exchange on the channel driver: the stream is suspect.
+                    await self._close_driver(driver, "read")
+                    raise PLCCommunicationError(
+                        f"PLC info read failed on Allen Bradley PLC at {self.ip_address}: {e}"
+                    ) from e
                 except Exception as e:
                     self.logger.warning(f"Could not get detailed Logix PLC info: {e}")
 
@@ -1261,7 +1312,7 @@ class AllenBradleyPLC(BasePLC):
             "features": [
                 "Auto-detection of PLC type with fallback hierarchy",
                 "Multi-driver support with driver-specific optimizations",
-                "Enhanced device discovery with network scanning",
+                "Targeted unicast identity probes",
                 "Comprehensive tag reading/writing for all driver types",
                 "CIP object messaging for generic devices",
                 "SLC data file mapping with bit-level access",
@@ -1275,7 +1326,7 @@ class AllenBradleyPLC(BasePLC):
                 "I/O module configuration and diagnostics",
             ],
             "enhanced_capabilities": {
-                "discovery": "Multi-method device discovery including CIP broadcast and network scanning",
+                "discovery": "Unicast ListIdentity probes plus driver open attempts",
                 "tag_support": "Full tag support across all driver types with enhanced addressing",
                 "cip_messaging": "Complete CIP object messaging with service code support",
                 "error_handling": "Comprehensive error handling with driver-specific error codes",

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/error_text.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/error_text.py
@@ -35,9 +35,16 @@ _MISSING_TAG_PATTERNS = (
     "address out of range",  # 0xFF ext 0x2104
     "invalid symbol name",  # 0xFF ext 0x210A
     "request path for tag",  # packets stamp "Failed to build/create request path for tag"
+    "error parsing the tag passed to",  # slc_driver read()/write() address rejection
 )
 # logix_driver.py "Error encoding value" + cip/data_types.py "Error packing/unpacking ... as {type}"
-_ENCODE_PATTERNS = ("error encoding value", "error packing", "error unpacking")
+_ENCODE_PATTERNS = (
+    "error encoding value",
+    "error packing",
+    "error unpacking",
+    "unable to create a writable value",  # logix/slc write pack wrapper
+    "insufficient data for requested elements",  # array write with too few values
+)
 # The three type-refusal texts, verbatim - matched exactly so nothing else
 # mentioning types (e.g. "'NoneType' object ...") can drift in.
 _TYPE_PATTERNS = (
@@ -69,11 +76,16 @@ _SESSION_DEAD_PHRASES = (
 )
 
 
+# Config verdicts echo caller input (addresses, values); only text the classifier
+# could NOT attribute to the caller may testify about the session.
+_CONFIG_VERDICT_KINDS = frozenset({TagErrorKind.missing_tag, TagErrorKind.encode, TagErrorKind.type_mismatch})
+
+
 def session_dead_addresses(results) -> list:
     """Addresses whose error text says the SESSION died, not the address."""
     dead = []
     for address, result in results.items():
-        if result.error is not None:
+        if result.error is not None and result.error.kind not in _CONFIG_VERDICT_KINDS:
             if _matches(result.error.message.lower(), _SESSION_DEAD_PHRASES):
                 dead.append(address)
     return dead

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/error_text.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/error_text.py
@@ -1,0 +1,116 @@
+"""The Allen-Bradley backend's knowledge of pycomm3's error strings.
+
+Per-tag errors arrive as flattened TEXT (no exception type survives pycomm3's
+result pipeline; controller CIP statuses exist only as table strings), so
+classification is enumerated string matching by necessity. Every pattern is
+quoted from pycomm3 source. This is driver-specific vocabulary — the generic
+contract (``TagResult`` / ``TagError`` / ``TagErrorKind``) lives in
+``mindtrace.hardware.plcs.types``.
+
+One engine, two questions: ``classify_tag_error`` labels a failure for the
+caller; ``session_dead_addresses`` detects the statuses that oblige the
+backend to close the channel and raise.
+"""
+
+from typing import Any
+
+from mindtrace.hardware.plcs.types import TagError, TagErrorKind, TagResult
+
+
+def _matches(text: str, phrases: tuple) -> bool:
+    return any(phrase in text for phrase in phrases)
+
+
+# logix_driver.py parse/request errors + cip/status_info.py 0x04/0x05/0x16 and 0x210B rejections
+_MISSING_TAG_PATTERNS = (
+    "tag doesn't exist",
+    "does not exist",
+    "failed to parse tag request",
+    "invalid tag request",
+    "destination unknown",
+    "instance undefined",
+    "structure element undefined",
+    "ioi syntax error",
+    "access beyond end of the object",  # 0xFF ext 0x2105 - array index past the end (wrong station index)
+    "address out of range",  # 0xFF ext 0x2104
+    "invalid symbol name",  # 0xFF ext 0x210A
+    "request path for tag",  # packets stamp "Failed to build/create request path for tag"
+)
+# logix_driver.py "Error encoding value" + cip/data_types.py "Error packing/unpacking ... as {type}"
+_ENCODE_PATTERNS = ("error encoding value", "error packing", "error unpacking")
+# The three type-refusal texts, verbatim - matched exactly so nothing else
+# mentioning types (e.g. "'NoneType' object ...") can drift in.
+_TYPE_PATTERNS = (
+    "wrong data type",  # 0xFF ext 0x7
+    "does not match the target tag's data type",  # 0xFF ext 0x2107
+    "message unsupported data type",  # CIP 0xFC
+)
+# The stamped transport surface: statuses a DELIVERED reply can carry about the
+# session itself — CIP connection statuses (SERVICE_STATUS/EXTEND_CODES 0x01/0x07/
+# 0x0203/0x0204) and encapsulation session statuses.
+_TRANSIENT_PATTERNS = (
+    "insufficient resource",  # CIP 0x02 - controller busy
+    "insufficient packet space",  # CIP 0x06
+    "message timeout",  # CIP 0xFE - controller-side message timer
+    "invalid reply received",  # CIP 0x22 - garbled, this exchange only
+    "failed to parse reply",  # pycomm3 packet parse failure, stamped per packet
+    "connection timeout",  # CIP ext 0x0203 - timeout-flavored, tolerance rule
+    "unconnected message timeout",  # CIP ext 0x0204
+    "connection failure",  # CIP 0x01 - establishment family; cannot occur on the data path
+    "connection related failure",  # CIP 0x1F - same
+)
+
+
+# The ONLY documented statuses by which a DELIVERED reply positively states that
+# OUR session/connection is gone.(thus should be marked as session dead)
+_SESSION_DEAD_PHRASES = (
+    "connection lost",  # CIP 0x07 - the connection you were using is gone
+    "invalid session handle",  # encapsulation 0x0064 - your registration is gone
+)
+
+
+def session_dead_addresses(results) -> list:
+    """Addresses whose error text says the SESSION died, not the address."""
+    dead = []
+    for address, result in results.items():
+        if result.error is not None:
+            if _matches(result.error.message.lower(), _SESSION_DEAD_PHRASES):
+                dead.append(address)
+    return dead
+
+
+def classify_tag_error(message: Any) -> TagError:
+    """Map a driver error string onto a TagErrorKind, preserving the raw text.
+
+    Order: missing → transient → encode → type; transient before encode so
+    "Failed to parse reply - Error unpacking ..." reads as the reply corruption
+    it is, not a value problem. The residue is ``unknown``.
+    """
+    raw = str(message)
+    text = raw.lower()
+    if _matches(text, _MISSING_TAG_PATTERNS):
+        kind = TagErrorKind.missing_tag
+    elif _matches(text, _TRANSIENT_PATTERNS):
+        kind = TagErrorKind.transient
+    elif _matches(text, _ENCODE_PATTERNS):
+        kind = TagErrorKind.encode
+    elif _matches(text, _TYPE_PATTERNS):
+        kind = TagErrorKind.type_mismatch
+    else:
+        kind = TagErrorKind.unknown
+    return TagError(kind=kind, message=raw)
+
+
+def tag_to_result(tag: Any, value_on_success: Any = None, use_tag_value: bool = True) -> TagResult:
+    """Convert a driver's per-tag answer (a pycomm3 Tag or Tag-like object) to a TagResult."""
+    # None/False in place of a Tag: a failure with no self-description — ``unknown``,
+    # since nothing says the exchange failed.
+    if tag is None or tag is False:
+        return TagResult(error=TagError(kind=TagErrorKind.unknown, message=f"driver returned {tag!r}"))
+    error = getattr(tag, "error", None)
+    if error:
+        return TagResult(error=classify_tag_error(error))
+    return TagResult(value=getattr(tag, "value", tag) if use_tag_value else value_on_success)
+
+
+__all__ = ["classify_tag_error", "session_dead_addresses", "tag_to_result"]

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
@@ -578,65 +578,52 @@ class MockAllenBradleyPLC(BasePLC):
         """
         await self._channel("read")
 
-        try:
-            base_info = {
-                "name": self.plc_name,
-                "ip_address": self.ip_address,
-                "driver_type": self.driver_type,
-                "plc_type": self.plc_type,
-                "connected": self._ever_connected,
-                "read_channel_open": self._channels_open["read"],
-                "write_channel_open": self._channels_open["write"],
-                "mock": True,
-            }
+        base_info = {
+            "name": self.plc_name,
+            "ip_address": self.ip_address,
+            "driver_type": self.driver_type,
+            "plc_type": self.plc_type,
+            "connected": self._ever_connected,
+            "read_channel_open": self._channels_open["read"],
+            "write_channel_open": self._channels_open["write"],
+            "mock": True,
+        }
 
-            # Add driver-specific info
-            if self.driver_type == "LogixDriver":
-                base_info.update(
-                    {
-                        "product_name": "Mock ControlLogix 5580",
-                        "product_type": "Programmable Logic Controller",
-                        "vendor": "Mock Allen Bradley",
-                        "revision": "32.011",
-                        "serial": f"MOCK{hash(self.plc_name) % 10000:04d}",
-                        "program_name": "MockProgram",
-                    }
-                )
-            elif self.driver_type == "SLCDriver":
-                base_info.update(
-                    {
-                        "product_type": "Mock SLC 5/05 PLC",
-                        "vendor": "Mock Allen Bradley",
-                        "description": "Mock SLC500 series PLC",
-                        "processor": "SLC 5/05",
-                    }
-                )
-            elif self.driver_type == "CIPDriver":
-                base_info.update(
-                    {
-                        "product_name": "Mock PowerFlex 755",
-                        "product_type": "AC Drive",
-                        "vendor": "Mock Allen Bradley",
-                        "product_code": 55,
-                        "revision": {"major": 1, "minor": 1},
-                        "serial": f"MOCK{hash(self.ip_address) % 10000:04d}",
-                        "status": b"\x20\x00",  # Mock status word
-                    }
-                )
+        # Add driver-specific info
+        if self.driver_type == "LogixDriver":
+            base_info.update(
+                {
+                    "product_name": "Mock ControlLogix 5580",
+                    "product_type": "Programmable Logic Controller",
+                    "vendor": "Mock Allen Bradley",
+                    "revision": "32.011",
+                    "serial": f"MOCK{hash(self.plc_name) % 10000:04d}",
+                    "program_name": "MockProgram",
+                }
+            )
+        elif self.driver_type == "SLCDriver":
+            base_info.update(
+                {
+                    "product_type": "Mock SLC 5/05 PLC",
+                    "vendor": "Mock Allen Bradley",
+                    "description": "Mock SLC500 series PLC",
+                    "processor": "SLC 5/05",
+                }
+            )
+        elif self.driver_type == "CIPDriver":
+            base_info.update(
+                {
+                    "product_name": "Mock PowerFlex 755",
+                    "product_type": "AC Drive",
+                    "vendor": "Mock Allen Bradley",
+                    "product_code": 55,
+                    "revision": {"major": 1, "minor": 1},
+                    "serial": f"MOCK{hash(self.ip_address) % 10000:04d}",
+                    "status": b"\x20\x00",  # Mock status word
+                }
+            )
 
-            return base_info
-
-        except Exception as e:
-            self.logger.error(f"Mock failed to get PLC info: {e}")
-            return {
-                "name": self.plc_name,
-                "ip_address": self.ip_address,
-                "driver_type": self.driver_type,
-                "plc_type": self.plc_type,
-                "connected": False,
-                "error": str(e),
-                "mock": True,
-            }
+        return base_info
 
     @staticmethod
     def get_available_plcs() -> List[str]:

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
@@ -80,7 +80,6 @@ class MockAllenBradleyPLC(BasePLC):
         connection_timeout: Optional[float] = None,
         read_timeout: Optional[float] = None,
         write_timeout: Optional[float] = None,
-        retry_count: Optional[int] = None,
         retry_delay: Optional[float] = None,
     ):
         """
@@ -94,7 +93,6 @@ class MockAllenBradleyPLC(BasePLC):
             connection_timeout: Connection timeout in seconds
             read_timeout: Tag read timeout in seconds
             write_timeout: Tag write timeout in seconds
-            retry_count: Number of retry attempts
             retry_delay: Delay between retries in seconds
         """
         super().__init__(
@@ -104,7 +102,6 @@ class MockAllenBradleyPLC(BasePLC):
             connection_timeout=connection_timeout,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
-            retry_count=retry_count,
             retry_delay=retry_delay,
         )
 
@@ -112,6 +109,7 @@ class MockAllenBradleyPLC(BasePLC):
         self.driver_type = None
         # One flag per channel: reopening read must not report write as open.
         self._channels_open: Dict[str, bool] = {"read": False, "write": False}
+        self._ever_connected = False
         self._tag_values: Dict[str, Any] = {}
         self._tag_types: Dict[str, str] = {}
         self._cache_ttl = 300  # 5 minutes
@@ -139,10 +137,20 @@ class MockAllenBradleyPLC(BasePLC):
     def _is_connected(self, value: bool) -> None:
         self._channels_open = {channel: bool(value) for channel in self._channels_open}
 
-    def _channel(self, channel: str) -> None:
-        """Raise unless ``channel`` is open, like the real backend's channel guards."""
+    async def _channel(self, channel: str) -> None:
+        """Entry guard, like the real backend's: a never-connected channel is a
+        lifecycle error; one that died reopens here."""
+        if not self._ever_connected:
+            raise PLCConnectionError(
+                f"The {channel} channel to mock Allen Bradley PLC at {self.ip_address} was never opened - call connect()"
+            )
         if not self._channels_open[channel]:
-            raise PLCCommunicationError(f"Mock not connected to Allen Bradley PLC at {self.ip_address}")
+            if self.fail_connect:
+                raise PLCCommunicationError(f"Could not reopen the {channel} channel (simulated)")
+            self._channels_open[channel] = True
+            if channel == "read":
+                self.plc = self._tag_namespace()
+            self.logger.info(f"Mock reopened the {channel} channel to Allen Bradley PLC at {self.ip_address}")
 
     def _initialize_mock_data(self):
         """Initialize realistic mock tag data based on PLC type."""
@@ -341,6 +349,7 @@ class MockAllenBradleyPLC(BasePLC):
         await asyncio.sleep(0.05)  # Simulate connection delay
 
         self._is_connected = True
+        self._ever_connected = True
         self.plc = self._tag_namespace()
         self.logger.info(f"Mock connected to Allen Bradley PLC using {self.driver_type}")
         return True
@@ -366,26 +375,17 @@ class MockAllenBradleyPLC(BasePLC):
         """pycomm3-shaped tag definitions for the simulated controller tags."""
         return {name: {"tag_type": "atomic", "data_type": tag_type} for name, tag_type in self._tag_types.items()}
 
-    async def _reconnect_channel(self, channel: str) -> bool:
-        """Reopen ONE simulated channel; the other channel's state is untouched.
-
-        ``fail_connect`` still decides the outcome, which keeps the
-        failed-reconnect path testable.
-        """
-        if self.fail_connect:
-            raise PLCConnectionError(f"Simulated {channel} channel reconnect failure")
-
-        await self._resolve_driver_type()
-        self._channels_open[channel] = True
+    async def _close_channel(self, channel: str) -> None:
+        """Close ONE simulated channel; it reopens at the next call's entry."""
+        self._channels_open[channel] = False
         if channel == "read":
-            self.plc = self._tag_namespace()
-        self.logger.info(f"Mock reopened the {channel} channel to Allen Bradley PLC at {self.ip_address}")
-        return True
+            self.plc = None
 
     async def _disconnect(self) -> bool:
         """Simulate closing the connection."""
         await asyncio.sleep(0.01)  # Simulate disconnect delay
         self._is_connected = False
+        self._ever_connected = False
         self.plc = None
         self.initialized = False
         self.logger.info(f"Mock disconnected from Allen Bradley PLC at {self.ip_address}")
@@ -406,12 +406,12 @@ class MockAllenBradleyPLC(BasePLC):
             raise PLCTagReadError("Simulated tag read failure")
 
         if self.simulate_timeout:
-            # A real AB timeout surfaces as CommError -> PLCCommunicationError
-            # (retryable); the simulation must land in the same contract class.
+            # Chained from TimeoutError like the real thing: a timeout raises but
+            # is NOT proof of death, so it must not close the channel.
             await asyncio.sleep(self.read_timeout)
-            raise PLCCommunicationError("Simulated read timeout")
+            raise PLCCommunicationError("Simulated read timeout") from TimeoutError("simulated socket timeout")
 
-        self._channel("read")
+        await self._channel("read")
 
         # One batched exchange is one round trip: latency must not scale with
         # batch size, or a big poll starves other readers of the channel lock.
@@ -445,7 +445,7 @@ class MockAllenBradleyPLC(BasePLC):
         if self.fail_write:
             raise PLCTagWriteError("Simulated tag write failure")
 
-        self._channel("write")
+        await self._channel("write")
 
         await asyncio.sleep(self.io_delay_s)  # one round trip, batch-size independent
 
@@ -491,7 +491,7 @@ class MockAllenBradleyPLC(BasePLC):
         if self._tags_cache is not None and current_time - self._cache_timestamp < self._cache_ttl:
             return self._tags_cache
 
-        self._channel("read")
+        await self._channel("read")
 
         # Return available tags based on driver type
         try:
@@ -543,7 +543,7 @@ class MockAllenBradleyPLC(BasePLC):
         Returns:
             Dictionary with tag information
         """
-        self._channel("read")
+        await self._channel("read")
 
         try:
             if tag_name not in self._tag_values:
@@ -574,7 +574,7 @@ class MockAllenBradleyPLC(BasePLC):
         Returns:
             Dictionary with PLC information
         """
-        self._channel("read")
+        await self._channel("read")
 
         try:
             base_info = {

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
@@ -123,6 +123,7 @@ class MockAllenBradleyPLC(BasePLC):
         self.fail_read = os.getenv("MOCK_AB_FAIL_READ", "false").lower() == "true"
         self.fail_write = os.getenv("MOCK_AB_FAIL_WRITE", "false").lower() == "true"
         self.simulate_timeout = os.getenv("MOCK_AB_TIMEOUT", "false").lower() == "true"
+        self.io_delay_s = float(os.getenv("MOCK_AB_IO_DELAY_S", "0.002"))
 
         # Initialize simulated tag data
         self._initialize_mock_data()
@@ -412,7 +413,9 @@ class MockAllenBradleyPLC(BasePLC):
 
         self._channel("read")
 
-        await asyncio.sleep(0.01 * len(addresses))  # Simulate read delay
+        # One batched exchange is one round trip: latency must not scale with
+        # batch size, or a big poll starves other readers of the channel lock.
+        await asyncio.sleep(self.io_delay_s)
 
         results: Dict[str, TagResult] = {}
         for address in addresses:
@@ -444,7 +447,7 @@ class MockAllenBradleyPLC(BasePLC):
 
         self._channel("write")
 
-        await asyncio.sleep(0.01 * len(writes))  # Simulate write delay
+        await asyncio.sleep(self.io_delay_s)  # one round trip, batch-size independent
 
         results: Dict[str, TagResult] = {}
         for address, value in writes:

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
@@ -42,7 +42,6 @@ from mindtrace.hardware.core.exceptions import (
     PLCTagNotFoundError,
     PLCTagReadError,
     PLCTagWriteError,
-    PLCTimeoutError,
 )
 from mindtrace.hardware.plcs.backends.base import BasePLC
 from mindtrace.hardware.plcs.types import TagError, TagErrorKind, TagResult
@@ -406,8 +405,10 @@ class MockAllenBradleyPLC(BasePLC):
             raise PLCTagReadError("Simulated tag read failure")
 
         if self.simulate_timeout:
-            await asyncio.sleep(10)  # Simulate timeout
-            raise PLCTimeoutError("Simulated read timeout")
+            # A real AB timeout surfaces as CommError -> PLCCommunicationError
+            # (retryable); the simulation must land in the same contract class.
+            await asyncio.sleep(self.read_timeout)
+            raise PLCCommunicationError("Simulated read timeout")
 
         self._channel("read")
 

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
@@ -22,7 +22,7 @@ Usage:
 
     # Use exactly like real PLC
     await plc.connect()
-    tags = await plc.read_tag(["Motor1_Speed", "Conveyor_Status"])
+    results = await plc.read_tag(["Motor1_Speed", "Conveyor_Status"])
     await plc.write_tag([("Pump1_Command", True)])
     await plc.disconnect()
 """
@@ -31,7 +31,8 @@ import asyncio
 import os
 import random
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
 
 from mindtrace.hardware.core.exceptions import (
     PLCCommunicationError,
@@ -44,6 +45,10 @@ from mindtrace.hardware.core.exceptions import (
     PLCTimeoutError,
 )
 from mindtrace.hardware.plcs.backends.base import BasePLC
+from mindtrace.hardware.plcs.types import TagError, TagErrorKind, TagResult
+
+# Type check only: the conversion result is discarded, a rejection is type_mismatch.
+_COERCERS = {"BOOL": bool, "DINT": int, "REAL": float}
 
 
 class MockAllenBradleyPLC(BasePLC):
@@ -106,7 +111,8 @@ class MockAllenBradleyPLC(BasePLC):
 
         self.plc_type = plc_type or "auto"
         self.driver_type = None
-        self._is_connected = False
+        # One flag per channel: reopening read must not report write as open.
+        self._channels_open: Dict[str, bool] = {"read": False, "write": False}
         self._tag_values: Dict[str, Any] = {}
         self._tag_types: Dict[str, str] = {}
         self._cache_ttl = 300  # 5 minutes
@@ -123,6 +129,20 @@ class MockAllenBradleyPLC(BasePLC):
         self._initialize_mock_data()
 
         self.logger.info(f"Mock Allen Bradley PLC initialized: plc_type={self.plc_type}, ip_address={self.ip_address}")
+
+    @property
+    def _is_connected(self) -> bool:
+        """Connected means BOTH simulated channels are open, as on the real backend."""
+        return all(self._channels_open.values())
+
+    @_is_connected.setter
+    def _is_connected(self, value: bool) -> None:
+        self._channels_open = {channel: bool(value) for channel in self._channels_open}
+
+    def _channel(self, channel: str) -> None:
+        """Raise unless ``channel`` is open, like the real backend's channel guards."""
+        if not self._channels_open[channel]:
+            raise PLCCommunicationError(f"Mock not connected to Allen Bradley PLC at {self.ip_address}")
 
     def _initialize_mock_data(self):
         """Initialize realistic mock tag data based on PLC type."""
@@ -309,68 +329,67 @@ class MockAllenBradleyPLC(BasePLC):
         await asyncio.sleep(0.1)
         return detected_type
 
-    async def connect(self) -> bool:
-        """
-        Simulate connection to the Allen Bradley PLC.
-
-        Returns:
-            True if connection successful, False otherwise
-        """
+    async def _connect(self) -> bool:
+        """Simulate opening the connection. Single attempt, raises on failure."""
         if self.fail_connect:
             raise PLCConnectionError("Simulated connection failure")
 
         self.logger.info(f"Mock connecting to Allen Bradley PLC at {self.ip_address}")
 
-        # Determine driver type
+        await self._resolve_driver_type()
+
+        await asyncio.sleep(0.05)  # Simulate connection delay
+
+        self._is_connected = True
+        self.plc = self._tag_namespace()
+        self.logger.info(f"Mock connected to Allen Bradley PLC using {self.driver_type}")
+        return True
+
+    async def _resolve_driver_type(self) -> None:
+        """Pin ``driver_type`` from ``plc_type``, auto-detecting once if needed."""
         if self.plc_type == "auto":
-            detected_type = await self._detect_plc_type()
-            self.plc_type = detected_type
+            self.plc_type = await self._detect_plc_type()
 
-        for attempt in range(self.retry_count):
-            try:
-                # Simulate connection delay
-                await asyncio.sleep(0.05 * (attempt + 1))
+        if self.plc_type == "logix":
+            self.driver_type = "LogixDriver"
+        elif self.plc_type == "slc":
+            self.driver_type = "SLCDriver"
+        else:  # cip or fallback
+            self.driver_type = "CIPDriver"
 
-                # Set driver type based on PLC type
-                if self.plc_type == "logix":
-                    self.driver_type = "LogixDriver"
-                elif self.plc_type == "slc":
-                    self.driver_type = "SLCDriver"
-                else:  # cip or fallback
-                    self.driver_type = "CIPDriver"
+    def _tag_namespace(self) -> SimpleNamespace:
+        """Mirrors the real backend's ``plc`` read-driver alias, which downstream code
+        reads as ``plc.plc.tags``; only a Logix controller uploads a tag database."""
+        return SimpleNamespace(tags=self._tag_structure() if self.driver_type == "LogixDriver" else {})
 
-                # Simulate successful connection
-                self._is_connected = True
-                self.logger.info(f"Mock successfully connected to Allen Bradley PLC using {self.driver_type}")
-                return True
+    def _tag_structure(self) -> Dict[str, Dict[str, Any]]:
+        """pycomm3-shaped tag definitions for the simulated controller tags."""
+        return {name: {"tag_type": "atomic", "data_type": tag_type} for name, tag_type in self._tag_types.items()}
 
-            except Exception as e:
-                self.logger.warning(f"Mock connection attempt {attempt + 1} failed: {e}")
-                if attempt < self.retry_count - 1:
-                    await asyncio.sleep(self.retry_delay)
-                else:
-                    raise PLCConnectionError(
-                        f"Mock failed to connect to Allen Bradley PLC at {self.ip_address} after {self.retry_count} attempts"
-                    )
+    async def _reconnect_channel(self, channel: str) -> bool:
+        """Reopen ONE simulated channel; the other channel's state is untouched.
 
-        return False
-
-    async def disconnect(self) -> bool:
+        ``fail_connect`` still decides the outcome, which keeps the
+        failed-reconnect path testable.
         """
-        Simulate disconnection from the Allen Bradley PLC.
+        if self.fail_connect:
+            raise PLCConnectionError(f"Simulated {channel} channel reconnect failure")
 
-        Returns:
-            True if disconnection successful, False otherwise
-        """
-        try:
-            await asyncio.sleep(0.01)  # Simulate disconnect delay
-            self._is_connected = False
-            self.initialized = False
-            self.logger.info(f"Mock disconnected from Allen Bradley PLC at {self.ip_address}")
-            return True
-        except Exception as e:
-            self.logger.error(f"Mock disconnection error: {e}")
-            return False
+        await self._resolve_driver_type()
+        self._channels_open[channel] = True
+        if channel == "read":
+            self.plc = self._tag_namespace()
+        self.logger.info(f"Mock reopened the {channel} channel to Allen Bradley PLC at {self.ip_address}")
+        return True
+
+    async def _disconnect(self) -> bool:
+        """Simulate closing the connection."""
+        await asyncio.sleep(0.01)  # Simulate disconnect delay
+        self._is_connected = False
+        self.plc = None
+        self.initialized = False
+        self.logger.info(f"Mock disconnected from Allen Bradley PLC at {self.ip_address}")
+        return True
 
     async def is_connected(self) -> bool:
         """
@@ -381,16 +400,8 @@ class MockAllenBradleyPLC(BasePLC):
         """
         return self._is_connected
 
-    async def read_tag(self, tags: Union[str, List[str]]) -> Dict[str, Any]:
-        """
-        Simulate reading values from Allen Bradley PLC tags.
-
-        Args:
-            tags: Single tag name or list of tag names
-
-        Returns:
-            Dictionary mapping tag names to their values
-        """
+    async def _read_tags(self, addresses: List[str]) -> Dict[str, TagResult]:
+        """Simulate a batched read; unknown addresses come back as missing_tag."""
         if self.fail_read:
             raise PLCTagReadError("Simulated tag read failure")
 
@@ -398,121 +409,72 @@ class MockAllenBradleyPLC(BasePLC):
             await asyncio.sleep(10)  # Simulate timeout
             raise PLCTimeoutError("Simulated read timeout")
 
-        if not self._is_connected:
-            raise PLCCommunicationError(f"Mock not connected to Allen Bradley PLC at {self.ip_address}")
+        self._channel("read")
 
-        try:
-            if isinstance(tags, str):
-                tag_list = [tags]
-            else:
-                tag_list = tags
+        await asyncio.sleep(0.01 * len(addresses))  # Simulate read delay
 
-            # Simulate read delay
-            await asyncio.sleep(0.01 * len(tag_list))
+        results: Dict[str, TagResult] = {}
+        for address in addresses:
+            if address not in self._tag_values:
+                results[address] = TagResult(
+                    error=TagError(
+                        kind=TagErrorKind.missing_tag,
+                        message=f"Tag '{address}' does not exist on mock {self.driver_type}",
+                    )
+                )
+                continue
+            results[address] = TagResult(value=self._simulated_value(address))
+        return results
 
-            # Prepare results
-            tag_values = {}
+    def _simulated_value(self, address: str) -> Any:
+        """Stored value, with +/-2% drift on sensor-like tags to mimic live data."""
+        value = self._tag_values[address]
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            if any(keyword in address.lower() for keyword in ["temp", "pressure", "speed", "level"]):
+                drifted = value + value * 0.02 * (random.random() - 0.5)
+                value = int(drifted) if isinstance(value, int) else drifted
+                self._tag_values[address] = value
+        return value
 
-            for tag_name in tag_list:
-                if tag_name in self._tag_values:
-                    value = self._tag_values[tag_name]
-
-                    # Add some realistic variation to certain tags
-                    if isinstance(value, (int, float)) and any(
-                        keyword in tag_name.lower() for keyword in ["temp", "pressure", "speed", "level"]
-                    ):
-                        # Add ±2% random variation to simulate real sensor data
-                        variation = value * 0.02 * (random.random() - 0.5)
-                        value = value + variation
-                        if isinstance(self._tag_values[tag_name], int):
-                            value = int(value)
-                        # Update stored value for consistency
-                        self._tag_values[tag_name] = value
-
-                    tag_values[tag_name] = value
-                else:
-                    # Tag not found - different behavior per driver type
-                    if self.driver_type == "LogixDriver":
-                        self.logger.warning(f"Mock tag '{tag_name}' not found in Logix PLC")
-                        tag_values[tag_name] = None
-                    elif self.driver_type == "SLCDriver":
-                        # SLC might return 0 for non-existent addresses
-                        self.logger.warning(f"Mock SLC address '{tag_name}' not configured, returning 0")
-                        tag_values[tag_name] = 0
-                    else:  # CIP
-                        self.logger.warning(f"Mock CIP object '{tag_name}' not available")
-                        tag_values[tag_name] = None
-
-            return tag_values
-
-        except Exception as e:
-            self.logger.error(f"Mock failed to read tags: {e}")
-            raise PLCTagReadError(f"Mock failed to read tags from Allen Bradley PLC: {e}")
-
-    async def write_tag(self, tags: Union[Tuple[str, Any], List[Tuple[str, Any]]]) -> Dict[str, bool]:
-        """
-        Simulate writing values to Allen Bradley PLC tags.
-
-        Args:
-            tags: Single (tag_name, value) tuple or list of tuples
-
-        Returns:
-            Dictionary mapping tag names to write success status
-        """
+    async def _write_tags(self, writes: List[Tuple[str, Any]]) -> Dict[str, TagResult]:
+        """Simulate a batched write; unknown addresses come back as missing_tag."""
         if self.fail_write:
             raise PLCTagWriteError("Simulated tag write failure")
 
-        if not self._is_connected:
-            raise PLCCommunicationError(f"Mock not connected to Allen Bradley PLC at {self.ip_address}")
+        self._channel("write")
 
-        try:
-            if isinstance(tags, tuple):
-                tag_list = [tags]
-            else:
-                tag_list = tags
+        await asyncio.sleep(0.01 * len(writes))  # Simulate write delay
 
-            # Simulate write delay
-            await asyncio.sleep(0.01 * len(tag_list))
+        results: Dict[str, TagResult] = {}
+        for address, value in writes:
+            if address not in self._tag_values:
+                results[address] = TagResult(
+                    error=TagError(
+                        kind=TagErrorKind.missing_tag,
+                        message=f"Tag '{address}' does not exist on mock {self.driver_type}",
+                    )
+                )
+                continue
 
-            # Prepare results
-            write_status = {}
+            expected_type = self._tag_types.get(address, "UNKNOWN")
+            try:
+                # Type check only: the real backend returns the caller's value, so
+                # the mock must not substitute a coerced one.
+                _COERCERS.get(expected_type, lambda v: v)(value)
+            except (ValueError, TypeError) as e:
+                results[address] = TagResult(
+                    error=TagError(
+                        kind=TagErrorKind.type_mismatch,
+                        message=f"Value {value!r} is not compatible with tag type {expected_type}: {e}",
+                    )
+                )
+                continue
 
-            for tag_name, value in tag_list:
-                if tag_name in self._tag_values:
-                    # Validate value type based on tag type
-                    expected_type = self._tag_types.get(tag_name, "UNKNOWN")
+            self._tag_values[address] = value
+            results[address] = TagResult(value=value)
+        return results
 
-                    try:
-                        # Type validation and conversion
-                        if expected_type == "BOOL":
-                            value = bool(value)
-                        elif expected_type == "DINT":
-                            value = int(value)
-                        elif expected_type == "REAL":
-                            value = float(value)
-
-                        # Update stored value
-                        self._tag_values[tag_name] = value
-                        write_status[tag_name] = True
-
-                        self.logger.debug(f"Mock wrote {tag_name} = {value}")
-
-                    except (ValueError, TypeError) as e:
-                        self.logger.warning(f"Mock type conversion failed for {tag_name}: {e}")
-                        write_status[tag_name] = False
-
-                else:
-                    # Tag doesn't exist
-                    self.logger.warning(f"Mock tag '{tag_name}' not found for writing")
-                    write_status[tag_name] = False
-
-            return write_status
-
-        except Exception as e:
-            self.logger.error(f"Mock failed to write tags: {e}")
-            raise PLCTagWriteError(f"Mock failed to write tags to Allen Bradley PLC: {e}")
-
-    async def get_all_tags(self) -> List[str]:
+    async def _get_all_tags(self) -> List[str]:
         """
         Get list of all available mock tags.
 
@@ -525,8 +487,7 @@ class MockAllenBradleyPLC(BasePLC):
         if self._tags_cache is not None and current_time - self._cache_timestamp < self._cache_ttl:
             return self._tags_cache
 
-        if not self._is_connected:
-            raise PLCCommunicationError(f"Mock not connected to Allen Bradley PLC at {self.ip_address}")
+        self._channel("read")
 
         # Return available tags based on driver type
         try:
@@ -568,7 +529,7 @@ class MockAllenBradleyPLC(BasePLC):
             self.logger.error(f"Mock failed to get tags: {e}")
             raise PLCTagError(f"Mock failed to get tags from Allen Bradley PLC: {e}")
 
-    async def get_tag_info(self, tag_name: str) -> Dict[str, Any]:
+    async def _get_tag_info(self, tag_name: str) -> Dict[str, Any]:
         """
         Get detailed information about a mock tag.
 
@@ -578,8 +539,7 @@ class MockAllenBradleyPLC(BasePLC):
         Returns:
             Dictionary with tag information
         """
-        if not self._is_connected:
-            raise PLCCommunicationError(f"Mock not connected to Allen Bradley PLC at {self.ip_address}")
+        self._channel("read")
 
         try:
             if tag_name not in self._tag_values:
@@ -603,15 +563,14 @@ class MockAllenBradleyPLC(BasePLC):
             self.logger.error(f"Mock failed to get tag info: {e}")
             raise PLCTagError(f"Mock failed to get tag info from Allen Bradley PLC: {e}")
 
-    async def get_plc_info(self) -> Dict[str, Any]:
+    async def _get_plc_info(self) -> Dict[str, Any]:
         """
         Get detailed information about the mock PLC.
 
         Returns:
             Dictionary with PLC information
         """
-        if not self._is_connected:
-            raise PLCCommunicationError(f"Mock not connected to Allen Bradley PLC at {self.ip_address}")
+        self._channel("read")
 
         try:
             base_info = {
@@ -743,7 +702,7 @@ class MockAllenBradleyPLC(BasePLC):
                 "Multi-driver type support",
                 "Error simulation capabilities",
                 "Deterministic behavior for testing",
-                "Type validation and conversion",
+                "Type validation without silent coercion",
                 "Connection state management",
                 "Comprehensive logging",
             ],

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
@@ -42,6 +42,7 @@ from mindtrace.hardware.core.exceptions import (
     PLCTagNotFoundError,
     PLCTagReadError,
     PLCTagWriteError,
+    PLCTimeoutError,
 )
 from mindtrace.hardware.plcs.backends.base import BasePLC
 from mindtrace.hardware.plcs.types import TagError, TagErrorKind, TagResult
@@ -392,13 +393,9 @@ class MockAllenBradleyPLC(BasePLC):
         return True
 
     async def is_connected(self) -> bool:
-        """
-        Check if mock Allen Bradley PLC is currently connected.
-
-        Returns:
-            True if connected, False otherwise
-        """
-        return self._is_connected
+        """In the connected LIFECYCLE state, as on the real backend: a channel
+        closed on proof reopens at the next call's entry and does not count."""
+        return self._ever_connected
 
     async def _read_tags(self, addresses: List[str]) -> Dict[str, TagResult]:
         """Simulate a batched read; unknown addresses come back as missing_tag."""
@@ -406,10 +403,12 @@ class MockAllenBradleyPLC(BasePLC):
             raise PLCTagReadError("Simulated tag read failure")
 
         if self.simulate_timeout:
-            # Chained from TimeoutError like the real thing: a timeout raises but
-            # is NOT proof of death, so it must not close the channel.
+            # Chained from TimeoutError like the real thing. A timed-out exchange
+            # leaves the reply stream misaligned, so the channel closes and
+            # reopens at the next call's entry.
             await asyncio.sleep(self.read_timeout)
-            raise PLCCommunicationError("Simulated read timeout") from TimeoutError("simulated socket timeout")
+            await self._close_channel("read")
+            raise PLCTimeoutError("Simulated read timeout") from TimeoutError("simulated socket timeout")
 
         await self._channel("read")
 
@@ -582,7 +581,9 @@ class MockAllenBradleyPLC(BasePLC):
                 "ip_address": self.ip_address,
                 "driver_type": self.driver_type,
                 "plc_type": self.plc_type,
-                "connected": self._is_connected,
+                "connected": self._ever_connected,
+                "read_channel_open": self._channels_open["read"],
+                "write_channel_open": self._channels_open["write"],
                 "mock": True,
             }
 

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/allen_bradley/mock_allen_bradley.py
@@ -399,18 +399,16 @@ class MockAllenBradleyPLC(BasePLC):
 
     async def _read_tags(self, addresses: List[str]) -> Dict[str, TagResult]:
         """Simulate a batched read; unknown addresses come back as missing_tag."""
+        await self._channel("read")
+
         if self.fail_read:
             raise PLCTagReadError("Simulated tag read failure")
 
         if self.simulate_timeout:
-            # Chained from TimeoutError like the real thing. A timed-out exchange
-            # leaves the reply stream misaligned, so the channel closes and
-            # reopens at the next call's entry.
+            # Chained from TimeoutError like the real thing: closes, reopens at entry.
             await asyncio.sleep(self.read_timeout)
             await self._close_channel("read")
             raise PLCTimeoutError("Simulated read timeout") from TimeoutError("simulated socket timeout")
-
-        await self._channel("read")
 
         # One batched exchange is one round trip: latency must not scale with
         # batch size, or a big poll starves other readers of the channel lock.
@@ -441,10 +439,15 @@ class MockAllenBradleyPLC(BasePLC):
 
     async def _write_tags(self, writes: List[Tuple[str, Any]]) -> Dict[str, TagResult]:
         """Simulate a batched write; unknown addresses come back as missing_tag."""
+        await self._channel("write")
+
         if self.fail_write:
             raise PLCTagWriteError("Simulated tag write failure")
 
-        await self._channel("write")
+        if self.simulate_timeout:
+            await asyncio.sleep(self.write_timeout)
+            await self._close_channel("write")
+            raise PLCTimeoutError("Simulated write timeout") from TimeoutError("simulated socket timeout")
 
         await asyncio.sleep(self.io_delay_s)  # one round trip, batch-size independent
 

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/base.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/base.py
@@ -4,40 +4,25 @@ Transport contract — every ``read_tag`` / ``write_tag`` outcome is one of:
 
 - ``{addr: value}``: it worked.
 - ``{addr: error}``: that ADDRESS is wrong — a stable verdict; retrying is pointless.
-- raises ``PLCCommunicationError``: the LINK is sick; already retried
-  ``retry_count`` times with a channel reconnect between attempts.
-- raises ``PLCTagError``: the REQUEST is wrong; never retried.
+- raises ``PLCCommunicationError``: the LINK failed this call. One attempt, no
+  retry — re-issuing is the caller's job. The BACKEND closes its channel only on
+  PROOF the session is dead (a wire-dead exception class, or a delivered reply
+  carrying connection/session error statuses) and reopens it at the next call's
+  entry. Timeouts and garbled replies raise but keep the session.
+- raises ``PLCTagError``: the REQUEST is wrong; the session is fine.
 
-Link trouble never appears in a returned map: pycomm3 stamps a failed packet
-exchange onto that packet's tags instead of raising, so any transport-kind entry
-is promoted here into the retry loop and, past the budget, into the raise (the
-partial map rides on ``.results``). Access is serialized per channel (read/write
-locks); the first retry on a still-connected session skips the reconnect.
+Link trouble never appears in a returned map — a BACKEND OBLIGATION: detect
+session-dead statuses on the raw driver text, close the channel, raise. Access
+is serialized per channel (read/write locks); that is all this base adds.
 """
 
 import asyncio
 from abc import abstractmethod
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from mindtrace.core import MindtraceABC
 from mindtrace.hardware.core.config import get_hardware_config
-from mindtrace.hardware.core.exceptions import PLCCommunicationError
-from mindtrace.hardware.plcs.types import TagErrorKind, TagResult
-
-
-def _transport_failures(results: Optional[Dict[str, TagResult]]) -> List[str]:
-    """Addresses whose error says the exchange failed, not that the address is wrong.
-
-    One is enough to condemn the call: pycomm3 stamps a failed packet onto every
-    tag it carried, and stamped entries escalate instead of being returned.
-    """
-    if not results:
-        return []
-    return [
-        address
-        for address, result in results.items()
-        if result.error is not None and result.error.kind is TagErrorKind.transport
-    ]
+from mindtrace.hardware.plcs.types import TagResult
 
 
 class BasePLC(MindtraceABC):
@@ -50,7 +35,6 @@ class BasePLC(MindtraceABC):
         connection_timeout: Connection timeout in seconds
         read_timeout: Tag read timeout in seconds
         write_timeout: Tag write timeout in seconds
-        retry_count: Number of retry attempts for operations
         retry_delay: Delay between retry attempts in seconds
         plc: The underlying PLC connection object (read channel, where applicable)
         device_manager: Device-specific manager instance
@@ -65,7 +49,6 @@ class BasePLC(MindtraceABC):
         connection_timeout: Optional[float] = None,
         read_timeout: Optional[float] = None,
         write_timeout: Optional[float] = None,
-        retry_count: Optional[int] = None,
         retry_delay: Optional[float] = None,
     ):
         """
@@ -78,7 +61,6 @@ class BasePLC(MindtraceABC):
             connection_timeout: Connection timeout in seconds
             read_timeout: Tag read timeout in seconds
             write_timeout: Tag write timeout in seconds
-            retry_count: Number of retry attempts
             retry_delay: Delay between retries in seconds
         """
         super().__init__()
@@ -92,7 +74,6 @@ class BasePLC(MindtraceABC):
         self.connection_timeout = connection_timeout or config.plcs.connection_timeout
         self.read_timeout = read_timeout or config.plcs.read_timeout
         self.write_timeout = write_timeout or config.plcs.write_timeout
-        self.retry_count = retry_count or config.plcs.retry_count
         self.retry_delay = retry_delay or config.plcs.retry_delay
 
         self.plc = None
@@ -134,7 +115,7 @@ class BasePLC(MindtraceABC):
     # --- Public API: takes the lock, delegates to the backend implementation ---
 
     async def read_tag(self, tags: Union[str, List[str]]) -> Dict[str, TagResult]:
-        """Read tags on the read channel, recovering the channel if it fails.
+        """Read tags on the read channel; a channel closed on proof reopens at entry.
 
         Address verdicts land in the results, keyed by address — a repeated address
         collapses to its last result. Link trouble raises; see the module
@@ -142,10 +123,10 @@ class BasePLC(MindtraceABC):
         """
         batch = [tags] if isinstance(tags, str) else list(tags)
         async with self._read_lock:
-            return await self._run_with_recovery("read", lambda: self._read_tags(list(batch)))
+            return await self._read_tags(list(batch))
 
     async def write_tag(self, tags: Union[Tuple[str, Any], List[Tuple[str, Any]]]) -> Dict[str, TagResult]:
-        """Write tags on the write channel, recovering the channel if it fails.
+        """Write tags on the write channel; a channel closed on proof reopens at entry.
 
         Address verdicts land in the results, keyed by address — a repeated address
         collapses to its last result, though every write is still issued. Link
@@ -153,93 +134,7 @@ class BasePLC(MindtraceABC):
         """
         batch = [tags] if isinstance(tags, tuple) else list(tags)
         async with self._write_lock:
-            return await self._run_with_recovery("write", lambda: self._write_tags(list(batch)))
-
-    # --- In-transport recovery: bounded retry + channel-scoped reconnect ---
-
-    async def _run_with_recovery(
-        self, channel: str, operation: Callable[[], Awaitable[Dict[str, TagResult]]]
-    ) -> Dict[str, TagResult]:
-        """Attempt ``operation`` up to ``retry_count`` times, resetting ``channel`` between tries.
-
-        Transport-class = a raised ``PLCCommunicationError`` or a batch carrying
-        any transport-kind result; anything else propagates on attempt 1. The
-        caller holds this channel's lock, so recovery uses ``_reconnect_channel``
-        — never the public ``reconnect`` (both locks: deadlock).
-        """
-        attempts = max(1, int(self.retry_count or 1))
-        last_error: Optional[PLCCommunicationError] = None
-        results: Optional[Dict[str, TagResult]] = None
-        stamped: List[str] = []
-
-        for attempt in range(1, attempts + 1):
-            try:
-                results = await operation()
-            except PLCCommunicationError as error:
-                last_error, results, stamped = error, None, []
-            else:
-                last_error = None
-                stamped = _transport_failures(results)
-                if not stamped:
-                    return results
-                self.logger.warning(
-                    f"{self.plc_name} {channel} channel stamped {len(stamped)}/{len(results)} "
-                    f"results with transport errors"
-                )
-
-            if attempt == attempts:
-                break
-
-            await asyncio.sleep(self.retry_delay)
-
-            # The first retry on a session the driver still calls open is free:
-            # bouncing it would turn one hiccup into a torn-down socket. After
-            # that the session is lying, so reset it.
-            if attempt == 1 and await self.is_connected():
-                continue
-
-            # A failed reconnect is logged, never fatal: the next attempt fails fast
-            # into another reconnect or the exhausted raise.
-            self.logger.info(f"{self.plc_name} {channel} channel reconnect attempt")
-            try:
-                if await self._reconnect_channel(channel):
-                    self.logger.info(f"{self.plc_name} {channel} channel reconnect ok")
-                    continue
-                detail = " (channel did not reopen)"
-            except Exception as error:
-                detail = f" ({error})"
-            self.logger.warning(f"{self.plc_name} {channel} channel reconnect failed{detail}")
-
-        if last_error is not None:
-            # A fresh PLCCommunicationError, not type(last_error)(...): subclass
-            # constructors differ. Chained to the original driver cause.
-            cause = last_error.__cause__ or last_error
-            raise PLCCommunicationError(f"{last_error} (attempts={attempts})") from cause
-        if stamped:
-            # Stamped entries are transient (and, for writes, ambiguous: the
-            # request may have executed with only the reply lost) — returning them
-            # would reintroduce retryable map errors. Raise, partial map attached.
-            message = (
-                f"{self.plc_name} {channel} channel failed on {len(stamped)}/{len(results or {})} tags: "
-                f"{(results or {})[stamped[0]].error.message} (attempts={attempts})"
-            )
-            error = PLCCommunicationError(message)
-            error.results = results  # type: ignore[attr-defined]
-            error.transport_addresses = tuple(stamped)  # type: ignore[attr-defined]
-            raise error
-        return results if results is not None else {}
-
-    @abstractmethod
-    async def _reconnect_channel(self, channel: str) -> bool:
-        """Reset ONLY this channel's transport; ``channel`` is "read" or "write".
-
-        The caller holds this channel's lock — never call the public
-        ``reconnect``/``connect``/``disconnect`` from here. A backend whose
-        channels share one driver cannot reset it safely mid-call and should
-        return ``False`` (recovery then retries and raises honestly; healing
-        happens via the explicit public ``reconnect``).
-        """
-        pass
+            return await self._write_tags(list(batch))
 
     async def get_plc_info(self) -> Dict[str, Any]:
         """Controller identity/status. Probes share the read channel by design."""

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/base.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/base.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from mindtrace.core import MindtraceABC
 from mindtrace.hardware.core.config import get_hardware_config
+from mindtrace.hardware.core.exceptions import PLCTagWriteError
 from mindtrace.hardware.plcs.types import TagResult
 
 
@@ -135,6 +136,11 @@ class BasePLC(MindtraceABC):
         trouble raises; see the module docstring's table.
         """
         batch = [tags] if isinstance(tags, tuple) else list(tags)
+        for entry in batch:
+            # Rejecting the shape here keeps PLCTagWriteError's promise: nothing
+            # malformed ever reaches the wire. Lists count as pairs (JSON callers).
+            if not (isinstance(entry, (tuple, list)) and len(entry) == 2):
+                raise PLCTagWriteError(f"write_tag takes (address, value) pairs; got {entry!r}")
         async with self._write_lock:
             return await self._write_tags(list(batch))
 

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/base.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/base.py
@@ -1,18 +1,18 @@
 """Abstract base class for PLC backends.
 
-Transport contract, enforced here so every backend inherits it:
+Transport contract — every ``read_tag`` / ``write_tag`` outcome is one of:
 
-- Access is serialized on two channels, read and write. Public methods take the
-  lock; backends implement the underscore-prefixed bodies and run alone on their
-  channel.
-- Per-tag failures are reported as ``TagResult.error``, never as a sentinel value.
-- Whole-call failures raise typed exceptions from
-  ``mindtrace.hardware.core.exceptions``: ``PLCCommunicationError`` when
-  reconnecting the channel can plausibly fix it, ``PLCTagReadError`` /
-  ``PLCTagWriteError`` when it cannot (malformed request, programming error).
-- ``read_tag`` / ``write_tag`` retry transport-class failures up to
-  ``retry_count`` times, reconnecting THAT channel only between attempts. Nothing
-  else reconnects behind the caller's back.
+- ``{addr: value}``: it worked.
+- ``{addr: error}``: that ADDRESS is wrong — a stable verdict; retrying is pointless.
+- raises ``PLCCommunicationError``: the LINK is sick; already retried
+  ``retry_count`` times with a channel reconnect between attempts.
+- raises ``PLCTagError``: the REQUEST is wrong; never retried.
+
+Link trouble never appears in a returned map: pycomm3 stamps a failed packet
+exchange onto that packet's tags instead of raising, so any transport-kind entry
+is promoted here into the retry loop and, past the budget, into the raise (the
+partial map rides on ``.results``). Access is serialized per channel (read/write
+locks); the first retry on a still-connected session skips the reconnect.
 """
 
 import asyncio
@@ -25,12 +25,19 @@ from mindtrace.hardware.core.exceptions import PLCCommunicationError
 from mindtrace.hardware.plcs.types import TagErrorKind, TagResult
 
 
-def _is_wedged(results: Optional[Dict[str, TagResult]]) -> bool:
-    """True when EVERY tag in a non-empty batch failed at transport level: a sick
-    socket, not a batch of bad addresses."""
+def _transport_failures(results: Optional[Dict[str, TagResult]]) -> List[str]:
+    """Addresses whose error says the exchange failed, not that the address is wrong.
+
+    One is enough to condemn the call: pycomm3 stamps a failed packet onto every
+    tag it carried, and stamped entries escalate instead of being returned.
+    """
     if not results:
-        return False
-    return all(result.error is not None and result.error.kind is TagErrorKind.transport for result in results.values())
+        return []
+    return [
+        address
+        for address, result in results.items()
+        if result.error is not None and result.error.kind is TagErrorKind.transport
+    ]
 
 
 class BasePLC(MindtraceABC):
@@ -129,8 +136,9 @@ class BasePLC(MindtraceABC):
     async def read_tag(self, tags: Union[str, List[str]]) -> Dict[str, TagResult]:
         """Read tags on the read channel, recovering the channel if it fails.
 
-        Per-tag failures land in the results, keyed by address — a repeated address
-        collapses to its last result.
+        Address verdicts land in the results, keyed by address — a repeated address
+        collapses to its last result. Link trouble raises; see the module
+        docstring's table.
         """
         batch = [tags] if isinstance(tags, str) else list(tags)
         async with self._read_lock:
@@ -139,8 +147,9 @@ class BasePLC(MindtraceABC):
     async def write_tag(self, tags: Union[Tuple[str, Any], List[Tuple[str, Any]]]) -> Dict[str, TagResult]:
         """Write tags on the write channel, recovering the channel if it fails.
 
-        Per-tag failures land in the results, keyed by address — a repeated address
-        collapses to its last result, though every write is still issued.
+        Address verdicts land in the results, keyed by address — a repeated address
+        collapses to its last result, though every write is still issued. Link
+        trouble raises; see the module docstring's table.
         """
         batch = [tags] if isinstance(tags, tuple) else list(tags)
         async with self._write_lock:
@@ -153,27 +162,29 @@ class BasePLC(MindtraceABC):
     ) -> Dict[str, TagResult]:
         """Attempt ``operation`` up to ``retry_count`` times, resetting ``channel`` between tries.
 
-        A transport-class failure is a raised ``PLCCommunicationError`` or a batch
-        in which every tag failed at transport level; anything else propagates on
-        the first attempt. The caller holds this channel's lock, so recovery goes
-        through ``_reconnect_channel`` — never the public ``reconnect``, which
-        takes both locks and would deadlock here.
+        Transport-class = a raised ``PLCCommunicationError`` or a batch carrying
+        any transport-kind result; anything else propagates on attempt 1. The
+        caller holds this channel's lock, so recovery uses ``_reconnect_channel``
+        — never the public ``reconnect`` (both locks: deadlock).
         """
         attempts = max(1, int(self.retry_count or 1))
         last_error: Optional[PLCCommunicationError] = None
         results: Optional[Dict[str, TagResult]] = None
+        stamped: List[str] = []
 
         for attempt in range(1, attempts + 1):
             try:
                 results = await operation()
             except PLCCommunicationError as error:
-                last_error, results = error, None
+                last_error, results, stamped = error, None, []
             else:
                 last_error = None
-                if not _is_wedged(results):
+                stamped = _transport_failures(results)
+                if not stamped:
                     return results
                 self.logger.warning(
-                    f"{self.plc_name} {channel} channel returned {len(results)} results, all transport errors"
+                    f"{self.plc_name} {channel} channel stamped {len(stamped)}/{len(results)} "
+                    f"results with transport errors"
                 )
 
             if attempt == attempts:
@@ -181,8 +192,10 @@ class BasePLC(MindtraceABC):
 
             await asyncio.sleep(self.retry_delay)
 
-            # skip reconnect if the channel is still connected
-            if self.is_connected():
+            # The first retry on a session the driver still calls open is free:
+            # bouncing it would turn one hiccup into a torn-down socket. After
+            # that the session is lying, so reset it.
+            if attempt == 1 and await self.is_connected():
                 continue
 
             # A failed reconnect is logged, never fatal: the next attempt fails fast
@@ -202,7 +215,18 @@ class BasePLC(MindtraceABC):
             # constructors differ. Chained to the original driver cause.
             cause = last_error.__cause__ or last_error
             raise PLCCommunicationError(f"{last_error} (attempts={attempts})") from cause
-        # A wedged batch is still a batch: return the per-tag errors, never raise.
+        if stamped:
+            # Stamped entries are transient (and, for writes, ambiguous: the
+            # request may have executed with only the reply lost) — returning them
+            # would reintroduce retryable map errors. Raise, partial map attached.
+            message = (
+                f"{self.plc_name} {channel} channel failed on {len(stamped)}/{len(results or {})} tags: "
+                f"{(results or {})[stamped[0]].error.message} (attempts={attempts})"
+            )
+            error = PLCCommunicationError(message)
+            error.results = results  # type: ignore[attr-defined]
+            error.transport_addresses = tuple(stamped)  # type: ignore[attr-defined]
+            raise error
         return results if results is not None else {}
 
     @abstractmethod

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/base.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/base.py
@@ -1,84 +1,40 @@
-"""
-Abstract base classes for PLC implementations.
+"""Abstract base class for PLC backends.
 
-This module defines the interface that all PLC backends must implement,
-providing a consistent API for PLC operations across different manufacturers
-and communication protocols.
+Transport contract, enforced here so every backend inherits it:
 
-Features:
-    - Abstract base class with comprehensive async PLC interface
-    - Consistent async pattern matching camera backends
-    - Type-safe method signatures with full type hints
-    - Configuration system integration
-    - Resource management and cleanup
-    - Default implementations for optional features
-    - Standardized constructor signature across all backends
-    - Retry logic with exponential backoff
-    - Connection management and monitoring
-
-Usage:
-    This is an abstract base class and cannot be instantiated directly.
-    PLC backends should inherit from BasePLC and implement all
-    abstract methods.
-
-Example:
-    class MyPLCBackend(BasePLC):
-        async def initialize(self) -> Tuple[bool, Any, Any]:
-            # Implementation here
-            pass
-
-        async def connect(self) -> bool:
-            # Implementation here
-            pass
-
-        async def read_tag(self, tags: Union[str, List[str]]) -> Dict[str, Any]:
-            # Implementation here
-            pass
-
-        # ... implement other abstract methods
-
-Backend Requirements:
-    All PLC backends must implement the following abstract methods:
-    - initialize(): Establish initial connection and setup
-    - connect(): Connect to the PLC
-    - disconnect(): Disconnect from the PLC
-    - is_connected(): Check connection status
-    - read_tag(): Read tag values from PLC
-    - write_tag(): Write tag values to PLC
-    - get_all_tags(): List all available tags
-    - get_tag_info(): Get detailed tag information
-    - get_available_plcs(): Static method for PLC discovery
-    - get_backend_info(): Static method for backend information
-
-Error Handling:
-    Backends should raise appropriate exceptions from the PLC exception hierarchy:
-    - PLCError: Base exception for all PLC-related errors
-    - PLCNotFoundError: PLC not found during discovery
-    - PLCConnectionError: Connection establishment or maintenance failures
-    - PLCInitializationError: PLC initialization failures
-    - PLCCommunicationError: Communication protocol errors
-    - PLCTagError: Tag-related operation errors
-    - PLCTimeoutError: Operation timeout errors
-    - PLCConfigurationError: Configuration-related errors
+- Access is serialized on two channels, read and write. Public methods take the
+  lock; backends implement the underscore-prefixed bodies and run alone on their
+  channel.
+- Per-tag failures are reported as ``TagResult.error``, never as a sentinel value.
+- Whole-call failures raise typed exceptions from
+  ``mindtrace.hardware.core.exceptions``: ``PLCCommunicationError`` when
+  reconnecting the channel can plausibly fix it, ``PLCTagReadError`` /
+  ``PLCTagWriteError`` when it cannot (malformed request, programming error).
+- ``read_tag`` / ``write_tag`` retry transport-class failures up to
+  ``retry_count`` times, reconnecting THAT channel only between attempts. Nothing
+  else reconnects behind the caller's back.
 """
 
 import asyncio
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
 
 from mindtrace.core import MindtraceABC
 from mindtrace.hardware.core.config import get_hardware_config
-from mindtrace.hardware.core.exceptions import (
-    PLCTagError,
-)
+from mindtrace.hardware.core.exceptions import PLCCommunicationError
+from mindtrace.hardware.plcs.types import TagErrorKind, TagResult
+
+
+def _is_wedged(results: Optional[Dict[str, TagResult]]) -> bool:
+    """True when EVERY tag in a non-empty batch failed at transport level: a sick
+    socket, not a batch of bad addresses."""
+    if not results:
+        return False
+    return all(result.error is not None and result.error.kind is TagErrorKind.transport for result in results.values())
 
 
 class BasePLC(MindtraceABC):
-    """
-    Abstract base class for PLC implementations.
-
-    This class defines the interface that all PLC backends must implement
-    to ensure consistent behavior across different manufacturers and protocols.
+    """Base for PLC backends: serialized channels, typed results, honest errors.
 
     Attributes:
         plc_name: Unique identifier for the PLC instance
@@ -89,7 +45,7 @@ class BasePLC(MindtraceABC):
         write_timeout: Tag write timeout in seconds
         retry_count: Number of retry attempts for operations
         retry_delay: Delay between retry attempts in seconds
-        plc: The underlying PLC connection object
+        plc: The underlying PLC connection object (read channel, where applicable)
         device_manager: Device-specific manager instance
         initialized: Whether the PLC has been initialized
     """
@@ -136,13 +92,14 @@ class BasePLC(MindtraceABC):
         self.device_manager = None
         self.initialized = False
 
+        # Per-instance channel locks. Lifecycle ops take BOTH, always
+        # read-then-write — the single global ordering that avoids deadlock.
+        self._read_lock = asyncio.Lock()
+        self._write_lock = asyncio.Lock()
+
         self._setup_plc_logger_formatting()
 
-        self.logger.info(
-            f"PLC base initialized: plc_name={self.plc_name}, "
-            f"ip_address={self.ip_address}, "
-            f"connection_timeout={self.connection_timeout}s"
-        )
+        self.logger.info(f"PLC base initialized: plc_name={self.plc_name}, ip_address={self.ip_address}")
 
     def _setup_plc_logger_formatting(self):
         """
@@ -167,6 +124,134 @@ class BasePLC(MindtraceABC):
 
         self.logger.propagate = False
 
+    # --- Public API: takes the lock, delegates to the backend implementation ---
+
+    async def read_tag(self, tags: Union[str, List[str]]) -> Dict[str, TagResult]:
+        """Read tags on the read channel, recovering the channel if it fails.
+
+        Per-tag failures land in the results, keyed by address — a repeated address
+        collapses to its last result.
+        """
+        batch = [tags] if isinstance(tags, str) else list(tags)
+        async with self._read_lock:
+            return await self._run_with_recovery("read", lambda: self._read_tags(list(batch)))
+
+    async def write_tag(self, tags: Union[Tuple[str, Any], List[Tuple[str, Any]]]) -> Dict[str, TagResult]:
+        """Write tags on the write channel, recovering the channel if it fails.
+
+        Per-tag failures land in the results, keyed by address — a repeated address
+        collapses to its last result, though every write is still issued.
+        """
+        batch = [tags] if isinstance(tags, tuple) else list(tags)
+        async with self._write_lock:
+            return await self._run_with_recovery("write", lambda: self._write_tags(list(batch)))
+
+    # --- In-transport recovery: bounded retry + channel-scoped reconnect ---
+
+    async def _run_with_recovery(
+        self, channel: str, operation: Callable[[], Awaitable[Dict[str, TagResult]]]
+    ) -> Dict[str, TagResult]:
+        """Attempt ``operation`` up to ``retry_count`` times, resetting ``channel`` between tries.
+
+        A transport-class failure is a raised ``PLCCommunicationError`` or a batch
+        in which every tag failed at transport level; anything else propagates on
+        the first attempt. The caller holds this channel's lock, so recovery goes
+        through ``_reconnect_channel`` — never the public ``reconnect``, which
+        takes both locks and would deadlock here.
+        """
+        attempts = max(1, int(self.retry_count or 1))
+        last_error: Optional[PLCCommunicationError] = None
+        results: Optional[Dict[str, TagResult]] = None
+
+        for attempt in range(1, attempts + 1):
+            try:
+                results = await operation()
+            except PLCCommunicationError as error:
+                last_error, results = error, None
+            else:
+                last_error = None
+                if not _is_wedged(results):
+                    return results
+                self.logger.warning(
+                    f"{self.plc_name} {channel} channel returned {len(results)} results, all transport errors"
+                )
+
+            if attempt == attempts:
+                break
+
+            await asyncio.sleep(self.retry_delay)
+
+            # skip reconnect if the channel is still connected
+            if self.is_connected():
+                continue
+
+            # A failed reconnect is logged, never fatal: the next attempt fails fast
+            # into another reconnect or the exhausted raise.
+            self.logger.info(f"{self.plc_name} {channel} channel reconnect attempt")
+            try:
+                if await self._reconnect_channel(channel):
+                    self.logger.info(f"{self.plc_name} {channel} channel reconnect ok")
+                    continue
+                detail = " (channel did not reopen)"
+            except Exception as error:
+                detail = f" ({error})"
+            self.logger.warning(f"{self.plc_name} {channel} channel reconnect failed{detail}")
+
+        if last_error is not None:
+            # A fresh PLCCommunicationError, not type(last_error)(...): subclass
+            # constructors differ. Chained to the original driver cause.
+            cause = last_error.__cause__ or last_error
+            raise PLCCommunicationError(f"{last_error} (attempts={attempts})") from cause
+        # A wedged batch is still a batch: return the per-tag errors, never raise.
+        return results if results is not None else {}
+
+    @abstractmethod
+    async def _reconnect_channel(self, channel: str) -> bool:
+        """Reset ONLY this channel's transport; ``channel`` is "read" or "write".
+
+        The caller holds this channel's lock — never call the public
+        ``reconnect``/``connect``/``disconnect`` from here. A backend whose
+        channels share one driver cannot reset it safely mid-call and should
+        return ``False`` (recovery then retries and raises honestly; healing
+        happens via the explicit public ``reconnect``).
+        """
+        pass
+
+    async def get_plc_info(self) -> Dict[str, Any]:
+        """Controller identity/status. Probes share the read channel by design."""
+        async with self._read_lock:
+            return await self._get_plc_info()
+
+    async def get_all_tags(self) -> List[str]:
+        """List available tags; hits the device, so it takes the read channel."""
+        async with self._read_lock:
+            return await self._get_all_tags()
+
+    async def get_tag_info(self, tag_name: str) -> Dict[str, Any]:
+        """Describe one tag; hits the device, so it takes the read channel."""
+        async with self._read_lock:
+            return await self._get_tag_info(tag_name)
+
+    async def connect(self) -> bool:
+        """Open the connection. Holds both channels so no op sees a half-open device."""
+        async with self._read_lock, self._write_lock:
+            return await self._connect()
+
+    async def disconnect(self) -> bool:
+        """Close the connection. Holds both channels for the same reason as connect."""
+        async with self._read_lock, self._write_lock:
+            return await self._disconnect()
+
+    async def reconnect(self) -> bool:
+        """Close, settle, reopen under both locks, so no queued read or write lands
+        on a socket being torn down. Failures propagate as ``connect`` propagates them."""
+        async with self._read_lock, self._write_lock:
+            await self._disconnect()
+            await asyncio.sleep(self.retry_delay)
+            return await self._connect()
+
+    # --- Backend implementations: run alone on their channel ---
+
     @abstractmethod
     async def initialize(self) -> Tuple[bool, Any, Any]:
         """
@@ -178,23 +263,13 @@ class BasePLC(MindtraceABC):
         pass
 
     @abstractmethod
-    async def connect(self) -> bool:
-        """
-        Establish connection to the PLC.
-
-        Returns:
-            True if connection successful, False otherwise
-        """
+    async def _connect(self) -> bool:
+        """Open the device connection. Raises on failure."""
         pass
 
     @abstractmethod
-    async def disconnect(self) -> bool:
-        """
-        Disconnect from the PLC.
-
-        Returns:
-            True if disconnection successful, False otherwise
-        """
+    async def _disconnect(self) -> bool:
+        """Close the device connection."""
         pass
 
     @abstractmethod
@@ -202,59 +277,44 @@ class BasePLC(MindtraceABC):
         """
         Check if PLC is currently connected.
 
+        Lock-free: callers use it as a cheap predicate.
+
         Returns:
             True if connected, False otherwise
         """
         pass
 
     @abstractmethod
-    async def read_tag(self, tags: Union[str, List[str]]) -> Dict[str, Any]:
-        """
-        Read values from PLC tags.
+    async def _read_tags(self, addresses: List[str]) -> Dict[str, TagResult]:
+        """Read ``addresses``, one TagResult each.
 
-        Args:
-            tags: Single tag name or list of tag names
-
-        Returns:
-            Dictionary mapping tag names to their values
+        Whole-call failures raise ``PLCCommunicationError`` if reconnecting the
+        channel could fix it, anything else typed and final.
         """
         pass
 
     @abstractmethod
-    async def write_tag(self, tags: Union[Tuple[str, Any], List[Tuple[str, Any]]]) -> Dict[str, bool]:
-        """
-        Write values to PLC tags.
-
-        Args:
-            tags: Single (tag_name, value) tuple or list of tuples
-
-        Returns:
-            Dictionary mapping tag names to write success status
-        """
+    async def _write_tags(self, writes: List[Tuple[str, Any]]) -> Dict[str, TagResult]:
+        """Write ``(address, value)`` pairs, one TagResult each; same raise contract as ``_read_tags``."""
         pass
 
     @abstractmethod
-    async def get_all_tags(self) -> List[str]:
-        """
-        Get list of all available tags on the PLC.
-
-        Returns:
-            List of tag names
-        """
+    async def _get_all_tags(self) -> List[str]:
+        """List available tag names."""
         pass
 
     @abstractmethod
-    async def get_tag_info(self, tag_name: str) -> Dict[str, Any]:
-        """
-        Get detailed information about a specific tag.
-
-        Args:
-            tag_name: Name of the tag
-
-        Returns:
-            Dictionary with tag information (type, description, etc.)
-        """
+    async def _get_tag_info(self, tag_name: str) -> Dict[str, Any]:
+        """Describe a single tag (type, description, size, driver)."""
         pass
+
+    async def _get_plc_info(self) -> Dict[str, Any]:
+        """Backend-agnostic identity; backends override with device detail."""
+        return {
+            "name": self.plc_name,
+            "ip_address": self.ip_address,
+            "connected": await self.is_connected(),
+        }
 
     @staticmethod
     @abstractmethod
@@ -303,79 +363,6 @@ class BasePLC(MindtraceABC):
             Dictionary with backend information
         """
         pass
-
-    async def reconnect(self) -> bool:
-        """
-        Attempt to reconnect to the PLC.
-
-        Returns:
-            True if reconnection successful, False otherwise
-        """
-        try:
-            await self.disconnect()
-            await asyncio.sleep(self.retry_delay)
-            return await self.connect()
-        except Exception as e:
-            self.logger.error(f"Reconnection failed: {e}")
-            return False
-
-    async def read_tag_with_retry(self, tags: Union[str, List[str]]) -> Dict[str, Any]:
-        """
-        Read tags with retry mechanism.
-
-        Args:
-            tags: Single tag name or list of tag names
-
-        Returns:
-            Dictionary mapping tag names to their values
-
-        Raises:
-            PLCTagError: If all retry attempts fail
-        """
-        last_exception = None
-
-        for attempt in range(self.retry_count):
-            try:
-                return await self.read_tag(tags)
-            except Exception as e:
-                last_exception = e
-                self.logger.warning(f"Read attempt {attempt + 1} failed: {e}")
-
-                if attempt < self.retry_count - 1:
-                    await asyncio.sleep(self.retry_delay)
-                    if not await self.is_connected():
-                        await self.reconnect()
-
-        raise PLCTagError(f"Failed to read tags after {self.retry_count} attempts: {last_exception}")
-
-    async def write_tag_with_retry(self, tags: Union[Tuple[str, Any], List[Tuple[str, Any]]]) -> Dict[str, bool]:
-        """
-        Write tags with retry mechanism.
-
-        Args:
-            tags: Single (tag_name, value) tuple or list of tuples
-
-        Returns:
-            Dictionary mapping tag names to write success status
-
-        Raises:
-            PLCTagError: If all retry attempts fail
-        """
-        last_exception = None
-
-        for attempt in range(self.retry_count):
-            try:
-                return await self.write_tag(tags)
-            except Exception as e:
-                last_exception = e
-                self.logger.warning(f"Write attempt {attempt + 1} failed: {e}")
-
-                if attempt < self.retry_count - 1:
-                    await asyncio.sleep(self.retry_delay)
-                    if not await self.is_connected():
-                        await self.reconnect()
-
-        raise PLCTagError(f"Failed to write tags after {self.retry_count} attempts: {last_exception}")
 
     def __str__(self) -> str:
         """String representation of the PLC."""

--- a/mindtrace/hardware/mindtrace/hardware/plcs/backends/base.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/backends/base.py
@@ -5,11 +5,13 @@ Transport contract — every ``read_tag`` / ``write_tag`` outcome is one of:
 - ``{addr: value}``: it worked.
 - ``{addr: error}``: that ADDRESS is wrong — a stable verdict; retrying is pointless.
 - raises ``PLCCommunicationError``: the LINK failed this call. One attempt, no
-  retry — re-issuing is the caller's job. The BACKEND closes its channel only on
-  PROOF the session is dead (a wire-dead exception class, or a delivered reply
-  carrying connection/session error statuses) and reopens it at the next call's
-  entry. Timeouts and garbled replies raise but keep the session.
-- raises ``PLCTagError``: the REQUEST is wrong; the session is fine.
+  retry — re-issuing is the caller's job. Only a delivered, parsed reply proves
+  the reply stream is still aligned with the request stream, so the BACKEND
+  closes its channel on ANY failed exchange (wire death, timeout, garbled
+  reply, or a delivered reply carrying session-dead statuses) and reopens it
+  at the next call's entry.
+- raises ``PLCTagError``: the REQUEST is wrong (rejected before the wire); the
+  session is fine.
 
 Link trouble never appears in a returned map — a BACKEND OBLIGATION: detect
 session-dead statuses on the raw driver text, close the channel, raise. Access

--- a/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
@@ -104,7 +104,6 @@ from mindtrace.hardware.core.config import get_hardware_config
 from mindtrace.hardware.core.exceptions import (
     PLCConnectionError,
     PLCNotFoundError,
-    PLCTagError,
 )
 from mindtrace.hardware.plcs.backends.base import BasePLC
 from mindtrace.hardware.plcs.types import TagResult
@@ -586,47 +585,35 @@ class PLCManager(Mindtrace):
         return results
 
     async def get_plc_status(self, plc_name: str) -> Dict[str, Any]:
-        """
-        Get status information for a specific PLC.
+        """The manager's OWN knowledge of the PLC: lifecycle state, local facts.
 
-        Args:
-            plc_name: Name of the PLC
-
-        Returns:
-            Dictionary with PLC status information
+        Zero wire I/O, so it is total and safe to poll; the only raise is
+        ``PLCNotFoundError``. For the device's testimony, use ``get_plc_info``.
         """
         if plc_name not in self.plcs:
             raise PLCNotFoundError(f"PLC '{plc_name}' not registered")
 
-        try:
-            plc = self.plcs[plc_name]
+        plc = self.plcs[plc_name]
+        return {
+            "name": plc_name,
+            "ip_address": plc.ip_address,
+            "connected": await plc.is_connected(),
+            "initialized": plc.initialized,
+            "backend": plc.__class__.__name__,
+            "plc_type": getattr(plc, "plc_type", None),
+            "driver_type": getattr(plc, "driver_type", None),
+        }
 
-            status = {
-                "name": plc_name,
-                "ip_address": plc.ip_address,
-                "connected": await plc.is_connected(),
-                "initialized": plc.initialized,
-                "backend": plc.__class__.__name__,
-            }
+    async def get_plc_info(self, plc_name: str) -> Dict[str, Any]:
+        """The DEVICE's testimony: a wire probe on the read channel.
 
-            # Get additional info if available
-            if hasattr(plc, "get_plc_info"):
-                try:
-                    plc_info = await plc.get_plc_info()
-                    status.update(plc_info)
-                except Exception as e:
-                    status["info_error"] = str(e)
+        Thin passthrough; typed exceptions propagate unwrapped (an exchange
+        failure closes the channel in the backend and heals at the next call).
+        """
+        if plc_name not in self.plcs:
+            raise PLCNotFoundError(f"PLC '{plc_name}' not registered")
 
-            return status
-
-        except Exception as e:
-            self.logger.error(f"Failed to get status for PLC '{plc_name}': {e}")
-            return {
-                "name": plc_name,
-                "error": str(e),
-                "connected": False,
-                "initialized": False,
-            }
+        return await self.plcs[plc_name].get_plc_info()
 
     async def get_all_plc_status(self) -> Dict[str, Dict[str, Any]]:
         """
@@ -643,12 +630,7 @@ class PLCManager(Mindtrace):
                 results[plc_name] = await self.get_plc_status(plc_name)
             except Exception as e:
                 self.logger.error(f"Failed to get status for PLC '{plc_name}': {e}")
-                results[plc_name] = {
-                    "name": plc_name,
-                    "error": str(e),
-                    "connected": False,
-                    "initialized": False,
-                }
+                results[plc_name] = {"name": plc_name, "error": str(e)}
 
         return results
 
@@ -665,13 +647,7 @@ class PLCManager(Mindtrace):
         if plc_name not in self.plcs:
             raise PLCNotFoundError(f"PLC '{plc_name}' not registered")
 
-        try:
-            plc = self.plcs[plc_name]
-            return await plc.get_all_tags()
-
-        except Exception as e:
-            self.logger.error(f"Failed to get tags for PLC '{plc_name}': {e}")
-            raise PLCTagError(f"Failed to get tags for PLC '{plc_name}': {e}")
+        return await self.plcs[plc_name].get_all_tags()
 
     def get_registered_plcs(self) -> List[str]:
         """

--- a/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
@@ -69,7 +69,6 @@ Configuration:
     - MINDTRACE_HW_PLC_CONNECTION_TIMEOUT: Connection timeout in seconds
     - MINDTRACE_HW_PLC_READ_TIMEOUT: Tag read timeout in seconds
     - MINDTRACE_HW_PLC_WRITE_TIMEOUT: Tag write timeout in seconds
-    - MINDTRACE_HW_PLC_RETRY_COUNT: Number of retry attempts
     - MINDTRACE_HW_PLC_MAX_CONCURRENT_CONNECTIONS: Maximum concurrent connections
     - MINDTRACE_HW_PLC_ALLEN_BRADLEY_ENABLED: Enable Allen-Bradley backend
     - MINDTRACE_HW_PLC_SIEMENS_ENABLED: Enable Siemens backend
@@ -465,7 +464,7 @@ class PLCManager(Mindtrace):
         """
         Read tags from a specific PLC.
 
-        Thin passthrough: retry and reconnect live in the backend, and its
+        Thin passthrough: the backend makes one attempt (a channel closed on proof reopens at the next call), and its
         exceptions propagate unwrapped.
 
         Args:
@@ -486,7 +485,7 @@ class PLCManager(Mindtrace):
         """
         Write tags to a specific PLC.
 
-        Thin passthrough: retry and reconnect live in the backend, and its
+        Thin passthrough: the backend makes one attempt (a channel closed on proof reopens at the next call), and its
         exceptions propagate unwrapped.
 
         Args:

--- a/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
@@ -85,11 +85,11 @@ Error Handling:
     - PLCTagError: Tag-related operation errors
     - PLCTagReadError: Tag read operation failures
     - PLCTagWriteError: Tag write operation failures
-    - HardwareOperationError: General hardware operation failures
 
-Thread Safety:
-    All PLC operations are thread-safe. Multiple PLCs can be operated
-    simultaneously from different threads without interference.
+Concurrency:
+    Operations on one PLC are serialized per channel (read/write) by asyncio
+    locks in the backend — safe for concurrent tasks on one event loop. PLC
+    instances are not thread-safe across event loops.
 
 Performance Notes:
     - PLC discovery may take several seconds depending on network size

--- a/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
@@ -93,7 +93,6 @@ Concurrency:
 Performance Notes:
     - PLC discovery may take several seconds depending on network size
     - Batch operations are more efficient than individual tag operations
-    - Connection pooling is used for optimal performance
     - Consider PLC-specific optimizations for production use
 """
 

--- a/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
@@ -329,6 +329,8 @@ class PLCManager(Mindtrace):
             self.logger.info(f"Registered PLC '{plc_name}' with {backend} backend")
             return True
 
+        except TypeError:
+            raise
         except Exception as e:
             self.logger.error(f"Failed to register PLC '{plc_name}': {e}")
             return False
@@ -349,8 +351,8 @@ class PLCManager(Mindtrace):
 
         try:
             plc = self.plcs[plc_name]
-            if await plc.is_connected():
-                await plc.disconnect()
+            # Unconditional: a half-open PLC still holds a live session.
+            await plc.disconnect()
 
             del self.plcs[plc_name]
             self.logger.info(f"Unregistered PLC '{plc_name}'")

--- a/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/plc_manager.py
@@ -37,8 +37,12 @@ Usage:
         await manager.register_plc("PLC1", "AllenBradley", "192.168.1.100")
         await manager.connect_plc("PLC1")
 
-        # Read tags
-        values = await manager.read_tag("PLC1", ["Tag1", "Tag2"])
+        # Read tags; one TagResult per tag, a value or a classified error
+        results = await manager.read_tag("PLC1", ["Tag1", "Tag2"])
+        if results["Tag1"].ok:
+            value = results["Tag1"].value
+        else:
+            kind = results["Tag1"].error.kind
 
         # Write tags
         await manager.write_tag("PLC1", [("Tag1", 100), ("Tag2", 200)])
@@ -57,7 +61,7 @@ Usage:
             ("PLC1", ["Temperature", "Pressure"]),
             ("PLC2", ["Speed", "Position"])
         ]
-        values = await manager.read_tags_batch(read_requests)
+        results = await manager.read_tags_batch(read_requests)
 
 Configuration:
     All parameters are configurable via the hardware configuration system:
@@ -103,10 +107,9 @@ from mindtrace.hardware.core.exceptions import (
     PLCConnectionError,
     PLCNotFoundError,
     PLCTagError,
-    PLCTagReadError,
-    PLCTagWriteError,
 )
 from mindtrace.hardware.plcs.backends.base import BasePLC
+from mindtrace.hardware.plcs.types import TagResult
 
 
 class PLCManager(Mindtrace):
@@ -148,7 +151,7 @@ class PLCManager(Mindtrace):
             await manager.connect_plc("PLC1")
 
             # Read and write tags
-            values = await manager.read_tag("PLC1", ["Temperature", "Pressure"])
+            results = await manager.read_tag("PLC1", ["Temperature", "Pressure"])
             await manager.write_tag("PLC1", [("Setpoint", 75.0)])
 
         # Batch operations
@@ -458,51 +461,49 @@ class PLCManager(Mindtrace):
 
         return results
 
-    async def read_tag(self, plc_name: str, tags: Union[str, List[str]]) -> Dict[str, Any]:
+    async def read_tag(self, plc_name: str, tags: Union[str, List[str]]) -> Dict[str, TagResult]:
         """
         Read tags from a specific PLC.
+
+        Thin passthrough: retry and reconnect live in the backend, and its
+        exceptions propagate unwrapped.
 
         Args:
             plc_name: Name of the PLC
             tags: Single tag name or list of tag names
 
         Returns:
-            Dictionary mapping tag names to their values
+            Dictionary mapping tag names to their TagResult
         """
         if plc_name not in self.plcs:
             raise PLCNotFoundError(f"PLC '{plc_name}' not registered")
 
-        try:
-            plc = self.plcs[plc_name]
-            return await plc.read_tag_with_retry(tags)
+        return await self.plcs[plc_name].read_tag(tags)
 
-        except Exception as e:
-            self.logger.error(f"Failed to read tags from PLC '{plc_name}': {e}")
-            raise PLCTagReadError(f"Failed to read tags from PLC '{plc_name}': {e}")
-
-    async def write_tag(self, plc_name: str, tags: Union[Tuple[str, Any], List[Tuple[str, Any]]]) -> Dict[str, bool]:
+    async def write_tag(
+        self, plc_name: str, tags: Union[Tuple[str, Any], List[Tuple[str, Any]]]
+    ) -> Dict[str, TagResult]:
         """
         Write tags to a specific PLC.
+
+        Thin passthrough: retry and reconnect live in the backend, and its
+        exceptions propagate unwrapped.
 
         Args:
             plc_name: Name of the PLC
             tags: Single (tag_name, value) tuple or list of tuples
 
         Returns:
-            Dictionary mapping tag names to write success status
+            Dictionary mapping tag names to their TagResult
         """
         if plc_name not in self.plcs:
             raise PLCNotFoundError(f"PLC '{plc_name}' not registered")
 
-        try:
-            plc = self.plcs[plc_name]
-            return await plc.write_tag_with_retry(tags)
+        return await self.plcs[plc_name].write_tag(tags)
 
-        except Exception as e:
-            self.logger.error(f"Failed to write tags to PLC '{plc_name}': {e}")
-            raise PLCTagWriteError(f"Failed to write tags to PLC '{plc_name}': {e}")
-
-    async def read_tags_batch(self, requests: List[Tuple[str, Union[str, List[str]]]]) -> Dict[str, Dict[str, Any]]:
+    async def read_tags_batch(
+        self, requests: List[Tuple[str, Union[str, List[str]]]]
+    ) -> Dict[str, Union[Dict[str, TagResult], Dict[str, str]]]:
         """
         Read tags from multiple PLCs in batch.
 
@@ -510,7 +511,8 @@ class PLCManager(Mindtrace):
             requests: List of (plc_name, tags) tuples
 
         Returns:
-            Dictionary mapping PLC names to their tag read results
+            Dictionary mapping PLC names to their tag read results; a PLC whose
+            read raised yields {"error": ...} instead
         """
         self.logger.info(f"Executing batch read for {len(requests)} PLCs")
         results = {}
@@ -543,7 +545,7 @@ class PLCManager(Mindtrace):
 
     async def write_tags_batch(
         self, requests: List[Tuple[str, Union[Tuple[str, Any], List[Tuple[str, Any]]]]]
-    ) -> Dict[str, Dict[str, bool]]:
+    ) -> Dict[str, Union[Dict[str, TagResult], Dict[str, str]]]:
         """
         Write tags to multiple PLCs in batch.
 
@@ -551,7 +553,8 @@ class PLCManager(Mindtrace):
             requests: List of (plc_name, tags) tuples
 
         Returns:
-            Dictionary mapping PLC names to their tag write results
+            Dictionary mapping PLC names to their tag write results; a PLC whose
+            write raised yields {"error": ...} instead
         """
         self.logger.info(f"Executing batch write for {len(requests)} PLCs")
         results = {}

--- a/mindtrace/hardware/mindtrace/hardware/plcs/types.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/types.py
@@ -1,11 +1,11 @@
 """Typed per-tag results for the PLC transport, and the classifier that produces them.
 
-``missing_tag`` / ``type_mismatch`` / ``encode`` / ``unknown`` are stable
-address verdicts, returned to the caller. ``transport`` means the exchange
-failed — the transport escalates it (retry, then raise); it never reaches a
-caller in a result map. Hence transport is matched POSITIVELY from pycomm3's
-link-level strings; the unrecognized residue is ``unknown``, never an excuse to
-bounce a live session.
+Kinds describe; they never act. Config kinds (``missing_tag`` /
+``type_mismatch`` / ``encode``) are stable verdicts about the address or value.
+``transient`` marks an exchange that misbehaved (busy / timeout / garbled) —
+re-asking can succeed, and the transport takes no channel action. ``unknown``
+is the residue. Session-DEAD statuses never reach a result map: backends
+detect those on the raw driver text, close the channel, and raise.
 """
 
 from dataclasses import dataclass
@@ -14,17 +14,13 @@ from typing import Any, Optional
 
 
 class TagErrorKind(str, Enum):
-    """Why a single tag operation failed.
-
-    The first four are address verdicts the caller receives; ``transport`` is the
-    escalating kind and never survives in a returned map.
-    """
+    """Why a single tag operation failed. Labels only — the transport never acts on them."""
 
     missing_tag = "missing_tag"  # tag/member does not exist on the controller
     type_mismatch = "type_mismatch"  # value type incompatible with the tag type
     encode = "encode"  # value could not be encoded for the wire
+    transient = "transient"  # this exchange misbehaved (busy/timeout/garbled); re-ask later
     unknown = "unknown"  # the controller refused it for a reason we cannot name
-    transport = "transport"  # the exchange carrying this tag failed: escalate
 
 
 @dataclass(frozen=True)
@@ -47,6 +43,10 @@ class TagResult:
         return self.error is None
 
 
+def _matches(text: str, phrases: tuple) -> bool:
+    return any(phrase in text for phrase in phrases)
+
+
 # Per-tag errors arrive as flattened TEXT (no exception type survives pycomm3's
 # result pipeline); every pattern below is quoted from pycomm3 source.
 
@@ -66,46 +66,57 @@ _ENCODE_PATTERNS = ("error encoding value", "error packing", "error unpacking")
 # status_info.py EXTEND_CODES 0xFF wrong data type; last two are defensive spellings.
 # A bare "type" would also catch "'NoneType' object ...".
 _TYPE_PATTERNS = ("data type", "invalid type", "type mismatch")
-# The enumerated link-level surface: cip_driver.py CommError texts, forward-open
-# refusal, connection-describing SERVICE_STATUS/EXTEND_CODES (0x01/0x07/0x1F/
-# 0x0203/0x0204), and OS errno text stamped onto tags. Every entry names a failed
-# exchange or dead link outright.
-_TRANSPORT_PATTERNS = (
-    "failed to send message",
-    "failed to receive reply",
-    "target did not connect",
-    "connection failure",
-    "connection lost",
-    "connection related failure",
-    "connection timeout",
-    "connection timed out",
-    "unconnected message timeout",
-    "invalid session handle",
-    "session handle",
-    # errno text; "connection abort" stem covers "abort"/"aborted" spellings
-    "connection reset",
-    "broken pipe",
-    "connection abort",
-    "connection refused",
+# The stamped transport surface: statuses a DELIVERED reply can carry about the
+# session itself — CIP connection statuses (SERVICE_STATUS/EXTEND_CODES 0x01/0x07/
+# 0x0203/0x0204) and encapsulation session statuses.
+_TRANSIENT_PATTERNS = (
+    "insufficient resource",  # CIP 0x02 - controller busy
+    "insufficient packet space",  # CIP 0x06
+    "message timeout",  # CIP 0xFE - controller-side message timer
+    "invalid reply received",  # CIP 0x22 - garbled, this exchange only
+    "failed to parse reply",  # pycomm3 packet parse failure, stamped per packet
+    "connection timeout",  # CIP ext 0x0203 - timeout-flavored, tolerance rule
+    "connection timed out",  # defensive spelling of the same
+    "unconnected message timeout",  # CIP ext 0x0204
+    "connection failure",  # CIP 0x01 - establishment family; cannot occur on the data path
+    "connection related failure",  # CIP 0x1F - same
 )
+
+
+# The ONLY documented statuses by which a DELIVERED reply positively states that
+# OUR session/connection is gone.(thus should be marked as session dead)
+_SESSION_DEAD_PHRASES = (
+    "connection lost",  # CIP 0x07 - the connection you were using is gone
+    "invalid session handle",  # encapsulation 0x0064 - your registration is gone
+    "session handle",
+)
+
+
+def session_dead_addresses(results) -> list:
+    """Addresses whose error text says the SESSION died, not the address."""
+    dead = []
+    for address, result in results.items():
+        if result.error is not None:
+            if _matches(result.error.message.lower(), _SESSION_DEAD_PHRASES):
+                dead.append(address)
+    return dead
 
 
 def classify_tag_error(message: Any) -> TagError:
     """Map a driver error string onto a TagErrorKind, preserving the raw text.
 
-    Order: missing → encode → type → transport; the residue is ``unknown``,
-    which never escalates.
+    Order: missing → encode → type → transient; the residue is ``unknown``.
     """
     raw = str(message)
     text = raw.lower()
-    if any(pattern in text for pattern in _MISSING_TAG_PATTERNS):
+    if _matches(text, _MISSING_TAG_PATTERNS):
         kind = TagErrorKind.missing_tag
-    elif any(pattern in text for pattern in _ENCODE_PATTERNS):
+    elif _matches(text, _ENCODE_PATTERNS):
         kind = TagErrorKind.encode
-    elif any(pattern in text for pattern in _TYPE_PATTERNS):
+    elif _matches(text, _TYPE_PATTERNS):
         kind = TagErrorKind.type_mismatch
-    elif any(pattern in text for pattern in _TRANSPORT_PATTERNS):
-        kind = TagErrorKind.transport
+    elif _matches(text, _TRANSIENT_PATTERNS):
+        kind = TagErrorKind.transient
     else:
         kind = TagErrorKind.unknown
     return TagError(kind=kind, message=raw)

--- a/mindtrace/hardware/mindtrace/hardware/plcs/types.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/types.py
@@ -1,6 +1,11 @@
 """Typed per-tag results for the PLC transport, and the classifier that produces them.
 
-A failure is never laundered into a sentinel value.
+``missing_tag`` / ``type_mismatch`` / ``encode`` / ``unknown`` are stable
+address verdicts, returned to the caller. ``transport`` means the exchange
+failed — the transport escalates it (retry, then raise); it never reaches a
+caller in a result map. Hence transport is matched POSITIVELY from pycomm3's
+link-level strings; the unrecognized residue is ``unknown``, never an excuse to
+bounce a live session.
 """
 
 from dataclasses import dataclass
@@ -9,12 +14,17 @@ from typing import Any, Optional
 
 
 class TagErrorKind(str, Enum):
-    """Why a single tag operation failed."""
+    """Why a single tag operation failed.
+
+    The first four are address verdicts the caller receives; ``transport`` is the
+    escalating kind and never survives in a returned map.
+    """
 
     missing_tag = "missing_tag"  # tag/member does not exist on the controller
     type_mismatch = "type_mismatch"  # value type incompatible with the tag type
     encode = "encode"  # value could not be encoded for the wire
-    transport = "transport"  # comms-level failure attributed to this tag
+    unknown = "unknown"  # the controller refused it for a reason we cannot name
+    transport = "transport"  # the exchange carrying this tag failed: escalate
 
 
 @dataclass(frozen=True)
@@ -37,8 +47,8 @@ class TagResult:
         return self.error is None
 
 
-# Per-tag errors arrive as flattened TEXT — pycomm3 records them on the Tag, so no type
-# survives to switch on; every pattern below is quoted from the pycomm3
+# Per-tag errors arrive as flattened TEXT (no exception type survives pycomm3's
+# result pipeline); every pattern below is quoted from pycomm3 source.
 
 # logix_driver.py parse/request errors + cip/status_info.py 0x04/0x05/0x16 and 0x210B rejections
 _MISSING_TAG_PATTERNS = (
@@ -56,12 +66,35 @@ _ENCODE_PATTERNS = ("error encoding value", "error packing", "error unpacking")
 # status_info.py EXTEND_CODES 0xFF wrong data type; last two are defensive spellings.
 # A bare "type" would also catch "'NoneType' object ...".
 _TYPE_PATTERNS = ("data type", "invalid type", "type mismatch")
+# The enumerated link-level surface: cip_driver.py CommError texts, forward-open
+# refusal, connection-describing SERVICE_STATUS/EXTEND_CODES (0x01/0x07/0x1F/
+# 0x0203/0x0204), and OS errno text stamped onto tags. Every entry names a failed
+# exchange or dead link outright.
+_TRANSPORT_PATTERNS = (
+    "failed to send message",
+    "failed to receive reply",
+    "target did not connect",
+    "connection failure",
+    "connection lost",
+    "connection related failure",
+    "connection timeout",
+    "connection timed out",
+    "unconnected message timeout",
+    "invalid session handle",
+    "session handle",
+    # errno text; "connection abort" stem covers "abort"/"aborted" spellings
+    "connection reset",
+    "broken pipe",
+    "connection abort",
+    "connection refused",
+)
 
 
 def classify_tag_error(message: Any) -> TagError:
     """Map a driver error string onto a TagErrorKind, preserving the raw text.
 
-    Order is missing → encode → type; anything unrecognized is transport.
+    Order: missing → encode → type → transport; the residue is ``unknown``,
+    which never escalates.
     """
     raw = str(message)
     text = raw.lower()
@@ -71,16 +104,19 @@ def classify_tag_error(message: Any) -> TagError:
         kind = TagErrorKind.encode
     elif any(pattern in text for pattern in _TYPE_PATTERNS):
         kind = TagErrorKind.type_mismatch
-    else:
+    elif any(pattern in text for pattern in _TRANSPORT_PATTERNS):
         kind = TagErrorKind.transport
+    else:
+        kind = TagErrorKind.unknown
     return TagError(kind=kind, message=raw)
 
 
 def tag_to_result(tag: Any, value_on_success: Any = None, use_tag_value: bool = True) -> TagResult:
     """Convert a driver's per-tag answer (a pycomm3 Tag or Tag-like object) to a TagResult."""
-    # A driver that answers None/False reported a failure without a Tag to carry it.
+    # None/False in place of a Tag: a failure with no self-description — ``unknown``,
+    # since nothing says the exchange failed.
     if tag is None or tag is False:
-        return TagResult(error=TagError(kind=TagErrorKind.transport, message=f"driver returned {tag!r}"))
+        return TagResult(error=TagError(kind=TagErrorKind.unknown, message=f"driver returned {tag!r}"))
     error = getattr(tag, "error", None)
     if error:
         return TagResult(error=classify_tag_error(error))

--- a/mindtrace/hardware/mindtrace/hardware/plcs/types.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/types.py
@@ -129,7 +129,6 @@ _TRANSIENT_PATTERNS = (
 _SESSION_DEAD_PHRASES = (
     "connection lost",  # CIP 0x07 - the connection you were using is gone
     "invalid session handle",  # encapsulation 0x0064 - your registration is gone
-    "session handle",
 )
 
 

--- a/mindtrace/hardware/mindtrace/hardware/plcs/types.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/types.py
@@ -1,0 +1,90 @@
+"""Typed per-tag results for the PLC transport, and the classifier that produces them.
+
+A failure is never laundered into a sentinel value.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional
+
+
+class TagErrorKind(str, Enum):
+    """Why a single tag operation failed."""
+
+    missing_tag = "missing_tag"  # tag/member does not exist on the controller
+    type_mismatch = "type_mismatch"  # value type incompatible with the tag type
+    encode = "encode"  # value could not be encoded for the wire
+    transport = "transport"  # comms-level failure attributed to this tag
+
+
+@dataclass(frozen=True)
+class TagError:
+    """A classified per-tag failure; ``message`` preserves the driver's raw text."""
+
+    kind: TagErrorKind
+    message: str
+
+
+@dataclass(frozen=True)
+class TagResult:
+    """Outcome of one tag read/write: a value, or an error — never both."""
+
+    value: Any = None
+    error: Optional[TagError] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+# Per-tag errors arrive as flattened TEXT — pycomm3 records them on the Tag, so no type
+# survives to switch on; every pattern below is quoted from the pycomm3
+
+# logix_driver.py parse/request errors + cip/status_info.py 0x04/0x05/0x16 and 0x210B rejections
+_MISSING_TAG_PATTERNS = (
+    "tag doesn't exist",
+    "does not exist",
+    "failed to parse tag request",
+    "invalid tag request",
+    "destination unknown",
+    "instance undefined",
+    "structure element undefined",
+    "ioi syntax error",
+)
+# logix_driver.py "Error encoding value" + cip/data_types.py "Error packing/unpacking ... as {type}"
+_ENCODE_PATTERNS = ("error encoding value", "error packing", "error unpacking")
+# status_info.py EXTEND_CODES 0xFF wrong data type; last two are defensive spellings.
+# A bare "type" would also catch "'NoneType' object ...".
+_TYPE_PATTERNS = ("data type", "invalid type", "type mismatch")
+
+
+def classify_tag_error(message: Any) -> TagError:
+    """Map a driver error string onto a TagErrorKind, preserving the raw text.
+
+    Order is missing → encode → type; anything unrecognized is transport.
+    """
+    raw = str(message)
+    text = raw.lower()
+    if any(pattern in text for pattern in _MISSING_TAG_PATTERNS):
+        kind = TagErrorKind.missing_tag
+    elif any(pattern in text for pattern in _ENCODE_PATTERNS):
+        kind = TagErrorKind.encode
+    elif any(pattern in text for pattern in _TYPE_PATTERNS):
+        kind = TagErrorKind.type_mismatch
+    else:
+        kind = TagErrorKind.transport
+    return TagError(kind=kind, message=raw)
+
+
+def tag_to_result(tag: Any, value_on_success: Any = None, use_tag_value: bool = True) -> TagResult:
+    """Convert a driver's per-tag answer (a pycomm3 Tag or Tag-like object) to a TagResult."""
+    # A driver that answers None/False reported a failure without a Tag to carry it.
+    if tag is None or tag is False:
+        return TagResult(error=TagError(kind=TagErrorKind.transport, message=f"driver returned {tag!r}"))
+    error = getattr(tag, "error", None)
+    if error:
+        return TagResult(error=classify_tag_error(error))
+    return TagResult(value=getattr(tag, "value", tag) if use_tag_value else value_on_success)
+
+
+__all__ = ["TagError", "TagErrorKind", "TagResult", "classify_tag_error", "tag_to_result"]

--- a/mindtrace/hardware/mindtrace/hardware/plcs/types.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/types.py
@@ -1,11 +1,12 @@
-"""Typed per-tag results for the PLC transport, and the classifier that produces them.
+"""The PLC transport's generic vocabulary: TagResult, TagError, TagErrorKind.
 
 Kinds describe; they never act. Config kinds (``missing_tag`` /
 ``type_mismatch`` / ``encode``) are stable verdicts about the address or value.
 ``transient`` marks an exchange that misbehaved (busy / timeout / garbled) —
 re-asking can succeed, and the transport takes no channel action. ``unknown``
 is the residue. Session-DEAD statuses never reach a result map: backends
-detect those on the raw driver text, close the channel, and raise.
+detect those on their own driver's raw text (see the Allen-Bradley backend's
+``error_text`` module), close the channel, and raise.
 """
 
 from dataclasses import dataclass
@@ -74,104 +75,8 @@ class TagResult:
             return NotImplemented
         return (self._value, self.error) == (other._value, other.error)
 
-    def __hash__(self) -> int:
-        return hash((self._value, self.error))
-
     def __repr__(self) -> str:
         return f"TagResult(value={self._value!r}, error={self.error!r})"
 
-    def __reduce__(self):
-        return (TagResult, (self._value, self.error) if self.error is None else (None, self.error))
 
-
-def _matches(text: str, phrases: tuple) -> bool:
-    return any(phrase in text for phrase in phrases)
-
-
-# Per-tag errors arrive as flattened TEXT (no exception type survives pycomm3's
-# result pipeline); every pattern below is quoted from pycomm3 source.
-
-# logix_driver.py parse/request errors + cip/status_info.py 0x04/0x05/0x16 and 0x210B rejections
-_MISSING_TAG_PATTERNS = (
-    "tag doesn't exist",
-    "does not exist",
-    "failed to parse tag request",
-    "invalid tag request",
-    "destination unknown",
-    "instance undefined",
-    "structure element undefined",
-    "ioi syntax error",
-)
-# logix_driver.py "Error encoding value" + cip/data_types.py "Error packing/unpacking ... as {type}"
-_ENCODE_PATTERNS = ("error encoding value", "error packing", "error unpacking")
-# status_info.py EXTEND_CODES 0xFF wrong data type; last two are defensive spellings.
-# A bare "type" would also catch "'NoneType' object ...".
-_TYPE_PATTERNS = ("data type", "invalid type", "type mismatch")
-# The stamped transport surface: statuses a DELIVERED reply can carry about the
-# session itself — CIP connection statuses (SERVICE_STATUS/EXTEND_CODES 0x01/0x07/
-# 0x0203/0x0204) and encapsulation session statuses.
-_TRANSIENT_PATTERNS = (
-    "insufficient resource",  # CIP 0x02 - controller busy
-    "insufficient packet space",  # CIP 0x06
-    "message timeout",  # CIP 0xFE - controller-side message timer
-    "invalid reply received",  # CIP 0x22 - garbled, this exchange only
-    "failed to parse reply",  # pycomm3 packet parse failure, stamped per packet
-    "connection timeout",  # CIP ext 0x0203 - timeout-flavored, tolerance rule
-    "connection timed out",  # defensive spelling of the same
-    "unconnected message timeout",  # CIP ext 0x0204
-    "connection failure",  # CIP 0x01 - establishment family; cannot occur on the data path
-    "connection related failure",  # CIP 0x1F - same
-)
-
-
-# The ONLY documented statuses by which a DELIVERED reply positively states that
-# OUR session/connection is gone.(thus should be marked as session dead)
-_SESSION_DEAD_PHRASES = (
-    "connection lost",  # CIP 0x07 - the connection you were using is gone
-    "invalid session handle",  # encapsulation 0x0064 - your registration is gone
-)
-
-
-def session_dead_addresses(results) -> list:
-    """Addresses whose error text says the SESSION died, not the address."""
-    dead = []
-    for address, result in results.items():
-        if result.error is not None:
-            if _matches(result.error.message.lower(), _SESSION_DEAD_PHRASES):
-                dead.append(address)
-    return dead
-
-
-def classify_tag_error(message: Any) -> TagError:
-    """Map a driver error string onto a TagErrorKind, preserving the raw text.
-
-    Order: missing → encode → type → transient; the residue is ``unknown``.
-    """
-    raw = str(message)
-    text = raw.lower()
-    if _matches(text, _MISSING_TAG_PATTERNS):
-        kind = TagErrorKind.missing_tag
-    elif _matches(text, _ENCODE_PATTERNS):
-        kind = TagErrorKind.encode
-    elif _matches(text, _TYPE_PATTERNS):
-        kind = TagErrorKind.type_mismatch
-    elif _matches(text, _TRANSIENT_PATTERNS):
-        kind = TagErrorKind.transient
-    else:
-        kind = TagErrorKind.unknown
-    return TagError(kind=kind, message=raw)
-
-
-def tag_to_result(tag: Any, value_on_success: Any = None, use_tag_value: bool = True) -> TagResult:
-    """Convert a driver's per-tag answer (a pycomm3 Tag or Tag-like object) to a TagResult."""
-    # None/False in place of a Tag: a failure with no self-description — ``unknown``,
-    # since nothing says the exchange failed.
-    if tag is None or tag is False:
-        return TagResult(error=TagError(kind=TagErrorKind.unknown, message=f"driver returned {tag!r}"))
-    error = getattr(tag, "error", None)
-    if error:
-        return TagResult(error=classify_tag_error(error))
-    return TagResult(value=getattr(tag, "value", tag) if use_tag_value else value_on_success)
-
-
-__all__ = ["TagError", "TagErrorKind", "TagResult", "classify_tag_error", "tag_to_result"]
+__all__ = ["TagError", "TagErrorKind", "TagResult"]

--- a/mindtrace/hardware/mindtrace/hardware/plcs/types.py
+++ b/mindtrace/hardware/mindtrace/hardware/plcs/types.py
@@ -9,11 +9,11 @@ detect those on the raw driver text, close the channel, and raise.
 """
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Optional
 
 
-class TagErrorKind(str, Enum):
+class TagErrorKind(StrEnum):
     """Why a single tag operation failed. Labels only — the transport never acts on them."""
 
     missing_tag = "missing_tag"  # tag/member does not exist on the controller
@@ -31,16 +31,57 @@ class TagError:
     message: str
 
 
-@dataclass(frozen=True)
 class TagResult:
-    """Outcome of one tag read/write: a value, or an error — never both."""
+    """Outcome of one tag read/write: a value OR an error — never both, enforced.
 
-    value: Any = None
-    error: Optional[TagError] = None
+    ``.value`` raises on a failed result so the shortest expression is the
+    correct one; ``.value_or(default)`` is the explicit lossy opt-in. Truth
+    testing raises — check ``.ok``.
+    """
+
+    __slots__ = ("_value", "error")
+
+    def __init__(self, value: Any = None, error: Optional[TagError] = None) -> None:
+        if error is not None and value is not None:
+            raise ValueError("TagResult carries a value or an error, never both")
+        object.__setattr__(self, "_value", value)
+        object.__setattr__(self, "error", error)
 
     @property
     def ok(self) -> bool:
         return self.error is None
+
+    @property
+    def value(self) -> Any:
+        if self.error is not None:
+            raise ValueError(f"TagResult carries no value; {self.error.kind}: {self.error.message}")
+        return self._value
+
+    def value_or(self, default: Any = None) -> Any:
+        return self._value if self.error is None else default
+
+    def __bool__(self) -> bool:
+        raise TypeError("TagResult has no truth value; test .ok")
+
+    def __setattr__(self, name: str, val: Any) -> None:
+        raise AttributeError("TagResult is immutable")
+
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError("TagResult is immutable")
+
+    def __eq__(self, other: Any) -> Any:
+        if not isinstance(other, TagResult):
+            return NotImplemented
+        return (self._value, self.error) == (other._value, other.error)
+
+    def __hash__(self) -> int:
+        return hash((self._value, self.error))
+
+    def __repr__(self) -> str:
+        return f"TagResult(value={self._value!r}, error={self.error!r})"
+
+    def __reduce__(self):
+        return (TagResult, (self._value, self.error) if self.error is None else (None, self.error))
 
 
 def _matches(text: str, phrases: tuple) -> bool:

--- a/mindtrace/hardware/mindtrace/hardware/services/plcs/connection_manager.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/plcs/connection_manager.py
@@ -93,7 +93,6 @@ class PLCManagerConnectionManager(ConnectionManager):
         connection_timeout: Optional[float] = None,
         read_timeout: Optional[float] = None,
         write_timeout: Optional[float] = None,
-        retry_count: Optional[int] = None,
         retry_delay: Optional[float] = None,
     ) -> bool:
         """Connect to a PLC.
@@ -106,7 +105,6 @@ class PLCManagerConnectionManager(ConnectionManager):
             connection_timeout: Connection timeout in seconds
             read_timeout: Tag read timeout in seconds
             write_timeout: Tag write timeout in seconds
-            retry_count: Number of retry attempts
             retry_delay: Delay between retries in seconds
 
         Returns:
@@ -120,7 +118,6 @@ class PLCManagerConnectionManager(ConnectionManager):
             connection_timeout=connection_timeout,
             read_timeout=read_timeout,
             write_timeout=write_timeout,
-            retry_count=retry_count,
             retry_delay=retry_delay,
         )
         response = await self.post("/plcs/connect", request.model_dump())

--- a/mindtrace/hardware/mindtrace/hardware/services/plcs/models/requests.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/plcs/models/requests.py
@@ -28,7 +28,6 @@ class PLCConnectRequest(BaseModel):
     connection_timeout: Optional[float] = Field(None, description="Connection timeout in seconds")
     read_timeout: Optional[float] = Field(None, description="Tag read timeout in seconds")
     write_timeout: Optional[float] = Field(None, description="Tag write timeout in seconds")
-    retry_count: Optional[int] = Field(None, description="Number of retry attempts")
     retry_delay: Optional[float] = Field(None, description="Delay between retries in seconds")
 
 

--- a/mindtrace/hardware/mindtrace/hardware/services/plcs/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/plcs/service.py
@@ -527,24 +527,24 @@ class PLCManagerService(Service):
             raise
 
     async def get_plc_info(self, request: PLCQueryRequest) -> PLCInfoResponse:
-        """Get detailed PLC information."""
+        """Get detailed PLC information (a live device probe; typed failures propagate)."""
         try:
             manager = self._get_plc_manager()
-            status_dict = await manager.get_plc_status(request.plc)
+            info_dict = await manager.get_plc_info(request.plc)
 
             info = PLCInfo(
                 name=request.plc,
-                backend=status_dict.get("backend", "Unknown"),
-                ip_address=status_dict.get("ip_address", ""),
-                plc_type=status_dict.get("plc_type"),
+                backend=manager.plcs[request.plc].__class__.__name__,
+                ip_address=info_dict.get("ip_address", ""),
+                plc_type=info_dict.get("plc_type"),
                 active=True,
-                connected=status_dict.get("connected", False),
-                driver_type=status_dict.get("driver_type"),
-                product_name=status_dict.get("product_name"),
-                product_type=status_dict.get("product_type"),
-                vendor=status_dict.get("vendor"),
-                revision=status_dict.get("revision"),
-                serial=status_dict.get("serial"),
+                connected=info_dict.get("connected", False),
+                driver_type=info_dict.get("driver_type"),
+                product_name=info_dict.get("product_name"),
+                product_type=info_dict.get("product_type"),
+                vendor=info_dict.get("vendor"),
+                revision=info_dict.get("revision"),
+                serial=info_dict.get("serial"),
             )
 
             return PLCInfoResponse(success=True, message=f"Retrieved information for PLC '{request.plc}'", data=info)

--- a/mindtrace/hardware/mindtrace/hardware/services/plcs/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/plcs/service.py
@@ -266,7 +266,6 @@ class PLCManagerService(Service):
                 connection_timeout=request.connection_timeout,
                 read_timeout=request.read_timeout,
                 write_timeout=request.write_timeout,
-                retry_count=request.retry_count,
                 retry_delay=request.retry_delay,
             )
 
@@ -299,7 +298,6 @@ class PLCManagerService(Service):
                         connection_timeout=plc_req.connection_timeout,
                         read_timeout=plc_req.read_timeout,
                         write_timeout=plc_req.write_timeout,
-                        retry_count=plc_req.retry_count,
                         retry_delay=plc_req.retry_delay,
                     )
 

--- a/mindtrace/hardware/mindtrace/hardware/services/plcs/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/plcs/service.py
@@ -7,13 +7,14 @@ architecture with comprehensive MCP tool integration and typed client access.
 
 import logging
 import time
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from fastapi.middleware.cors import CORSMiddleware
 
 from mindtrace.hardware.core.exceptions import PLCNotFoundError
 from mindtrace.hardware.core.types import ServiceStatus
 from mindtrace.hardware.plcs.plc_manager import PLCManager
+from mindtrace.hardware.plcs.types import TagResult
 from mindtrace.hardware.services.plcs.models import (
     # Response models
     ActivePLCsResponse,
@@ -52,6 +53,25 @@ from mindtrace.hardware.services.plcs.models import (
 from mindtrace.hardware.services.plcs.models.requests import BackendFilterRequest
 from mindtrace.hardware.services.plcs.schemas import ALL_SCHEMAS, HealthSchema
 from mindtrace.services import Service
+
+# The HTTP surface predates typed tag results: value-or-None for reads, bool for
+# writes. These adapters do that lossy mapping at the boundary only.
+
+
+def _read_values(results: Dict[str, TagResult]) -> Dict[str, Any]:
+    return {tag: result.value if result.ok else None for tag, result in results.items()}
+
+
+def _write_flags(results: Dict[str, TagResult]) -> Dict[str, bool]:
+    return {tag: result.ok for tag, result in results.items()}
+
+
+def _adapt_batch(batch: Dict[str, Dict[str, Any]], adapt) -> Dict[str, Dict[str, Any]]:
+    """Adapt per-PLC TagResult maps, passing through the {"error": ...} entries."""
+    return {
+        plc: adapt(entry) if all(isinstance(v, TagResult) for v in entry.values()) else entry
+        for plc, entry in batch.items()
+    }
 
 
 class PLCManagerService(Service):
@@ -380,11 +400,11 @@ class PLCManagerService(Service):
         """Read tag values from a PLC."""
         try:
             manager = self._get_plc_manager()
-            values = await manager.read_tag(request.plc, request.tags)
+            values = _read_values(await manager.read_tag(request.plc, request.tags))
 
-            self._total_tag_reads += len(values) if isinstance(values, dict) else 1
+            self._total_tag_reads += len(values)
 
-            tag_count = len(values) if isinstance(values, dict) else 1
+            tag_count = len(values)
             return TagReadResponse(success=True, message=f"Read {tag_count} tags from PLC '{request.plc}'", data=values)
         except Exception as e:
             self.logger.error(f"Failed to read tags from PLC '{request.plc}': {e}")
@@ -394,11 +414,11 @@ class PLCManagerService(Service):
         """Write tag values to a PLC."""
         try:
             manager = self._get_plc_manager()
-            results = await manager.write_tag(request.plc, request.tags)
+            results = _write_flags(await manager.write_tag(request.plc, request.tags))
 
-            self._total_tag_writes += len(results) if isinstance(results, dict) else 1
+            self._total_tag_writes += len(results)
 
-            tag_count = len(results) if isinstance(results, dict) else 1
+            tag_count = len(results)
             return TagWriteResponse(
                 success=True, message=f"Wrote {tag_count} tags to PLC '{request.plc}'", data=results
             )
@@ -410,7 +430,7 @@ class PLCManagerService(Service):
         """Read tags from multiple PLCs in batch."""
         try:
             manager = self._get_plc_manager()
-            results = await manager.read_tags_batch(request.requests)
+            results = _adapt_batch(await manager.read_tags_batch(request.requests), _read_values)
 
             successful_count = sum(1 for v in results.values() if not isinstance(v, dict) or "error" not in v)
             failed_count = len(results) - successful_count
@@ -430,7 +450,7 @@ class PLCManagerService(Service):
         """Write tags to multiple PLCs in batch."""
         try:
             manager = self._get_plc_manager()
-            results = await manager.write_tags_batch(request.requests)
+            results = _adapt_batch(await manager.write_tags_batch(request.requests), _write_flags)
 
             successful_count = sum(1 for v in results.values() if not isinstance(v, dict) or "error" not in v)
             failed_count = len(results) - successful_count

--- a/mindtrace/hardware/mindtrace/hardware/services/plcs/service.py
+++ b/mindtrace/hardware/mindtrace/hardware/services/plcs/service.py
@@ -59,7 +59,7 @@ from mindtrace.services import Service
 
 
 def _read_values(results: Dict[str, TagResult]) -> Dict[str, Any]:
-    return {tag: result.value if result.ok else None for tag, result in results.items()}
+    return {tag: result.value_or(None) for tag, result in results.items()}
 
 
 def _write_flags(results: Dict[str, TagResult]) -> Dict[str, bool]:

--- a/tests/unit/mindtrace/hardware/core/test_hardware_core_config.py
+++ b/tests/unit/mindtrace/hardware/core/test_hardware_core_config.py
@@ -308,7 +308,7 @@ class TestHardwareConfigManagerCoverage:
             assert hasattr(config.cameras, attr), f"Missing camera attribute: {attr}"
 
         # Test PLC config
-        plc_attrs = ["connection_timeout", "read_timeout", "write_timeout", "retry_count", "max_concurrent_connections"]
+        plc_attrs = ["connection_timeout", "read_timeout", "write_timeout", "retry_delay", "max_concurrent_connections"]
         for attr in plc_attrs:
             assert hasattr(config.plcs, attr), f"Missing PLC attribute: {attr}"
 
@@ -927,21 +927,6 @@ class TestHardwareConfigManagerEnvironmentVariables:
             config = config_mgr.get_config()
             # Should keep default value
             assert isinstance(config.plcs.write_timeout, float)
-
-    def test_load_plc_retry_count(self):
-        """Test loading PLC retry count from env."""
-        with patch.dict(os.environ, {"MINDTRACE_HW_PLC_RETRY_COUNT": "5"}):
-            config_mgr = HardwareConfigManager(config_file="/nonexistent.json")
-            config = config_mgr.get_config()
-            assert config.plcs.retry_count == 5
-
-    def test_load_plc_retry_count_invalid(self):
-        """Test loading PLC retry count with invalid value."""
-        with patch.dict(os.environ, {"MINDTRACE_HW_PLC_RETRY_COUNT": "invalid"}):
-            config_mgr = HardwareConfigManager(config_file="/nonexistent.json")
-            config = config_mgr.get_config()
-            # Should keep default value
-            assert isinstance(config.plcs.retry_count, int)
 
     def test_load_plc_backend_allen_bradley_enabled_true(self):
         """Test loading PLC backend Allen Bradley enabled from env (true)."""

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
@@ -1982,6 +1982,47 @@ class TestAllenBradleyPLCTagDiscovery:
         assert any("0x04:" in tag for tag in tags)
 
     @pytest.mark.asyncio
+    async def test_get_all_tags_wire_death_escapes_typed(self, mock_pycomm3_available, mock_cip_driver):
+        """A CommError during discovery closes the channel and ESCAPES as
+        PLCCommunicationError - the outer catch-all must not rewrap it."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            CIPDriver,
+        )
+
+        CIPDriver.list_identity.return_value = {}
+        mock_cip_driver.generic_message.side_effect = CommError("socket closed")
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
+        CIPDriver.return_value = mock_cip_driver
+        await plc.connect()
+
+        with pytest.raises(PLCCommunicationError, match="Tag discovery failed"):
+            await plc.get_all_tags()
+
+        mock_cip_driver.close.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_get_plc_info_wire_death_escapes_typed(self, mock_pycomm3_available, mock_logix_driver):
+        """An exchange failure in the info probe closes the channel and ESCAPES -
+        the outer catch-all must not turn it into a returned dict."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        mock_logix_driver.get_plc_info.side_effect = CommError("socket closed")
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        LogixDriver.return_value = mock_logix_driver
+        await plc.connect()
+
+        with pytest.raises(PLCCommunicationError, match="PLC info read failed"):
+            await plc.get_plc_info()
+
+        mock_logix_driver.close.assert_called()
+
+    @pytest.mark.asyncio
     async def test_get_all_tags_cache_valid(self, mock_pycomm3_available, mock_logix_driver):
         """Test tag cache is used when still valid."""
         import time
@@ -2457,9 +2498,11 @@ class TestAllenBradleyPLCPLCInfo:
         # Device info exception should be caught and logged, but basic info should still be returned
         assert "product_name" not in info or info.get("product_name") == "Unknown"
 
+
     @pytest.mark.asyncio
     async def test_get_plc_info_outer_exception(self, mock_pycomm3_available, mock_logix_driver):
-        """An unexpected failure is reported as the in-band error dict, as before."""
+        """An unexpected failure is reported in-band — with only honest fields:
+        no fabricated ``connected``."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
@@ -2476,8 +2519,8 @@ class TestAllenBradleyPLCPLCInfo:
         info = await plc.get_plc_info()
 
         assert info["name"] == "TestPLC"
-        assert info["connected"] is False
         assert "Connection check failed" in info["error"]
+        assert "connected" not in info  # absent is honest; fabricated is not
 
 
 class TestAllenBradleyPLCStaticMethods:

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
@@ -515,8 +515,10 @@ class TestAllenBradleyPLCConnection:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_is_connected_requires_both_sessions(self, mock_pycomm3_available):
-        """Connected means BOTH sessions are open; a dropped write socket is not connected."""
+    async def test_is_connected_is_the_lifecycle_state(self, mock_pycomm3_available):
+        """A dropped channel is NOT a disconnection — it reopens at the next
+        call's entry, and a supervisor reacting to False here would tear down
+        the healthy channel. Only disconnect() (or never connecting) is False."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
@@ -530,34 +532,12 @@ class TestAllenBradleyPLCConnection:
         await plc.connect()
         assert await plc.is_connected() is True
 
-        write_driver.connected = False
-        assert await plc.is_connected() is False
+        write_driver.connected = False  # closed on proof: self-healing, still connected
+        assert await plc.is_connected() is True
 
-        write_driver.connected = True
         read_driver.connected = False
+        await plc.disconnect()
         assert await plc.is_connected() is False
-
-    @pytest.mark.asyncio
-    async def test_is_connected_exception_handling(self, mock_pycomm3_available, mock_logix_driver):
-        """Test is_connected exception handling."""
-        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
-            AllenBradleyPLC,
-            LogixDriver,
-        )
-
-        # Make accessing connected property raise an exception
-        def _get_connected():
-            raise Exception("Access failed")
-
-        type(mock_logix_driver).connected = property(_get_connected)
-
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
-        LogixDriver.return_value = mock_logix_driver
-        await plc.connect()
-
-        result = await plc.is_connected()
-
-        assert result is False
 
 
 class TestAllenBradleyPLCInitialize:

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
@@ -658,9 +658,9 @@ class TestTagErrorClassification:
             ("Error encoding value for tag", TagErrorKind.encode),
             ("Invalid data type for tag", TagErrorKind.type_mismatch),
             ("Tag type mismatch", TagErrorKind.type_mismatch),
+            # socket related
             ("Connection reset by peer", TagErrorKind.transport),
-            # "type" alone is not evidence of a tag type problem.
-            ("'NoneType' object has no attribute 'read'", TagErrorKind.transport),
+            ("'NoneType' object has no attribute 'read'", TagErrorKind.unknown),
         ],
     )
     def test_classify_tag_error(self, mock_pycomm3_available, message, expected_kind):
@@ -682,13 +682,14 @@ class TestTagErrorClassification:
         assert error.message == "Tag does not exist"
 
     def test_tag_to_result_missing_driver_result(self, mock_pycomm3_available):
-        """A missing driver result is a transport failure, not a None value."""
+        """A missing driver result is an error, not a None value — and not a
+        licence to bounce the session: nothing here says the exchange failed."""
         from mindtrace.hardware.plcs.types import tag_to_result
 
         result = tag_to_result(None)
 
         assert result.ok is False
-        assert result.error.kind is TagErrorKind.transport
+        assert result.error.kind is TagErrorKind.unknown
         assert result.error.message == "driver returned None"
 
     def test_tag_to_result_write_reports_the_written_value(self, mock_pycomm3_available):
@@ -904,7 +905,11 @@ class TestAllenBradleyPLCTagReading:
 
     @pytest.mark.asyncio
     async def test_read_tag_slc_with_error(self, mock_pycomm3_available, mock_slc_driver):
-        """A failing SLC address is a per-tag error; its neighbours still report values."""
+        """A failing SLC address is a per-tag verdict; its neighbours still report values.
+
+        The driver's text names no link trouble, so the address — not the channel —
+        is what failed, and the batch is returned rather than retried.
+        """
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             SLCDriver,
@@ -922,7 +927,7 @@ class TestAllenBradleyPLCTagReading:
         assert result["N7:0"] == TagResult(value=100)
         assert result["B3:0"].ok is False
         assert result["B3:0"].value is None
-        assert result["B3:0"].error.kind is TagErrorKind.transport
+        assert result["B3:0"].error.kind is TagErrorKind.unknown
         assert result["B3:0"].error.message == "Read failed"
 
     @pytest.mark.asyncio
@@ -1173,7 +1178,8 @@ class TestAllenBradleyPLCTagReading:
 
     @pytest.mark.asyncio
     async def test_read_tag_none_result(self, mock_pycomm3_available, mock_logix_driver):
-        """A driver that returns nothing is a transport failure, not a None value."""
+        """A driver that returns nothing is an error, not a None value — and an
+        unnameable one, so it stays a verdict on the address."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
@@ -1190,7 +1196,7 @@ class TestAllenBradleyPLCTagReading:
         assert "Motor1_Speed" in result
         assert result["Motor1_Speed"].ok is False
         assert result["Motor1_Speed"].value is None
-        assert result["Motor1_Speed"].error.kind is TagErrorKind.transport
+        assert result["Motor1_Speed"].error.kind is TagErrorKind.unknown
         assert result["Motor1_Speed"].error.message == "driver returned None"
 
     @pytest.mark.asyncio
@@ -1215,7 +1221,7 @@ class TestAllenBradleyPLCTagReading:
         assert "Assembly:20" in result
         assert result["Assembly:20"].ok is False
         assert result["Assembly:20"].value is None
-        assert result["Assembly:20"].error.kind is TagErrorKind.transport
+        assert result["Assembly:20"].error.kind is TagErrorKind.unknown
         assert result["Assembly:20"].error.message == "Read error"
 
     @pytest.mark.asyncio
@@ -1259,7 +1265,7 @@ class TestAllenBradleyPLCTagReading:
 
         assert "Identity" in result
         assert result["Identity"].ok is False
-        assert result["Identity"].error.kind is TagErrorKind.transport
+        assert result["Identity"].error.kind is TagErrorKind.unknown
         assert result["Identity"].error.message == "Identity read failed"
 
     @pytest.mark.asyncio
@@ -1280,7 +1286,7 @@ class TestAllenBradleyPLCTagReading:
 
         assert "Assembly:20" in result
         assert result["Assembly:20"].ok is False
-        assert result["Assembly:20"].error.kind is TagErrorKind.transport
+        assert result["Assembly:20"].error.kind is TagErrorKind.unknown
         assert result["Assembly:20"].error.message == "Assembly read failed"
 
     @pytest.mark.asyncio
@@ -1301,7 +1307,7 @@ class TestAllenBradleyPLCTagReading:
 
         assert "Module:0" in result
         assert result["Module:0"].ok is False
-        assert result["Module:0"].error.kind is TagErrorKind.transport
+        assert result["Module:0"].error.kind is TagErrorKind.unknown
         assert result["Module:0"].error.message == "Module read failed"
 
     @pytest.mark.asyncio
@@ -1322,7 +1328,7 @@ class TestAllenBradleyPLCTagReading:
 
         assert "Connection" in result
         assert result["Connection"].ok is False
-        assert result["Connection"].error.kind is TagErrorKind.transport
+        assert result["Connection"].error.kind is TagErrorKind.unknown
         assert result["Connection"].error.message == "Connection read failed"
 
     @pytest.mark.asyncio
@@ -1343,7 +1349,7 @@ class TestAllenBradleyPLCTagReading:
 
         assert "0x04:1:3" in result
         assert result["0x04:1:3"].ok is False
-        assert result["0x04:1:3"].error.kind is TagErrorKind.transport
+        assert result["0x04:1:3"].error.kind is TagErrorKind.unknown
         assert result["0x04:1:3"].error.message == "Generic read failed"
 
 
@@ -1516,7 +1522,11 @@ class TestAllenBradleyPLCTagWriting:
 
     @pytest.mark.asyncio
     async def test_write_tag_slc_with_error(self, mock_pycomm3_available, mock_slc_driver):
-        """A failing SLC address is a per-tag error; its neighbours still succeed."""
+        """A failing SLC address is a per-tag verdict; its neighbours still succeed.
+
+        The driver's text names no link trouble, so the address — not the channel —
+        is what failed, and the batch is returned rather than retried.
+        """
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             SLCDriver,
@@ -1534,7 +1544,7 @@ class TestAllenBradleyPLCTagWriting:
         assert result["N7:0"] == TagResult(value=100)
         assert result["B3:0"].ok is False
         assert result["B3:0"].value is None
-        assert result["B3:0"].error.kind is TagErrorKind.transport
+        assert result["B3:0"].error.kind is TagErrorKind.unknown
         assert result["B3:0"].error.message == "Write failed"
 
     @pytest.mark.asyncio
@@ -1649,7 +1659,7 @@ class TestAllenBradleyPLCTagWriting:
 
         assert result["Assembly:20"].ok is False
         assert result["Assembly:20"].value is None
-        assert result["Assembly:20"].error.kind is TagErrorKind.transport
+        assert result["Assembly:20"].error.kind is TagErrorKind.unknown
         assert result["Assembly:20"].error.message == "Write error"
 
     @pytest.mark.asyncio
@@ -1739,25 +1749,32 @@ class TestAllenBradleyPLCTagWriting:
         assert result["Motor1_Speed"].error.message == "Invalid data type for tag"
 
     @pytest.mark.asyncio
-    async def test_write_tag_result_with_error_attribute(self, mock_pycomm3_available, mock_cip_driver):
-        """Test writing tag when result has error attribute."""
+    async def test_write_tag_result_stamped_with_link_trouble_raises(self, mock_pycomm3_available, mock_cip_driver):
+        """A tag stamped with pycomm3's own link text is a channel failure, not a result.
+
+        The exchange carrying this write never happened, so the caller is told by a
+        raise — with the partial map attached for the log — rather than handed a
+        write it cannot tell apart from a completed one.
+        """
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             CIPDriver,
         )
 
         error_result = MagicMock()
-        error_result.error = "Write error"
+        error_result.error = "failed to receive reply"
         mock_cip_driver.generic_message.return_value = error_result
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip", retry_count=2, retry_delay=0.01)
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.write_tag([("Assembly:20", [1500, 0, 255, 0])])
+        with pytest.raises(PLCCommunicationError, match=r"attempts=2") as exc_info:
+            await plc.write_tag([("Assembly:20", [1500, 0, 255, 0])])
 
-        assert result["Assembly:20"].ok is False
-        assert result["Assembly:20"].error.kind is TagErrorKind.transport
+        assert exc_info.value.transport_addresses == ("Assembly:20",)
+        assert exc_info.value.results["Assembly:20"].error.kind is TagErrorKind.transport
+        assert mock_cip_driver.generic_message.call_count == 2
 
     @pytest.mark.asyncio
     async def test_write_tag_cip_assembly_exception(self, mock_pycomm3_available, mock_cip_driver):
@@ -1776,7 +1793,7 @@ class TestAllenBradleyPLCTagWriting:
         result = await plc.write_tag([("Assembly:20", [1500, 0, 255, 0])])
 
         assert result["Assembly:20"].ok is False
-        assert result["Assembly:20"].error.kind is TagErrorKind.transport
+        assert result["Assembly:20"].error.kind is TagErrorKind.unknown
         assert result["Assembly:20"].error.message == "Assembly write failed"
 
     @pytest.mark.asyncio
@@ -1796,7 +1813,7 @@ class TestAllenBradleyPLCTagWriting:
         result = await plc.write_tag([("Parameter:1", 1500.0)])
 
         assert result["Parameter:1"].ok is False
-        assert result["Parameter:1"].error.kind is TagErrorKind.transport
+        assert result["Parameter:1"].error.kind is TagErrorKind.unknown
         assert result["Parameter:1"].error.message == "Parameter write failed"
 
     @pytest.mark.asyncio
@@ -1816,7 +1833,7 @@ class TestAllenBradleyPLCTagWriting:
         result = await plc.write_tag([("0x04:1:3", [1500, 0, 255, 0])])
 
         assert result["0x04:1:3"].ok is False
-        assert result["0x04:1:3"].error.kind is TagErrorKind.transport
+        assert result["0x04:1:3"].error.kind is TagErrorKind.unknown
         assert result["0x04:1:3"].error.message == "Generic write failed"
 
 

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
@@ -6,6 +6,7 @@ allowing full test coverage without requiring physical hardware.
 """
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -169,13 +170,11 @@ class TestAllenBradleyPLCInitialization:
             connection_timeout=5.0,
             read_timeout=2.0,
             write_timeout=2.0,
-            retry_count=3,
             retry_delay=1.0,
         )
         assert plc.connection_timeout == 5.0
         assert plc.read_timeout == 2.0
         assert plc.write_timeout == 2.0
-        assert plc.retry_count == 3
         assert plc.retry_delay == 1.0
 
 
@@ -348,7 +347,7 @@ class TestAllenBradleyPLCConnection:
 
         mock_logix_driver.open.side_effect = [Exception("Failed"), True, True]
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=3)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
 
         with pytest.raises(PLCConnectionError):
@@ -366,7 +365,7 @@ class TestAllenBradleyPLCConnection:
 
         mock_logix_driver.open.side_effect = Exception("Connection failed")
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=2)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
 
         with pytest.raises(PLCConnectionError) as exc_info:
@@ -392,8 +391,9 @@ class TestAllenBradleyPLCConnection:
         with pytest.raises(PLCConnectionError):
             await plc.connect()
 
-        # Both half-open sessions are closed again.
-        assert mock_logix_driver.close.call_count == 2
+        # The read open failed first, was closed, and the write driver was
+        # never constructed - sequential opens cannot leak a second session.
+        assert mock_logix_driver.close.call_count == 1
 
     @pytest.mark.asyncio
     async def test_connect_fails_when_only_the_read_session_opens(self, mock_pycomm3_available):
@@ -413,8 +413,7 @@ class TestAllenBradleyPLCConnection:
         with pytest.raises(PLCConnectionError) as exc_info:
             await plc.connect()
 
-        assert "read=True" in str(exc_info.value)
-        assert "write=False" in str(exc_info.value)
+        assert "read channel opened but the write channel did not" in str(exc_info.value)
         read_driver.close.assert_called_once()
         write_driver.close.assert_called_once()
 
@@ -592,7 +591,7 @@ class TestAllenBradleyPLCInitialize:
 
         mock_logix_driver.open.side_effect = Exception("Connection failed")
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=1)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
 
         with pytest.raises(PLCInitializationError):
@@ -609,7 +608,7 @@ class TestAllenBradleyPLCInitialize:
         mock_driver = MagicMock()
         mock_driver.open.return_value = False
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=1)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_driver
 
         # This will raise PLCConnectionError, which gets caught and re-raised as PLCInitializationError
@@ -627,7 +626,7 @@ class TestAllenBradleyPLCInitialize:
         mock_driver = MagicMock()
         mock_driver.open.return_value = False
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=1)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_driver
 
         # Mock connect to return False directly (simulating a case where it returns False)
@@ -659,7 +658,8 @@ class TestTagErrorClassification:
             ("Invalid data type for tag", TagErrorKind.type_mismatch),
             ("Tag type mismatch", TagErrorKind.type_mismatch),
             # socket related
-            ("Connection reset by peer", TagErrorKind.transport),
+            # Socket deaths always RAISE; their texts are not stamp patterns.
+            ("Connection reset by peer", TagErrorKind.unknown),
             ("'NoneType' object has no attribute 'read'", TagErrorKind.unknown),
         ],
     )
@@ -851,7 +851,7 @@ class TestAllenBradleyPLCTagReading:
 
         mock_logix_driver.read.side_effect = driver_error_class("socket closed")
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=1)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
 
@@ -859,7 +859,6 @@ class TestAllenBradleyPLCTagReading:
             await plc.read_tag(["Motor1_Speed"])
 
         assert isinstance(exc_info.value.__cause__, driver_error_class)
-        assert "attempts=1" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_read_request_error_is_never_retried(self, mock_pycomm3_available, mock_logix_driver):
@@ -871,7 +870,7 @@ class TestAllenBradleyPLCTagReading:
 
         mock_logix_driver.read.side_effect = RequestError("Failed to parse tag request")
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=3)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
         plc._reconnect_channel = AsyncMock(return_value=True)
@@ -940,7 +939,7 @@ class TestAllenBradleyPLCTagReading:
 
         mock_slc_driver.read.side_effect = [100, CommError("socket closed")]
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc", retry_count=1)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc")
         SLCDriver.return_value = mock_slc_driver
         await plc.connect()
 
@@ -1112,48 +1111,46 @@ class TestAllenBradleyPLCTagReading:
 
     @pytest.mark.asyncio
     async def test_read_tag_not_connected(self, mock_pycomm3_available, mock_logix_driver):
-        """A closed channel whose session will not reopen still raises, and never
-        goes through the public lifecycle."""
+        """A never-connected channel is a lifecycle error: nothing gets opened."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
         )
 
-        mock_logix_driver.open.return_value = False  # the channel refuses to come back
-
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=2)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
-        # A reconnect that WOULD succeed — recovery must still not take both locks.
-        plc.reconnect = AsyncMock(return_value=True)
 
-        with pytest.raises(PLCCommunicationError) as exc_info:
+        with pytest.raises(PLCConnectionError, match="never opened"):
             await plc.read_tag(["Motor1_Speed"])
 
-        assert "read channel" in str(exc_info.value)
-        assert "attempts=2" in str(exc_info.value)
-        plc.reconnect.assert_not_called()
+        LogixDriver.assert_not_called()
         mock_logix_driver.read.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_read_tag_after_channel_drops(self, mock_pycomm3_available, mock_logix_driver):
-        """A session that drops after connect is rebuilt on the read channel only."""
+        """A session that drops after connect reopens at the next call, read channel only."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
         )
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=2)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
         plc.reconnect = AsyncMock(return_value=True)
         write_driver = plc._write_driver
 
         mock_logix_driver.connected = False
-        # The replacement session is just as dead, so the read still fails — the
-        # point is that it failed after a channel reconnect, not a lifecycle one.
-        with pytest.raises(PLCCommunicationError):
-            await plc.read_tag(["Motor1_Speed"])
+        replacement = MagicMock()
+        replacement.open.return_value = True
+        replacement.connected = True
+        replacement.read.return_value = SimpleNamespace(value=1500.0, error=None)
+        LogixDriver.return_value = replacement
 
+        results = await plc.read_tag(["Motor1_Speed"])
+
+        assert results["Motor1_Speed"].value == 1500.0
+        assert plc._read_driver is replacement
         plc.reconnect.assert_not_called()
         assert plc._write_driver is write_driver
 
@@ -1469,7 +1466,7 @@ class TestAllenBradleyPLCTagWriting:
 
         mock_logix_driver.write.side_effect = driver_error_class("socket closed")
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=1)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
 
@@ -1477,7 +1474,6 @@ class TestAllenBradleyPLCTagWriting:
             await plc.write_tag([("Motor1_Speed", 1500.0)])
 
         assert isinstance(exc_info.value.__cause__, driver_error_class)
-        assert "attempts=1" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_write_request_error_is_never_retried(self, mock_pycomm3_available, mock_logix_driver):
@@ -1489,7 +1485,7 @@ class TestAllenBradleyPLCTagWriting:
 
         mock_logix_driver.write.side_effect = RequestError("Failed to parse tag request")
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=3)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
         plc._reconnect_channel = AsyncMock(return_value=True)
@@ -1664,46 +1660,45 @@ class TestAllenBradleyPLCTagWriting:
 
     @pytest.mark.asyncio
     async def test_write_tag_not_connected(self, mock_pycomm3_available, mock_logix_driver):
-        """A closed channel whose session will not reopen still raises, and never
-        goes through the public lifecycle."""
+        """A never-connected channel is a lifecycle error: nothing gets opened."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
         )
 
-        mock_logix_driver.open.return_value = False  # the channel refuses to come back
-
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=2)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
-        # A reconnect that WOULD succeed — recovery must still not take both locks.
-        plc.reconnect = AsyncMock(return_value=True)
 
-        with pytest.raises(PLCCommunicationError) as exc_info:
+        with pytest.raises(PLCConnectionError, match="never opened"):
             await plc.write_tag([("Motor1_Speed", 1500.0)])
 
-        assert "write channel" in str(exc_info.value)
-        assert "attempts=2" in str(exc_info.value)
-        plc.reconnect.assert_not_called()
+        LogixDriver.assert_not_called()
         mock_logix_driver.write.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_write_tag_after_channel_drops(self, mock_pycomm3_available, mock_logix_driver):
-        """A session that drops after connect is rebuilt on the write channel only."""
+        """A session that drops after connect reopens at the next call, write channel only."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
         )
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=2)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
         plc.reconnect = AsyncMock(return_value=True)
 
         mock_logix_driver.connected = False
+        replacement = MagicMock()
+        replacement.open.return_value = True
+        replacement.connected = True
+        replacement.write.return_value = SimpleNamespace(value=None, error=None)
+        LogixDriver.return_value = replacement
 
-        with pytest.raises(PLCCommunicationError):
-            await plc.write_tag([("Motor1_Speed", 1500.0)])
+        results = await plc.write_tag([("Motor1_Speed", 1500.0)])
 
+        assert results["Motor1_Speed"].value == 1500.0
+        assert plc._write_driver is replacement
         plc.reconnect.assert_not_called()
 
     @pytest.mark.asyncio
@@ -1752,9 +1747,9 @@ class TestAllenBradleyPLCTagWriting:
     async def test_write_tag_result_stamped_with_link_trouble_raises(self, mock_pycomm3_available, mock_cip_driver):
         """A tag stamped with pycomm3's own link text is a channel failure, not a result.
 
-        The exchange carrying this write never happened, so the caller is told by a
-        raise — with the partial map attached for the log — rather than handed a
-        write it cannot tell apart from a completed one.
+        The exchange carrying this write never happened, so the caller is told by
+        a raise (stamped addresses go to the log) and the channel is closed on
+        the controller's word.
         """
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
@@ -1762,19 +1757,20 @@ class TestAllenBradleyPLCTagWriting:
         )
 
         error_result = MagicMock()
-        error_result.error = "failed to receive reply"
+        error_result.error = "Connection lost"
         mock_cip_driver.generic_message.return_value = error_result
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip", retry_count=2, retry_delay=0.01)
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip", retry_delay=0.01)
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        with pytest.raises(PLCCommunicationError, match=r"attempts=2") as exc_info:
+        with pytest.raises(PLCCommunicationError, match=r"1/1") as exc_info:
             await plc.write_tag([("Assembly:20", [1500, 0, 255, 0])])
 
-        assert exc_info.value.transport_addresses == ("Assembly:20",)
-        assert exc_info.value.results["Assembly:20"].error.kind is TagErrorKind.transport
-        assert mock_cip_driver.generic_message.call_count == 2
+        assert not hasattr(exc_info.value, "transport_addresses")
+        assert not hasattr(exc_info.value, "results")
+        assert mock_cip_driver.generic_message.call_count == 1
+        assert mock_cip_driver.close.called  # the write channel was closed on proof
 
     @pytest.mark.asyncio
     async def test_write_tag_cip_assembly_exception(self, mock_pycomm3_available, mock_cip_driver):
@@ -2078,7 +2074,7 @@ class TestAllenBradleyPLCTagDiscovery:
 
     @pytest.mark.asyncio
     async def test_get_all_tags_not_connected(self, mock_pycomm3_available, mock_logix_driver):
-        """Listing tags on a closed channel raises; it never reconnects."""
+        """A never-connected channel is a lifecycle error: nothing gets opened."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
@@ -2086,13 +2082,11 @@ class TestAllenBradleyPLCTagDiscovery:
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
-        # A reconnect that WOULD succeed — the transport must still not call it.
-        plc.reconnect = AsyncMock(return_value=True)
 
-        with pytest.raises(PLCCommunicationError):
+        with pytest.raises(PLCConnectionError, match="never opened"):
             await plc.get_all_tags()
 
-        plc.reconnect.assert_not_called()
+        LogixDriver.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_all_tags_exception_raises_error(self, mock_pycomm3_available, mock_logix_driver):
@@ -2266,7 +2260,7 @@ class TestAllenBradleyPLCTagInfo:
 
     @pytest.mark.asyncio
     async def test_get_tag_info_not_connected(self, mock_pycomm3_available, mock_logix_driver):
-        """Describing a tag on a closed channel raises; it never reconnects."""
+        """A never-connected channel is a lifecycle error: nothing gets opened."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
@@ -2274,13 +2268,11 @@ class TestAllenBradleyPLCTagInfo:
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
-        # A reconnect that WOULD succeed — the transport must still not call it.
-        plc.reconnect = AsyncMock(return_value=True)
 
-        with pytest.raises(PLCCommunicationError):
+        with pytest.raises(PLCConnectionError, match="never opened"):
             await plc.get_tag_info("Motor1_Speed")
 
-        plc.reconnect.assert_not_called()
+        LogixDriver.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_tag_info_exception_raises_error(self, mock_pycomm3_available, mock_logix_driver):
@@ -2401,7 +2393,7 @@ class TestAllenBradleyPLCPLCInfo:
 
     @pytest.mark.asyncio
     async def test_get_plc_info_not_connected(self, mock_pycomm3_available, mock_logix_driver):
-        """Probing a closed channel raises; it never reconnects."""
+        """A never-connected channel is a lifecycle error: nothing gets opened."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
@@ -2409,13 +2401,11 @@ class TestAllenBradleyPLCPLCInfo:
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
-        # A reconnect that WOULD succeed — the transport must still not call it.
-        plc.reconnect = AsyncMock(return_value=True)
 
-        with pytest.raises(PLCCommunicationError):
+        with pytest.raises(PLCConnectionError, match="never opened"):
             await plc.get_plc_info()
 
-        plc.reconnect.assert_not_called()
+        LogixDriver.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_plc_info_exception_handling(self, mock_pycomm3_available, mock_logix_driver):

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
@@ -2498,7 +2498,6 @@ class TestAllenBradleyPLCPLCInfo:
         # Device info exception should be caught and logged, but basic info should still be returned
         assert "product_name" not in info or info.get("product_name") == "Unknown"
 
-
     @pytest.mark.asyncio
     async def test_get_plc_info_outer_exception(self, mock_pycomm3_available, mock_logix_driver):
         """An unexpected failure is reported in-band — with only honest fields:

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
@@ -895,7 +895,7 @@ class TestAllenBradleyPLCTagReading:
         )
 
         # First tag succeeds, second fails
-        mock_slc_driver.read.side_effect = [100, ResponseError("Read failed")]
+        mock_slc_driver.read.side_effect = [100, SimpleNamespace(value=None, error="Read failed")]
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc")
         SLCDriver.return_value = mock_slc_driver
@@ -936,7 +936,7 @@ class TestAllenBradleyPLCTagReading:
             SLCDriver,
         )
 
-        mock_slc_driver.read.side_effect = ResponseError("N99:0 does not exist")
+        mock_slc_driver.read.return_value = SimpleNamespace(value=None, error="N99:0 does not exist")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc")
         SLCDriver.return_value = mock_slc_driver
@@ -1070,15 +1070,12 @@ class TestAllenBradleyPLCTagReading:
         assert result["4:1:3"] == TagResult(value=cip_value)
 
     @pytest.mark.asyncio
-    async def test_read_tag_cip_direct_read(self, mock_pycomm3_available, mock_cip_driver):
-        """Test reading CIP tag with direct read fallback."""
+    async def test_read_tag_cip_unsupported_form_is_a_verdict(self, mock_pycomm3_available, mock_cip_driver):
+        """CIPDriver has no read(); an unservable address form is a per-tag verdict."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             CIPDriver,
         )
-
-        direct_value = "test_value"
-        mock_cip_driver.read.return_value = direct_value
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
@@ -1086,8 +1083,8 @@ class TestAllenBradleyPLCTagReading:
 
         result = await plc.read_tag(["SimpleTag"])
 
-        assert "SimpleTag" in result
-        assert result["SimpleTag"] == TagResult(value=direct_value)
+        assert result["SimpleTag"].error.kind is TagErrorKind.missing_tag
+        mock_cip_driver.read.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_read_tag_not_connected(self, mock_pycomm3_available, mock_logix_driver):
@@ -1226,7 +1223,8 @@ class TestAllenBradleyPLCTagReading:
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_identity_exception(self, mock_pycomm3_available, mock_cip_driver):
-        """Test reading CIP Identity tag when list_identity raises exception."""
+        """list_identity opens its own throwaway connection: its failure is a
+        per-tag verdict, never evidence against the channel driver."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             CIPDriver,
@@ -1240,10 +1238,9 @@ class TestAllenBradleyPLCTagReading:
 
         result = await plc.read_tag(["Identity"])
 
-        assert "Identity" in result
-        assert result["Identity"].ok is False
         assert result["Identity"].error.kind is TagErrorKind.unknown
-        assert result["Identity"].error.message == "Identity read failed"
+        assert "identity probe failed" in result["Identity"].error.message
+        mock_cip_driver.close.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_assembly_exception(self, mock_pycomm3_available, mock_cip_driver):
@@ -1253,7 +1250,7 @@ class TestAllenBradleyPLCTagReading:
             CIPDriver,
         )
 
-        mock_cip_driver.generic_message.side_effect = ResponseError("Assembly read failed")
+        mock_cip_driver.generic_message.return_value = MagicMock(value=None, error="Assembly read failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
@@ -1268,7 +1265,7 @@ class TestAllenBradleyPLCTagReading:
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_module_exception(self, mock_pycomm3_available, mock_cip_driver):
-        """Test reading CIP Module tag when get_module_info raises exception."""
+        """get_module_info raises (never stamps) in pycomm3: whole-call, channel closes."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             CIPDriver,
@@ -1280,12 +1277,10 @@ class TestAllenBradleyPLCTagReading:
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag(["Module:0"])
+        with pytest.raises(PLCCommunicationError, match="Module read failed"):
+            await plc.read_tag(["Module:0"])
 
-        assert "Module:0" in result
-        assert result["Module:0"].ok is False
-        assert result["Module:0"].error.kind is TagErrorKind.unknown
-        assert result["Module:0"].error.message == "Module read failed"
+        mock_cip_driver.close.assert_called()
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_connection_exception(self, mock_pycomm3_available, mock_cip_driver):
@@ -1295,7 +1290,7 @@ class TestAllenBradleyPLCTagReading:
             CIPDriver,
         )
 
-        mock_cip_driver.generic_message.side_effect = ResponseError("Connection read failed")
+        mock_cip_driver.generic_message.return_value = MagicMock(value=None, error="Connection read failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
@@ -1316,7 +1311,7 @@ class TestAllenBradleyPLCTagReading:
             CIPDriver,
         )
 
-        mock_cip_driver.generic_message.side_effect = ResponseError("Generic read failed")
+        mock_cip_driver.generic_message.return_value = MagicMock(value=None, error="Generic read failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
@@ -1509,7 +1504,7 @@ class TestAllenBradleyPLCTagWriting:
         )
 
         # First write succeeds, second fails
-        mock_slc_driver.write.side_effect = [True, ResponseError("Write failed")]
+        mock_slc_driver.write.side_effect = [True, SimpleNamespace(value=None, error="Write failed")]
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc")
         SLCDriver.return_value = mock_slc_driver
@@ -1531,7 +1526,7 @@ class TestAllenBradleyPLCTagWriting:
             SLCDriver,
         )
 
-        mock_slc_driver.write.side_effect = DataError("Error packing -128 as USINT")
+        mock_slc_driver.write.side_effect = RequestError("Unable to create a writable value")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc")
         SLCDriver.return_value = mock_slc_driver
@@ -1598,14 +1593,12 @@ class TestAllenBradleyPLCTagWriting:
         assert result["0x04:1:3"] == TagResult(value=[1500, 0, 255, 0])
 
     @pytest.mark.asyncio
-    async def test_write_tag_cip_direct_write(self, mock_pycomm3_available, mock_cip_driver):
-        """Test writing CIP tag with direct write fallback."""
+    async def test_write_tag_cip_unsupported_form_is_a_verdict(self, mock_pycomm3_available, mock_cip_driver):
+        """CIPDriver has no write(); an unservable address form is a per-tag verdict."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             CIPDriver,
         )
-
-        mock_cip_driver.write.return_value = True
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
@@ -1613,7 +1606,8 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("SimpleTag", "value")])
 
-        assert result["SimpleTag"] == TagResult(value="value")
+        assert result["SimpleTag"].error.kind is TagErrorKind.missing_tag
+        mock_cip_driver.write.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_write_tag_cip_with_error(self, mock_pycomm3_available, mock_cip_driver):
@@ -1760,7 +1754,7 @@ class TestAllenBradleyPLCTagWriting:
             CIPDriver,
         )
 
-        mock_cip_driver.generic_message.side_effect = ResponseError("Assembly write failed")
+        mock_cip_driver.generic_message.return_value = MagicMock(value=None, error="Assembly write failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
@@ -1780,7 +1774,7 @@ class TestAllenBradleyPLCTagWriting:
             CIPDriver,
         )
 
-        mock_cip_driver.generic_message.side_effect = ResponseError("Parameter write failed")
+        mock_cip_driver.generic_message.return_value = MagicMock(value=None, error="Parameter write failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
@@ -1800,7 +1794,7 @@ class TestAllenBradleyPLCTagWriting:
             CIPDriver,
         )
 
-        mock_cip_driver.generic_message.side_effect = ResponseError("Generic write failed")
+        mock_cip_driver.generic_message.return_value = MagicMock(value=None, error="Generic write failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
@@ -635,8 +635,8 @@ class TestTagErrorClassification:
             ("Error packing -128 as USINT", TagErrorKind.encode),
             ("Error unpacking response", TagErrorKind.encode),
             ("Error encoding value for tag", TagErrorKind.encode),
-            ("Invalid data type for tag", TagErrorKind.type_mismatch),
-            ("Tag type mismatch", TagErrorKind.type_mismatch),
+            # 0xFF ext 0x2107, verbatim.
+            ("Tag type used in request does not match the target tag's data type", TagErrorKind.type_mismatch),
             # socket related
             # Socket deaths always RAISE; their texts are not stamp patterns.
             ("Connection reset by peer", TagErrorKind.unknown),
@@ -645,7 +645,7 @@ class TestTagErrorClassification:
     )
     def test_classify_tag_error(self, mock_pycomm3_available, message, expected_kind):
         """Driver error strings map onto the documented kinds, raw text preserved."""
-        from mindtrace.hardware.plcs.types import classify_tag_error
+        from mindtrace.hardware.plcs.backends.allen_bradley.error_text import classify_tag_error
 
         error = classify_tag_error(message)
 
@@ -654,7 +654,7 @@ class TestTagErrorClassification:
 
     def test_classify_tag_error_accepts_an_exception(self, mock_pycomm3_available):
         """A raised exception classifies on its string form."""
-        from mindtrace.hardware.plcs.types import classify_tag_error
+        from mindtrace.hardware.plcs.backends.allen_bradley.error_text import classify_tag_error
 
         error = classify_tag_error(ValueError("Tag does not exist"))
 
@@ -664,7 +664,7 @@ class TestTagErrorClassification:
     def test_tag_to_result_missing_driver_result(self, mock_pycomm3_available):
         """A missing driver result is an error, not a None value — and not a
         licence to bounce the session: nothing here says the exchange failed."""
-        from mindtrace.hardware.plcs.types import tag_to_result
+        from mindtrace.hardware.plcs.backends.allen_bradley.error_text import tag_to_result
 
         result = tag_to_result(None)
 
@@ -674,7 +674,7 @@ class TestTagErrorClassification:
 
     def test_tag_to_result_write_reports_the_written_value(self, mock_pycomm3_available):
         """Write results carry the value that was written, not the driver's echo."""
-        from mindtrace.hardware.plcs.types import tag_to_result
+        from mindtrace.hardware.plcs.backends.allen_bradley.error_text import tag_to_result
 
         tag = MagicMock()
         tag.error = None
@@ -1709,7 +1709,7 @@ class TestAllenBradleyPLCTagWriting:
         )
 
         failed_result = MagicMock()
-        failed_result.error = "Invalid data type for tag"
+        failed_result.error = "General Error (see extended status) - Wrong data type"
         mock_logix_driver.write.return_value = failed_result
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
@@ -1721,7 +1721,7 @@ class TestAllenBradleyPLCTagWriting:
         assert result["Motor1_Speed"].ok is False
         assert result["Motor1_Speed"].value_or(None) is None
         assert result["Motor1_Speed"].error.kind is TagErrorKind.type_mismatch
-        assert result["Motor1_Speed"].error.message == "Invalid data type for tag"
+        assert result["Motor1_Speed"].error.message == "General Error (see extended status) - Wrong data type"
 
     @pytest.mark.asyncio
     async def test_write_tag_result_stamped_with_link_trouble_raises(self, mock_pycomm3_available, mock_cip_driver):

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
@@ -6,9 +6,10 @@ allowing full test coverage without requiring physical hardware.
 """
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+from pycomm3.exceptions import CommError, DataError, RequestError, ResponseError
 
 from mindtrace.hardware.core.exceptions import (
     PLCCommunicationError,
@@ -20,6 +21,7 @@ from mindtrace.hardware.core.exceptions import (
     PLCTagWriteError,
     SDKNotAvailableError,
 )
+from mindtrace.hardware.plcs.types import TagErrorKind, TagResult
 
 
 @pytest.fixture(scope="session")
@@ -49,9 +51,13 @@ def mock_pycomm3_unavailable():
         yield
 
 
-@pytest.fixture
-def mock_logix_driver():
-    """Create a mock LogixDriver instance."""
+def make_logix_driver():
+    """Build one mock LogixDriver session.
+
+    The backend opens two sessions per PLC (read + write). Tests that only care
+    about payloads let a single mock stand in for both channels; tests about the
+    channels themselves build one of these per channel.
+    """
     mock_driver = MagicMock()
     mock_driver.open.return_value = True
     mock_driver.close.return_value = None
@@ -65,7 +71,9 @@ def mock_logix_driver():
     mock_read_result.value = 1500.0
     mock_read_result.error = None
     mock_driver.read.return_value = mock_read_result
-    mock_driver.write.return_value = True
+    mock_write_result = MagicMock()
+    mock_write_result.error = None
+    mock_driver.write.return_value = mock_write_result
     mock_driver.get_plc_info.return_value = MagicMock(
         product_name="ControlLogix L75",
         product_type="Programmable Logic Controller",
@@ -75,6 +83,12 @@ def mock_logix_driver():
     )
     mock_driver.get_plc_name.return_value = "TestProgram"
     return mock_driver
+
+
+@pytest.fixture
+def mock_logix_driver():
+    """A mock LogixDriver instance, used for both channels unless a test splits them."""
+    return make_logix_driver()
 
 
 @pytest.fixture
@@ -169,23 +183,53 @@ class TestAllenBradleyPLCConnection:
     """Test suite for Allen Bradley PLC connection methods."""
 
     @pytest.mark.asyncio
-    async def test_connect_logix_driver(self, mock_pycomm3_available, mock_logix_driver):
-        """Test connection with LogixDriver."""
+    async def test_connect_logix_driver(self, mock_pycomm3_available):
+        """Connecting with LogixDriver opens a read session AND a write session."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
         )
 
-        LogixDriver.return_value = mock_logix_driver
+        read_driver = make_logix_driver()
+        write_driver = make_logix_driver()
+        LogixDriver.side_effect = [read_driver, write_driver]
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         result = await plc.connect()
 
         assert result is True
         assert plc.driver_type == "LogixDriver"
-        assert plc.plc is not None
-        LogixDriver.assert_called_once_with("192.168.1.100")
-        mock_logix_driver.open.assert_called_once()
+        assert plc._read_driver is read_driver
+        assert plc._write_driver is write_driver
+        # ``plc`` stays an alias of the READ session.
+        assert plc.plc is read_driver
+        assert LogixDriver.call_args_list == [call("192.168.1.100"), call("192.168.1.100")]
+        read_driver.open.assert_called_once()
+        write_driver.open.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_a_second_connect_closes_the_sessions_it_replaces(self, mock_pycomm3_available):
+        """Redundant connects must not orphan CIP sessions on a session-capped controller."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        first_read, first_write = make_logix_driver(), make_logix_driver()
+        second_read, second_write = make_logix_driver(), make_logix_driver()
+        LogixDriver.side_effect = [first_read, first_write, second_read, second_write]
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        await plc.connect()
+        await plc.connect()
+
+        first_read.close.assert_called_once()
+        first_write.close.assert_called_once()
+        second_read.close.assert_not_called()
+        second_write.close.assert_not_called()
+        assert plc._read_driver is second_read
+        assert plc._write_driver is second_write
+        assert plc.plc is second_read
 
     @pytest.mark.asyncio
     async def test_connect_slc_driver(self, mock_pycomm3_available, mock_slc_driver):
@@ -202,8 +246,8 @@ class TestAllenBradleyPLCConnection:
 
         assert result is True
         assert plc.driver_type == "SLCDriver"
-        SLCDriver.assert_called_once_with("192.168.1.100")
-        mock_slc_driver.open.assert_called_once()
+        assert SLCDriver.call_args_list == [call("192.168.1.100"), call("192.168.1.100")]
+        assert mock_slc_driver.open.call_count == 2
 
     @pytest.mark.asyncio
     async def test_connect_cip_driver(self, mock_pycomm3_available, mock_cip_driver):
@@ -220,8 +264,8 @@ class TestAllenBradleyPLCConnection:
 
         assert result is True
         assert plc.driver_type == "CIPDriver"
-        CIPDriver.assert_called_once_with("192.168.1.100")
-        mock_cip_driver.open.assert_called_once()
+        assert CIPDriver.call_args_list == [call("192.168.1.100"), call("192.168.1.100")]
+        assert mock_cip_driver.open.call_count == 2
 
     @pytest.mark.asyncio
     async def test_connect_auto_detection_logix(self, mock_pycomm3_available, mock_logix_driver):
@@ -291,27 +335,30 @@ class TestAllenBradleyPLCConnection:
         assert plc.driver_type == "CIPDriver"
 
     @pytest.mark.asyncio
-    async def test_connect_retry_logic(self, mock_pycomm3_available, mock_logix_driver):
-        """Test connection retry logic."""
+    async def test_connect_makes_a_single_attempt(self, mock_pycomm3_available, mock_logix_driver):
+        """Connect never retries: the first failed open ends the attempt.
+
+        ``retry_count`` is app-facing metadata; a would-be-successful second
+        attempt is never made.
+        """
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
         )
 
-        # First two attempts fail, third succeeds
-        mock_logix_driver.open.side_effect = [Exception("Failed"), Exception("Failed"), True]
+        mock_logix_driver.open.side_effect = [Exception("Failed"), True, True]
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=3)
         LogixDriver.return_value = mock_logix_driver
 
-        result = await plc.connect()
+        with pytest.raises(PLCConnectionError):
+            await plc.connect()
 
-        assert result is True
-        assert mock_logix_driver.open.call_count == 3
+        assert mock_logix_driver.open.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_connect_failure_after_retries(self, mock_pycomm3_available, mock_logix_driver):
-        """Test connection failure after all retries."""
+    async def test_connect_raises_on_open_exception(self, mock_pycomm3_available, mock_logix_driver):
+        """A driver exception during open surfaces as PLCConnectionError, chained."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
@@ -322,8 +369,12 @@ class TestAllenBradleyPLCConnection:
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=2)
         LogixDriver.return_value = mock_logix_driver
 
-        with pytest.raises(PLCConnectionError):
+        with pytest.raises(PLCConnectionError) as exc_info:
             await plc.connect()
+
+        assert "Connection failed" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, Exception)
+        assert mock_logix_driver.open.call_count == 1
 
     @pytest.mark.asyncio
     async def test_connect_returns_false(self, mock_pycomm3_available, mock_logix_driver):
@@ -341,26 +392,55 @@ class TestAllenBradleyPLCConnection:
         with pytest.raises(PLCConnectionError):
             await plc.connect()
 
+        # Both half-open sessions are closed again.
+        assert mock_logix_driver.close.call_count == 2
+
     @pytest.mark.asyncio
-    async def test_disconnect_success(self, mock_pycomm3_available, mock_logix_driver):
-        """Test successful disconnection."""
+    async def test_connect_fails_when_only_the_read_session_opens(self, mock_pycomm3_available):
+        """A half-open device is not a connection: both sessions must open."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
         )
 
-        mock_logix_driver.connected = True
+        read_driver = make_logix_driver()
+        write_driver = make_logix_driver()
+        write_driver.open.return_value = False
+        LogixDriver.side_effect = [read_driver, write_driver]
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
-        LogixDriver.return_value = mock_logix_driver
+
+        with pytest.raises(PLCConnectionError) as exc_info:
+            await plc.connect()
+
+        assert "read=True" in str(exc_info.value)
+        assert "write=False" in str(exc_info.value)
+        read_driver.close.assert_called_once()
+        write_driver.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_success(self, mock_pycomm3_available):
+        """Disconnecting closes both sessions."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        read_driver = make_logix_driver()
+        write_driver = make_logix_driver()
+        LogixDriver.side_effect = [read_driver, write_driver]
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         await plc.connect()
 
-        mock_logix_driver.connected = False
+        read_driver.connected = False
+        write_driver.connected = False
         result = await plc.disconnect()
 
         assert result is True
         assert not plc.initialized
-        mock_logix_driver.close.assert_called_once()
+        read_driver.close.assert_called_once()
+        write_driver.close.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_disconnect_when_not_connected(self, mock_pycomm3_available):
@@ -407,7 +487,7 @@ class TestAllenBradleyPLCConnection:
         result = await plc.disconnect()
 
         assert result is False
-        mock_logix_driver.close.assert_called_once()
+        assert mock_logix_driver.close.call_count == 2
 
     @pytest.mark.asyncio
     async def test_is_connected_true(self, mock_pycomm3_available, mock_logix_driver):
@@ -427,13 +507,36 @@ class TestAllenBradleyPLCConnection:
 
     @pytest.mark.asyncio
     async def test_is_connected_false_no_plc(self, mock_pycomm3_available):
-        """Test is_connected returns False when plc is None."""
+        """Test is_connected returns False when no session exists."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import AllenBradleyPLC
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         result = await plc.is_connected()
 
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_is_connected_requires_both_sessions(self, mock_pycomm3_available):
+        """Connected means BOTH sessions are open; a dropped write socket is not connected."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        read_driver = make_logix_driver()
+        write_driver = make_logix_driver()
+        LogixDriver.side_effect = [read_driver, write_driver]
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        await plc.connect()
+        assert await plc.is_connected() is True
+
+        write_driver.connected = False
+        assert await plc.is_connected() is False
+
+        write_driver.connected = True
+        read_driver.connected = False
+        assert await plc.is_connected() is False
 
     @pytest.mark.asyncio
     async def test_is_connected_exception_handling(self, mock_pycomm3_available, mock_logix_driver):
@@ -540,6 +643,67 @@ class TestAllenBradleyPLCInitialize:
         assert device_manager is None
 
 
+class TestTagErrorClassification:
+    """Test suite for the per-tag error classifier and Tag → TagResult conversion."""
+
+    @pytest.mark.parametrize(
+        "message, expected_kind",
+        [
+            ("Tag doesn't exist - Motor1_Speed", TagErrorKind.missing_tag),
+            ("Instance does not exist", TagErrorKind.missing_tag),
+            ("('Failed to parse tag request', 'Bad{Tag')", TagErrorKind.missing_tag),
+            ("Invalid tag request - RequestError('Failed to parse tag request', 'Bad{Tag')", TagErrorKind.missing_tag),
+            ("Error packing -128 as USINT", TagErrorKind.encode),
+            ("Error unpacking response", TagErrorKind.encode),
+            ("Error encoding value for tag", TagErrorKind.encode),
+            ("Invalid data type for tag", TagErrorKind.type_mismatch),
+            ("Tag type mismatch", TagErrorKind.type_mismatch),
+            ("Connection reset by peer", TagErrorKind.transport),
+            # "type" alone is not evidence of a tag type problem.
+            ("'NoneType' object has no attribute 'read'", TagErrorKind.transport),
+        ],
+    )
+    def test_classify_tag_error(self, mock_pycomm3_available, message, expected_kind):
+        """Driver error strings map onto the documented kinds, raw text preserved."""
+        from mindtrace.hardware.plcs.types import classify_tag_error
+
+        error = classify_tag_error(message)
+
+        assert error.kind is expected_kind
+        assert error.message == message
+
+    def test_classify_tag_error_accepts_an_exception(self, mock_pycomm3_available):
+        """A raised exception classifies on its string form."""
+        from mindtrace.hardware.plcs.types import classify_tag_error
+
+        error = classify_tag_error(ValueError("Tag does not exist"))
+
+        assert error.kind is TagErrorKind.missing_tag
+        assert error.message == "Tag does not exist"
+
+    def test_tag_to_result_missing_driver_result(self, mock_pycomm3_available):
+        """A missing driver result is a transport failure, not a None value."""
+        from mindtrace.hardware.plcs.types import tag_to_result
+
+        result = tag_to_result(None)
+
+        assert result.ok is False
+        assert result.error.kind is TagErrorKind.transport
+        assert result.error.message == "driver returned None"
+
+    def test_tag_to_result_write_reports_the_written_value(self, mock_pycomm3_available):
+        """Write results carry the value that was written, not the driver's echo."""
+        from mindtrace.hardware.plcs.types import tag_to_result
+
+        tag = MagicMock()
+        tag.error = None
+        tag.value = "driver echo"
+
+        result = tag_to_result(tag, value_on_success=1500.0, use_tag_value=False)
+
+        assert result == TagResult(value=1500.0)
+
+
 class TestAllenBradleyPLCTagReading:
     """Test suite for tag reading operations."""
 
@@ -551,28 +715,56 @@ class TestAllenBradleyPLCTagReading:
             LogixDriver,
         )
 
-        # For LogixDriver, the result can be the value directly or have a .value attribute
-        # The code checks hasattr(result, "value") and uses result.value if present, otherwise result
-        # Important: MagicMock has an 'error' attribute by default which is truthy, so we need to set it to None
         mock_result = MagicMock()
         mock_result.value = 1500.0
-        mock_result.error = None  # Explicitly set error to None to avoid the error check
+        mock_result.error = None
         mock_logix_driver.read.return_value = mock_result
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
 
-        # After connect, plc.plc should be mock_logix_driver, so we can also set it there
-        # But the fixture should already have it set, so this should work
-        result = await plc.read_tag("Motor1_Speed")
+        result = await plc.read_tag(["Motor1_Speed"])
 
         assert "Motor1_Speed" in result
-        # The code checks hasattr and uses .value if present
-        # Since we set mock_result.value = 1500.0, it should use that
-        assert result["Motor1_Speed"] == 1500.0
-        # Verify the read was called on the actual plc instance
-        assert plc.plc.read.called
+        assert result["Motor1_Speed"].ok is True
+        assert result["Motor1_Speed"].value == 1500.0
+        plc._read_driver.read.assert_called_once_with("Motor1_Speed")
+
+    @pytest.mark.asyncio
+    async def test_read_tag_use_the_read_session(self, mock_pycomm3_available):
+        """Reads go to the read session only; the write session is untouched."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        read_driver = make_logix_driver()
+        write_driver = make_logix_driver()
+        LogixDriver.side_effect = [read_driver, write_driver]
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        await plc.connect()
+
+        await plc.read_tag(["Motor1_Speed"])
+
+        read_driver.read.assert_called_once_with("Motor1_Speed")
+        write_driver.read.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_read_no_tags_is_a_no_op(self, mock_pycomm3_available, mock_logix_driver):
+        """An empty batch returns an empty mapping without hitting the device."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        LogixDriver.return_value = mock_logix_driver
+        await plc.connect()
+
+        assert await plc.read_tag([]) == {}
+        mock_logix_driver.read.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_read_tag_logix_multiple(self, mock_pycomm3_available, mock_logix_driver):
@@ -601,9 +793,9 @@ class TestAllenBradleyPLCTagReading:
         result = await plc.read_tag(["Motor1_Speed", "Production_Count", "Conveyor_Status"])
 
         assert len(result) == 3
-        assert result["Motor1_Speed"] == 1500.0
-        assert result["Production_Count"] == 100
-        assert result["Conveyor_Status"] is True
+        assert result["Motor1_Speed"] == TagResult(value=1500.0)
+        assert result["Production_Count"] == TagResult(value=100)
+        assert result["Conveyor_Status"] == TagResult(value=True)
 
     @pytest.mark.asyncio
     async def test_read_tag_logix_single_as_list(self, mock_pycomm3_available, mock_logix_driver):
@@ -613,16 +805,82 @@ class TestAllenBradleyPLCTagReading:
             LogixDriver,
         )
 
-        mock_result = [MagicMock(value=1500.0)]
+        mock_result = [MagicMock(value=1500.0, error=None)]
         mock_logix_driver.read.return_value = mock_result
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
 
-        result = await plc.read_tag("Motor1_Speed")
+        result = await plc.read_tag(["Motor1_Speed"])
 
         assert "Motor1_Speed" in result
+        assert result["Motor1_Speed"] == TagResult(value=1500.0)
+
+    @pytest.mark.asyncio
+    async def test_read_tag_result_count_mismatch_raises(self, mock_pycomm3_available, mock_logix_driver):
+        """A short result list is a whole-call failure, not a silently truncated dict."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        mock_logix_driver.read.return_value = [MagicMock(value=1500.0, error=None)]
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        LogixDriver.return_value = mock_logix_driver
+        await plc.connect()
+
+        with pytest.raises(PLCTagReadError) as exc_info:
+            await plc.read_tag(["Motor1_Speed", "Production_Count"])
+
+        assert "1 results" in str(exc_info.value)
+        assert "2 requested tags" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver_error_class", [CommError, DataError, ResponseError])
+    async def test_read_transport_errors_raise_communication_error(
+        self, mock_pycomm3_available, mock_logix_driver, driver_error_class
+    ):
+        """Transport-class pycomm3 failures are retryable: PLCCommunicationError, chained."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        mock_logix_driver.read.side_effect = driver_error_class("socket closed")
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=1)
+        LogixDriver.return_value = mock_logix_driver
+        await plc.connect()
+
+        with pytest.raises(PLCCommunicationError) as exc_info:
+            await plc.read_tag(["Motor1_Speed"])
+
+        assert isinstance(exc_info.value.__cause__, driver_error_class)
+        assert "attempts=1" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_read_request_error_is_never_retried(self, mock_pycomm3_available, mock_logix_driver):
+        """A malformed request is a config problem: PLCTagReadError on the first try."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        mock_logix_driver.read.side_effect = RequestError("Failed to parse tag request")
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=3)
+        LogixDriver.return_value = mock_logix_driver
+        await plc.connect()
+        plc._reconnect_channel = AsyncMock(return_value=True)
+
+        with pytest.raises(PLCTagReadError) as exc_info:
+            await plc.read_tag(["Motor1_Speed"])
+
+        assert isinstance(exc_info.value.__cause__, RequestError)
+        assert mock_logix_driver.read.call_count == 1
+        plc._reconnect_channel.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_read_tag_slc_success(self, mock_pycomm3_available, mock_slc_driver):
@@ -642,18 +900,18 @@ class TestAllenBradleyPLCTagReading:
 
         assert "N7:0" in result
         assert "B3:0" in result
-        assert result["N7:0"] == 100
+        assert result["N7:0"] == TagResult(value=100)
 
     @pytest.mark.asyncio
     async def test_read_tag_slc_with_error(self, mock_pycomm3_available, mock_slc_driver):
-        """Test reading SLC tags with error handling."""
+        """A failing SLC address is a per-tag error; its neighbours still report values."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             SLCDriver,
         )
 
         # First tag succeeds, second fails
-        mock_slc_driver.read.side_effect = [100, Exception("Read failed")]
+        mock_slc_driver.read.side_effect = [100, ResponseError("Read failed")]
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc")
         SLCDriver.return_value = mock_slc_driver
@@ -661,10 +919,49 @@ class TestAllenBradleyPLCTagReading:
 
         result = await plc.read_tag(["N7:0", "B3:0"])
 
-        assert "N7:0" in result
-        assert result["N7:0"] == 100
-        assert "B3:0" in result
-        assert result["B3:0"] is None  # Error result returns None
+        assert result["N7:0"] == TagResult(value=100)
+        assert result["B3:0"].ok is False
+        assert result["B3:0"].value is None
+        assert result["B3:0"].error.kind is TagErrorKind.transport
+        assert result["B3:0"].error.message == "Read failed"
+
+    @pytest.mark.asyncio
+    async def test_read_tag_slc_comm_error_is_a_whole_call_failure(self, mock_pycomm3_available, mock_slc_driver):
+        """A dropped socket mid-batch raises typed; it is not spread over the tags."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            SLCDriver,
+        )
+
+        mock_slc_driver.read.side_effect = [100, CommError("socket closed")]
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc", retry_count=1)
+        SLCDriver.return_value = mock_slc_driver
+        await plc.connect()
+
+        with pytest.raises(PLCCommunicationError) as exc_info:
+            await plc.read_tag(["N7:0", "B3:0"])
+
+        assert isinstance(exc_info.value.__cause__, CommError)
+
+    @pytest.mark.asyncio
+    async def test_read_tag_slc_missing_address(self, mock_pycomm3_available, mock_slc_driver):
+        """An address the controller doesn't have is classified as a missing tag."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            SLCDriver,
+        )
+
+        mock_slc_driver.read.side_effect = ResponseError("N99:0 does not exist")
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc")
+        SLCDriver.return_value = mock_slc_driver
+        await plc.connect()
+
+        result = await plc.read_tag(["N99:0"])
+
+        assert result["N99:0"].ok is False
+        assert result["N99:0"].error.kind is TagErrorKind.missing_tag
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_identity(self, mock_pycomm3_available, mock_cip_driver):
@@ -682,10 +979,10 @@ class TestAllenBradleyPLCTagReading:
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("Identity")
+        result = await plc.read_tag(["Identity"])
 
         assert "Identity" in result
-        assert result["Identity"] == device_info
+        assert result["Identity"] == TagResult(value=device_info)
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_assembly(self, mock_pycomm3_available, mock_cip_driver):
@@ -702,10 +999,10 @@ class TestAllenBradleyPLCTagReading:
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("Assembly:20")
+        result = await plc.read_tag(["Assembly:20"])
 
         assert "Assembly:20" in result
-        assert result["Assembly:20"] == assembly_data
+        assert result["Assembly:20"] == TagResult(value=assembly_data)
         mock_cip_driver.generic_message.assert_called_once()
 
     @pytest.mark.asyncio
@@ -723,10 +1020,10 @@ class TestAllenBradleyPLCTagReading:
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("Module:0")
+        result = await plc.read_tag(["Module:0"])
 
         assert "Module:0" in result
-        assert result["Module:0"] == module_info
+        assert result["Module:0"] == TagResult(value=module_info)
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_connection(self, mock_pycomm3_available, mock_cip_driver):
@@ -743,10 +1040,10 @@ class TestAllenBradleyPLCTagReading:
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("Connection")
+        result = await plc.read_tag(["Connection"])
 
         assert "Connection" in result
-        assert result["Connection"] == connection_data
+        assert result["Connection"] == TagResult(value=connection_data)
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_generic_format(self, mock_pycomm3_available, mock_cip_driver):
@@ -763,10 +1060,10 @@ class TestAllenBradleyPLCTagReading:
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("0x04:1:3")
+        result = await plc.read_tag(["0x04:1:3"])
 
         assert "0x04:1:3" in result
-        assert result["0x04:1:3"] == cip_value
+        assert result["0x04:1:3"] == TagResult(value=cip_value)
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_generic_decimal_format(self, mock_pycomm3_available, mock_cip_driver):
@@ -783,10 +1080,10 @@ class TestAllenBradleyPLCTagReading:
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("4:1:3")
+        result = await plc.read_tag(["4:1:3"])
 
         assert "4:1:3" in result
-        assert result["4:1:3"] == cip_value
+        assert result["4:1:3"] == TagResult(value=cip_value)
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_direct_read(self, mock_pycomm3_available, mock_cip_driver):
@@ -803,26 +1100,57 @@ class TestAllenBradleyPLCTagReading:
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("SimpleTag")
+        result = await plc.read_tag(["SimpleTag"])
 
         assert "SimpleTag" in result
-        assert result["SimpleTag"] == direct_value
+        assert result["SimpleTag"] == TagResult(value=direct_value)
 
     @pytest.mark.asyncio
     async def test_read_tag_not_connected(self, mock_pycomm3_available, mock_logix_driver):
-        """Test reading tag when not connected."""
+        """A closed channel whose session will not reopen still raises, and never
+        goes through the public lifecycle."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
         )
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
-        LogixDriver.return_value = mock_logix_driver
-        # Mock reconnect to fail
-        plc.reconnect = AsyncMock(return_value=False)
+        mock_logix_driver.open.return_value = False  # the channel refuses to come back
 
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=2)
+        LogixDriver.return_value = mock_logix_driver
+        # A reconnect that WOULD succeed — recovery must still not take both locks.
+        plc.reconnect = AsyncMock(return_value=True)
+
+        with pytest.raises(PLCCommunicationError) as exc_info:
+            await plc.read_tag(["Motor1_Speed"])
+
+        assert "read channel" in str(exc_info.value)
+        assert "attempts=2" in str(exc_info.value)
+        plc.reconnect.assert_not_called()
+        mock_logix_driver.read.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_read_tag_after_channel_drops(self, mock_pycomm3_available, mock_logix_driver):
+        """A session that drops after connect is rebuilt on the read channel only."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=2)
+        LogixDriver.return_value = mock_logix_driver
+        await plc.connect()
+        plc.reconnect = AsyncMock(return_value=True)
+        write_driver = plc._write_driver
+
+        mock_logix_driver.connected = False
+        # The replacement session is just as dead, so the read still fails — the
+        # point is that it failed after a channel reconnect, not a lifecycle one.
         with pytest.raises(PLCCommunicationError):
-            await plc.read_tag("Motor1_Speed")
+            await plc.read_tag(["Motor1_Speed"])
+
+        plc.reconnect.assert_not_called()
+        assert plc._write_driver is write_driver
 
     @pytest.mark.asyncio
     async def test_read_tag_exception_raises_error(self, mock_pycomm3_available, mock_logix_driver):
@@ -838,12 +1166,14 @@ class TestAllenBradleyPLCTagReading:
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
 
-        with pytest.raises(PLCTagReadError):
-            await plc.read_tag("Motor1_Speed")
+        with pytest.raises(PLCTagReadError) as exc_info:
+            await plc.read_tag(["Motor1_Speed"])
+
+        assert isinstance(exc_info.value.__cause__, Exception)
 
     @pytest.mark.asyncio
     async def test_read_tag_none_result(self, mock_pycomm3_available, mock_logix_driver):
-        """Test reading tag when result is None."""
+        """A driver that returns nothing is a transport failure, not a None value."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
@@ -855,14 +1185,17 @@ class TestAllenBradleyPLCTagReading:
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
 
-        result = await plc.read_tag("Motor1_Speed")
+        result = await plc.read_tag(["Motor1_Speed"])
 
         assert "Motor1_Speed" in result
-        assert result["Motor1_Speed"] is None
+        assert result["Motor1_Speed"].ok is False
+        assert result["Motor1_Speed"].value is None
+        assert result["Motor1_Speed"].error.kind is TagErrorKind.transport
+        assert result["Motor1_Speed"].error.message == "driver returned None"
 
     @pytest.mark.asyncio
     async def test_read_tag_result_with_error_attribute(self, mock_pycomm3_available, mock_cip_driver):
-        """Test reading tag when result has error attribute."""
+        """A driver Tag carrying an error becomes a classified per-tag failure."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             CIPDriver,
@@ -877,10 +1210,36 @@ class TestAllenBradleyPLCTagReading:
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("Assembly:20")
+        result = await plc.read_tag(["Assembly:20"])
 
         assert "Assembly:20" in result
-        assert result["Assembly:20"] is None
+        assert result["Assembly:20"].ok is False
+        assert result["Assembly:20"].value is None
+        assert result["Assembly:20"].error.kind is TagErrorKind.transport
+        assert result["Assembly:20"].error.message == "Read error"
+
+    @pytest.mark.asyncio
+    async def test_read_tag_missing_tag_is_classified(self, mock_pycomm3_available, mock_logix_driver):
+        """A tag the controller doesn't have reports kind ``missing_tag``."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        missing = MagicMock()
+        missing.error = "Tag doesn't exist - NoSuchTag"
+        missing.value = None
+        mock_logix_driver.read.return_value = missing
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        LogixDriver.return_value = mock_logix_driver
+        await plc.connect()
+
+        result = await plc.read_tag(["NoSuchTag"])
+
+        assert result["NoSuchTag"].ok is False
+        assert result["NoSuchTag"].error.kind is TagErrorKind.missing_tag
+        assert result["NoSuchTag"].error.message == "Tag doesn't exist - NoSuchTag"
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_identity_exception(self, mock_pycomm3_available, mock_cip_driver):
@@ -890,16 +1249,18 @@ class TestAllenBradleyPLCTagReading:
             CIPDriver,
         )
 
-        mock_cip_driver.list_identity.side_effect = Exception("Identity read failed")
+        mock_cip_driver.list_identity.side_effect = ResponseError("Identity read failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("Identity")
+        result = await plc.read_tag(["Identity"])
 
         assert "Identity" in result
-        assert result["Identity"] is None
+        assert result["Identity"].ok is False
+        assert result["Identity"].error.kind is TagErrorKind.transport
+        assert result["Identity"].error.message == "Identity read failed"
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_assembly_exception(self, mock_pycomm3_available, mock_cip_driver):
@@ -909,16 +1270,18 @@ class TestAllenBradleyPLCTagReading:
             CIPDriver,
         )
 
-        mock_cip_driver.generic_message.side_effect = Exception("Assembly read failed")
+        mock_cip_driver.generic_message.side_effect = ResponseError("Assembly read failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("Assembly:20")
+        result = await plc.read_tag(["Assembly:20"])
 
         assert "Assembly:20" in result
-        assert result["Assembly:20"] is None
+        assert result["Assembly:20"].ok is False
+        assert result["Assembly:20"].error.kind is TagErrorKind.transport
+        assert result["Assembly:20"].error.message == "Assembly read failed"
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_module_exception(self, mock_pycomm3_available, mock_cip_driver):
@@ -928,16 +1291,18 @@ class TestAllenBradleyPLCTagReading:
             CIPDriver,
         )
 
-        mock_cip_driver.get_module_info.side_effect = Exception("Module read failed")
+        mock_cip_driver.get_module_info.side_effect = ResponseError("Module read failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("Module:0")
+        result = await plc.read_tag(["Module:0"])
 
         assert "Module:0" in result
-        assert result["Module:0"] is None
+        assert result["Module:0"].ok is False
+        assert result["Module:0"].error.kind is TagErrorKind.transport
+        assert result["Module:0"].error.message == "Module read failed"
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_connection_exception(self, mock_pycomm3_available, mock_cip_driver):
@@ -947,16 +1312,18 @@ class TestAllenBradleyPLCTagReading:
             CIPDriver,
         )
 
-        mock_cip_driver.generic_message.side_effect = Exception("Connection read failed")
+        mock_cip_driver.generic_message.side_effect = ResponseError("Connection read failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("Connection")
+        result = await plc.read_tag(["Connection"])
 
         assert "Connection" in result
-        assert result["Connection"] is None
+        assert result["Connection"].ok is False
+        assert result["Connection"].error.kind is TagErrorKind.transport
+        assert result["Connection"].error.message == "Connection read failed"
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_generic_format_exception(self, mock_pycomm3_available, mock_cip_driver):
@@ -966,16 +1333,18 @@ class TestAllenBradleyPLCTagReading:
             CIPDriver,
         )
 
-        mock_cip_driver.generic_message.side_effect = Exception("Generic read failed")
+        mock_cip_driver.generic_message.side_effect = ResponseError("Generic read failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
         await plc.connect()
 
-        result = await plc.read_tag("0x04:1:3")
+        result = await plc.read_tag(["0x04:1:3"])
 
         assert "0x04:1:3" in result
-        assert result["0x04:1:3"] is None
+        assert result["0x04:1:3"].ok is False
+        assert result["0x04:1:3"].error.kind is TagErrorKind.transport
+        assert result["0x04:1:3"].error.message == "Generic read failed"
 
 
 class TestAllenBradleyPLCTagWriting:
@@ -989,17 +1358,56 @@ class TestAllenBradleyPLCTagWriting:
             LogixDriver,
         )
 
-        mock_logix_driver.write.return_value = True
+        write_result = MagicMock()
+        write_result.error = None
+        mock_logix_driver.write.return_value = write_result
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
 
-        result = await plc.write_tag(("Motor1_Speed", 1500.0))
+        result = await plc.write_tag([("Motor1_Speed", 1500.0)])
 
         assert "Motor1_Speed" in result
-        assert result["Motor1_Speed"] is True
-        mock_logix_driver.write.assert_called_once_with(("Motor1_Speed", 1500.0))
+        # A successful write reports the value that was written.
+        assert result["Motor1_Speed"] == TagResult(value=1500.0)
+        assert result["Motor1_Speed"].ok is True
+        plc._write_driver.write.assert_called_once_with(("Motor1_Speed", 1500.0))
+
+    @pytest.mark.asyncio
+    async def test_write_tag_use_the_write_session(self, mock_pycomm3_available):
+        """Writes go to the write session only; the read session is untouched."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        read_driver = make_logix_driver()
+        write_driver = make_logix_driver()
+        LogixDriver.side_effect = [read_driver, write_driver]
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        await plc.connect()
+
+        await plc.write_tag([("Motor1_Speed", 1500.0)])
+
+        write_driver.write.assert_called_once_with(("Motor1_Speed", 1500.0))
+        read_driver.write.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_no_tags_is_a_no_op(self, mock_pycomm3_available, mock_logix_driver):
+        """An empty batch returns an empty mapping without hitting the device."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        LogixDriver.return_value = mock_logix_driver
+        await plc.connect()
+
+        assert await plc.write_tag([]) == {}
+        mock_logix_driver.write.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_write_tag_logix_multiple(self, mock_pycomm3_available, mock_logix_driver):
@@ -1009,7 +1417,7 @@ class TestAllenBradleyPLCTagWriting:
             LogixDriver,
         )
 
-        mock_results = [True, True]
+        mock_results = [MagicMock(error=None), MagicMock(error=None)]
         mock_logix_driver.write.return_value = mock_results
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
@@ -1019,8 +1427,73 @@ class TestAllenBradleyPLCTagWriting:
         result = await plc.write_tag([("Motor1_Speed", 1500.0), ("Production_Count", 100)])
 
         assert len(result) == 2
-        assert result["Motor1_Speed"] is True
-        assert result["Production_Count"] is True
+        assert result["Motor1_Speed"] == TagResult(value=1500.0)
+        assert result["Production_Count"] == TagResult(value=100)
+
+    @pytest.mark.asyncio
+    async def test_write_tag_result_count_mismatch_raises(self, mock_pycomm3_available, mock_logix_driver):
+        """A short result list is a whole-call failure, not a silently truncated dict."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        mock_logix_driver.write.return_value = [MagicMock(error=None)]
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        LogixDriver.return_value = mock_logix_driver
+        await plc.connect()
+
+        with pytest.raises(PLCTagWriteError) as exc_info:
+            await plc.write_tag([("Motor1_Speed", 1500.0), ("Production_Count", 100)])
+
+        assert "1 results" in str(exc_info.value)
+        assert "2 requested writes" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("driver_error_class", [CommError, DataError, ResponseError])
+    async def test_write_transport_errors_raise_communication_error(
+        self, mock_pycomm3_available, mock_logix_driver, driver_error_class
+    ):
+        """Transport-class pycomm3 failures are retryable: PLCCommunicationError, chained."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        mock_logix_driver.write.side_effect = driver_error_class("socket closed")
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=1)
+        LogixDriver.return_value = mock_logix_driver
+        await plc.connect()
+
+        with pytest.raises(PLCCommunicationError) as exc_info:
+            await plc.write_tag([("Motor1_Speed", 1500.0)])
+
+        assert isinstance(exc_info.value.__cause__, driver_error_class)
+        assert "attempts=1" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_write_request_error_is_never_retried(self, mock_pycomm3_available, mock_logix_driver):
+        """A malformed request is a config problem: PLCTagWriteError on the first try."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        mock_logix_driver.write.side_effect = RequestError("Failed to parse tag request")
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=3)
+        LogixDriver.return_value = mock_logix_driver
+        await plc.connect()
+        plc._reconnect_channel = AsyncMock(return_value=True)
+
+        with pytest.raises(PLCTagWriteError) as exc_info:
+            await plc.write_tag([("Motor1_Speed", 1500.0)])
+
+        assert isinstance(exc_info.value.__cause__, RequestError)
+        assert mock_logix_driver.write.call_count == 1
+        plc._reconnect_channel.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_write_tag_slc_success(self, mock_pycomm3_available, mock_slc_driver):
@@ -1038,19 +1511,19 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("N7:0", 100), ("B3:0", True)])
 
-        assert result["N7:0"] is True
-        assert result["B3:0"] is True
+        assert result["N7:0"] == TagResult(value=100)
+        assert result["B3:0"] == TagResult(value=True)
 
     @pytest.mark.asyncio
     async def test_write_tag_slc_with_error(self, mock_pycomm3_available, mock_slc_driver):
-        """Test writing SLC tags with error handling."""
+        """A failing SLC address is a per-tag error; its neighbours still succeed."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             SLCDriver,
         )
 
         # First write succeeds, second fails
-        mock_slc_driver.write.side_effect = [True, Exception("Write failed")]
+        mock_slc_driver.write.side_effect = [True, ResponseError("Write failed")]
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc")
         SLCDriver.return_value = mock_slc_driver
@@ -1058,8 +1531,30 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("N7:0", 100), ("B3:0", True)])
 
-        assert result["N7:0"] is True
-        assert result["B3:0"] is False
+        assert result["N7:0"] == TagResult(value=100)
+        assert result["B3:0"].ok is False
+        assert result["B3:0"].value is None
+        assert result["B3:0"].error.kind is TagErrorKind.transport
+        assert result["B3:0"].error.message == "Write failed"
+
+    @pytest.mark.asyncio
+    async def test_write_tag_slc_encode_failure(self, mock_pycomm3_available, mock_slc_driver):
+        """A value the driver can't pack is classified as an encode failure."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            SLCDriver,
+        )
+
+        mock_slc_driver.write.side_effect = DataError("Error packing -128 as USINT")
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc")
+        SLCDriver.return_value = mock_slc_driver
+        await plc.connect()
+
+        result = await plc.write_tag([("N7:0", -128)])
+
+        assert result["N7:0"].ok is False
+        assert result["N7:0"].error.kind is TagErrorKind.encode
 
     @pytest.mark.asyncio
     async def test_write_tag_cip_assembly(self, mock_pycomm3_available, mock_cip_driver):
@@ -1077,7 +1572,7 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("Assembly:20", [1500, 0, 255, 0])])
 
-        assert result["Assembly:20"] is True
+        assert result["Assembly:20"] == TagResult(value=[1500, 0, 255, 0])
         mock_cip_driver.generic_message.assert_called_once()
 
     @pytest.mark.asyncio
@@ -1096,7 +1591,7 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("Parameter:1", 1500.0)])
 
-        assert result["Parameter:1"] is True
+        assert result["Parameter:1"] == TagResult(value=1500.0)
 
     @pytest.mark.asyncio
     async def test_write_tag_cip_generic_format(self, mock_pycomm3_available, mock_cip_driver):
@@ -1114,7 +1609,7 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("0x04:1:3", [1500, 0, 255, 0])])
 
-        assert result["0x04:1:3"] is True
+        assert result["0x04:1:3"] == TagResult(value=[1500, 0, 255, 0])
 
     @pytest.mark.asyncio
     async def test_write_tag_cip_direct_write(self, mock_pycomm3_available, mock_cip_driver):
@@ -1132,7 +1627,7 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("SimpleTag", "value")])
 
-        assert result["SimpleTag"] is True
+        assert result["SimpleTag"] == TagResult(value="value")
 
     @pytest.mark.asyncio
     async def test_write_tag_cip_with_error(self, mock_pycomm3_available, mock_cip_driver):
@@ -1152,23 +1647,54 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("Assembly:20", [1500, 0, 255, 0])])
 
-        assert result["Assembly:20"] is False
+        assert result["Assembly:20"].ok is False
+        assert result["Assembly:20"].value is None
+        assert result["Assembly:20"].error.kind is TagErrorKind.transport
+        assert result["Assembly:20"].error.message == "Write error"
 
     @pytest.mark.asyncio
     async def test_write_tag_not_connected(self, mock_pycomm3_available, mock_logix_driver):
-        """Test writing tag when not connected."""
+        """A closed channel whose session will not reopen still raises, and never
+        goes through the public lifecycle."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
         )
 
-        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        mock_logix_driver.open.return_value = False  # the channel refuses to come back
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=2)
         LogixDriver.return_value = mock_logix_driver
-        # Mock reconnect to fail
-        plc.reconnect = AsyncMock(return_value=False)
+        # A reconnect that WOULD succeed — recovery must still not take both locks.
+        plc.reconnect = AsyncMock(return_value=True)
+
+        with pytest.raises(PLCCommunicationError) as exc_info:
+            await plc.write_tag([("Motor1_Speed", 1500.0)])
+
+        assert "write channel" in str(exc_info.value)
+        assert "attempts=2" in str(exc_info.value)
+        plc.reconnect.assert_not_called()
+        mock_logix_driver.write.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_tag_after_channel_drops(self, mock_pycomm3_available, mock_logix_driver):
+        """A session that drops after connect is rebuilt on the write channel only."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
+            AllenBradleyPLC,
+            LogixDriver,
+        )
+
+        plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=2)
+        LogixDriver.return_value = mock_logix_driver
+        await plc.connect()
+        plc.reconnect = AsyncMock(return_value=True)
+
+        mock_logix_driver.connected = False
 
         with pytest.raises(PLCCommunicationError):
             await plc.write_tag([("Motor1_Speed", 1500.0)])
+
+        plc.reconnect.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_write_tag_exception_raises_error(self, mock_pycomm3_available, mock_logix_driver):
@@ -1184,18 +1710,22 @@ class TestAllenBradleyPLCTagWriting:
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
 
-        with pytest.raises(PLCTagWriteError):
+        with pytest.raises(PLCTagWriteError) as exc_info:
             await plc.write_tag([("Motor1_Speed", 1500.0)])
 
+        assert isinstance(exc_info.value.__cause__, Exception)
+
     @pytest.mark.asyncio
-    async def test_write_tag_false_result(self, mock_pycomm3_available, mock_logix_driver):
-        """Test writing tag when result is False."""
+    async def test_write_tag_failed_result(self, mock_pycomm3_available, mock_logix_driver):
+        """A rejected Logix write is a classified per-tag failure, not a value."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
         )
 
-        mock_logix_driver.write.return_value = False
+        failed_result = MagicMock()
+        failed_result.error = "Invalid data type for tag"
+        mock_logix_driver.write.return_value = failed_result
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
@@ -1203,7 +1733,10 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("Motor1_Speed", 1500.0)])
 
-        assert result["Motor1_Speed"] is False
+        assert result["Motor1_Speed"].ok is False
+        assert result["Motor1_Speed"].value is None
+        assert result["Motor1_Speed"].error.kind is TagErrorKind.type_mismatch
+        assert result["Motor1_Speed"].error.message == "Invalid data type for tag"
 
     @pytest.mark.asyncio
     async def test_write_tag_result_with_error_attribute(self, mock_pycomm3_available, mock_cip_driver):
@@ -1223,7 +1756,8 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("Assembly:20", [1500, 0, 255, 0])])
 
-        assert result["Assembly:20"] is False
+        assert result["Assembly:20"].ok is False
+        assert result["Assembly:20"].error.kind is TagErrorKind.transport
 
     @pytest.mark.asyncio
     async def test_write_tag_cip_assembly_exception(self, mock_pycomm3_available, mock_cip_driver):
@@ -1233,7 +1767,7 @@ class TestAllenBradleyPLCTagWriting:
             CIPDriver,
         )
 
-        mock_cip_driver.generic_message.side_effect = Exception("Assembly write failed")
+        mock_cip_driver.generic_message.side_effect = ResponseError("Assembly write failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
@@ -1241,7 +1775,9 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("Assembly:20", [1500, 0, 255, 0])])
 
-        assert result["Assembly:20"] is False
+        assert result["Assembly:20"].ok is False
+        assert result["Assembly:20"].error.kind is TagErrorKind.transport
+        assert result["Assembly:20"].error.message == "Assembly write failed"
 
     @pytest.mark.asyncio
     async def test_write_tag_cip_parameter_exception(self, mock_pycomm3_available, mock_cip_driver):
@@ -1251,7 +1787,7 @@ class TestAllenBradleyPLCTagWriting:
             CIPDriver,
         )
 
-        mock_cip_driver.generic_message.side_effect = Exception("Parameter write failed")
+        mock_cip_driver.generic_message.side_effect = ResponseError("Parameter write failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
@@ -1259,7 +1795,9 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("Parameter:1", 1500.0)])
 
-        assert result["Parameter:1"] is False
+        assert result["Parameter:1"].ok is False
+        assert result["Parameter:1"].error.kind is TagErrorKind.transport
+        assert result["Parameter:1"].error.message == "Parameter write failed"
 
     @pytest.mark.asyncio
     async def test_write_tag_cip_generic_format_exception(self, mock_pycomm3_available, mock_cip_driver):
@@ -1269,7 +1807,7 @@ class TestAllenBradleyPLCTagWriting:
             CIPDriver,
         )
 
-        mock_cip_driver.generic_message.side_effect = Exception("Generic write failed")
+        mock_cip_driver.generic_message.side_effect = ResponseError("Generic write failed")
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
         CIPDriver.return_value = mock_cip_driver
@@ -1277,7 +1815,9 @@ class TestAllenBradleyPLCTagWriting:
 
         result = await plc.write_tag([("0x04:1:3", [1500, 0, 255, 0])])
 
-        assert result["0x04:1:3"] is False
+        assert result["0x04:1:3"].ok is False
+        assert result["0x04:1:3"].error.kind is TagErrorKind.transport
+        assert result["0x04:1:3"].error.message == "Generic write failed"
 
 
 class TestAllenBradleyPLCTagDiscovery:
@@ -1521,7 +2061,7 @@ class TestAllenBradleyPLCTagDiscovery:
 
     @pytest.mark.asyncio
     async def test_get_all_tags_not_connected(self, mock_pycomm3_available, mock_logix_driver):
-        """Test getting all tags when not connected."""
+        """Listing tags on a closed channel raises; it never reconnects."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
@@ -1529,11 +2069,13 @@ class TestAllenBradleyPLCTagDiscovery:
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
-        # Mock reconnect to fail
-        plc.reconnect = AsyncMock(return_value=False)
+        # A reconnect that WOULD succeed — the transport must still not call it.
+        plc.reconnect = AsyncMock(return_value=True)
 
         with pytest.raises(PLCCommunicationError):
             await plc.get_all_tags()
+
+        plc.reconnect.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_all_tags_exception_raises_error(self, mock_pycomm3_available, mock_logix_driver):
@@ -1707,7 +2249,7 @@ class TestAllenBradleyPLCTagInfo:
 
     @pytest.mark.asyncio
     async def test_get_tag_info_not_connected(self, mock_pycomm3_available, mock_logix_driver):
-        """Test getting tag info when not connected."""
+        """Describing a tag on a closed channel raises; it never reconnects."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
@@ -1715,11 +2257,13 @@ class TestAllenBradleyPLCTagInfo:
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
-        # Mock reconnect to fail
-        plc.reconnect = AsyncMock(return_value=False)
+        # A reconnect that WOULD succeed — the transport must still not call it.
+        plc.reconnect = AsyncMock(return_value=True)
 
         with pytest.raises(PLCCommunicationError):
             await plc.get_tag_info("Motor1_Speed")
+
+        plc.reconnect.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_tag_info_exception_raises_error(self, mock_pycomm3_available, mock_logix_driver):
@@ -1840,7 +2384,7 @@ class TestAllenBradleyPLCPLCInfo:
 
     @pytest.mark.asyncio
     async def test_get_plc_info_not_connected(self, mock_pycomm3_available, mock_logix_driver):
-        """Test getting PLC info when not connected."""
+        """Probing a closed channel raises; it never reconnects."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
@@ -1848,11 +2392,13 @@ class TestAllenBradleyPLCPLCInfo:
 
         plc = AllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         LogixDriver.return_value = mock_logix_driver
-        # Mock reconnect to fail
-        plc.reconnect = AsyncMock(return_value=False)
+        # A reconnect that WOULD succeed — the transport must still not call it.
+        plc.reconnect = AsyncMock(return_value=True)
 
         with pytest.raises(PLCCommunicationError):
             await plc.get_plc_info()
+
+        plc.reconnect.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_plc_info_exception_handling(self, mock_pycomm3_available, mock_logix_driver):
@@ -1932,7 +2478,7 @@ class TestAllenBradleyPLCPLCInfo:
 
     @pytest.mark.asyncio
     async def test_get_plc_info_outer_exception(self, mock_pycomm3_available, mock_logix_driver):
-        """Test getting PLC info when outer exception occurs."""
+        """An unexpected failure is reported as the in-band error dict, as before."""
         from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import (
             AllenBradleyPLC,
             LogixDriver,
@@ -1942,24 +2488,14 @@ class TestAllenBradleyPLCPLCInfo:
         LogixDriver.return_value = mock_logix_driver
         await plc.connect()
 
-        # Make is_connected raise an exception when called inside the try block
-        original_is_connected = plc.is_connected
-        call_count = 0
-
-        async def mock_is_connected():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 2:  # Second call is inside the try block
-                raise Exception("Connection check failed")
-            return await original_is_connected()
-
-        plc.is_connected = mock_is_connected
+        # The read channel is open (so the channel check passes), but the status
+        # probe blows up.
+        plc.is_connected = AsyncMock(side_effect=RuntimeError("Connection check failed"))
 
         info = await plc.get_plc_info()
 
         assert info["name"] == "TestPLC"
         assert info["connected"] is False
-        assert "error" in info
         assert "Connection check failed" in info["error"]
 
 

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_allen_bradley_plc.py
@@ -925,7 +925,7 @@ class TestAllenBradleyPLCTagReading:
 
         assert result["N7:0"] == TagResult(value=100)
         assert result["B3:0"].ok is False
-        assert result["B3:0"].value is None
+        assert result["B3:0"].value_or(None) is None
         assert result["B3:0"].error.kind is TagErrorKind.unknown
         assert result["B3:0"].error.message == "Read failed"
 
@@ -1192,7 +1192,7 @@ class TestAllenBradleyPLCTagReading:
 
         assert "Motor1_Speed" in result
         assert result["Motor1_Speed"].ok is False
-        assert result["Motor1_Speed"].value is None
+        assert result["Motor1_Speed"].value_or(None) is None
         assert result["Motor1_Speed"].error.kind is TagErrorKind.unknown
         assert result["Motor1_Speed"].error.message == "driver returned None"
 
@@ -1217,7 +1217,7 @@ class TestAllenBradleyPLCTagReading:
 
         assert "Assembly:20" in result
         assert result["Assembly:20"].ok is False
-        assert result["Assembly:20"].value is None
+        assert result["Assembly:20"].value_or(None) is None
         assert result["Assembly:20"].error.kind is TagErrorKind.unknown
         assert result["Assembly:20"].error.message == "Read error"
 
@@ -1539,7 +1539,7 @@ class TestAllenBradleyPLCTagWriting:
 
         assert result["N7:0"] == TagResult(value=100)
         assert result["B3:0"].ok is False
-        assert result["B3:0"].value is None
+        assert result["B3:0"].value_or(None) is None
         assert result["B3:0"].error.kind is TagErrorKind.unknown
         assert result["B3:0"].error.message == "Write failed"
 
@@ -1654,7 +1654,7 @@ class TestAllenBradleyPLCTagWriting:
         result = await plc.write_tag([("Assembly:20", [1500, 0, 255, 0])])
 
         assert result["Assembly:20"].ok is False
-        assert result["Assembly:20"].value is None
+        assert result["Assembly:20"].value_or(None) is None
         assert result["Assembly:20"].error.kind is TagErrorKind.unknown
         assert result["Assembly:20"].error.message == "Write error"
 
@@ -1739,7 +1739,7 @@ class TestAllenBradleyPLCTagWriting:
         result = await plc.write_tag([("Motor1_Speed", 1500.0)])
 
         assert result["Motor1_Speed"].ok is False
-        assert result["Motor1_Speed"].value is None
+        assert result["Motor1_Speed"].value_or(None) is None
         assert result["Motor1_Speed"].error.kind is TagErrorKind.type_mismatch
         assert result["Motor1_Speed"].error.message == "Invalid data type for tag"
 

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
@@ -1000,30 +1000,6 @@ class TestMockAllenBradleyPLCPLCInfo:
         with pytest.raises(PLCConnectionError, match="never opened"):
             await mock_plc.get_plc_info()
 
-    @pytest.mark.asyncio
-    async def test_get_plc_info_exception_handling(self, mock_plc):
-        """An unexpected failure is reported as the in-band error dict, as before."""
-        await mock_plc.connect()
-
-        original_plc_name = mock_plc.plc_name
-
-        # hash(plc_name) is taken for the simulated serial number.
-        class HashError:
-            def __hash__(self):
-                raise RuntimeError("Hash failed")
-
-        mock_plc.plc_name = HashError()
-
-        info = await mock_plc.get_plc_info()
-
-        assert info["connected"] is False
-        assert "Hash failed" in info["error"]
-        assert info["mock"] is True
-
-        # Restore
-        mock_plc.plc_name = original_plc_name
-
-
 class TestMockAllenBradleyPLCStaticMethods:
     """Test suite for static methods."""
 

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
@@ -491,7 +491,7 @@ class TestMockAllenBradleyPLCTagReading:
 
         assert "NonExistentTag" in result
         assert result["NonExistentTag"].ok is False
-        assert result["NonExistentTag"].value is None
+        assert result["NonExistentTag"].value_or(None) is None
         assert result["NonExistentTag"].error.kind is TagErrorKind.missing_tag
         assert "NonExistentTag" in result["NonExistentTag"].error.message
 
@@ -507,7 +507,7 @@ class TestMockAllenBradleyPLCTagReading:
 
         assert "N99:999" in result
         assert result["N99:999"].ok is False
-        assert result["N99:999"].value is None
+        assert result["N99:999"].value_or(None) is None
         assert result["N99:999"].error.kind is TagErrorKind.missing_tag
 
     @pytest.mark.asyncio
@@ -522,7 +522,7 @@ class TestMockAllenBradleyPLCTagReading:
 
         assert "NonExistentCIP" in result
         assert result["NonExistentCIP"].ok is False
-        assert result["NonExistentCIP"].value is None
+        assert result["NonExistentCIP"].value_or(None) is None
         assert result["NonExistentCIP"].error.kind is TagErrorKind.missing_tag
 
     @pytest.mark.asyncio
@@ -681,7 +681,7 @@ class TestMockAllenBradleyPLCTagWriting:
         result = await mock_plc.write_tag([("Production_Count", "invalid")])
 
         assert result["Production_Count"].ok is False
-        assert result["Production_Count"].value is None
+        assert result["Production_Count"].value_or(None) is None
         assert result["Production_Count"].error.kind is TagErrorKind.type_mismatch
 
     @pytest.mark.asyncio
@@ -692,7 +692,7 @@ class TestMockAllenBradleyPLCTagWriting:
         result = await mock_plc.write_tag(("NonExistentTag", 123))
 
         assert result["NonExistentTag"].ok is False
-        assert result["NonExistentTag"].value is None
+        assert result["NonExistentTag"].value_or(None) is None
         assert result["NonExistentTag"].error.kind is TagErrorKind.missing_tag
 
     @pytest.mark.asyncio

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
@@ -7,7 +7,7 @@ functionality including error simulation, tag variation, and edge cases.
 
 import asyncio
 import os
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
@@ -22,6 +22,7 @@ from mindtrace.hardware.core.exceptions import (
     PLCTagWriteError,
     PLCTimeoutError,
 )
+from mindtrace.hardware.plcs import TagErrorKind
 
 
 @pytest.fixture(scope="session")
@@ -233,15 +234,56 @@ class TestMockAllenBradleyPLCConnection:
             await plc.connect()
 
     @pytest.mark.asyncio
-    async def test_connect_retry_logic(self):
-        """Test connection retry logic."""
+    async def test_connect_makes_a_single_attempt(self):
+        """Connect never retries: a configured retry_count does not add attempts."""
         from mindtrace.hardware.plcs.backends.allen_bradley.mock_allen_bradley import MockAllenBradleyPLC
 
         plc = MockAllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=3)
-        # Connection should succeed on first attempt
-        result = await plc.connect()
+        plc.fail_connect = True
 
-        assert result is True
+        attempts = 0
+        inner_connect = plc._connect
+
+        async def counting_connect():
+            nonlocal attempts
+            attempts += 1
+            return await inner_connect()
+
+        plc._connect = counting_connect
+
+        with pytest.raises(PLCConnectionError):
+            await plc.connect()
+
+        assert attempts == 1
+        assert plc._is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_connect_exposes_the_controller_tag_structure(self):
+        """The real backend aliases the read driver as ``plc``; chiron's preflight
+        reads ``plc.plc.tags`` for the controller tag database."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.mock_allen_bradley import MockAllenBradleyPLC
+
+        plc = MockAllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        await plc.connect()
+
+        tags = plc.plc.tags
+        assert isinstance(tags, dict)
+        assert tags["Motor1_Speed"] == {"tag_type": "atomic", "data_type": "REAL"}
+        assert tags["Motor1_Command"]["data_type"] == "BOOL"
+
+        await plc.disconnect()
+
+        assert plc.plc is None
+
+    @pytest.mark.asyncio
+    async def test_non_logix_drivers_have_no_tag_database(self):
+        """SLC and CIP controllers upload no tag list — neither does the mock."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.mock_allen_bradley import MockAllenBradleyPLC
+
+        plc = MockAllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc")
+        await plc.connect()
+
+        assert plc.plc.tags == {}
 
     @pytest.mark.asyncio
     async def test_disconnect_success(self):
@@ -289,6 +331,23 @@ class TestMockAllenBradleyPLCConnection:
 
         assert result is False
 
+    @pytest.mark.asyncio
+    async def test_reconnect_channel_is_channel_scoped(self):
+        """One channel reopening is not a connection, exactly as on the real backend.
+
+        The real backend opens only the failed channel's driver, so ``is_connected``
+        — which needs BOTH sessions — stays False. A mock that bounced the whole
+        lifecycle here would hide that difference from every test above it.
+        """
+        from mindtrace.hardware.plcs.backends.allen_bradley.mock_allen_bradley import MockAllenBradleyPLC
+
+        plc = MockAllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+
+        assert await plc._reconnect_channel("read") is True
+
+        assert plc._channels_open == {"read": True, "write": False}
+        assert await plc.is_connected() is False
+
 
 class TestMockAllenBradleyPLCInitialize:
     """Test suite for PLC initialization method."""
@@ -325,12 +384,15 @@ class TestMockAllenBradleyPLCInitialize:
         """Test initialization returns False when connect returns False."""
         from mindtrace.hardware.plcs.backends.allen_bradley.mock_allen_bradley import MockAllenBradleyPLC
 
-        plc = MockAllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=1)
-        plc.fail_connect = True
+        plc = MockAllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        plc.connect = AsyncMock(return_value=False)
 
-        # This will raise PLCConnectionError which gets caught and re-raised as PLCInitializationError
-        with pytest.raises(PLCInitializationError):
-            await plc.initialize()
+        success, plc_obj, device_manager = await plc.initialize()
+
+        assert success is False
+        assert plc_obj is None
+        assert device_manager is None
+        assert plc.initialized is False
 
 
 class TestMockAllenBradleyPLCTagReading:
@@ -344,7 +406,8 @@ class TestMockAllenBradleyPLCTagReading:
         result = await mock_plc.read_tag("Motor1_Speed")
 
         assert "Motor1_Speed" in result
-        assert isinstance(result["Motor1_Speed"], float)
+        assert result["Motor1_Speed"].ok is True
+        assert isinstance(result["Motor1_Speed"].value, float)
 
     @pytest.mark.asyncio
     async def test_read_tag_multiple(self, mock_plc):
@@ -357,9 +420,10 @@ class TestMockAllenBradleyPLCTagReading:
         assert "Motor1_Speed" in result
         assert "Production_Count" in result
         assert "Conveyor_Status" in result
-        assert isinstance(result["Motor1_Speed"], float)
-        assert isinstance(result["Production_Count"], int)
-        assert isinstance(result["Conveyor_Status"], bool)
+        assert all(tag_result.ok for tag_result in result.values())
+        assert isinstance(result["Motor1_Speed"].value, float)
+        assert isinstance(result["Production_Count"].value, int)
+        assert isinstance(result["Conveyor_Status"].value, bool)
 
     @pytest.mark.asyncio
     async def test_read_tag_logix_tags(self, mock_plc):
@@ -369,6 +433,7 @@ class TestMockAllenBradleyPLCTagReading:
         result = await mock_plc.read_tag(["Motor1_Speed", "Production_Count", "Conveyor_Status"])
 
         assert all(tag in result for tag in ["Motor1_Speed", "Production_Count", "Conveyor_Status"])
+        assert all(tag_result.ok for tag_result in result.values())
 
     @pytest.mark.asyncio
     async def test_read_tag_slc_tags(self):
@@ -384,6 +449,7 @@ class TestMockAllenBradleyPLCTagReading:
         assert "B3:0" in result
         assert "T4:0.PRE" in result
         assert "C5:0.ACC" in result
+        assert all(tag_result.ok for tag_result in result.values())
 
     @pytest.mark.asyncio
     async def test_read_tag_cip_tags(self):
@@ -398,36 +464,43 @@ class TestMockAllenBradleyPLCTagReading:
         assert "Assembly:20" in result
         assert "Parameter:1" in result
         assert "Identity" in result
+        assert all(tag_result.ok for tag_result in result.values())
 
     @pytest.mark.asyncio
     async def test_read_tag_with_variation(self, mock_plc):
         """Test reading tags with realistic variation."""
         await mock_plc.connect()
 
-        # Read a tag that should have variation (temperature, pressure, speed, level)
+        # Read a tag that should have variation (temperature, pressure, speed, level).
+        # Drift is ±1% of the *stored* value, and the drifted value is written back,
+        # so each read is measured against the value the previous read left behind.
         original_value = mock_plc._tag_values["Motor1_Speed"]
         result1 = await mock_plc.read_tag("Motor1_Speed")
+        value1 = result1["Motor1_Speed"].value
         result2 = await mock_plc.read_tag("Motor1_Speed")
+        value2 = result2["Motor1_Speed"].value
 
-        # Values should be within ±2% of original
-        assert abs(result1["Motor1_Speed"] - original_value) <= original_value * 0.02
-        assert abs(result2["Motor1_Speed"] - original_value) <= original_value * 0.02
-        # Values might be different due to variation
-        # (though they could be the same by chance)
+        assert result1["Motor1_Speed"].ok is True
+        assert result2["Motor1_Speed"].ok is True
+        assert abs(value1 - original_value) <= original_value * 0.01
+        assert abs(value2 - value1) <= abs(value1) * 0.01
 
     @pytest.mark.asyncio
     async def test_read_tag_non_existent_logix(self, mock_plc):
-        """Test reading non-existent tag with LogixDriver."""
+        """An unknown Logix tag comes back as a missing_tag error, not a sentinel."""
         await mock_plc.connect()
 
         result = await mock_plc.read_tag("NonExistentTag")
 
         assert "NonExistentTag" in result
-        assert result["NonExistentTag"] is None
+        assert result["NonExistentTag"].ok is False
+        assert result["NonExistentTag"].value is None
+        assert result["NonExistentTag"].error.kind is TagErrorKind.missing_tag
+        assert "NonExistentTag" in result["NonExistentTag"].error.message
 
     @pytest.mark.asyncio
     async def test_read_tag_non_existent_slc(self):
-        """Test reading non-existent tag with SLCDriver."""
+        """An unknown SLC address is a missing_tag error (it no longer reads back 0)."""
         from mindtrace.hardware.plcs.backends.allen_bradley.mock_allen_bradley import MockAllenBradleyPLC
 
         plc = MockAllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="slc")
@@ -436,11 +509,13 @@ class TestMockAllenBradleyPLCTagReading:
         result = await plc.read_tag("N99:999")
 
         assert "N99:999" in result
-        assert result["N99:999"] == 0  # SLC returns 0 for non-existent addresses
+        assert result["N99:999"].ok is False
+        assert result["N99:999"].value is None
+        assert result["N99:999"].error.kind is TagErrorKind.missing_tag
 
     @pytest.mark.asyncio
     async def test_read_tag_non_existent_cip(self):
-        """Test reading non-existent tag with CIPDriver."""
+        """An unknown CIP object is a missing_tag error, not a sentinel."""
         from mindtrace.hardware.plcs.backends.allen_bradley.mock_allen_bradley import MockAllenBradleyPLC
 
         plc = MockAllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="cip")
@@ -449,13 +524,44 @@ class TestMockAllenBradleyPLCTagReading:
         result = await plc.read_tag("NonExistentCIP")
 
         assert "NonExistentCIP" in result
-        assert result["NonExistentCIP"] is None
+        assert result["NonExistentCIP"].ok is False
+        assert result["NonExistentCIP"].value is None
+        assert result["NonExistentCIP"].error.kind is TagErrorKind.missing_tag
+
+    @pytest.mark.asyncio
+    async def test_read_tag_mixed_success_and_missing(self, mock_plc):
+        """One bad address in a batch does not spoil the good ones."""
+        await mock_plc.connect()
+
+        result = await mock_plc.read_tag(["Motor1_Speed", "NonExistentTag", "Production_Count"])
+
+        assert len(result) == 3
+        assert result["Motor1_Speed"].ok is True
+        assert result["Production_Count"].ok is True
+        assert result["NonExistentTag"].ok is False
+        assert result["NonExistentTag"].error.kind is TagErrorKind.missing_tag
 
     @pytest.mark.asyncio
     async def test_read_tag_not_connected(self, mock_plc):
-        """Test reading tag when not connected."""
-        with pytest.raises(PLCCommunicationError):
-            await mock_plc.read_tag("Motor1_Speed")
+        """A closed channel that cannot be reopened still raises, after N attempts."""
+        mock_plc.fail_connect = True  # recovery is attempted; the simulated device refuses
+
+        with pytest.raises(PLCCommunicationError) as exc_info:
+            await mock_plc.read_tag(["Motor1_Speed"])
+
+        assert f"attempts={mock_plc.retry_count}" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_read_tag_recovers_a_dropped_channel(self, mock_plc):
+        """A channel that dropped after connect is reopened in place, no raise."""
+        await mock_plc.connect()
+        mock_plc._is_connected = False
+
+        result = await mock_plc.read_tag(["Motor1_Speed"])
+
+        assert result["Motor1_Speed"].ok is True
+        # Only the failing channel came back, exactly as on the real backend.
+        assert mock_plc._channels_open == {"read": True, "write": False}
 
     @pytest.mark.asyncio
     async def test_read_tag_with_fail_read_flag(self, mock_plc):
@@ -464,7 +570,7 @@ class TestMockAllenBradleyPLCTagReading:
         mock_plc.fail_read = True
 
         with pytest.raises(PLCTagReadError):
-            await mock_plc.read_tag("Motor1_Speed")
+            await mock_plc.read_tag(["Motor1_Speed"])
 
     @pytest.mark.asyncio
     async def test_read_tag_with_timeout_flag(self, mock_plc):
@@ -473,19 +579,19 @@ class TestMockAllenBradleyPLCTagReading:
         mock_plc.simulate_timeout = True
 
         with pytest.raises(PLCTimeoutError):
-            await mock_plc.read_tag("Motor1_Speed")
+            await mock_plc.read_tag(["Motor1_Speed"])
 
     @pytest.mark.asyncio
-    async def test_read_tag_exception_handling(self, mock_plc):
-        """Test reading tag exception handling."""
+    async def test_read_tag_internal_error_propagates_unwrapped(self, mock_plc):
+        """An unexpected internal failure is not laundered into a PLC exception."""
         await mock_plc.connect()
 
-        # Patch _tag_values to raise an exception
+        # Patch _tag_values so the membership test blows up mid-read.
         original_tag_values = mock_plc._tag_values
         mock_plc._tag_values = None
 
-        with pytest.raises(PLCTagReadError):
-            await mock_plc.read_tag("Motor1_Speed")
+        with pytest.raises(TypeError):
+            await mock_plc.read_tag(["Motor1_Speed"])
 
         # Restore
         mock_plc._tag_values = original_tag_values
@@ -502,7 +608,8 @@ class TestMockAllenBradleyPLCTagWriting:
         result = await mock_plc.write_tag(("Production_Count", 2000))
 
         assert "Production_Count" in result
-        assert result["Production_Count"] is True
+        assert result["Production_Count"].ok is True
+        assert result["Production_Count"].value == 2000
 
     @pytest.mark.asyncio
     async def test_write_tag_multiple(self, mock_plc):
@@ -512,8 +619,10 @@ class TestMockAllenBradleyPLCTagWriting:
         result = await mock_plc.write_tag([("Production_Count", 2000), ("Motor1_Command", True)])
 
         assert len(result) == 2
-        assert result["Production_Count"] is True
-        assert result["Motor1_Command"] is True
+        assert result["Production_Count"].ok is True
+        assert result["Production_Count"].value == 2000
+        assert result["Motor1_Command"].ok is True
+        assert result["Motor1_Command"].value is True
 
     @pytest.mark.asyncio
     async def test_write_tag_verify_read_back(self, mock_plc):
@@ -521,82 +630,114 @@ class TestMockAllenBradleyPLCTagWriting:
         await mock_plc.connect()
 
         write_result = await mock_plc.write_tag([("Production_Count", 2000)])
-        assert write_result["Production_Count"] is True
+        assert write_result["Production_Count"].ok is True
 
-        read_result = await mock_plc.read_tag("Production_Count")
-        assert read_result["Production_Count"] == 2000
+        read_result = await mock_plc.read_tag(["Production_Count"])
+        assert read_result["Production_Count"].ok is True
+        assert read_result["Production_Count"].value == 2000
 
     @pytest.mark.asyncio
-    async def test_write_tag_type_conversion_bool(self, mock_plc):
-        """Test writing tag with bool type conversion."""
+    async def test_write_tag_bool_returns_the_callers_value(self, mock_plc):
+        """A BOOL write reports back what the caller handed in, uncoerced."""
         await mock_plc.connect()
 
-        # Write with different truthy values
         result1 = await mock_plc.write_tag([("Motor1_Command", 1)])
         result2 = await mock_plc.write_tag([("Motor1_Command", "true")])
         result3 = await mock_plc.write_tag([("Motor1_Command", 0)])
 
-        assert result1["Motor1_Command"] is True
-        assert result2["Motor1_Command"] is True
-        assert result3["Motor1_Command"] is True  # bool(0) is False, but we're testing conversion
-
-        # Verify the actual stored value
-        read_result = await mock_plc.read_tag("Motor1_Command")
-        assert isinstance(read_result["Motor1_Command"], bool)
+        assert result1["Motor1_Command"].ok is True
+        assert result1["Motor1_Command"].value == 1
+        assert result2["Motor1_Command"].ok is True
+        assert result2["Motor1_Command"].value == "true"
+        # 0 is a successful write of a falsy value, not a failure.
+        assert result3["Motor1_Command"].ok is True
+        assert result3["Motor1_Command"].value == 0
 
     @pytest.mark.asyncio
-    async def test_write_tag_type_conversion_int(self, mock_plc):
-        """Test writing tag with int type conversion."""
+    async def test_write_tag_int_returns_the_callers_value(self, mock_plc):
+        """The real backend never rewrites the value it was given; nor does the mock."""
         await mock_plc.connect()
 
         result = await mock_plc.write_tag([("Production_Count", 1500.7)])
 
-        assert result["Production_Count"] is True
-        # Verify it was converted to int
-        read_result = await mock_plc.read_tag("Production_Count")
-        assert isinstance(read_result["Production_Count"], int)
-        assert read_result["Production_Count"] == 1500
+        assert result["Production_Count"].ok is True
+        assert result["Production_Count"].value == 1500.7
+
+        read_result = await mock_plc.read_tag(["Production_Count"])
+        assert read_result["Production_Count"].value == 1500.7
 
     @pytest.mark.asyncio
-    async def test_write_tag_type_conversion_float(self, mock_plc):
-        """Test writing tag with float type conversion."""
+    async def test_write_tag_float_returns_the_callers_value(self, mock_plc):
         await mock_plc.connect()
 
         result = await mock_plc.write_tag([("Motor1_Speed", 2000)])
 
-        assert result["Motor1_Speed"] is True
-        # Verify it was converted to float
-        read_result = await mock_plc.read_tag("Motor1_Speed")
-        assert isinstance(read_result["Motor1_Speed"], float)
-        # Motor1_Speed has variation, so check it's within ±2% of 2000
-        assert abs(read_result["Motor1_Speed"] - 2000.0) <= 2000.0 * 0.02
+        assert result["Motor1_Speed"].ok is True
+        assert result["Motor1_Speed"].value == 2000
+
+        read_result = await mock_plc.read_tag(["Motor1_Speed"])
+        # Motor1_Speed drifts on read, so check it's within ±1% of 2000
+        assert abs(read_result["Motor1_Speed"].value - 2000) <= 2000 * 0.01
 
     @pytest.mark.asyncio
     async def test_write_tag_type_conversion_failure(self, mock_plc):
-        """Test writing tag with type conversion failure."""
+        """A value that cannot be coerced to the tag type yields a type_mismatch error."""
         await mock_plc.connect()
 
-        # Try to write invalid value that can't be converted
-        # This depends on the tag type - let's try writing a non-numeric string to a numeric tag
         result = await mock_plc.write_tag([("Production_Count", "invalid")])
 
-        # Should fail type conversion
-        assert result["Production_Count"] is False
+        assert result["Production_Count"].ok is False
+        assert result["Production_Count"].value is None
+        assert result["Production_Count"].error.kind is TagErrorKind.type_mismatch
 
     @pytest.mark.asyncio
     async def test_write_tag_non_existent(self, mock_plc):
-        """Test writing to non-existent tag."""
+        """Writing an unknown tag yields a missing_tag error, not a False sentinel."""
         await mock_plc.connect()
 
-        result = await mock_plc.write_tag([("NonExistentTag", 123)])
+        result = await mock_plc.write_tag(("NonExistentTag", 123))
 
-        assert result["NonExistentTag"] is False
+        assert result["NonExistentTag"].ok is False
+        assert result["NonExistentTag"].value is None
+        assert result["NonExistentTag"].error.kind is TagErrorKind.missing_tag
+
+    @pytest.mark.asyncio
+    async def test_write_tag_mixed_success_and_failure(self, mock_plc):
+        """One bad write in a batch does not spoil the good ones."""
+        await mock_plc.connect()
+
+        result = await mock_plc.write_tag(
+            [("Production_Count", 2000), ("NonExistentTag", 123), ("Motor1_Command", "nope")]
+        )
+
+        assert len(result) == 3
+        assert result["Production_Count"].ok is True
+        assert result["NonExistentTag"].error.kind is TagErrorKind.missing_tag
+        # "nope" passes the BOOL check, so Motor1_Command is a successful write
+        assert result["Motor1_Command"].ok is True
+        assert result["Motor1_Command"].value == "nope"
 
     @pytest.mark.asyncio
     async def test_write_tag_not_connected(self, mock_plc):
-        """Test writing tag when not connected."""
-        with pytest.raises(PLCCommunicationError):
+        """A closed channel that cannot be reopened still raises, after N attempts."""
+        mock_plc.fail_connect = True  # recovery is attempted; the simulated device refuses
+
+        with pytest.raises(PLCCommunicationError) as exc_info:
             await mock_plc.write_tag([("Production_Count", 2000)])
+
+        assert f"attempts={mock_plc.retry_count}" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_write_tag_recovers_a_dropped_channel(self, mock_plc):
+        """A channel that dropped after connect is reopened in place, no raise."""
+        await mock_plc.connect()
+        mock_plc._is_connected = False
+
+        result = await mock_plc.write_tag([("Production_Count", 2000)])
+
+        assert result["Production_Count"].ok is True
+        # Only the failing channel came back, exactly as on the real backend.
+        assert mock_plc._channels_open == {"read": False, "write": True}
 
     @pytest.mark.asyncio
     async def test_write_tag_with_fail_write_flag(self, mock_plc):
@@ -608,15 +749,15 @@ class TestMockAllenBradleyPLCTagWriting:
             await mock_plc.write_tag([("Production_Count", 2000)])
 
     @pytest.mark.asyncio
-    async def test_write_tag_exception_handling(self, mock_plc):
-        """Test writing tag exception handling."""
+    async def test_write_tag_internal_error_propagates_unwrapped(self, mock_plc):
+        """An unexpected internal failure is not laundered into a PLC exception."""
         await mock_plc.connect()
 
-        # Patch _tag_values to raise an exception
+        # Patch _tag_values so the membership test blows up mid-write.
         original_tag_values = mock_plc._tag_values
         mock_plc._tag_values = None
 
-        with pytest.raises(PLCTagWriteError):
+        with pytest.raises(TypeError):
             await mock_plc.write_tag([("Production_Count", 2000)])
 
         # Restore
@@ -839,27 +980,22 @@ class TestMockAllenBradleyPLCPLCInfo:
 
     @pytest.mark.asyncio
     async def test_get_plc_info_exception_handling(self, mock_plc):
-        """Test getting PLC info exception handling."""
+        """An unexpected failure is reported as the in-band error dict, as before."""
         await mock_plc.connect()
 
-        # Make hash() fail when called in the LogixDriver section
-        # by making plc_name something that causes hash to fail
-        # Actually, hash() rarely fails, so let's make the f-string formatting fail
         original_plc_name = mock_plc.plc_name
 
-        # Create a class that raises when hash() is called
+        # hash(plc_name) is taken for the simulated serial number.
         class HashError:
             def __hash__(self):
-                raise Exception("Hash failed")
+                raise RuntimeError("Hash failed")
 
         mock_plc.plc_name = HashError()
 
         info = await mock_plc.get_plc_info()
 
-        # Should return error dict
-        assert "name" in info  # The error dict has name from exception handler
         assert info["connected"] is False
-        assert "error" in info
+        assert "Hash failed" in info["error"]
         assert info["mock"] is True
 
         # Restore
@@ -917,15 +1053,20 @@ class TestMockAllenBradleyPLCEdgeCases:
         """Test that tag variation preserves int type for integer tags."""
         await mock_plc.connect()
 
-        # Read a tag that should have variation but is stored as int
-        # Temperature tags are floats, but let's test with a tag that's an int
-        # Actually, variation only applies to tags with keywords, and they're converted
-        # Let's test with a tag that gets variation but should stay as int
-        original_value = mock_plc._tag_values.get("Production_Count")
-        if original_value and isinstance(original_value, int):
-            # Production_Count doesn't have variation keywords, so it won't vary
-            result = await mock_plc.read_tag("Production_Count")
-            assert isinstance(result["Production_Count"], int)
+        # Production_Count has no variation keyword, so it is returned untouched.
+        original_value = mock_plc._tag_values["Production_Count"]
+        assert isinstance(original_value, int)
+        result = await mock_plc.read_tag(["Production_Count"])
+        assert result["Production_Count"].ok is True
+        assert isinstance(result["Production_Count"].value, int)
+        assert result["Production_Count"].value == original_value
+
+        # A tag that does drift ("speed") keeps its integer type through the drift.
+        mock_plc._tag_values["Custom_Speed"] = 100
+        drifted = await mock_plc.read_tag(["Custom_Speed"])
+        assert drifted["Custom_Speed"].ok is True
+        assert isinstance(drifted["Custom_Speed"].value, int)
+        assert abs(drifted["Custom_Speed"].value - 100) <= 1
 
     @pytest.mark.asyncio
     async def test_multiple_connections(self, mock_plc):

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
@@ -339,7 +339,7 @@ class TestMockAllenBradleyPLCConnection:
         await plc._close_channel("read")
 
         assert plc._channels_open == {"read": False, "write": True}
-        assert await plc.is_connected() is False
+        assert await plc.is_connected() is True  # lifecycle state; the channel self-heals
 
         result = await plc.read_tag(["Motor1_Speed"])  # entry reopens the read channel
         assert result["Motor1_Speed"].ok is True
@@ -567,13 +567,17 @@ class TestMockAllenBradleyPLCTagReading:
 
     @pytest.mark.asyncio
     async def test_read_tag_with_timeout_flag(self, mock_plc):
-        """A simulated timeout is transport-class: retried, then raised typed."""
+        """A simulated timeout raises typed and closes the read channel, like
+        the real backend: a late reply must not answer the next request."""
         await mock_plc.connect()
         mock_plc.simulate_timeout = True
         mock_plc.read_timeout = 0.01
 
         with pytest.raises(PLCCommunicationError):
             await mock_plc.read_tag(["Motor1_Speed"])
+
+        assert mock_plc._channels_open == {"read": False, "write": True}
+        assert await mock_plc.is_connected() is True  # lifecycle state; self-heals
 
     @pytest.mark.asyncio
     async def test_read_tag_internal_error_propagates_unwrapped(self, mock_plc):

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
@@ -1000,6 +1000,7 @@ class TestMockAllenBradleyPLCPLCInfo:
         with pytest.raises(PLCConnectionError, match="never opened"):
             await mock_plc.get_plc_info()
 
+
 class TestMockAllenBradleyPLCStaticMethods:
     """Test suite for static methods."""
 

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
@@ -84,13 +84,11 @@ class TestMockAllenBradleyPLCInitialization:
             connection_timeout=5.0,
             read_timeout=2.0,
             write_timeout=2.0,
-            retry_count=3,
             retry_delay=1.0,
         )
         assert plc.connection_timeout == 5.0
         assert plc.read_timeout == 2.0
         assert plc.write_timeout == 2.0
-        assert plc.retry_count == 3
         assert plc.retry_delay == 1.0
 
     def test_init_mock_data_initialization(self):
@@ -237,7 +235,7 @@ class TestMockAllenBradleyPLCConnection:
         """Connect never retries: a configured retry_count does not add attempts."""
         from mindtrace.hardware.plcs.backends.allen_bradley.mock_allen_bradley import MockAllenBradleyPLC
 
-        plc = MockAllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix", retry_count=3)
+        plc = MockAllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
         plc.fail_connect = True
 
         attempts = 0
@@ -331,21 +329,21 @@ class TestMockAllenBradleyPLCConnection:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_reconnect_channel_is_channel_scoped(self):
-        """One channel reopening is not a connection, exactly as on the real backend.
-
-        The real backend opens only the failed channel's driver, so ``is_connected``
-        — which needs BOTH sessions — stays False. A mock that bounced the whole
-        lifecycle here would hide that difference from every test above it.
-        """
+    async def test_close_and_reopen_is_channel_scoped(self):
+        """Closing one channel leaves the other open; the next call reopens it."""
         from mindtrace.hardware.plcs.backends.allen_bradley.mock_allen_bradley import MockAllenBradleyPLC
 
         plc = MockAllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        await plc.connect()
 
-        assert await plc._reconnect_channel("read") is True
+        await plc._close_channel("read")
 
-        assert plc._channels_open == {"read": True, "write": False}
+        assert plc._channels_open == {"read": False, "write": True}
         assert await plc.is_connected() is False
+
+        result = await plc.read_tag(["Motor1_Speed"])  # entry reopens the read channel
+        assert result["Motor1_Speed"].ok is True
+        assert plc._channels_open == {"read": True, "write": True}
 
 
 class TestMockAllenBradleyPLCInitialize:
@@ -542,13 +540,9 @@ class TestMockAllenBradleyPLCTagReading:
 
     @pytest.mark.asyncio
     async def test_read_tag_not_connected(self, mock_plc):
-        """A closed channel that cannot be reopened still raises, after N attempts."""
-        mock_plc.fail_connect = True  # recovery is attempted; the simulated device refuses
-
-        with pytest.raises(PLCCommunicationError) as exc_info:
+        """A never-connected channel is a lifecycle error: nothing gets opened."""
+        with pytest.raises(PLCConnectionError, match="never opened"):
             await mock_plc.read_tag(["Motor1_Speed"])
-
-        assert f"attempts={mock_plc.retry_count}" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_read_tag_recovers_a_dropped_channel(self, mock_plc):
@@ -577,7 +571,6 @@ class TestMockAllenBradleyPLCTagReading:
         await mock_plc.connect()
         mock_plc.simulate_timeout = True
         mock_plc.read_timeout = 0.01
-        mock_plc.retry_count = 1
 
         with pytest.raises(PLCCommunicationError):
             await mock_plc.read_tag(["Motor1_Speed"])
@@ -720,13 +713,9 @@ class TestMockAllenBradleyPLCTagWriting:
 
     @pytest.mark.asyncio
     async def test_write_tag_not_connected(self, mock_plc):
-        """A closed channel that cannot be reopened still raises, after N attempts."""
-        mock_plc.fail_connect = True  # recovery is attempted; the simulated device refuses
-
-        with pytest.raises(PLCCommunicationError) as exc_info:
+        """A never-connected channel is a lifecycle error: nothing gets opened."""
+        with pytest.raises(PLCConnectionError, match="never opened"):
             await mock_plc.write_tag([("Production_Count", 2000)])
-
-        assert f"attempts={mock_plc.retry_count}" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_write_tag_recovers_a_dropped_channel(self, mock_plc):
@@ -859,7 +848,7 @@ class TestMockAllenBradleyPLCTagDiscovery:
     @pytest.mark.asyncio
     async def test_get_all_tags_not_connected(self, mock_plc):
         """Test getting all tags when not connected."""
-        with pytest.raises(PLCCommunicationError):
+        with pytest.raises(PLCConnectionError, match="never opened"):
             await mock_plc.get_all_tags()
 
     @pytest.mark.asyncio
@@ -907,7 +896,7 @@ class TestMockAllenBradleyPLCTagInfo:
     @pytest.mark.asyncio
     async def test_get_tag_info_not_connected(self, mock_plc):
         """Test getting tag info when not connected."""
-        with pytest.raises(PLCCommunicationError):
+        with pytest.raises(PLCConnectionError, match="never opened"):
             await mock_plc.get_tag_info("Motor1_Speed")
 
     @pytest.mark.asyncio
@@ -976,7 +965,7 @@ class TestMockAllenBradleyPLCPLCInfo:
     @pytest.mark.asyncio
     async def test_get_plc_info_not_connected(self, mock_plc):
         """Test getting PLC info when not connected."""
-        with pytest.raises(PLCCommunicationError):
+        with pytest.raises(PLCConnectionError, match="never opened"):
             await mock_plc.get_plc_info()
 
     @pytest.mark.asyncio

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
@@ -20,7 +20,6 @@ from mindtrace.hardware.core.exceptions import (
     PLCTagNotFoundError,
     PLCTagReadError,
     PLCTagWriteError,
-    PLCTimeoutError,
 )
 from mindtrace.hardware.plcs import TagErrorKind
 
@@ -574,11 +573,13 @@ class TestMockAllenBradleyPLCTagReading:
 
     @pytest.mark.asyncio
     async def test_read_tag_with_timeout_flag(self, mock_plc):
-        """Test reading tag when simulate_timeout flag is set."""
+        """A simulated timeout is transport-class: retried, then raised typed."""
         await mock_plc.connect()
         mock_plc.simulate_timeout = True
+        mock_plc.read_timeout = 0.01
+        mock_plc.retry_count = 1
 
-        with pytest.raises(PLCTimeoutError):
+        with pytest.raises(PLCCommunicationError):
             await mock_plc.read_tag(["Motor1_Speed"])
 
     @pytest.mark.asyncio

--- a/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/allen_bradley/test_mock_allen_bradley_plc.py
@@ -580,6 +580,34 @@ class TestMockAllenBradleyPLCTagReading:
         assert await mock_plc.is_connected() is True  # lifecycle state; self-heals
 
     @pytest.mark.asyncio
+    async def test_write_tag_with_timeout_flag(self, mock_plc):
+        """The write channel has its own timeout simulation, like the real backend."""
+        await mock_plc.connect()
+        mock_plc.simulate_timeout = True
+        mock_plc.write_timeout = 0.01
+
+        with pytest.raises(PLCCommunicationError):
+            await mock_plc.write_tag([("Pump1_Command", True)])
+
+        assert mock_plc._channels_open == {"read": True, "write": False}
+
+    @pytest.mark.asyncio
+    async def test_error_flags_do_not_preempt_the_lifecycle_guard(self):
+        """A never-connected mock raises PLCConnectionError like the real
+        backend, no matter which simulation flags are set."""
+        from mindtrace.hardware.plcs.backends.allen_bradley.mock_allen_bradley import MockAllenBradleyPLC
+
+        plc = MockAllenBradleyPLC("TestPLC", "192.168.1.100", plc_type="logix")
+        plc.simulate_timeout = True
+        plc.fail_read = True
+        plc.fail_write = True
+
+        with pytest.raises(PLCConnectionError):
+            await plc.read_tag(["Motor1_Speed"])
+        with pytest.raises(PLCConnectionError):
+            await plc.write_tag([("Pump1_Command", True)])
+
+    @pytest.mark.asyncio
     async def test_read_tag_internal_error_propagates_unwrapped(self, mock_plc):
         """An unexpected internal failure is not laundered into a PLC exception."""
         await mock_plc.connect()

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_hardware_plcs_backends_base.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_hardware_plcs_backends_base.py
@@ -1,18 +1,22 @@
-"""Unit tests for the BasePLC helper behavior."""
+"""Unit tests for the BasePLC transport contract."""
 
 from __future__ import annotations
 
 import logging
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock, patch
+from typing import Any, Dict, List, Tuple
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from mindtrace.hardware.core.exceptions import PLCTagError
+from mindtrace.hardware.core.exceptions import PLCConnectionError
 from mindtrace.hardware.plcs.backends.base import BasePLC
+from mindtrace.hardware.plcs.types import TagResult
 
 
 class MinimalPLC(BasePLC):
+    """Smallest backend that satisfies the abstract surface."""
+
     def __init__(self, *args, **kwargs):
         self._connected = False
         super().__init__(*args, **kwargs)
@@ -21,29 +25,31 @@ class MinimalPLC(BasePLC):
         self.initialized = True
         return True, object(), object()
 
-    async def connect(self) -> bool:
+    async def _connect(self) -> bool:
         self._connected = True
         return True
 
-    async def disconnect(self) -> bool:
+    async def _disconnect(self) -> bool:
         self._connected = False
+        return True
+
+    async def _reconnect_channel(self, channel: str) -> bool:
+        self._connected = True
         return True
 
     async def is_connected(self) -> bool:
         return self._connected
 
-    async def read_tag(self, tags):
-        return {"Tag1": 1} if isinstance(tags, str) else {tag: index for index, tag in enumerate(tags)}
+    async def _read_tags(self, addresses: List[str]) -> Dict[str, TagResult]:
+        return {address: TagResult(value=index) for index, address in enumerate(addresses)}
 
-    async def write_tag(self, tags):
-        if isinstance(tags, tuple):
-            return {tags[0]: True}
-        return {tag_name: True for tag_name, _ in tags}
+    async def _write_tags(self, writes: List[Tuple[str, Any]]) -> Dict[str, TagResult]:
+        return {address: TagResult(value=value) for address, value in writes}
 
-    async def get_all_tags(self):
+    async def _get_all_tags(self):
         return ["Tag1", "Tag2"]
 
-    async def get_tag_info(self, tag_name: str):
+    async def _get_tag_info(self, tag_name: str):
         return {"name": tag_name, "type": "int"}
 
     @staticmethod
@@ -67,13 +73,20 @@ def _mock_hardware_config():
     )
 
 
-class TestBasePLCInitialization:
-    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
-    def test_constructor_uses_config_defaults(self, mock_get_hardware_config):
+@pytest.fixture
+def hardware_config():
+    with patch("mindtrace.hardware.plcs.backends.base.get_hardware_config") as mock_get_hardware_config:
         mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
+        yield mock_get_hardware_config
 
-        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
 
+@pytest.fixture
+def plc(hardware_config):
+    return MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
+
+
+class TestBasePLCInitialization:
+    def test_constructor_uses_config_defaults(self, plc):
         assert plc.plc_name == "PLC1"
         assert plc.ip_address == "192.168.1.100"
         assert plc.connection_timeout == 1.5
@@ -83,10 +96,7 @@ class TestBasePLCInitialization:
         assert plc.retry_delay == 0.01
         assert plc.initialized is False
 
-    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
-    def test_constructor_respects_explicit_overrides(self, mock_get_hardware_config):
-        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
-
+    def test_constructor_respects_explicit_overrides(self, hardware_config):
         plc = MinimalPLC(
             plc_name="PLC1",
             ip_address="192.168.1.100",
@@ -103,121 +113,185 @@ class TestBasePLCInitialization:
         assert plc.retry_count == 4
         assert plc.retry_delay == 0.5
 
-    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
-    def test_logger_formatting_is_configured(self, mock_get_hardware_config):
-        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
+    def test_constructor_creates_independent_channel_locks(self, plc):
+        assert plc._read_lock is not plc._write_lock
+        assert not plc._read_lock.locked()
+        assert not plc._write_lock.locked()
 
-        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
+    def test_channel_locks_are_per_instance(self, hardware_config):
+        first = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
+        second = MinimalPLC(plc_name="PLC2", ip_address="192.168.1.101")
 
+        assert first._read_lock is not second._read_lock
+        assert first._write_lock is not second._write_lock
+
+    def test_logger_formatting_is_configured(self, plc):
         assert plc.logger.propagate is False
         assert plc.logger.level <= logging.INFO
         assert plc.logger.handlers
         formatter = plc.logger.handlers[0].formatter
-        assert "%(message)s" in formatter._fmt
         assert formatter is not None
+        assert "%(message)s" in formatter._fmt
 
 
-class TestBasePLCRetryHelpers:
-    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
-    @pytest.mark.asyncio
-    async def test_reconnect_disconnects_sleeps_and_reconnects(self, mock_get_hardware_config):
-        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
-        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
-        plc.disconnect = AsyncMock(return_value=True)
-        plc.connect = AsyncMock(return_value=True)
+class TestBasePLCRemovedRetryHelpers:
+    """The retry helpers are gone; recovery is internal to read_tag / write_tag."""
+
+    @pytest.mark.parametrize("name", ["read_tag_with_retry", "write_tag_with_retry"])
+    def test_legacy_helpers_are_removed(self, name):
+        assert not hasattr(BasePLC, name)
+
+
+class TestBasePLCCallShapes:
+    """The single-or-list call shapes are unchanged; only the return shape moved."""
+
+    async def test_read_tag_accepts_a_bare_string(self, plc):
+        results = await plc.read_tag("Tag1")
+
+        assert set(results) == {"Tag1"}
+        assert results["Tag1"].ok is True
+        assert not plc._read_lock.locked()
+
+    async def test_write_tag_accepts_a_bare_pair(self, plc):
+        results = await plc.write_tag(("Tag1", 100))
+
+        assert results["Tag1"].value == 100
+        assert not plc._write_lock.locked()
+
+    async def test_a_list_of_two_pair_lists_is_not_mistaken_for_one_pair(self, plc):
+        results = await plc.write_tag([["Tag1", 1], ["Tag2", 2]])
+
+        assert results["Tag1"].value == 1
+        assert results["Tag2"].value == 2
+
+    async def test_a_list_of_two_writes_is_not_mistaken_for_one_pair(self, plc):
+        results = await plc.write_tag([("Tag1", 1), ("Tag2", 2)])
+
+        assert results["Tag1"].value == 1
+        assert results["Tag2"].value == 2
+
+
+class TestBasePLCPublicApiDelegates:
+    async def test_read_tag_delegates_under_the_read_lock(self, plc):
+        seen = {}
+
+        async def _read_tags(addresses):
+            seen["locked"] = (plc._read_lock.locked(), plc._write_lock.locked())
+            return {address: TagResult(value=address) for address in addresses}
+
+        plc._read_tags = _read_tags
+        results = await plc.read_tag(["Tag1", "Tag2"])
+
+        assert seen["locked"] == (True, False)
+        assert results["Tag1"].value == "Tag1"
+        assert results["Tag2"].ok is True
+
+    async def test_write_tag_delegates_under_the_write_lock(self, plc):
+        seen = {}
+
+        async def _write_tags(writes):
+            seen["locked"] = (plc._read_lock.locked(), plc._write_lock.locked())
+            return {address: TagResult(value=value) for address, value in writes}
+
+        plc._write_tags = _write_tags
+        results = await plc.write_tag([("Tag1", 100)])
+
+        assert seen["locked"] == (False, True)
+        assert results["Tag1"].value == 100
+
+    @pytest.mark.parametrize(
+        "public,private,args",
+        [
+            ("get_all_tags", "_get_all_tags", ()),
+            ("get_tag_info", "_get_tag_info", ("Tag1",)),
+            ("get_plc_info", "_get_plc_info", ()),
+        ],
+    )
+    async def test_read_side_probes_take_the_read_lock(self, plc, public, private, args):
+        seen = {}
+
+        async def _probe(*_args):
+            seen["locked"] = (plc._read_lock.locked(), plc._write_lock.locked())
+            return {}
+
+        setattr(plc, private, _probe)
+        await getattr(plc, public)(*args)
+
+        assert seen["locked"] == (True, False)
+
+    @pytest.mark.parametrize("public,private", [("connect", "_connect"), ("disconnect", "_disconnect")])
+    async def test_lifecycle_takes_both_locks(self, plc, public, private):
+        seen = {}
+
+        async def _lifecycle():
+            seen["locked"] = (plc._read_lock.locked(), plc._write_lock.locked())
+            return True
+
+        setattr(plc, private, _lifecycle)
+        assert await getattr(plc, public)() is True
+        assert seen["locked"] == (True, True)
+
+    async def test_default_get_plc_info_reports_identity(self, plc):
+        await plc.connect()
+
+        info = await plc.get_plc_info()
+
+        assert info == {"name": "PLC1", "ip_address": "192.168.1.100", "connected": True}
+
+
+class TestBasePLCReconnect:
+    async def test_reconnect_disconnects_sleeps_and_reconnects(self, plc):
+        plc._disconnect = AsyncMock(return_value=True)
+        plc._connect = AsyncMock(return_value=True)
 
         with patch("mindtrace.hardware.plcs.backends.base.asyncio.sleep", AsyncMock()) as sleep:
             result = await plc.reconnect()
 
-        plc.disconnect.assert_awaited_once_with()
+        plc._disconnect.assert_awaited_once_with()
         sleep.assert_awaited_once_with(plc.retry_delay)
-        plc.connect.assert_awaited_once_with()
+        plc._connect.assert_awaited_once_with()
         assert result is True
 
-    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
-    @pytest.mark.asyncio
-    async def test_reconnect_returns_false_when_disconnect_fails(self, mock_get_hardware_config):
-        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
-        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
-        plc.disconnect = AsyncMock(side_effect=RuntimeError("boom"))
-        plc.logger.error = Mock()
+    async def test_reconnect_holds_both_locks_for_the_whole_sequence(self, plc):
+        held = []
 
-        result = await plc.reconnect()
+        async def _record():
+            held.append((plc._read_lock.locked(), plc._write_lock.locked()))
+            return True
 
-        assert result is False
-        plc.logger.error.assert_called_once()
+        plc._disconnect = _record
+        plc._connect = _record
 
-    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
-    @pytest.mark.asyncio
-    async def test_read_tag_with_retry_retries_and_reconnects(self, mock_get_hardware_config):
-        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
-        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
-        plc.read_tag = AsyncMock(side_effect=[RuntimeError("fail once"), {"Tag1": 123}])
-        plc.is_connected = AsyncMock(return_value=False)
-        plc.reconnect = AsyncMock(return_value=True)
+        assert await plc.reconnect() is True
+        assert held == [(True, True), (True, True)]
 
-        with patch("mindtrace.hardware.plcs.backends.base.asyncio.sleep", AsyncMock()) as sleep:
-            result = await plc.read_tag_with_retry("Tag1")
+    async def test_reconnect_propagates_the_typed_failure(self, plc):
+        """Reconnect is an explicit lifecycle call: it raises like connect does."""
+        plc._connect = AsyncMock(side_effect=PLCConnectionError("device refused"))
 
-        assert result == {"Tag1": 123}
-        assert plc.read_tag.await_count == 2
-        plc.reconnect.assert_awaited_once_with()
-        sleep.assert_awaited_once_with(plc.retry_delay)
+        with pytest.raises(PLCConnectionError, match="device refused"):
+            await plc.reconnect()
 
-    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
-    @pytest.mark.asyncio
-    async def test_read_tag_with_retry_raises_after_exhausting_attempts(self, mock_get_hardware_config):
-        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
-        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
-        plc.read_tag = AsyncMock(side_effect=RuntimeError("still failing"))
-        plc.is_connected = AsyncMock(return_value=True)
-        plc.reconnect = AsyncMock()
+    async def test_reconnect_does_not_swallow_a_disconnect_failure(self, plc):
+        plc._disconnect = AsyncMock(side_effect=RuntimeError("boom"))
+        plc._connect = AsyncMock(return_value=True)
 
-        with patch("mindtrace.hardware.plcs.backends.base.asyncio.sleep", AsyncMock()):
-            with pytest.raises(PLCTagError, match="Failed to read tags after 3 attempts"):
-                await plc.read_tag_with_retry("Tag1")
+        with pytest.raises(RuntimeError, match="boom"):
+            await plc.reconnect()
 
-        assert plc.read_tag.await_count == 3
-        plc.reconnect.assert_not_called()
+        plc._connect.assert_not_awaited()
 
-    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
-    @pytest.mark.asyncio
-    async def test_write_tag_with_retry_retries_and_reconnects(self, mock_get_hardware_config):
-        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
-        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
-        plc.write_tag = AsyncMock(side_effect=[RuntimeError("fail once"), {"Tag1": True}])
-        plc.is_connected = AsyncMock(return_value=False)
-        plc.reconnect = AsyncMock(return_value=True)
+    async def test_failed_reconnect_releases_both_locks(self, plc):
+        plc._disconnect = AsyncMock(side_effect=RuntimeError("boom"))
 
-        with patch("mindtrace.hardware.plcs.backends.base.asyncio.sleep", AsyncMock()) as sleep:
-            result = await plc.write_tag_with_retry(("Tag1", 100))
+        with pytest.raises(RuntimeError):
+            await plc.reconnect()
 
-        assert result == {"Tag1": True}
-        assert plc.write_tag.await_count == 2
-        plc.reconnect.assert_awaited_once_with()
-        sleep.assert_awaited_once_with(plc.retry_delay)
-
-    @patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
-    @pytest.mark.asyncio
-    async def test_write_tag_with_retry_raises_after_exhausting_attempts(self, mock_get_hardware_config):
-        mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
-        plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
-        plc.write_tag = AsyncMock(side_effect=RuntimeError("still failing"))
-        plc.is_connected = AsyncMock(return_value=True)
-        plc.reconnect = AsyncMock()
-
-        with patch("mindtrace.hardware.plcs.backends.base.asyncio.sleep", AsyncMock()):
-            with pytest.raises(PLCTagError, match="Failed to write tags after 3 attempts"):
-                await plc.write_tag_with_retry(("Tag1", 100))
-
-        assert plc.write_tag.await_count == 3
-        plc.reconnect.assert_not_called()
+        assert not plc._read_lock.locked()
+        assert not plc._write_lock.locked()
 
 
-@patch("mindtrace.hardware.plcs.backends.base.get_hardware_config")
-def test_string_representations_include_identity(mock_get_hardware_config):
-    mock_get_hardware_config.return_value.get_config.return_value = _mock_hardware_config()
-
+def test_string_representations_include_identity(hardware_config):
     plc = MinimalPLC(plc_name="PLC1", ip_address="192.168.1.100")
     plc.initialized = True
 

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_hardware_plcs_backends_base.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_hardware_plcs_backends_base.py
@@ -67,7 +67,6 @@ def _mock_hardware_config():
             connection_timeout=1.5,
             read_timeout=2.5,
             write_timeout=3.5,
-            retry_count=3,
             retry_delay=0.01,
         )
     )
@@ -92,7 +91,6 @@ class TestBasePLCInitialization:
         assert plc.connection_timeout == 1.5
         assert plc.read_timeout == 2.5
         assert plc.write_timeout == 3.5
-        assert plc.retry_count == 3
         assert plc.retry_delay == 0.01
         assert plc.initialized is False
 
@@ -103,14 +101,12 @@ class TestBasePLCInitialization:
             connection_timeout=10.0,
             read_timeout=20.0,
             write_timeout=30.0,
-            retry_count=4,
             retry_delay=0.5,
         )
 
         assert plc.connection_timeout == 10.0
         assert plc.read_timeout == 20.0
         assert plc.write_timeout == 30.0
-        assert plc.retry_count == 4
         assert plc.retry_delay == 0.5
 
     def test_constructor_creates_independent_channel_locks(self, plc):

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
@@ -543,12 +543,15 @@ class TestErrorTaxonomy:
         assert results["Tag1"].ok is False
         assert results["Tag1"].error.kind is TagErrorKind.unknown
 
-    async def test_an_empty_batch_still_checks_the_channel(self):
+    async def test_an_empty_batch_still_checks_the_channel(self, monkeypatch):
         read_driver = FakeLogixDriver()
         read_driver.connected = False
+        dead = FakeLogixDriver()
+        dead.open = lambda: False
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: dead)
         plc = _allen_bradley(read_driver, FakeLogixDriver())
 
-        with pytest.raises(PLCCommunicationError):
+        with pytest.raises(PLCCommunicationError, match="Could not reopen"):
             await plc.read_tag([])
 
     async def test_an_empty_batch_on_an_open_channel_is_a_no_op(self):
@@ -561,13 +564,16 @@ class TestErrorTaxonomy:
         assert read_driver.read_calls == []
         assert write_driver.write_calls == []
 
-    async def test_closed_channel_raises_without_reconnecting(self):
+    async def test_closed_channel_raises_without_reconnecting(self, monkeypatch):
         read_driver = FakeLogixDriver()
         read_driver.connected = False
+        dead = FakeLogixDriver()
+        dead.open = lambda: False
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: dead)
         plc = _allen_bradley(read_driver, FakeLogixDriver())
         plc.reconnect = AsyncMock()
 
-        with pytest.raises(PLCCommunicationError):
+        with pytest.raises(PLCCommunicationError, match="Could not reopen"):
             await plc.read_tag(["Tag1"])
 
         plc.reconnect.assert_not_awaited()
@@ -575,17 +581,15 @@ class TestErrorTaxonomy:
 
 
 class TestPerTagNetsAreNarrow:
-    """The unbatched SLC/CIP paths classify per-tag driver errors and nothing else.
+    """The unbatched SLC/CIP paths keep exactly ONE raised class per-tag: the
+    pre-wire RequestError. Everything else aborted an exchange - the same
+    DataError/ResponseError that closes the channel on the Logix path must not
+    become a per-tag verdict here, or link death gets laundered into results
+    (the forward-open refusal wedge)."""
 
-    A dropped socket or a code bug hit halfway through a batch is a whole-call
-    failure; laundering it into per-tag transport errors would report the batch
-    as "mostly fine" while the session was already gone.
-    """
-
-    @pytest.mark.parametrize("driver_type", ["SLCDriver", "CIPDriver"])
-    async def test_a_comm_error_mid_batch_raises_typed(self, driver_type):
+    async def test_a_comm_error_mid_batch_raises_typed(self):
         read_driver = FakeLogixDriver(read_error=CommError("socket closed"))
-        plc = _allen_bradley(read_driver, FakeLogixDriver(), driver_type)
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), "SLCDriver")
 
         with pytest.raises(PLCCommunicationError) as excinfo:
             await plc.read_tag(["Tag1", "Tag2"])
@@ -594,10 +598,9 @@ class TestPerTagNetsAreNarrow:
         # The batch stopped at the first address instead of marching on.
         assert len(read_driver.read_calls) == 1
 
-    @pytest.mark.parametrize("driver_type", ["SLCDriver", "CIPDriver"])
-    async def test_a_write_comm_error_mid_batch_raises_typed(self, driver_type):
+    async def test_a_write_comm_error_mid_batch_raises_typed(self):
         write_driver = FakeLogixDriver(write_error=CommError("socket closed"))
-        plc = _allen_bradley(FakeLogixDriver(), write_driver, driver_type)
+        plc = _allen_bradley(FakeLogixDriver(), write_driver, "SLCDriver")
 
         with pytest.raises(PLCCommunicationError) as excinfo:
             await plc.write_tag([("Tag1", 1), ("Tag2", 2)])
@@ -605,28 +608,92 @@ class TestPerTagNetsAreNarrow:
         assert isinstance(excinfo.value.__cause__, CommError)
         assert len(write_driver.write_calls) == 1
 
-    @pytest.mark.parametrize("driver_type", ["SLCDriver", "CIPDriver"])
-    async def test_a_programming_error_is_not_reported_as_a_tag_error(self, driver_type):
+    async def test_a_programming_error_is_not_reported_as_a_tag_error(self):
         """A code bug reaches the outer net chained, not a per-tag transport result."""
         boom = AttributeError("'NoneType' object has no attribute 'read'")
         read_driver = FakeLogixDriver(read_error=boom)
-        plc = _allen_bradley(read_driver, FakeLogixDriver(), driver_type)
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), "SLCDriver")
 
         with pytest.raises(PLCTagReadError) as excinfo:
             await plc.read_tag(["Tag1"])
 
         assert excinfo.value.__cause__ is boom
 
-    @pytest.mark.parametrize("driver_type", ["SLCDriver", "CIPDriver"])
-    async def test_a_per_tag_driver_error_still_stays_per_tag(self, driver_type):
-        read_driver = FakeLogixDriver(read_error=DataError("Error packing -128 as USINT"))
-        plc = _allen_bradley(read_driver, FakeLogixDriver(), driver_type)
+    async def test_a_pre_wire_request_error_stays_per_tag(self):
+        read_driver = FakeLogixDriver(read_error=RequestError("Error parsing the tag passed to read() - N7:X"))
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), "SLCDriver")
 
         results = await plc.read_tag(["Tag1", "Tag2"])
 
-        assert results["Tag1"].error.kind is TagErrorKind.encode
-        assert results["Tag2"].error.kind is TagErrorKind.encode
+        assert results["Tag1"].error.kind is TagErrorKind.missing_tag
+        assert results["Tag2"].error.kind is TagErrorKind.missing_tag
         assert len(read_driver.read_calls) == 2
+        assert read_driver.connected is True
+
+    async def test_a_raised_data_error_closes_like_any_aborted_exchange(self):
+        """The same class means the same policy on every driver family."""
+        read_driver = FakeLogixDriver(read_error=DataError("Error packing -128 as USINT"))
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), "SLCDriver")
+
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1", "Tag2"])
+
+        assert read_driver.connected is False
+        assert len(read_driver.read_calls) == 1
+
+    async def test_a_forward_open_refusal_closes_the_channel(self):
+        """with_forward_open raises ResponseError for a SESSION-level failure;
+        kept per-tag it would wedge the PLC (connected stays True, no reopen)."""
+        from pycomm3.exceptions import ResponseError
+
+        refusal = ResponseError("Target did not connected. read will not be executed.")
+        read_driver = FakeLogixDriver(read_error=refusal)
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), "SLCDriver")
+
+        with pytest.raises(PLCCommunicationError) as excinfo:
+            await plc.read_tag(["N7:0", "N7:1"])
+
+        assert excinfo.value.__cause__ is refusal
+        assert read_driver.connected is False
+
+    async def test_echoed_caller_text_cannot_impersonate_the_session(self):
+        """Fabricated verdicts embed caller input; a junk address containing a
+        session-dead phrase must stay a config verdict, not close the channel."""
+        read_driver = FakeLogixDriver()
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), "CIPDriver")
+
+        results = await plc.read_tag(["junk connection lost tag"])
+
+        assert results["junk connection lost tag"].error.kind is TagErrorKind.missing_tag
+        assert read_driver.connected is True
+
+    async def test_a_malformed_write_is_rejected_before_the_wire(self):
+        """The flat-list typo shape must never reach the driver: pycomm3 would
+        interpret ["Tag", value] as ONE valid write and issue it."""
+        write_driver = FakeLogixDriver(write_results=[_tag(value=1)])
+        plc = _allen_bradley(FakeLogixDriver(), write_driver)
+
+        with pytest.raises(PLCTagWriteError, match="pairs"):
+            await plc.write_tag(["Tag1", 1])
+
+        assert write_driver.write_calls == []
+        assert write_driver.connected is True
+
+    async def test_an_unsupported_cip_address_form_is_a_per_tag_verdict(self):
+        """CIPDriver has no read()/write(); unservable address forms come back
+        as per-tag config verdicts without touching the driver."""
+        read_driver = FakeLogixDriver()
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), "CIPDriver")
+
+        results = await plc.read_tag(["Parameter:1", "Assembly:abc"])
+
+        assert results["Parameter:1"].error.kind is TagErrorKind.missing_tag
+        assert results["Assembly:abc"].error.kind is TagErrorKind.missing_tag
+        assert read_driver.read_calls == []
+        assert read_driver.connected is True
+
+        write_results = await plc.write_tag([("NotAForm", 1)])
+        assert write_results["NotAForm"].error.kind is TagErrorKind.missing_tag
 
 
 class TestTagResultHardening:
@@ -1023,6 +1090,33 @@ class TestAllenBradleyChannelLifecycle:
         assert constructed == []
         assert plc._write_driver is None
 
+    async def test_disconnect_forgets_drivers_even_when_close_raises(self):
+        """pycomm3's close() resets its own state before raising, so a failed
+        close is still closed - keeping the refs would let the next poll
+        silently reopen a PLC the operator just tore down."""
+        read_driver = FakeLogixDriver()
+
+        def _explode():
+            raise CommError("failed to send message")
+
+        read_driver.close = _explode
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+
+        assert await plc.disconnect() is False  # the failure is still reported
+        assert await plc.is_connected() is False
+        with pytest.raises(PLCConnectionError, match="call connect"):
+            await plc.read_tag(["Tag1"])
+
+    async def test_a_miscounted_reply_closes_the_channel(self):
+        """Delivered-but-miscounted is misalignment evidence like any other."""
+        read_driver = FakeLogixDriver(read_results=[_tag(value=1)])
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+
+        with pytest.raises(PLCTagReadError, match="returned 1 results"):
+            await plc.read_tag(["Tag1", "Tag2"])
+
+        assert read_driver.connected is False
+
     async def test_a_reopen_that_wont_open_raises_typed(self, monkeypatch):
         read_driver = FakeLogixDriver(read_error=_socket_death_comm_error())
         dead = FakeLogixDriver()
@@ -1117,6 +1211,52 @@ class TestAllenBradleyChannelLifecycle:
         results = await plc.read_tag(["Tag1"])  # entry opens a FRESH driver
         assert results["Tag1"].value == 42
         assert plc._read_driver is replacement
+
+    async def test_write_backstop_expiry_abandons_the_write_channel(self, monkeypatch):
+        import time as _time
+
+        stalled = FakeLogixDriver(write_results=[_tag(value=1)])
+        original_write = stalled.write
+        close_calls = []
+        stalled.close = lambda: close_calls.append(True)
+
+        def _slow_write(*writes):
+            _time.sleep(1.5)
+            return original_write(*writes)
+
+        stalled.write = _slow_write
+        replacement = FakeLogixDriver(write_results=[_tag(value=7)])
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: replacement)
+        plc = _allen_bradley(FakeLogixDriver(), stalled)
+        plc.write_timeout = 0.02
+
+        with pytest.raises(PLCTimeoutError, match="backstop"):
+            await plc.write_tag([("Tag1", 7)])
+
+        assert close_calls == []
+        assert plc._write_driver is not stalled
+        assert plc._read_driver.connected is True  # the other channel is untouched
+
+        results = await plc.write_tag([("Tag1", 7)])
+        assert results["Tag1"].value == 7
+
+    async def test_disconnect_tears_down_cleanly_with_an_abandoned_channel(self, monkeypatch):
+        """The sentinel's no-op close must make lifecycle teardown safe."""
+        import time as _time
+
+        stalled = FakeLogixDriver(read_results=[_tag(value=1)])
+        original_read = stalled.read
+        stalled.read = lambda *a: (_time.sleep(1.5), original_read(*a))[1]
+        plc = _allen_bradley(stalled, FakeLogixDriver())
+        plc.read_timeout = 0.02
+
+        with pytest.raises(PLCTimeoutError, match="backstop"):
+            await plc.read_tag(["Tag1"])
+
+        assert await plc.disconnect() is True
+        assert await plc.is_connected() is False
+        with pytest.raises(PLCConnectionError, match="call connect"):
+            await plc.read_tag(["Tag1"])
 
     async def test_caller_cancellation_abandons_the_channel(self, monkeypatch):
         """Cancellation mid-exchange (a plan push cancelling the poll task, an

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
@@ -34,8 +34,9 @@ from mindtrace.hardware.core.exceptions import (
 )
 from mindtrace.hardware.plcs.backends.allen_bradley import AllenBradleyPLC, MockAllenBradleyPLC
 from mindtrace.hardware.plcs.backends.allen_bradley import allen_bradley_plc as ab_module
+from mindtrace.hardware.plcs.backends.allen_bradley.error_text import classify_tag_error
 from mindtrace.hardware.plcs.backends.base import BasePLC
-from mindtrace.hardware.plcs.types import TagError, TagErrorKind, TagResult, classify_tag_error
+from mindtrace.hardware.plcs.types import TagError, TagErrorKind, TagResult
 
 
 class FakeDevice:
@@ -416,13 +417,29 @@ class TestErrorTaxonomy:
                 TagErrorKind.missing_tag,
             ),
             ("Symbol does not exist", TagErrorKind.missing_tag),
+            # 0xFF extended texts for a wrong address INTO a real tag — the
+            # array-index config mistakes (station index, step base) chiron makes.
+            ("General Error (see extended status) - Access beyond end of the object", TagErrorKind.missing_tag),
+            ("General Error (see extended status) - Address out of range", TagErrorKind.missing_tag),
+            ("General Error (see extended status) - Invalid symbol name", TagErrorKind.missing_tag),
+            ("Failed to build request path for tag", TagErrorKind.missing_tag),
+            ("Failed to create request path for tag", TagErrorKind.missing_tag),
             ("Error packing -128 as USINT", TagErrorKind.encode),
             ("Error encoding value for tag", TagErrorKind.encode),
             ("Error unpacking response", TagErrorKind.encode),
-            ("Invalid data type for tag", TagErrorKind.type_mismatch),
+            # Transient is checked before encode: a stamped parse failure whose
+            # cause was a value unpack is reply corruption, not a value problem.
+            ("Failed to parse reply - Error unpacking int from b''", TagErrorKind.transient),
             ("Wrong data type", TagErrorKind.type_mismatch),
+            ("Message unsupported data type", TagErrorKind.type_mismatch),
+            # Type patterns are verbatim texts, not fragments: an invented
+            # spelling no driver produces stays in the residue.
+            ("Invalid data type for tag", TagErrorKind.unknown),
             # Timeout-flavored CIP statuses are TRANSIENT: never a channel action.
-            ("Connection timed out", TagErrorKind.transient),
+            ("Connection failure (see extended status) - Connection timeout", TagErrorKind.transient),
+            # No stamped text spells it this way (socket timeouts RAISE); the
+            # residue verdict is the honest one.
+            ("Connection timed out", TagErrorKind.unknown),
             ("Insufficient resource", TagErrorKind.transient),
             ("Message timeout", TagErrorKind.transient),
             # SERVICE_STATUS 0x07 is session-dead: the AB backend promotes it to a
@@ -467,9 +484,9 @@ class TestErrorTaxonomy:
         assert results["Motor1_Speed"].error.kind is TagErrorKind.encode
 
     async def test_whole_call_data_error_is_transport_class(self):
-        """A raised DataError cannot occur on the audited Logix path (packing
-        errors are wrapped and stamped per-tag) - transport-class defense: if
-        one ever escapes, it is unaudited territory and the channel closes."""
+        """A raised DataError cannot occur on any audited path (packing errors
+        are wrapped and stamped per-tag, decodes are stamped) - transport-class
+        defense against driver version drift: if one ever escapes, close."""
         write_driver = FakeLogixDriver(write_error=DataError("Error packing -128 as USINT"))
         plc = _allen_bradley(FakeLogixDriver(), write_driver)
 
@@ -841,9 +858,9 @@ class TestCloseOnProof:
         assert read_driver.connected is False
 
     async def test_a_garbled_reply_closes_the_channel(self):
-        """Defensive pin: on the audited Logix path parse failures are STAMPED
-        (frame-atomic receive), so a RAISED reply-class error means an exchange
-        aborted somewhere unaudited - close rather than trust the stream."""
+        """Defensive pin: parse failures are STAMPED on every audited path
+        (frame-atomic receive), so a RAISED reply-class error can only come from
+        driver version drift - close rather than trust the stream."""
         read_driver = FakeLogixDriver(read_error=DataError("Error unpacking reply"))
         plc = _allen_bradley(read_driver, FakeLogixDriver())
 

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
@@ -852,7 +852,7 @@ class TestCloseOnProof:
         read_driver = FakeLogixDriver(read_error=comm)
         plc = _allen_bradley(read_driver, FakeLogixDriver())
 
-        with pytest.raises(PLCCommunicationError):
+        with pytest.raises(PLCTimeoutError, match="Read timed out after"):
             await plc.read_tag(["Tag1"])
 
         assert read_driver.connected is False
@@ -1038,53 +1038,119 @@ class TestAllenBradleyChannelLifecycle:
         # The failed reopen closed the replacement rather than leaking it.
         assert dead.connected is False
 
-    async def test_timeout_knobs_bound_the_exchange_not_just_the_config(self, monkeypatch):
-        """Behavior, not assignment: pycomm3's socket_timeout setter only writes
-        config, so the per-channel knob must be enforced at this layer. A read
-        that outlives ``read_timeout`` raises typed and closes the channel."""
+    async def test_the_channel_knob_is_the_socket_deadline_at_open(self, monkeypatch):
+        """pycomm3 applies socket_timeout exactly once, when open() constructs the
+        Socket - so the value present AT open is the live deadline. Each channel
+        opens with its own knob; connection_timeout is out of the channel path."""
+
+        class SnapshottingDriver(FakeLogixDriver):
+            def open(self):
+                self.timeout_at_open = self.socket_timeout
+                return super().open()
+
+        dead_read = FakeLogixDriver(read_error=_socket_death_comm_error())
+        dead_write = FakeLogixDriver(write_error=_socket_death_comm_error())
+        replacements = [
+            SnapshottingDriver(read_results=[_tag(value=1)]),
+            SnapshottingDriver(write_results=[_tag(value=1)]),
+        ]
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: replacements.pop(0))
+        plc = _allen_bradley(dead_read, dead_write)
+        plc.connection_timeout = 9.0
+        plc.read_timeout = 2.5
+        plc.write_timeout = 3.5
+
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1"])  # closes the read channel
+        await plc.read_tag(["Tag1"])  # entry reopen applies the read knob
+        with pytest.raises(PLCCommunicationError):
+            await plc.write_tag([("Tag1", 1)])
+        await plc.write_tag([("Tag1", 1)])
+
+        assert plc._read_driver.timeout_at_open == 2.5
+        assert plc._write_driver.timeout_at_open == 3.5
+
+    async def test_a_socket_deadline_timeout_is_typed_and_closes_the_channel(self):
+        """The NORMAL timeout path: the driver's own deadline fires on the worker
+        thread as a CommError chained from TimeoutError - the thread is finished,
+        so the close is single-threaded and safe, and the label is the finer
+        PLCTimeoutError."""
+        comm = CommError("failed to receive reply")
+        comm.__cause__ = TimeoutError("timed out")
+        write_driver = FakeLogixDriver(write_error=comm)
+        plc = _allen_bradley(FakeLogixDriver(), write_driver)
+
+        with pytest.raises(PLCTimeoutError, match="Write timed out after"):
+            await plc.write_tag([("Tag1", 1)])
+
+        assert write_driver.connected is False
+
+    async def test_backstop_expiry_abandons_the_driver_without_touching_it(self, monkeypatch):
+        """When even the socket deadline fails to fire (a dripping reply), the
+        worker thread is still INSIDE the driver: the channel is swapped out
+        untouched - never closed from a second thread - and a fresh driver
+        opens at the next entry."""
         import time as _time
 
         stalled = FakeLogixDriver(read_results=[_tag(value=1)])
         original_read = stalled.read
+        close_calls = []
+        stalled.close = lambda: close_calls.append(True)
 
         def _slow_read(*addresses):
-            _time.sleep(0.2)  # blocks the worker thread, like a silent controller
+            _time.sleep(1.5)  # outlives the 0.02 * 1.5 + 1 backstop
             return original_read(*addresses)
 
         stalled.read = _slow_read
+        replacement = FakeLogixDriver(read_results=[_tag(value=42)])
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: replacement)
         plc = _allen_bradley(stalled, FakeLogixDriver())
-        plc.read_timeout = 0.05
+        plc.read_timeout = 0.02
 
-        started = _time.monotonic()
-        # PLCTimeoutError subclasses PLCCommunicationError: same contract, finer label.
-        with pytest.raises(PLCTimeoutError, match="timed out after 0.05s"):
+        with pytest.raises(PLCTimeoutError, match="backstop"):
             await plc.read_tag(["Tag1"])
-        elapsed = _time.monotonic() - started
 
-        assert elapsed < 0.19  # the knob cut the call short, not the sleep
-        assert stalled.connected is False  # a late reply must not answer the next request
+        assert close_calls == []  # never called into the live-thread driver
+        assert stalled.connected is True  # untouched
+        assert plc._read_driver is not stalled  # abandoned
 
-    async def test_write_timeout_is_the_write_channels_knob(self):
-        """The channels' knobs are independent: a stalled write is cut by
-        write_timeout even when read_timeout is generous."""
+        results = await plc.read_tag(["Tag1"])  # entry opens a FRESH driver
+        assert results["Tag1"].value == 42
+        assert plc._read_driver is replacement
+
+    async def test_caller_cancellation_abandons_the_channel(self, monkeypatch):
+        """Cancellation mid-exchange (a plan push cancelling the poll task, an
+        HTTP client disconnecting) leaves a live thread inside the driver;
+        reusing that driver would interleave two exchanges on one socket, so
+        the channel is abandoned and the next call opens a fresh driver."""
+        import threading
         import time as _time
 
-        stalled = FakeLogixDriver(write_results=[_tag(value=1)])
-        original_write = stalled.write
+        stalled = FakeLogixDriver(read_results=[_tag(value=1)])
+        original_read = stalled.read
+        entered = threading.Event()
 
-        def _slow_write(*writes):
-            _time.sleep(0.2)
-            return original_write(*writes)
+        def _slow_read(*addresses):
+            entered.set()
+            _time.sleep(0.3)
+            return original_read(*addresses)
 
-        stalled.write = _slow_write
-        plc = _allen_bradley(FakeLogixDriver(), stalled)
-        plc.read_timeout = 30.0
-        plc.write_timeout = 0.05
+        stalled.read = _slow_read
+        replacement = FakeLogixDriver(read_results=[_tag(value=42)])
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: replacement)
+        plc = _allen_bradley(stalled, FakeLogixDriver())
 
-        with pytest.raises(PLCTimeoutError, match="Write timed out after 0.05s"):
-            await plc.write_tag([("Tag1", 1)])
+        task = asyncio.create_task(plc.read_tag(["Tag1"]))
+        assert await asyncio.to_thread(entered.wait, 1.0)  # worker is inside driver.read
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
 
-        assert stalled.connected is False
+        assert stalled.connected is True  # never touched
+        assert plc._read_driver is not stalled  # abandoned
+
+        results = await plc.read_tag(["Tag1"])  # lock is free; a fresh driver serves
+        assert results["Tag1"].value == 42
 
     async def test_an_open_that_raises_does_not_leak_the_driver(self, monkeypatch):
         read_driver = FakeLogixDriver(read_error=_socket_death_comm_error())

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
@@ -1207,10 +1207,12 @@ class TestAllenBradleyChannelLifecycle:
         assert close_calls == []  # never called into the live-thread driver
         assert stalled.connected is True  # untouched
         assert plc._read_driver is not stalled  # abandoned
+        assert plc.plc is not stalled  # the alias must not keep the driver alive
 
         results = await plc.read_tag(["Tag1"])  # entry opens a FRESH driver
         assert results["Tag1"].value == 42
         assert plc._read_driver is replacement
+        assert plc.plc is replacement
 
     async def test_write_backstop_expiry_abandons_the_write_channel(self, monkeypatch):
         import time as _time
@@ -1288,6 +1290,7 @@ class TestAllenBradleyChannelLifecycle:
 
         assert stalled.connected is True  # never touched
         assert plc._read_driver is not stalled  # abandoned
+        assert plc.plc is not stalled  # the alias must not keep the driver alive
 
         results = await plc.read_tag(["Tag1"])  # lock is free; a fresh driver serves
         assert results["Tag1"].value == 42

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
@@ -443,8 +443,19 @@ class TestErrorTaxonomy:
             ("Connection timed out", TagErrorKind.transport),
             # SERVICE_STATUS 0x07: the socket, not the address.
             ("Connection lost", TagErrorKind.transport),
+            # cip_driver's own CommError texts, stamped rather than raised.
+            ("failed to receive reply", TagErrorKind.transport),
+            # errno text for a socket that died under the driver, flattened onto the tag.
+            ("[Errno 104] Connection reset by peer", TagErrorKind.transport),
+            ("[Errno 32] Broken pipe", TagErrorKind.transport),
+            ("[Errno 103] Software caused connection abort", TagErrorKind.transport),
+            ("[Errno 111] Connection refused", TagErrorKind.transport),
+            # A controller refusal we have no name for is NOT evidence of a sick
+            # socket: transport is matched, never assumed, because guessing it
+            # would cost the whole call a reconnect cycle.
+            ("Attribute not settable", TagErrorKind.unknown),
             # A bare "type" substring is not evidence of a tag type problem.
-            ("'NoneType' object is not subscriptable", TagErrorKind.transport),
+            ("'NoneType' object is not subscriptable", TagErrorKind.unknown),
         ],
     )
     def test_classification_preserves_the_raw_message(self, message, expected):
@@ -528,7 +539,7 @@ class TestErrorTaxonomy:
         results = await plc.write_tag([("Tag1", 5)])
 
         assert results["Tag1"].ok is False
-        assert results["Tag1"].error.kind is TagErrorKind.transport
+        assert results["Tag1"].error.kind is TagErrorKind.unknown
 
     async def test_an_empty_batch_still_checks_the_channel(self):
         read_driver = FakeLogixDriver()
@@ -814,31 +825,62 @@ class TestChannelRecovery:
         assert plc.read_calls == 2
         assert plc.reconnects == []
 
-    async def test_a_batch_that_stays_wedged_is_returned_honestly(self):
-        """Per-tag results never turn into a raise, however many attempts failed."""
+    async def test_a_batch_that_stays_wedged_is_raised_not_returned(self):
+        """A transport error never reaches the caller as a result: the budget ends in a raise."""
         plc = ScriptedPLC(read_script=[{"Tag1": _transport_result()}], retry_count=3)
 
-        results = await plc.read_tag(["Tag1"])
+        with pytest.raises(PLCCommunicationError, match=r"attempts=3") as excinfo:
+            await plc.read_tag(["Tag1"])
 
-        assert results["Tag1"].error.kind is TagErrorKind.transport
+        # The partial map rides along for the log, out of the caller's way.
+        assert excinfo.value.transport_addresses == ("Tag1",)
+        assert excinfo.value.results["Tag1"].error.kind is TagErrorKind.transport
         assert plc.read_calls == 3
         # Free first retry: only the gap before attempt 3 buys a reconnect.
         assert plc.reconnects == ["read"]
 
-    async def test_a_partly_errored_batch_is_not_a_channel_failure(self):
+    async def test_one_transport_entry_condemns_the_whole_batch(self):
+        """A packet that never happened cannot be reported as a per-address verdict.
+
+        pycomm3 stamps a failed exchange on every tag that packet carried, so a
+        multi-packet batch can come back half real. Retrying is the only cure, and
+        a batch that stays half real is a channel failure: its transport entries
+        are transient (and, for writes, ambiguous — the request may have executed
+        with only the reply lost), so they must not be returned as if they were
+        stable address verdicts.
+        """
         plc = ScriptedPLC(
             read_script=[
                 {
                     "Tag1": _transport_result(),
                     "Ghost": TagResult(error=TagError(kind=TagErrorKind.missing_tag, message="no such tag")),
+                    "Tag2": TagResult(value=2),
+                }
+            ],
+            retry_count=2,
+        )
+
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1", "Ghost", "Tag2"])
+
+        assert plc.read_calls == 2
+
+    async def test_a_batch_of_address_verdicts_is_returned_unretried(self):
+        """Verdicts are stable: retrying could only produce the same answer."""
+        plc = ScriptedPLC(
+            read_script=[
+                {
+                    "Ghost": TagResult(error=TagError(kind=TagErrorKind.missing_tag, message="no such tag")),
+                    "Odd": TagResult(error=TagError(kind=TagErrorKind.unknown, message="Attribute not settable")),
                 }
             ],
             retry_count=3,
         )
 
-        results = await plc.read_tag(["Tag1", "Ghost"])
+        results = await plc.read_tag(["Ghost", "Odd"])
 
         assert results["Ghost"].error.kind is TagErrorKind.missing_tag
+        assert results["Odd"].error.kind is TagErrorKind.unknown
         assert plc.read_calls == 1
         assert plc.reconnects == []
 

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
@@ -608,6 +608,49 @@ class TestPerTagNetsAreNarrow:
         assert len(read_driver.read_calls) == 2
 
 
+class TestTagResultHardening:
+    """The result type is impossible to misuse: no sentinels, no truthiness, no both."""
+
+    def test_a_value_and_an_error_cannot_coexist(self):
+        with pytest.raises(ValueError, match="never both"):
+            TagResult(value=5, error=TagError(kind=TagErrorKind.unknown, message="x"))
+
+    def test_an_empty_ok_result_is_legal(self):
+        result = TagResult()  # an empty CIP answer: ok, value None
+        assert result.ok is True
+        assert result.value is None
+
+    def test_value_raises_on_a_failed_result(self):
+        result = TagResult(error=TagError(kind=TagErrorKind.missing_tag, message="no such tag"))
+        with pytest.raises(ValueError, match="missing_tag: no such tag"):
+            result.value
+
+    def test_value_or_is_the_explicit_lossy_accessor(self):
+        failed = TagResult(error=TagError(kind=TagErrorKind.unknown, message="x"))
+        assert failed.value_or(0) == 0
+        assert TagResult(value=7).value_or(0) == 7
+
+    def test_truth_testing_raises(self):
+        with pytest.raises(TypeError, match="test .ok"):
+            bool(TagResult(value=False))
+
+    def test_results_are_immutable(self):
+        result = TagResult(value=1)
+        with pytest.raises(AttributeError):
+            result.error = None
+
+    def test_equality_and_repr_survive_the_rewrite(self):
+        assert TagResult(value=1) == TagResult(value=1)
+        assert TagResult(value=1) != TagResult(value=2)
+        assert repr(TagResult(value=1)) == "TagResult(value=1, error=None)"
+
+    def test_kind_formats_the_same_everywhere(self):
+        import json
+
+        for kind in TagErrorKind:
+            assert f"{kind}" == kind.value == json.loads(json.dumps(kind))
+
+
 class TestNoSentinels:
     async def test_a_failed_read_is_never_a_bare_value(self):
         plc = MockAllenBradleyPLC("TestPLC", "192.168.1.99", plc_type="logix")
@@ -620,7 +663,9 @@ class TestNoSentinels:
         assert missing.ok is False
         assert missing.error.kind is TagErrorKind.missing_tag
         # The value slot stays empty, and `ok` — not the value — is the verdict.
-        assert missing.value is None
+        with pytest.raises(ValueError, match="missing_tag"):
+            missing.value  # a failed result has no value - the sentinel door is closed
+        assert missing.value_or(None) is None
 
     async def test_a_failed_write_is_never_a_bare_false(self):
         plc = MockAllenBradleyPLC("TestPLC", "192.168.1.99", plc_type="logix")

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
@@ -5,12 +5,12 @@ must never be inside the same channel at the same time, a reconnect must never
 interleave with an in-flight operation, and a driver failure must surface as a
 typed error rather than a sentinel value.
 
-They also pin the recovery contract built on top of that: a transport-class
-failure is retried inside the channel lock, the reconnect of that channel
-escalates (the first retry runs on a still-connected session, later retries — and
-any driver reporting disconnected — reset the channel first), a non-retryable
-failure is not retried at all, and a reconnect that itself fails never aborts the
-loop.
+They also pin the recovery contract built on top of that: one attempt per call,
+no retry. Any failed exchange (wire death, timeout, garbled reply, or a
+delivered reply carrying session-dead statuses) closes its channel and raises
+typed; the channel reopens at the next call's entry. Only a delivered, parsed
+reply keeps the session — and only ``RequestError`` (rejected before the wire)
+raises without touching it.
 """
 
 from __future__ import annotations
@@ -30,6 +30,7 @@ from mindtrace.hardware.core.exceptions import (
     PLCConnectionError,
     PLCTagReadError,
     PLCTagWriteError,
+    PLCTimeoutError,
 )
 from mindtrace.hardware.plcs.backends.allen_bradley import AllenBradleyPLC, MockAllenBradleyPLC
 from mindtrace.hardware.plcs.backends.allen_bradley import allen_bradley_plc as ab_module
@@ -466,7 +467,9 @@ class TestErrorTaxonomy:
         assert results["Motor1_Speed"].error.kind is TagErrorKind.encode
 
     async def test_whole_call_data_error_is_transport_class(self):
-        """A garbled reply leaves the session suspect, so it is retryable."""
+        """A raised DataError cannot occur on the audited Logix path (packing
+        errors are wrapped and stamped per-tag) - transport-class defense: if
+        one ever escapes, it is unaudited territory and the channel closes."""
         write_driver = FakeLogixDriver(write_error=DataError("Error packing -128 as USINT"))
         plc = _allen_bradley(FakeLogixDriver(), write_driver)
 
@@ -475,6 +478,7 @@ class TestErrorTaxonomy:
 
         assert isinstance(excinfo.value.__cause__, DataError)
         assert len(write_driver.write_calls) == 1
+        assert write_driver.connected is False
 
     async def test_whole_call_comm_error_is_transport_class(self):
         read_driver = FakeLogixDriver(read_error=CommError("socket closed"))
@@ -823,7 +827,9 @@ class TestCloseOnProof:
         assert excinfo.value is boom  # travels by identity
         assert plc.closes == []
 
-    async def test_a_timeout_keeps_the_session(self):
+    async def test_a_timeout_closes_the_channel(self):
+        """The timed-out request is still outstanding; its late reply would
+        answer the NEXT request. Replies match requests by arrival order only."""
         comm = CommError("failed to receive reply")
         comm.__cause__ = TimeoutError("timed out")
         read_driver = FakeLogixDriver(read_error=comm)
@@ -832,16 +838,19 @@ class TestCloseOnProof:
         with pytest.raises(PLCCommunicationError):
             await plc.read_tag(["Tag1"])
 
-        assert read_driver.connected is True  # busy is not dead
+        assert read_driver.connected is False
 
-    async def test_a_garbled_reply_keeps_the_session(self):
+    async def test_a_garbled_reply_closes_the_channel(self):
+        """Defensive pin: on the audited Logix path parse failures are STAMPED
+        (frame-atomic receive), so a RAISED reply-class error means an exchange
+        aborted somewhere unaudited - close rather than trust the stream."""
         read_driver = FakeLogixDriver(read_error=DataError("Error unpacking reply"))
         plc = _allen_bradley(read_driver, FakeLogixDriver())
 
         with pytest.raises(PLCCommunicationError):
             await plc.read_tag(["Tag1"])
 
-        assert read_driver.connected is True  # reply-level trouble is transient
+        assert read_driver.connected is False
 
     async def test_a_session_dead_status_condemns_the_whole_batch(self):
         """The controller stating our session is gone (CIP 0x07) closes + raises."""
@@ -1012,33 +1021,53 @@ class TestAllenBradleyChannelLifecycle:
         # The failed reopen closed the replacement rather than leaking it.
         assert dead.connected is False
 
-    async def test_timeout_knobs_are_applied_per_channel(self, monkeypatch):
-        """connection_timeout bounds the open itself; then the channel's own knob takes over."""
+    async def test_timeout_knobs_bound_the_exchange_not_just_the_config(self, monkeypatch):
+        """Behavior, not assignment: pycomm3's socket_timeout setter only writes
+        config, so the per-channel knob must be enforced at this layer. A read
+        that outlives ``read_timeout`` raises typed and closes the channel."""
+        import time as _time
 
-        class RecordingDriver(FakeLogixDriver):
-            def __init__(self, **kwargs):
-                object.__setattr__(self, "timeout_history", [])
-                super().__init__(**kwargs)
+        stalled = FakeLogixDriver(read_results=[_tag(value=1)])
+        original_read = stalled.read
 
-            def __setattr__(self, name, value):
-                if name == "socket_timeout":
-                    self.timeout_history.append(value)
-                super().__setattr__(name, value)
+        def _slow_read(*addresses):
+            _time.sleep(0.2)  # blocks the worker thread, like a silent controller
+            return original_read(*addresses)
 
-        dead = FakeLogixDriver(read_error=_socket_death_comm_error())
-        recorder = RecordingDriver(read_results=[_tag(value=1)])
-        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: recorder)
-        plc = _allen_bradley(dead, FakeLogixDriver())
-        plc.connection_timeout = 7.5
-        plc.read_timeout = 2.5
+        stalled.read = _slow_read
+        plc = _allen_bradley(stalled, FakeLogixDriver())
+        plc.read_timeout = 0.05
 
-        with pytest.raises(PLCCommunicationError):
-            await plc.read_tag(["Tag1"])  # wire death closes the read channel
+        started = _time.monotonic()
+        # PLCTimeoutError subclasses PLCCommunicationError: same contract, finer label.
+        with pytest.raises(PLCTimeoutError, match="timed out after 0.05s"):
+            await plc.read_tag(["Tag1"])
+        elapsed = _time.monotonic() - started
 
-        results = await plc.read_tag(["Tag1"])  # entry reopen applies the knobs
+        assert elapsed < 0.19  # the knob cut the call short, not the sleep
+        assert stalled.connected is False  # a late reply must not answer the next request
 
-        assert results["Tag1"].value == 1
-        assert recorder.timeout_history == [7.5, 2.5]
+    async def test_write_timeout_is_the_write_channels_knob(self):
+        """The channels' knobs are independent: a stalled write is cut by
+        write_timeout even when read_timeout is generous."""
+        import time as _time
+
+        stalled = FakeLogixDriver(write_results=[_tag(value=1)])
+        original_write = stalled.write
+
+        def _slow_write(*writes):
+            _time.sleep(0.2)
+            return original_write(*writes)
+
+        stalled.write = _slow_write
+        plc = _allen_bradley(FakeLogixDriver(), stalled)
+        plc.read_timeout = 30.0
+        plc.write_timeout = 0.05
+
+        with pytest.raises(PLCTimeoutError, match="Write timed out after 0.05s"):
+            await plc.write_tag([("Tag1", 1)])
+
+        assert stalled.connected is False
 
     async def test_an_open_that_raises_does_not_leak_the_driver(self, monkeypatch):
         read_driver = FakeLogixDriver(read_error=_socket_death_comm_error())

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
@@ -89,9 +89,8 @@ class InstrumentedPLC(BasePLC):
         kwargs.setdefault("ip_address", "192.168.1.100")
         super().__init__(**kwargs)
 
-    async def _reconnect_channel(self, channel: str) -> bool:
-        await self.device.run(f"reconnect_{channel}")
-        return True
+    async def _close_channel(self, channel: str) -> None:
+        await self.device.run(f"close_{channel}")
 
     async def initialize(self):
         return True, None, None
@@ -113,7 +112,9 @@ class InstrumentedPLC(BasePLC):
         await self.device.run("read", self.read_delay)
         if self.read_failures > 0:
             self.read_failures -= 1
-            raise PLCCommunicationError("socket closed")
+            # A real backend closes its channel inside the failing call.
+            await self._close_channel("read")
+            raise PLCCommunicationError("socket closed") from ConnectionResetError("peer reset")
         return {address: TagResult(value=address) for address in addresses}
 
     async def _write_tags(self, writes: List[Tuple[str, Any]]) -> Dict[str, TagResult]:
@@ -194,35 +195,21 @@ class FakeLogixDriver:
 
 
 class ScriptedPLC(BasePLC):
-    """Backend whose delegates replay a script and whose reconnects are recorded.
+    """Backend whose delegates replay a script and whose channel closes are recorded.
 
     A script entry is either a results dict or an exception to raise; the LAST
     entry sticks, so a one-element script is a permanent condition.
-
-    ``dies_on_error`` models the dead-socket case: a raised transport error also
-    flips the driver to disconnected, which is what makes recovery reconnect
-    before the first retry. Left False, the fake is the busy-but-live device whose
-    first retry is free.
     """
 
-    def __init__(
-        self,
-        read_script=None,
-        write_script=None,
-        reconnect: Any = True,
-        dies_on_error: bool = False,
-        **kwargs,
-    ):
+    def __init__(self, read_script=None, write_script=None, **kwargs):
         self._read_script = list(read_script or [])
         self._write_script = list(write_script or [])
-        self.reconnect_result = reconnect
-        self.dies_on_error = dies_on_error
         self.read_calls = 0
         self.write_calls = 0
-        self.reconnects: List[str] = []
-        # Delegate calls completed when each reconnect fired, so a test can pin
-        # WHICH attempt bought the reconnect and not merely how many there were.
-        self.reconnect_marks: List[int] = []
+        self.closes: List[str] = []
+        # Delegate calls completed when each close fired, so a test can pin WHEN
+        # the channel was condemned, not merely that it was.
+        self.close_marks: List[int] = []
         self._connected = True
         kwargs.setdefault("plc_name", "PLC1")
         kwargs.setdefault("ip_address", "192.168.1.100")
@@ -234,14 +221,6 @@ class ScriptedPLC(BasePLC):
         if isinstance(step, BaseException):
             raise step
         return step
-
-    def _play_channel(self, script: List[Any]) -> Dict[str, TagResult]:
-        try:
-            return self._play(script)
-        except PLCCommunicationError:
-            if self.dies_on_error:
-                self._connected = False
-            raise
 
     async def initialize(self):
         return True, None, None
@@ -259,20 +238,15 @@ class ScriptedPLC(BasePLC):
 
     async def _read_tags(self, addresses: List[str]) -> Dict[str, TagResult]:
         self.read_calls += 1
-        return self._play_channel(self._read_script)
+        return self._play(self._read_script)
 
     async def _write_tags(self, writes: List[Tuple[str, Any]]) -> Dict[str, TagResult]:
         self.write_calls += 1
-        return self._play_channel(self._write_script)
+        return self._play(self._write_script)
 
-    async def _reconnect_channel(self, channel: str) -> bool:
-        self.reconnects.append(channel)
-        self.reconnect_marks.append(self.read_calls + self.write_calls)
-        if isinstance(self.reconnect_result, BaseException):
-            raise self.reconnect_result
-        if self.reconnect_result:
-            self._connected = True
-        return self.reconnect_result
+    async def _close_channel(self, channel: str) -> None:
+        self.closes.append(channel)
+        self.close_marks.append(self.read_calls + self.write_calls)
 
     async def _get_all_tags(self):
         return []
@@ -289,8 +263,18 @@ class ScriptedPLC(BasePLC):
         return {"name": "ScriptedPLC"}
 
 
-def _transport_result(message: str = "socket closed") -> TagResult:
-    return TagResult(error=TagError(kind=TagErrorKind.transport, message=message))
+def _socket_death_comm_error() -> CommError:
+    """A pycomm3 CommError carrying kernel proof, as socket_.py produces it."""
+    error = CommError("failed to receive reply")
+    error.__cause__ = ConnectionResetError("peer reset")
+    return error
+
+
+def _socket_death(message: str = "failed to receive reply") -> PLCCommunicationError:
+    """A raise whose chain carries kernel proof (non-timeout OSError)."""
+    error = PLCCommunicationError(message)
+    error.__cause__ = ConnectionResetError("peer reset")
+    return error
 
 
 def _tag(value=None, error=None):
@@ -298,17 +282,13 @@ def _tag(value=None, error=None):
     return SimpleNamespace(value=value, error=error)
 
 
-def _allen_bradley(
-    read_driver, write_driver, driver_type: str = "LogixDriver", retry_count: int = 1
-) -> AllenBradleyPLC:
+def _allen_bradley(read_driver, write_driver, driver_type: str = "LogixDriver") -> AllenBradleyPLC:
     """An AB backend wired to fake sessions.
 
     ``retry_count`` defaults to 1 so taxonomy tests observe exactly one delegate
     call; the recovery tests raise it and supply their own ``_reconnect_channel``.
     """
-    plc = AllenBradleyPLC(
-        plc_name="PLC1", ip_address="192.168.1.100", plc_type="logix", retry_count=retry_count, retry_delay=0.0
-    )
+    plc = AllenBradleyPLC(plc_name="PLC1", ip_address="192.168.1.100", plc_type="logix", retry_delay=0.0)
     plc._read_driver = read_driver
     plc._write_driver = write_driver
     plc.plc = read_driver
@@ -440,16 +420,17 @@ class TestErrorTaxonomy:
             ("Error unpacking response", TagErrorKind.encode),
             ("Invalid data type for tag", TagErrorKind.type_mismatch),
             ("Wrong data type", TagErrorKind.type_mismatch),
-            ("Connection timed out", TagErrorKind.transport),
-            # SERVICE_STATUS 0x07: the socket, not the address.
-            ("Connection lost", TagErrorKind.transport),
-            # cip_driver's own CommError texts, stamped rather than raised.
-            ("failed to receive reply", TagErrorKind.transport),
-            # errno text for a socket that died under the driver, flattened onto the tag.
-            ("[Errno 104] Connection reset by peer", TagErrorKind.transport),
-            ("[Errno 32] Broken pipe", TagErrorKind.transport),
-            ("[Errno 103] Software caused connection abort", TagErrorKind.transport),
-            ("[Errno 111] Connection refused", TagErrorKind.transport),
+            # Timeout-flavored CIP statuses are TRANSIENT: never a channel action.
+            ("Connection timed out", TagErrorKind.transient),
+            ("Insufficient resource", TagErrorKind.transient),
+            ("Message timeout", TagErrorKind.transient),
+            # SERVICE_STATUS 0x07 is session-dead: the AB backend promotes it to a
+            # raise before any caller sees a map, so its classify label is moot.
+            ("Connection lost", TagErrorKind.unknown),
+            # Socket-level failures always RAISE (CommError) and never appear
+            # stamped, so their texts are deliberately not transport patterns.
+            ("failed to receive reply", TagErrorKind.unknown),
+            ("[Errno 104] Connection reset by peer", TagErrorKind.unknown),
             # A controller refusal we have no name for is NOT evidence of a sick
             # socket: transport is matched, never assumed, because guessing it
             # would cost the whole call a reconnect cycle.
@@ -508,7 +489,7 @@ class TestErrorTaxonomy:
     async def test_a_request_error_is_not_transport_class(self):
         """A malformed request is the caller's bug: typed, final, never retried."""
         read_driver = FakeLogixDriver(read_error=RequestError("Failed to parse tag request"))
-        plc = _allen_bradley(read_driver, FakeLogixDriver(), retry_count=3)
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
         plc._reconnect_channel = AsyncMock(return_value=True)
 
         with pytest.raises(PLCTagReadError) as excinfo:
@@ -520,7 +501,7 @@ class TestErrorTaxonomy:
 
     async def test_a_write_request_error_is_not_transport_class(self):
         write_driver = FakeLogixDriver(write_error=RequestError("Failed to parse tag request"))
-        plc = _allen_bradley(FakeLogixDriver(), write_driver, retry_count=3)
+        plc = _allen_bradley(FakeLogixDriver(), write_driver)
         plc._reconnect_channel = AsyncMock(return_value=True)
 
         with pytest.raises(PLCTagWriteError) as excinfo:
@@ -730,19 +711,18 @@ class TestLockOrdering:
 
         assert [snapshot[0] for snapshot in device.snapshots] == ["disconnect", "connect", "write"]
 
-    async def test_recovery_happens_inside_the_channel_lock(self):
-        """A reconnect between attempts is still alone on its channel."""
+    async def test_a_close_on_proof_is_alone_on_its_channel(self):
+        """The close after a kernel-reported failure runs under the channel lock."""
         device = FakeDevice()
-        plc = InstrumentedPLC(device, read_delay=0.002, read_failures=2, retry_count=3, retry_delay=0.0)
+        plc = InstrumentedPLC(device, read_delay=0.002, read_failures=2, retry_delay=0.0)
 
-        await asyncio.gather(*[plc.read_tag(["Tag1"]) for _ in range(6)])
+        results = await asyncio.gather(*[plc.read_tag(["Tag1"]) for _ in range(6)], return_exceptions=True)
 
-        # Free first retry: the driver stays connected, so the two scripted
-        # failures buy one reconnect (before attempt 3), not one each.
-        assert device.calls["reconnect_read"] == 1
+        assert sum(isinstance(result, PLCCommunicationError) for result in results) == 2
+        assert device.calls["close_read"] == 2
         assert device.concurrent("read") == 1, device.snapshots
-        for snapshot in device.snapshots_containing("reconnect_read"):
-            assert snapshot == ("reconnect_read",), snapshot
+        for snapshot in device.snapshots_containing("close_read"):
+            assert snapshot == ("close_read",), snapshot
 
     async def test_lifecycle_operations_use_one_lock_order(self):
         """connect/disconnect/reconnect all take read-then-write, so they cannot deadlock."""
@@ -758,123 +738,108 @@ class TestLockOrdering:
         assert device.calls["disconnect"] == 6
 
 
-class TestChannelRecovery:
-    """Transport-class failures are retried in place, escalating to a reconnect."""
+class TestCloseOnProof:
+    """One attempt, no retry; the channel closes only on proof the session is dead."""
 
-    async def test_a_transport_failure_reconnects_and_succeeds_on_the_next_attempt(self):
+    async def test_a_wire_error_closes_the_channel(self):
+        read_driver = FakeLogixDriver(read_error=_socket_death_comm_error())
+        write_driver = FakeLogixDriver()
+        plc = _allen_bradley(read_driver, write_driver)
+
+        with pytest.raises(PLCCommunicationError) as excinfo:
+            await plc.read_tag(["Tag1"])
+
+        assert isinstance(excinfo.value.__cause__, CommError)
+        assert read_driver.connected is False  # closed on the library's wire verdict
+        assert write_driver.connected is True
+
+    async def test_a_peers_clean_close_closes_the_channel(self):
+        """recv of b"" carries no OSError; pycomm3's CommError class is the verdict."""
+        import struct as _struct
+
+        comm = CommError("failed to receive reply")
+        comm.__cause__ = _struct.error("unpack requires a buffer of 4 bytes")
+        read_driver = FakeLogixDriver(read_error=comm)
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1"])
+
+        assert read_driver.connected is False
+
+    async def test_the_base_never_closes_on_a_raised_error(self):
+        """Raise-door closes are the backend's judgment; the base only passes them on."""
+        boom = _socket_death()
+        plc = ScriptedPLC(read_script=[boom])
+
+        with pytest.raises(PLCCommunicationError) as excinfo:
+            await plc.read_tag(["Tag1"])
+
+        assert excinfo.value is boom  # travels by identity
+        assert plc.closes == []
+
+    async def test_a_timeout_keeps_the_session(self):
+        comm = CommError("failed to receive reply")
+        comm.__cause__ = TimeoutError("timed out")
+        read_driver = FakeLogixDriver(read_error=comm)
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1"])
+
+        assert read_driver.connected is True  # busy is not dead
+
+    async def test_a_garbled_reply_keeps_the_session(self):
+        read_driver = FakeLogixDriver(read_error=DataError("Error unpacking reply"))
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1"])
+
+        assert read_driver.connected is True  # reply-level trouble is transient
+
+    async def test_a_session_dead_status_condemns_the_whole_batch(self):
+        """The controller stating our session is gone (CIP 0x07) closes + raises."""
+        read_driver = FakeLogixDriver(read_results=[_tag(error="Connection lost"), _tag(value=2)])
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+
+        with pytest.raises(PLCCommunicationError, match=r"1/2") as excinfo:
+            await plc.read_tag(["Tag1", "Tag2"])
+
+        assert read_driver.connected is False
+        assert not hasattr(excinfo.value, "results")
+        assert not hasattr(excinfo.value, "transport_addresses")
+
+    async def test_a_transient_status_is_returned_and_keeps_the_session(self):
+        """Busy/timeout/garbled statuses hand back a transient verdict - no action."""
+        read_driver = FakeLogixDriver(read_results=[_tag(error="Insufficient resource"), _tag(value=2)])
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+
+        results = await plc.read_tag(["Tag1", "Tag2"])
+
+        assert results["Tag1"].error.kind is TagErrorKind.transient
+        assert results["Tag2"].value == 2
+        assert read_driver.connected is True
+
+    async def test_the_base_returns_maps_untouched(self):
+        """Session-dead promotion is the BACKEND's duty; the base never inspects maps."""
         plc = ScriptedPLC(
-            read_script=[PLCCommunicationError("socket closed"), {"Tag1": TagResult(value=1)}],
-            dies_on_error=True,  # dead socket: the reconnect is owed before the first retry
-            retry_count=3,
+            read_script=[{"Tag1": TagResult(error=TagError(kind=TagErrorKind.unknown, message="Connection lost"))}]
         )
 
         results = await plc.read_tag(["Tag1"])
 
-        assert results["Tag1"].value == 1
-        assert plc.read_calls == 2
-        assert plc.reconnects == ["read"]
+        assert results["Tag1"].ok is False
+        assert plc.closes == []
 
-    async def test_recovery_stays_on_the_failing_channel(self):
-        plc = ScriptedPLC(
-            write_script=[PLCCommunicationError("socket closed"), {"Tag1": TagResult(value=1)}],
-            dies_on_error=True,  # dead socket: the reconnect is owed before the first retry
-            retry_count=3,
-        )
-
-        await plc.write_tag([("Tag1", 1)])
-
-        assert plc.write_calls == 2
-        assert plc.reconnects == ["write"]
-
-    async def test_exhausted_attempts_raise_with_the_attempt_count(self):
-        plc = ScriptedPLC(read_script=[PLCCommunicationError("socket closed")], retry_count=3)
-
-        with pytest.raises(PLCCommunicationError, match=r"attempts=3"):
-            await plc.read_tag(["Tag1"])
-
-        assert plc.read_calls == 3
-        # Free first retry on a still-connected driver: of the two gaps between
-        # the three attempts, only the second one buys a reconnect.
-        assert plc.reconnects == ["read"]
-
-    async def test_a_non_retryable_failure_is_not_retried(self):
-        plc = ScriptedPLC(read_script=[PLCTagReadError("malformed request")], retry_count=3)
-
-        with pytest.raises(PLCTagReadError):
-            await plc.read_tag(["Tag1"])
-
-        assert plc.read_calls == 1
-        assert plc.reconnects == []
-
-    async def test_a_wedged_batch_is_treated_as_a_channel_failure(self):
-        """Every tag failed on transport: the socket is sick, not the addresses."""
-        plc = ScriptedPLC(
-            read_script=[
-                {"Tag1": _transport_result(), "Tag2": _transport_result()},
-                {"Tag1": TagResult(value=1), "Tag2": TagResult(value=2)},
-            ],
-            retry_count=3,
-        )
-
-        results = await plc.read_tag(["Tag1", "Tag2"])
-
-        assert results["Tag1"].value == 1
-        # The wedged batch bought a retry — a per-tag failure would have returned
-        # after one call. Free first retry: on a still-connected driver that retry
-        # is re-sent on the live session, so no reconnect is owed yet.
-        assert plc.read_calls == 2
-        assert plc.reconnects == []
-
-    async def test_a_batch_that_stays_wedged_is_raised_not_returned(self):
-        """A transport error never reaches the caller as a result: the budget ends in a raise."""
-        plc = ScriptedPLC(read_script=[{"Tag1": _transport_result()}], retry_count=3)
-
-        with pytest.raises(PLCCommunicationError, match=r"attempts=3") as excinfo:
-            await plc.read_tag(["Tag1"])
-
-        # The partial map rides along for the log, out of the caller's way.
-        assert excinfo.value.transport_addresses == ("Tag1",)
-        assert excinfo.value.results["Tag1"].error.kind is TagErrorKind.transport
-        assert plc.read_calls == 3
-        # Free first retry: only the gap before attempt 3 buys a reconnect.
-        assert plc.reconnects == ["read"]
-
-    async def test_one_transport_entry_condemns_the_whole_batch(self):
-        """A packet that never happened cannot be reported as a per-address verdict.
-
-        pycomm3 stamps a failed exchange on every tag that packet carried, so a
-        multi-packet batch can come back half real. Retrying is the only cure, and
-        a batch that stays half real is a channel failure: its transport entries
-        are transient (and, for writes, ambiguous — the request may have executed
-        with only the reply lost), so they must not be returned as if they were
-        stable address verdicts.
-        """
-        plc = ScriptedPLC(
-            read_script=[
-                {
-                    "Tag1": _transport_result(),
-                    "Ghost": TagResult(error=TagError(kind=TagErrorKind.missing_tag, message="no such tag")),
-                    "Tag2": TagResult(value=2),
-                }
-            ],
-            retry_count=2,
-        )
-
-        with pytest.raises(PLCCommunicationError):
-            await plc.read_tag(["Tag1", "Ghost", "Tag2"])
-
-        assert plc.read_calls == 2
-
-    async def test_a_batch_of_address_verdicts_is_returned_unretried(self):
-        """Verdicts are stable: retrying could only produce the same answer."""
+    async def test_a_batch_of_address_verdicts_is_returned_untouched(self):
         plc = ScriptedPLC(
             read_script=[
                 {
                     "Ghost": TagResult(error=TagError(kind=TagErrorKind.missing_tag, message="no such tag")),
                     "Odd": TagResult(error=TagError(kind=TagErrorKind.unknown, message="Attribute not settable")),
                 }
-            ],
-            retry_count=3,
+            ]
         )
 
         results = await plc.read_tag(["Ghost", "Odd"])
@@ -882,215 +847,135 @@ class TestChannelRecovery:
         assert results["Ghost"].error.kind is TagErrorKind.missing_tag
         assert results["Odd"].error.kind is TagErrorKind.unknown
         assert plc.read_calls == 1
-        assert plc.reconnects == []
+        assert plc.closes == []
 
-    async def test_an_empty_batch_is_never_wedged(self):
-        plc = ScriptedPLC(read_script=[{}], retry_count=3)
+    async def test_a_request_class_failure_never_touches_the_channel(self):
+        plc = ScriptedPLC(read_script=[PLCTagReadError("driver rejected the read")])
 
-        assert await plc.read_tag([]) == {}
-        assert plc.reconnects == []
-
-    # --- The escalation rule itself: when a reconnect is owed, and when it is not ---
-
-    async def test_a_transient_failure_retries_on_the_live_session(self):
-        """The first retry is free: a busy PLC or a lone timeout costs no reconnect.
-
-        Bouncing a session the driver still reports as open turns one hiccup into
-        a torn-down socket, which is what the escalation exists to avoid.
-        """
-        plc = ScriptedPLC(
-            read_script=[PLCCommunicationError("connection timed out"), {"Tag1": TagResult(value=1)}],
-            retry_count=3,
-        )
-
-        results = await plc.read_tag(["Tag1"])
-
-        assert results["Tag1"].value == 1
-        assert plc.read_calls == 2
-        assert plc.reconnects == []
-
-    async def test_a_disconnected_driver_reconnects_before_the_first_retry(self):
-        """No free retry for a dead socket: re-sending on it could only fail again."""
-        plc = ScriptedPLC(
-            read_script=[PLCCommunicationError("socket closed"), {"Tag1": TagResult(value=1)}],
-            dies_on_error=True,
-            retry_count=3,
-        )
-
-        results = await plc.read_tag(["Tag1"])
-
-        assert results["Tag1"].value == 1
-        assert plc.read_calls == 2
-        assert plc.reconnects == ["read"]
-        # Fired after attempt 1 — i.e. before the FIRST retry, not the second.
-        assert plc.reconnect_marks == [1]
-
-    async def test_a_second_failure_on_a_live_session_escalates_to_a_reconnect(self):
-        """Twice-failed but still "connected" means the session is lying: reset it.
-
-        The driver reports open the whole way through, so only the second retry —
-        never the first — pays for a reconnect.
-        """
-        plc = ScriptedPLC(
-            read_script=[
-                PLCCommunicationError("socket closed"),
-                PLCCommunicationError("socket closed"),
-                {"Tag1": TagResult(value=1)},
-            ],
-            retry_count=3,
-        )
-
-        results = await plc.read_tag(["Tag1"])
-
-        assert results["Tag1"].value == 1
-        assert plc.read_calls == 3
-        assert plc.reconnects == ["read"]
-        # Fired after attempt 2 only: nothing was reconnected before attempt 2.
-        assert plc.reconnect_marks == [2]
-
-
-class TestFailedReconnects:
-    """A reconnect that fails is a logged event, not an escape from the loop."""
-
-    async def test_a_failed_reconnect_does_not_abort_the_loop(self):
-        plc = ScriptedPLC(
-            read_script=[PLCCommunicationError("socket closed")],
-            reconnect=PLCConnectionError("device refused"),
-            retry_count=3,
-        )
-
-        with pytest.raises(PLCCommunicationError, match=r"attempts=3"):
+        with pytest.raises(PLCTagReadError):
             await plc.read_tag(["Tag1"])
 
-        # Every attempt was made even though no reconnect succeeded.
-        assert plc.read_calls == 3
-        # Free first retry: the driver still reports connected, so the sole
-        # reconnect — the one that raised — is the one before attempt 3.
-        assert plc.reconnects == ["read"]
+        assert plc.closes == []
 
-    async def test_a_reconnect_returning_false_is_treated_the_same(self):
-        plc = ScriptedPLC(
-            read_script=[PLCCommunicationError("socket closed")],
-            reconnect=False,
-            retry_count=3,
-        )
-
-        with pytest.raises(PLCCommunicationError, match=r"attempts=3"):
-            await plc.read_tag(["Tag1"])
-
-        assert plc.read_calls == 3
-        # Free first retry: one reconnect is attempted, before attempt 3.
-        assert plc.reconnects == ["read"]
-
-    async def test_a_late_reconnect_success_still_saves_the_call(self):
-        """The budget is spent on attempts, not abandoned after the first failure."""
-        plc = ScriptedPLC(
-            read_script=[
-                PLCCommunicationError("socket closed"),
-                PLCCommunicationError("socket closed"),
-                {"Tag1": TagResult(value=1)},
-            ],
-            reconnect=PLCConnectionError("device refused"),
-            retry_count=3,
-        )
-
-        results = await plc.read_tag(["Tag1"])
-
-        assert results["Tag1"].value == 1
-        assert plc.read_calls == 3
-        # Free first retry: the failed reconnect is the one before attempt 3, and
-        # attempt 3 ran anyway.
-        assert plc.reconnects == ["read"]
-
-    async def test_a_dead_read_channel_does_not_fence_the_write_channel(self):
-        plc = ScriptedPLC(
-            read_script=[PLCCommunicationError("socket closed")],
-            write_script=[{"Tag1": TagResult(value=1)}],
-            reconnect=PLCConnectionError("device refused"),
-            retry_count=3,
-        )
+    async def test_channels_close_independently(self):
+        read_driver = FakeLogixDriver(read_error=_socket_death_comm_error())
+        write_driver = FakeLogixDriver(write_results=[_tag(value=None)])
+        plc = _allen_bradley(read_driver, write_driver)
 
         with pytest.raises(PLCCommunicationError):
             await plc.read_tag(["Tag1"])
+        assert read_driver.connected is False
 
-        assert (await plc.write_tag([("Tag1", 1)]))["Tag1"].value == 1
-        # Free first retry: one reconnect, and it stayed on the read channel.
-        assert plc.reconnects == ["read"]
+        results = await plc.write_tag([("Tag1", 1)])
+        assert results["Tag1"].value == 1
+        assert write_driver.connected is True  # the write channel was never touched
 
-    async def test_the_exhausted_raise_is_a_plain_communication_error(self):
-        """Never ``type(last_error)(msg)``: a subclass constructor may not take one."""
+    async def test_an_empty_batch_is_never_condemned(self):
+        plc = ScriptedPLC(read_script=[{}])
 
-        class PickyCommunicationError(PLCCommunicationError):
-            def __init__(self, message: str, code: int):
-                super().__init__(f"{message} [{code}]")
-                self.code = code
-
-        plc = ScriptedPLC(read_script=[PickyCommunicationError("socket closed", 7)], retry_count=2)
-
-        with pytest.raises(PLCCommunicationError) as excinfo:
-            await plc.read_tag(["Tag1"])
-
-        assert type(excinfo.value) is PLCCommunicationError
-        assert isinstance(excinfo.value.__cause__, PickyCommunicationError)
+        assert await plc.read_tag([]) == {}
+        assert plc.closes == []
 
 
-class TestAllenBradleyChannelRecovery:
-    """The AB backend rebuilds one driver session and leaves the other alone.
+class TestAllenBradleyChannelLifecycle:
+    """A channel closed on proof reopens at the NEXT call's entry; a channel that
+    was never opened is a lifecycle error and opens nothing."""
 
-    The failing driver dies with its error, the way a real session that lost its
-    socket does: ``is_connected`` then reports False and recovery reconnects before
-    the first retry, which is the path these tests are about.
-    """
-
-    async def test_read_recovery_replaces_only_the_read_session(self, monkeypatch):
-        read_driver = FakeLogixDriver(read_error=CommError("socket closed"), dies_on_error=True)
+    async def test_a_closed_read_channel_reopens_at_entry(self, monkeypatch):
+        read_driver = FakeLogixDriver(read_error=_socket_death_comm_error())
         write_driver = FakeLogixDriver()
         replacement = FakeLogixDriver(read_results=[_tag(value=42)])
         monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: replacement)
-        plc = _allen_bradley(read_driver, write_driver, retry_count=2)
+        plc = _allen_bradley(read_driver, write_driver)
 
-        results = await plc.read_tag(["Tag1"])
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1"])
+        assert read_driver.connected is False  # closed on proof
+        assert plc._read_driver is read_driver  # kept: closed is not "never connected"
+
+        results = await plc.read_tag(["Tag1"])  # entry reopens the channel
 
         assert results["Tag1"].value == 42
         assert plc._read_driver is replacement
-        # chiron's preflight reads plc.plc.tags — the alias must follow the new session.
+        # chiron's preflight reads plc.plc.tags - the alias must follow the new session.
         assert plc.plc is replacement
-        assert read_driver.connected is False
         assert plc._write_driver is write_driver
         assert write_driver.connected is True
 
-    async def test_write_recovery_replaces_only_the_write_session(self, monkeypatch):
+    async def test_a_closed_write_channel_reopens_at_entry(self, monkeypatch):
         read_driver = FakeLogixDriver()
-        write_driver = FakeLogixDriver(write_error=CommError("socket closed"), dies_on_error=True)
+        write_driver = FakeLogixDriver(write_error=_socket_death_comm_error())
         replacement = FakeLogixDriver(write_results=[_tag(value=7)])
         monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: replacement)
-        plc = _allen_bradley(read_driver, write_driver, retry_count=2)
+        plc = _allen_bradley(read_driver, write_driver)
+
+        with pytest.raises(PLCCommunicationError):
+            await plc.write_tag([("Tag1", 7)])
+        assert write_driver.connected is False
 
         results = await plc.write_tag([("Tag1", 7)])
 
         assert results["Tag1"].value == 7
         assert plc._write_driver is replacement
-        assert write_driver.connected is False
         assert plc._read_driver is read_driver
         assert plc.plc is read_driver
-        assert read_driver.connected is True
 
-    async def test_a_session_that_will_not_reopen_still_exhausts_the_budget(self, monkeypatch):
-        read_driver = FakeLogixDriver(read_error=CommError("socket closed"), dies_on_error=True)
+    async def test_a_never_opened_channel_raises_and_opens_nothing(self, monkeypatch):
+        constructed = []
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: constructed.append(ip_address))
+        plc = AllenBradleyPLC(plc_name="PLC1", ip_address="192.168.1.100", plc_type="logix", retry_delay=0.0)
+
+        with pytest.raises(PLCConnectionError, match="never opened"):
+            await plc.read_tag(["Tag1"])
+
+        assert constructed == []
+        assert plc._write_driver is None
+
+    async def test_a_reopen_that_wont_open_raises_typed(self, monkeypatch):
+        read_driver = FakeLogixDriver(read_error=_socket_death_comm_error())
         dead = FakeLogixDriver()
         dead.open = lambda: False
         monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: dead)
-        plc = _allen_bradley(read_driver, FakeLogixDriver(), retry_count=2)
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
 
-        with pytest.raises(PLCCommunicationError, match=r"attempts=2"):
-            await plc.read_tag(["Tag1"])
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1"])  # closes the read channel
+        with pytest.raises(PLCCommunicationError, match="Could not reopen"):
+            await plc.read_tag(["Tag1"])  # entry reopen fails, typed
 
         # The failed reopen closed the replacement rather than leaking it.
         assert dead.connected is False
 
+    async def test_timeout_knobs_are_applied_per_channel(self, monkeypatch):
+        """connection_timeout bounds the open itself; then the channel's own knob takes over."""
+
+        class RecordingDriver(FakeLogixDriver):
+            def __init__(self, **kwargs):
+                object.__setattr__(self, "timeout_history", [])
+                super().__init__(**kwargs)
+
+            def __setattr__(self, name, value):
+                if name == "socket_timeout":
+                    self.timeout_history.append(value)
+                super().__setattr__(name, value)
+
+        dead = FakeLogixDriver(read_error=_socket_death_comm_error())
+        recorder = RecordingDriver(read_results=[_tag(value=1)])
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: recorder)
+        plc = _allen_bradley(dead, FakeLogixDriver())
+        plc.connection_timeout = 7.5
+        plc.read_timeout = 2.5
+
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1"])  # wire death closes the read channel
+
+        results = await plc.read_tag(["Tag1"])  # entry reopen applies the knobs
+
+        assert results["Tag1"].value == 1
+        assert recorder.timeout_history == [7.5, 2.5]
+
     async def test_an_open_that_raises_does_not_leak_the_driver(self, monkeypatch):
-        """A constructed driver whose open() throws is closed before the raise travels."""
-        read_driver = FakeLogixDriver(read_error=CommError("socket closed"), dies_on_error=True)
+        read_driver = FakeLogixDriver(read_error=_socket_death_comm_error())
         leaky = FakeLogixDriver()
 
         def _explode():
@@ -1098,9 +983,11 @@ class TestAllenBradleyChannelRecovery:
 
         leaky.open = _explode
         monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: leaky)
-        plc = _allen_bradley(read_driver, FakeLogixDriver(), retry_count=2)
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
 
-        with pytest.raises(PLCCommunicationError, match=r"attempts=2"):
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1"])
+        with pytest.raises(PLCCommunicationError, match="Could not reopen"):
             await plc.read_tag(["Tag1"])
 
         assert leaky.connected is False
@@ -1111,9 +998,7 @@ class TestAllenBradleyAutoDetect:
 
     @staticmethod
     def _auto_plc() -> AllenBradleyPLC:
-        return AllenBradleyPLC(
-            plc_name="PLC1", ip_address="192.168.1.100", plc_type="auto", retry_count=1, retry_delay=0.0
-        )
+        return AllenBradleyPLC(plc_name="PLC1", ip_address="192.168.1.100", plc_type="auto", retry_delay=0.0)
 
     async def test_an_unreachable_device_does_not_latch_cip(self, monkeypatch):
         """Nothing answered, so "cip" is a guess for this attempt only."""

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
@@ -1,0 +1,1107 @@
+"""Regression tests for the PLC transport contract.
+
+These cover the production incident directly: concurrent tasks sharing one PLC
+must never be inside the same channel at the same time, a reconnect must never
+interleave with an in-flight operation, and a driver failure must surface as a
+typed error rather than a sentinel value.
+
+They also pin the recovery contract built on top of that: a transport-class
+failure is retried inside the channel lock, the reconnect of that channel
+escalates (the first retry runs on a still-connected session, later retries — and
+any driver reporting disconnected — reset the channel first), a non-retryable
+failure is not retried at all, and a reconnect that itself fails never aborts the
+loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import Counter
+from types import SimpleNamespace
+from typing import Any, Dict, List, Tuple
+from unittest.mock import AsyncMock
+
+import pytest
+from pycomm3.exceptions import CommError, DataError, RequestError
+
+from mindtrace.hardware.core.exceptions import (
+    PLCCommunicationError,
+    PLCConnectionError,
+    PLCTagReadError,
+    PLCTagWriteError,
+)
+from mindtrace.hardware.plcs.backends.allen_bradley import AllenBradleyPLC, MockAllenBradleyPLC
+from mindtrace.hardware.plcs.backends.allen_bradley import allen_bradley_plc as ab_module
+from mindtrace.hardware.plcs.backends.base import BasePLC
+from mindtrace.hardware.plcs.types import TagError, TagErrorKind, TagResult, classify_tag_error
+
+
+class FakeDevice:
+    """Instrumented stand-in for a driver socket.
+
+    ``run`` records the set of operations in flight on entry, so a snapshot
+    containing two reads (or a reconnect next to anything) is proof of the
+    interleaving that crossed frames on the real socket.
+    """
+
+    def __init__(self):
+        self.inflight: List[str] = []
+        self.snapshots: List[Tuple[str, ...]] = []
+        self.calls: Counter = Counter()
+
+    async def run(self, kind: str, delay: float = 0.0) -> None:
+        self.calls[kind] += 1
+        self.inflight.append(kind)
+        self.snapshots.append(tuple(self.inflight))
+        try:
+            await asyncio.sleep(delay)
+        finally:
+            self.inflight.remove(kind)
+
+    def concurrent(self, kind: str) -> int:
+        return max((snapshot.count(kind) for snapshot in self.snapshots), default=0)
+
+    def widest(self) -> int:
+        return max((len(snapshot) for snapshot in self.snapshots), default=0)
+
+    def snapshots_containing(self, kind: str) -> List[Tuple[str, ...]]:
+        return [snapshot for snapshot in self.snapshots if kind in snapshot]
+
+
+class InstrumentedPLC(BasePLC):
+    """Backend whose every channel operation is recorded on a FakeDevice."""
+
+    def __init__(
+        self,
+        device: FakeDevice,
+        read_delay: float = 0.0,
+        write_delay: float = 0.0,
+        read_failures: int = 0,
+        **kwargs,
+    ):
+        self.device = device
+        self.read_delay = read_delay
+        self.write_delay = write_delay
+        self.read_failures = read_failures
+        self._connected = True
+        kwargs.setdefault("plc_name", "PLC1")
+        kwargs.setdefault("ip_address", "192.168.1.100")
+        super().__init__(**kwargs)
+
+    async def _reconnect_channel(self, channel: str) -> bool:
+        await self.device.run(f"reconnect_{channel}")
+        return True
+
+    async def initialize(self):
+        return True, None, None
+
+    async def _connect(self) -> bool:
+        await self.device.run("connect")
+        self._connected = True
+        return True
+
+    async def _disconnect(self) -> bool:
+        await self.device.run("disconnect")
+        self._connected = False
+        return True
+
+    async def is_connected(self) -> bool:
+        return self._connected
+
+    async def _read_tags(self, addresses: List[str]) -> Dict[str, TagResult]:
+        await self.device.run("read", self.read_delay)
+        if self.read_failures > 0:
+            self.read_failures -= 1
+            raise PLCCommunicationError("socket closed")
+        return {address: TagResult(value=address) for address in addresses}
+
+    async def _write_tags(self, writes: List[Tuple[str, Any]]) -> Dict[str, TagResult]:
+        await self.device.run("write", self.write_delay)
+        return {address: TagResult(value=value) for address, value in writes}
+
+    async def _get_all_tags(self):
+        await self.device.run("read", self.read_delay)
+        return ["Tag1"]
+
+    async def _get_tag_info(self, tag_name: str):
+        await self.device.run("read", self.read_delay)
+        return {"name": tag_name}
+
+    @staticmethod
+    def get_available_plcs():
+        return []
+
+    @staticmethod
+    def get_backend_info():
+        return {"name": "InstrumentedPLC"}
+
+
+class FakeLogixDriver:
+    """Minimal pycomm3 LogixDriver stand-in: records calls, replays scripted results.
+
+    ``dies_on_error`` models the dead-socket case: the scripted failure also drops
+    ``connected``, the way a real session that lost its socket reports itself. That
+    is what makes recovery reconnect before the FIRST retry instead of re-sending
+    on a session the driver still calls live.
+    """
+
+    def __init__(
+        self,
+        read_results=None,
+        write_results=None,
+        read_error=None,
+        write_error=None,
+        delay: float = 0.0,
+        dies_on_error: bool = False,
+    ):
+        self.connected = True
+        self.read_results = read_results or []
+        self.write_results = write_results or []
+        self.read_error = read_error
+        self.write_error = write_error
+        self.delay = delay
+        self.dies_on_error = dies_on_error
+        self.read_calls: List[Tuple[str, ...]] = []
+        self.write_calls: List[Tuple[Any, ...]] = []
+
+    def read(self, *addresses):
+        self.read_calls.append(addresses)
+        if self.delay:
+            time.sleep(self.delay)
+        if self.read_error is not None:
+            if self.dies_on_error:
+                self.connected = False
+            raise self.read_error
+        return list(self.read_results)
+
+    def write(self, *writes):
+        self.write_calls.append(writes)
+        if self.delay:
+            time.sleep(self.delay)
+        if self.write_error is not None:
+            if self.dies_on_error:
+                self.connected = False
+            raise self.write_error
+        return list(self.write_results)
+
+    def open(self):
+        self.connected = True
+        return True
+
+    def close(self):
+        self.connected = False
+
+
+class ScriptedPLC(BasePLC):
+    """Backend whose delegates replay a script and whose reconnects are recorded.
+
+    A script entry is either a results dict or an exception to raise; the LAST
+    entry sticks, so a one-element script is a permanent condition.
+
+    ``dies_on_error`` models the dead-socket case: a raised transport error also
+    flips the driver to disconnected, which is what makes recovery reconnect
+    before the first retry. Left False, the fake is the busy-but-live device whose
+    first retry is free.
+    """
+
+    def __init__(
+        self,
+        read_script=None,
+        write_script=None,
+        reconnect: Any = True,
+        dies_on_error: bool = False,
+        **kwargs,
+    ):
+        self._read_script = list(read_script or [])
+        self._write_script = list(write_script or [])
+        self.reconnect_result = reconnect
+        self.dies_on_error = dies_on_error
+        self.read_calls = 0
+        self.write_calls = 0
+        self.reconnects: List[str] = []
+        # Delegate calls completed when each reconnect fired, so a test can pin
+        # WHICH attempt bought the reconnect and not merely how many there were.
+        self.reconnect_marks: List[int] = []
+        self._connected = True
+        kwargs.setdefault("plc_name", "PLC1")
+        kwargs.setdefault("ip_address", "192.168.1.100")
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def _play(script: List[Any]) -> Dict[str, TagResult]:
+        step = script.pop(0) if len(script) > 1 else (script[0] if script else {})
+        if isinstance(step, BaseException):
+            raise step
+        return step
+
+    def _play_channel(self, script: List[Any]) -> Dict[str, TagResult]:
+        try:
+            return self._play(script)
+        except PLCCommunicationError:
+            if self.dies_on_error:
+                self._connected = False
+            raise
+
+    async def initialize(self):
+        return True, None, None
+
+    async def _connect(self) -> bool:
+        self._connected = True
+        return True
+
+    async def _disconnect(self) -> bool:
+        self._connected = False
+        return True
+
+    async def is_connected(self) -> bool:
+        return self._connected
+
+    async def _read_tags(self, addresses: List[str]) -> Dict[str, TagResult]:
+        self.read_calls += 1
+        return self._play_channel(self._read_script)
+
+    async def _write_tags(self, writes: List[Tuple[str, Any]]) -> Dict[str, TagResult]:
+        self.write_calls += 1
+        return self._play_channel(self._write_script)
+
+    async def _reconnect_channel(self, channel: str) -> bool:
+        self.reconnects.append(channel)
+        self.reconnect_marks.append(self.read_calls + self.write_calls)
+        if isinstance(self.reconnect_result, BaseException):
+            raise self.reconnect_result
+        if self.reconnect_result:
+            self._connected = True
+        return self.reconnect_result
+
+    async def _get_all_tags(self):
+        return []
+
+    async def _get_tag_info(self, tag_name: str):
+        return {"name": tag_name}
+
+    @staticmethod
+    def get_available_plcs():
+        return []
+
+    @staticmethod
+    def get_backend_info():
+        return {"name": "ScriptedPLC"}
+
+
+def _transport_result(message: str = "socket closed") -> TagResult:
+    return TagResult(error=TagError(kind=TagErrorKind.transport, message=message))
+
+
+def _tag(value=None, error=None):
+    """A pycomm3 Tag is a namedtuple; only .value and .error are consumed here."""
+    return SimpleNamespace(value=value, error=error)
+
+
+def _allen_bradley(
+    read_driver, write_driver, driver_type: str = "LogixDriver", retry_count: int = 1
+) -> AllenBradleyPLC:
+    """An AB backend wired to fake sessions.
+
+    ``retry_count`` defaults to 1 so taxonomy tests observe exactly one delegate
+    call; the recovery tests raise it and supply their own ``_reconnect_channel``.
+    """
+    plc = AllenBradleyPLC(
+        plc_name="PLC1", ip_address="192.168.1.100", plc_type="logix", retry_count=retry_count, retry_delay=0.0
+    )
+    plc._read_driver = read_driver
+    plc._write_driver = write_driver
+    plc.plc = read_driver
+    plc.driver_type = driver_type
+    return plc
+
+
+class TestChannelSerialization:
+    """The regression test for the incident: no two tasks inside one channel."""
+
+    async def test_concurrent_reads_writes_and_reconnects_never_interleave(self):
+        device = FakeDevice()
+        plc = InstrumentedPLC(device, read_delay=0.002, write_delay=0.002, retry_delay=0.0)
+
+        tasks = []
+        for index in range(12):
+            tasks.append(plc.read_tag([f"Tag{index}"]))
+            tasks.append(plc.write_tag([(f"Tag{index}", index)]))
+        for _ in range(3):
+            tasks.append(plc.reconnect())
+
+        await asyncio.gather(*tasks)
+
+        assert device.calls["read"] == 12
+        assert device.calls["write"] == 12
+        assert device.concurrent("read") == 1, device.snapshots
+        assert device.concurrent("write") == 1, device.snapshots
+
+    async def test_reconnect_never_overlaps_an_in_flight_operation(self):
+        device = FakeDevice()
+        plc = InstrumentedPLC(device, read_delay=0.002, write_delay=0.002, retry_delay=0.0)
+
+        await asyncio.gather(
+            *[plc.read_tag(["Tag1"]) for _ in range(8)],
+            *[plc.write_tag([("Tag1", 1)]) for _ in range(8)],
+            plc.reconnect(),
+            plc.reconnect(),
+        )
+
+        for kind in ("connect", "disconnect"):
+            for snapshot in device.snapshots_containing(kind):
+                assert snapshot == (kind,), snapshot
+
+    async def test_read_side_probes_share_the_read_channel(self):
+        device = FakeDevice()
+        plc = InstrumentedPLC(device, read_delay=0.002)
+
+        await asyncio.gather(
+            plc.read_tag(["Tag1"]),
+            plc.get_all_tags(),
+            plc.get_tag_info("Tag1"),
+            plc.get_plc_info(),
+        )
+
+        assert device.concurrent("read") == 1, device.snapshots
+
+
+class TestDualChannel:
+    """Reads and writes ride separate driver sessions and can overlap."""
+
+    async def test_reads_and_writes_hit_their_own_driver(self):
+        read_driver = FakeLogixDriver(read_results=[_tag(value=42)])
+        write_driver = FakeLogixDriver(write_results=[_tag(value=7)])
+        plc = _allen_bradley(read_driver, write_driver)
+
+        assert (await plc.read_tag(["Tag1"]))["Tag1"].value == 42
+        assert (await plc.write_tag([("Tag1", 7)]))["Tag1"].value == 7
+
+        assert read_driver.read_calls == [("Tag1",)]
+        assert read_driver.write_calls == []
+        assert write_driver.write_calls == [(("Tag1", 7),)]
+        assert write_driver.read_calls == []
+
+    async def test_a_slow_read_does_not_block_a_write(self):
+        read_driver = FakeLogixDriver(read_results=[_tag(value=42)], delay=0.25)
+        write_driver = FakeLogixDriver(write_results=[_tag(value=7)])
+        plc = _allen_bradley(read_driver, write_driver)
+
+        finished: List[str] = []
+
+        async def _read():
+            await plc.read_tag(["Tag1"])
+            finished.append("read")
+
+        async def _write():
+            await plc.write_tag([("Tag1", 7)])
+            finished.append("write")
+
+        read_task = asyncio.create_task(_read())
+        await asyncio.sleep(0.02)  # let the read get inside the driver call
+        await asyncio.wait_for(_write(), timeout=0.2)
+        await read_task
+
+        assert finished == ["write", "read"]
+
+    async def test_the_read_driver_stays_reachable_as_plc(self):
+        read_driver = FakeLogixDriver()
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+
+        # chiron's preflight reads plc.plc.tags for the controller tag database.
+        assert plc.plc is plc._read_driver is read_driver
+
+
+class TestErrorTaxonomy:
+    @pytest.mark.parametrize(
+        "message,expected",
+        [
+            ("Tag doesn't exist - Motor1_Speed", TagErrorKind.missing_tag),
+            ("Instance does not exist", TagErrorKind.missing_tag),
+            # pycomm3 flattens a parse-stage RequestError into the per-tag string.
+            # Both spellings are the caller's address, not a sick socket — reading
+            # them as transport would make one bad address bounce a live session.
+            ("('Failed to parse tag request', 'Bad{Tag')", TagErrorKind.missing_tag),
+            ("Invalid tag request - RequestError('Failed to parse tag request', 'Bad{Tag')", TagErrorKind.missing_tag),
+            # SERVICE_STATUS 0x05 / 0x04, verbatim: the controller rejected the
+            # address, which is a missing tag however the reply is spelled.
+            (
+                "Destination unknown, class unsupported, instance undefined or "
+                "structure element undefined (see extended status)",
+                TagErrorKind.missing_tag,
+            ),
+            (
+                "IOI syntax error. A syntax error was detected decoding the Request Path (see extended status)",
+                TagErrorKind.missing_tag,
+            ),
+            ("Symbol does not exist", TagErrorKind.missing_tag),
+            ("Error packing -128 as USINT", TagErrorKind.encode),
+            ("Error encoding value for tag", TagErrorKind.encode),
+            ("Error unpacking response", TagErrorKind.encode),
+            ("Invalid data type for tag", TagErrorKind.type_mismatch),
+            ("Wrong data type", TagErrorKind.type_mismatch),
+            ("Connection timed out", TagErrorKind.transport),
+            # SERVICE_STATUS 0x07: the socket, not the address.
+            ("Connection lost", TagErrorKind.transport),
+            # A bare "type" substring is not evidence of a tag type problem.
+            ("'NoneType' object is not subscriptable", TagErrorKind.transport),
+        ],
+    )
+    def test_classification_preserves_the_raw_message(self, message, expected):
+        error = classify_tag_error(message)
+
+        assert error.kind is expected
+        assert error.message == message
+
+    async def test_read_tag_error_becomes_a_classified_result(self):
+        read_driver = FakeLogixDriver(read_results=[_tag(error="Tag doesn't exist - Ghost"), _tag(value=1)])
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+
+        results = await plc.read_tag(["Ghost", "Real"])
+
+        assert results["Ghost"].ok is False
+        assert results["Ghost"].error.kind is TagErrorKind.missing_tag
+        assert "Ghost" in results["Ghost"].error.message
+        assert results["Real"].value == 1
+
+    async def test_write_encode_error_becomes_a_classified_result(self):
+        write_driver = FakeLogixDriver(write_results=[_tag(error="Error packing -128 as USINT")])
+        plc = _allen_bradley(FakeLogixDriver(), write_driver)
+
+        results = await plc.write_tag([("Motor1_Speed", -128)])
+
+        assert results["Motor1_Speed"].ok is False
+        assert results["Motor1_Speed"].error.kind is TagErrorKind.encode
+
+    async def test_whole_call_data_error_is_transport_class(self):
+        """A garbled reply leaves the session suspect, so it is retryable."""
+        write_driver = FakeLogixDriver(write_error=DataError("Error packing -128 as USINT"))
+        plc = _allen_bradley(FakeLogixDriver(), write_driver)
+
+        with pytest.raises(PLCCommunicationError) as excinfo:
+            await plc.write_tag([("Motor1_Speed", -128)])
+
+        assert isinstance(excinfo.value.__cause__, DataError)
+        assert len(write_driver.write_calls) == 1
+
+    async def test_whole_call_comm_error_is_transport_class(self):
+        read_driver = FakeLogixDriver(read_error=CommError("socket closed"))
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+
+        with pytest.raises(PLCCommunicationError) as excinfo:
+            await plc.read_tag(["Tag1"])
+
+        assert isinstance(excinfo.value.__cause__, CommError)
+        assert len(read_driver.read_calls) == 1
+
+    async def test_a_request_error_is_not_transport_class(self):
+        """A malformed request is the caller's bug: typed, final, never retried."""
+        read_driver = FakeLogixDriver(read_error=RequestError("Failed to parse tag request"))
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), retry_count=3)
+        plc._reconnect_channel = AsyncMock(return_value=True)
+
+        with pytest.raises(PLCTagReadError) as excinfo:
+            await plc.read_tag(["Tag1"])
+
+        assert isinstance(excinfo.value.__cause__, RequestError)
+        assert len(read_driver.read_calls) == 1
+        plc._reconnect_channel.assert_not_awaited()
+
+    async def test_a_write_request_error_is_not_transport_class(self):
+        write_driver = FakeLogixDriver(write_error=RequestError("Failed to parse tag request"))
+        plc = _allen_bradley(FakeLogixDriver(), write_driver, retry_count=3)
+        plc._reconnect_channel = AsyncMock(return_value=True)
+
+        with pytest.raises(PLCTagWriteError) as excinfo:
+            await plc.write_tag([("Tag1", 1)])
+
+        assert isinstance(excinfo.value.__cause__, RequestError)
+        assert len(write_driver.write_calls) == 1
+        plc._reconnect_channel.assert_not_awaited()
+
+    @pytest.mark.parametrize("driver_result", [None, False])
+    async def test_a_driver_answering_without_a_tag_is_a_failure(self, driver_result):
+        """None/False carries no Tag to hold an error — it must not read as success."""
+        write_driver = FakeLogixDriver(write_results=[driver_result])
+        plc = _allen_bradley(FakeLogixDriver(), write_driver)
+
+        results = await plc.write_tag([("Tag1", 5)])
+
+        assert results["Tag1"].ok is False
+        assert results["Tag1"].error.kind is TagErrorKind.transport
+
+    async def test_an_empty_batch_still_checks_the_channel(self):
+        read_driver = FakeLogixDriver()
+        read_driver.connected = False
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag([])
+
+    async def test_an_empty_batch_on_an_open_channel_is_a_no_op(self):
+        read_driver = FakeLogixDriver()
+        write_driver = FakeLogixDriver()
+        plc = _allen_bradley(read_driver, write_driver)
+
+        assert await plc.read_tag([]) == {}
+        assert await plc.write_tag([]) == {}
+        assert read_driver.read_calls == []
+        assert write_driver.write_calls == []
+
+    async def test_closed_channel_raises_without_reconnecting(self):
+        read_driver = FakeLogixDriver()
+        read_driver.connected = False
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+        plc.reconnect = AsyncMock()
+
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1"])
+
+        plc.reconnect.assert_not_awaited()
+        assert read_driver.read_calls == []
+
+
+class TestPerTagNetsAreNarrow:
+    """The unbatched SLC/CIP paths classify per-tag driver errors and nothing else.
+
+    A dropped socket or a code bug hit halfway through a batch is a whole-call
+    failure; laundering it into per-tag transport errors would report the batch
+    as "mostly fine" while the session was already gone.
+    """
+
+    @pytest.mark.parametrize("driver_type", ["SLCDriver", "CIPDriver"])
+    async def test_a_comm_error_mid_batch_raises_typed(self, driver_type):
+        read_driver = FakeLogixDriver(read_error=CommError("socket closed"))
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), driver_type)
+
+        with pytest.raises(PLCCommunicationError) as excinfo:
+            await plc.read_tag(["Tag1", "Tag2"])
+
+        assert isinstance(excinfo.value.__cause__, CommError)
+        # The batch stopped at the first address instead of marching on.
+        assert len(read_driver.read_calls) == 1
+
+    @pytest.mark.parametrize("driver_type", ["SLCDriver", "CIPDriver"])
+    async def test_a_write_comm_error_mid_batch_raises_typed(self, driver_type):
+        write_driver = FakeLogixDriver(write_error=CommError("socket closed"))
+        plc = _allen_bradley(FakeLogixDriver(), write_driver, driver_type)
+
+        with pytest.raises(PLCCommunicationError) as excinfo:
+            await plc.write_tag([("Tag1", 1), ("Tag2", 2)])
+
+        assert isinstance(excinfo.value.__cause__, CommError)
+        assert len(write_driver.write_calls) == 1
+
+    @pytest.mark.parametrize("driver_type", ["SLCDriver", "CIPDriver"])
+    async def test_a_programming_error_is_not_reported_as_a_tag_error(self, driver_type):
+        """A code bug reaches the outer net chained, not a per-tag transport result."""
+        boom = AttributeError("'NoneType' object has no attribute 'read'")
+        read_driver = FakeLogixDriver(read_error=boom)
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), driver_type)
+
+        with pytest.raises(PLCTagReadError) as excinfo:
+            await plc.read_tag(["Tag1"])
+
+        assert excinfo.value.__cause__ is boom
+
+    @pytest.mark.parametrize("driver_type", ["SLCDriver", "CIPDriver"])
+    async def test_a_per_tag_driver_error_still_stays_per_tag(self, driver_type):
+        read_driver = FakeLogixDriver(read_error=DataError("Error packing -128 as USINT"))
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), driver_type)
+
+        results = await plc.read_tag(["Tag1", "Tag2"])
+
+        assert results["Tag1"].error.kind is TagErrorKind.encode
+        assert results["Tag2"].error.kind is TagErrorKind.encode
+        assert len(read_driver.read_calls) == 2
+
+
+class TestNoSentinels:
+    async def test_a_failed_read_is_never_a_bare_value(self):
+        plc = MockAllenBradleyPLC("TestPLC", "192.168.1.99", plc_type="logix")
+        await plc.connect()
+
+        results = await plc.read_tag(["Motor1_Speed", "DoesNotExist"])
+
+        assert results["Motor1_Speed"].ok is True
+        missing = results["DoesNotExist"]
+        assert missing.ok is False
+        assert missing.error.kind is TagErrorKind.missing_tag
+        # The value slot stays empty, and `ok` — not the value — is the verdict.
+        assert missing.value is None
+
+    async def test_a_failed_write_is_never_a_bare_false(self):
+        plc = MockAllenBradleyPLC("TestPLC", "192.168.1.99", plc_type="logix")
+        await plc.connect()
+
+        results = await plc.write_tag([("Motor1_Command", True), ("DoesNotExist", 1)])
+
+        assert results["Motor1_Command"] == TagResult(value=True)
+        assert results["DoesNotExist"].ok is False
+        assert results["DoesNotExist"].error.kind is TagErrorKind.missing_tag
+
+    async def test_a_type_mismatch_is_reported_as_such(self):
+        plc = MockAllenBradleyPLC("TestPLC", "192.168.1.99", plc_type="logix")
+        await plc.connect()
+
+        results = await plc.write_tag([("Production_Count", "not-a-number")])
+
+        assert results["Production_Count"].ok is False
+        assert results["Production_Count"].error.kind is TagErrorKind.type_mismatch
+
+    async def test_a_missing_tag_read_does_not_disturb_stored_values(self):
+        plc = MockAllenBradleyPLC("TestPLC", "192.168.1.99", plc_type="logix")
+        await plc.connect()
+
+        await plc.read_tag(["DoesNotExist"])
+
+        assert "DoesNotExist" not in plc._tag_values
+
+
+class TestLockOrdering:
+    async def test_reconnect_waits_for_an_in_flight_read(self):
+        device = FakeDevice()
+        plc = InstrumentedPLC(device, retry_delay=0.0)
+
+        release = asyncio.Event()
+        inside = asyncio.Event()
+
+        async def _slow_read(_addresses):
+            inside.set()
+            await release.wait()
+            await device.run("read")
+            return {}
+
+        plc._read_tags = _slow_read
+
+        read_task = asyncio.create_task(plc.read_tag(["Tag1"]))
+        await inside.wait()
+
+        reconnect_task = asyncio.create_task(plc.reconnect())
+        await asyncio.sleep(0.02)
+
+        assert not reconnect_task.done()
+        assert device.calls["disconnect"] == 0
+
+        release.set()
+        await read_task
+        await reconnect_task
+
+        assert device.calls["disconnect"] == 1
+        assert device.calls["connect"] == 1
+        # The read completed before the reconnect tore the connection down.
+        assert [snapshot[0] for snapshot in device.snapshots] == ["read", "disconnect", "connect"]
+
+    async def test_reconnect_blocks_a_queued_write_until_it_finishes(self):
+        device = FakeDevice()
+        plc = InstrumentedPLC(device, retry_delay=0.0)
+
+        release = asyncio.Event()
+
+        async def _slow_disconnect():
+            await release.wait()
+            await device.run("disconnect")
+            return True
+
+        plc._disconnect = _slow_disconnect
+
+        reconnect_task = asyncio.create_task(plc.reconnect())
+        await asyncio.sleep(0)
+        write_task = asyncio.create_task(plc.write_tag([("Tag1", 1)]))
+        await asyncio.sleep(0.02)
+
+        assert not write_task.done()
+        assert device.calls["write"] == 0
+
+        release.set()
+        await reconnect_task
+        await write_task
+
+        assert [snapshot[0] for snapshot in device.snapshots] == ["disconnect", "connect", "write"]
+
+    async def test_recovery_happens_inside_the_channel_lock(self):
+        """A reconnect between attempts is still alone on its channel."""
+        device = FakeDevice()
+        plc = InstrumentedPLC(device, read_delay=0.002, read_failures=2, retry_count=3, retry_delay=0.0)
+
+        await asyncio.gather(*[plc.read_tag(["Tag1"]) for _ in range(6)])
+
+        # Free first retry: the driver stays connected, so the two scripted
+        # failures buy one reconnect (before attempt 3), not one each.
+        assert device.calls["reconnect_read"] == 1
+        assert device.concurrent("read") == 1, device.snapshots
+        for snapshot in device.snapshots_containing("reconnect_read"):
+            assert snapshot == ("reconnect_read",), snapshot
+
+    async def test_lifecycle_operations_use_one_lock_order(self):
+        """connect/disconnect/reconnect all take read-then-write, so they cannot deadlock."""
+        device = FakeDevice()
+        plc = InstrumentedPLC(device, retry_delay=0.0)
+
+        await asyncio.wait_for(
+            asyncio.gather(*[plc.connect() for _ in range(5)], *[plc.disconnect() for _ in range(5)], plc.reconnect()),
+            timeout=2.0,
+        )
+
+        assert device.calls["connect"] == 6
+        assert device.calls["disconnect"] == 6
+
+
+class TestChannelRecovery:
+    """Transport-class failures are retried in place, escalating to a reconnect."""
+
+    async def test_a_transport_failure_reconnects_and_succeeds_on_the_next_attempt(self):
+        plc = ScriptedPLC(
+            read_script=[PLCCommunicationError("socket closed"), {"Tag1": TagResult(value=1)}],
+            dies_on_error=True,  # dead socket: the reconnect is owed before the first retry
+            retry_count=3,
+        )
+
+        results = await plc.read_tag(["Tag1"])
+
+        assert results["Tag1"].value == 1
+        assert plc.read_calls == 2
+        assert plc.reconnects == ["read"]
+
+    async def test_recovery_stays_on_the_failing_channel(self):
+        plc = ScriptedPLC(
+            write_script=[PLCCommunicationError("socket closed"), {"Tag1": TagResult(value=1)}],
+            dies_on_error=True,  # dead socket: the reconnect is owed before the first retry
+            retry_count=3,
+        )
+
+        await plc.write_tag([("Tag1", 1)])
+
+        assert plc.write_calls == 2
+        assert plc.reconnects == ["write"]
+
+    async def test_exhausted_attempts_raise_with_the_attempt_count(self):
+        plc = ScriptedPLC(read_script=[PLCCommunicationError("socket closed")], retry_count=3)
+
+        with pytest.raises(PLCCommunicationError, match=r"attempts=3"):
+            await plc.read_tag(["Tag1"])
+
+        assert plc.read_calls == 3
+        # Free first retry on a still-connected driver: of the two gaps between
+        # the three attempts, only the second one buys a reconnect.
+        assert plc.reconnects == ["read"]
+
+    async def test_a_non_retryable_failure_is_not_retried(self):
+        plc = ScriptedPLC(read_script=[PLCTagReadError("malformed request")], retry_count=3)
+
+        with pytest.raises(PLCTagReadError):
+            await plc.read_tag(["Tag1"])
+
+        assert plc.read_calls == 1
+        assert plc.reconnects == []
+
+    async def test_a_wedged_batch_is_treated_as_a_channel_failure(self):
+        """Every tag failed on transport: the socket is sick, not the addresses."""
+        plc = ScriptedPLC(
+            read_script=[
+                {"Tag1": _transport_result(), "Tag2": _transport_result()},
+                {"Tag1": TagResult(value=1), "Tag2": TagResult(value=2)},
+            ],
+            retry_count=3,
+        )
+
+        results = await plc.read_tag(["Tag1", "Tag2"])
+
+        assert results["Tag1"].value == 1
+        # The wedged batch bought a retry — a per-tag failure would have returned
+        # after one call. Free first retry: on a still-connected driver that retry
+        # is re-sent on the live session, so no reconnect is owed yet.
+        assert plc.read_calls == 2
+        assert plc.reconnects == []
+
+    async def test_a_batch_that_stays_wedged_is_returned_honestly(self):
+        """Per-tag results never turn into a raise, however many attempts failed."""
+        plc = ScriptedPLC(read_script=[{"Tag1": _transport_result()}], retry_count=3)
+
+        results = await plc.read_tag(["Tag1"])
+
+        assert results["Tag1"].error.kind is TagErrorKind.transport
+        assert plc.read_calls == 3
+        # Free first retry: only the gap before attempt 3 buys a reconnect.
+        assert plc.reconnects == ["read"]
+
+    async def test_a_partly_errored_batch_is_not_a_channel_failure(self):
+        plc = ScriptedPLC(
+            read_script=[
+                {
+                    "Tag1": _transport_result(),
+                    "Ghost": TagResult(error=TagError(kind=TagErrorKind.missing_tag, message="no such tag")),
+                }
+            ],
+            retry_count=3,
+        )
+
+        results = await plc.read_tag(["Tag1", "Ghost"])
+
+        assert results["Ghost"].error.kind is TagErrorKind.missing_tag
+        assert plc.read_calls == 1
+        assert plc.reconnects == []
+
+    async def test_an_empty_batch_is_never_wedged(self):
+        plc = ScriptedPLC(read_script=[{}], retry_count=3)
+
+        assert await plc.read_tag([]) == {}
+        assert plc.reconnects == []
+
+    # --- The escalation rule itself: when a reconnect is owed, and when it is not ---
+
+    async def test_a_transient_failure_retries_on_the_live_session(self):
+        """The first retry is free: a busy PLC or a lone timeout costs no reconnect.
+
+        Bouncing a session the driver still reports as open turns one hiccup into
+        a torn-down socket, which is what the escalation exists to avoid.
+        """
+        plc = ScriptedPLC(
+            read_script=[PLCCommunicationError("connection timed out"), {"Tag1": TagResult(value=1)}],
+            retry_count=3,
+        )
+
+        results = await plc.read_tag(["Tag1"])
+
+        assert results["Tag1"].value == 1
+        assert plc.read_calls == 2
+        assert plc.reconnects == []
+
+    async def test_a_disconnected_driver_reconnects_before_the_first_retry(self):
+        """No free retry for a dead socket: re-sending on it could only fail again."""
+        plc = ScriptedPLC(
+            read_script=[PLCCommunicationError("socket closed"), {"Tag1": TagResult(value=1)}],
+            dies_on_error=True,
+            retry_count=3,
+        )
+
+        results = await plc.read_tag(["Tag1"])
+
+        assert results["Tag1"].value == 1
+        assert plc.read_calls == 2
+        assert plc.reconnects == ["read"]
+        # Fired after attempt 1 — i.e. before the FIRST retry, not the second.
+        assert plc.reconnect_marks == [1]
+
+    async def test_a_second_failure_on_a_live_session_escalates_to_a_reconnect(self):
+        """Twice-failed but still "connected" means the session is lying: reset it.
+
+        The driver reports open the whole way through, so only the second retry —
+        never the first — pays for a reconnect.
+        """
+        plc = ScriptedPLC(
+            read_script=[
+                PLCCommunicationError("socket closed"),
+                PLCCommunicationError("socket closed"),
+                {"Tag1": TagResult(value=1)},
+            ],
+            retry_count=3,
+        )
+
+        results = await plc.read_tag(["Tag1"])
+
+        assert results["Tag1"].value == 1
+        assert plc.read_calls == 3
+        assert plc.reconnects == ["read"]
+        # Fired after attempt 2 only: nothing was reconnected before attempt 2.
+        assert plc.reconnect_marks == [2]
+
+
+class TestFailedReconnects:
+    """A reconnect that fails is a logged event, not an escape from the loop."""
+
+    async def test_a_failed_reconnect_does_not_abort_the_loop(self):
+        plc = ScriptedPLC(
+            read_script=[PLCCommunicationError("socket closed")],
+            reconnect=PLCConnectionError("device refused"),
+            retry_count=3,
+        )
+
+        with pytest.raises(PLCCommunicationError, match=r"attempts=3"):
+            await plc.read_tag(["Tag1"])
+
+        # Every attempt was made even though no reconnect succeeded.
+        assert plc.read_calls == 3
+        # Free first retry: the driver still reports connected, so the sole
+        # reconnect — the one that raised — is the one before attempt 3.
+        assert plc.reconnects == ["read"]
+
+    async def test_a_reconnect_returning_false_is_treated_the_same(self):
+        plc = ScriptedPLC(
+            read_script=[PLCCommunicationError("socket closed")],
+            reconnect=False,
+            retry_count=3,
+        )
+
+        with pytest.raises(PLCCommunicationError, match=r"attempts=3"):
+            await plc.read_tag(["Tag1"])
+
+        assert plc.read_calls == 3
+        # Free first retry: one reconnect is attempted, before attempt 3.
+        assert plc.reconnects == ["read"]
+
+    async def test_a_late_reconnect_success_still_saves_the_call(self):
+        """The budget is spent on attempts, not abandoned after the first failure."""
+        plc = ScriptedPLC(
+            read_script=[
+                PLCCommunicationError("socket closed"),
+                PLCCommunicationError("socket closed"),
+                {"Tag1": TagResult(value=1)},
+            ],
+            reconnect=PLCConnectionError("device refused"),
+            retry_count=3,
+        )
+
+        results = await plc.read_tag(["Tag1"])
+
+        assert results["Tag1"].value == 1
+        assert plc.read_calls == 3
+        # Free first retry: the failed reconnect is the one before attempt 3, and
+        # attempt 3 ran anyway.
+        assert plc.reconnects == ["read"]
+
+    async def test_a_dead_read_channel_does_not_fence_the_write_channel(self):
+        plc = ScriptedPLC(
+            read_script=[PLCCommunicationError("socket closed")],
+            write_script=[{"Tag1": TagResult(value=1)}],
+            reconnect=PLCConnectionError("device refused"),
+            retry_count=3,
+        )
+
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1"])
+
+        assert (await plc.write_tag([("Tag1", 1)]))["Tag1"].value == 1
+        # Free first retry: one reconnect, and it stayed on the read channel.
+        assert plc.reconnects == ["read"]
+
+    async def test_the_exhausted_raise_is_a_plain_communication_error(self):
+        """Never ``type(last_error)(msg)``: a subclass constructor may not take one."""
+
+        class PickyCommunicationError(PLCCommunicationError):
+            def __init__(self, message: str, code: int):
+                super().__init__(f"{message} [{code}]")
+                self.code = code
+
+        plc = ScriptedPLC(read_script=[PickyCommunicationError("socket closed", 7)], retry_count=2)
+
+        with pytest.raises(PLCCommunicationError) as excinfo:
+            await plc.read_tag(["Tag1"])
+
+        assert type(excinfo.value) is PLCCommunicationError
+        assert isinstance(excinfo.value.__cause__, PickyCommunicationError)
+
+
+class TestAllenBradleyChannelRecovery:
+    """The AB backend rebuilds one driver session and leaves the other alone.
+
+    The failing driver dies with its error, the way a real session that lost its
+    socket does: ``is_connected`` then reports False and recovery reconnects before
+    the first retry, which is the path these tests are about.
+    """
+
+    async def test_read_recovery_replaces_only_the_read_session(self, monkeypatch):
+        read_driver = FakeLogixDriver(read_error=CommError("socket closed"), dies_on_error=True)
+        write_driver = FakeLogixDriver()
+        replacement = FakeLogixDriver(read_results=[_tag(value=42)])
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: replacement)
+        plc = _allen_bradley(read_driver, write_driver, retry_count=2)
+
+        results = await plc.read_tag(["Tag1"])
+
+        assert results["Tag1"].value == 42
+        assert plc._read_driver is replacement
+        # chiron's preflight reads plc.plc.tags — the alias must follow the new session.
+        assert plc.plc is replacement
+        assert read_driver.connected is False
+        assert plc._write_driver is write_driver
+        assert write_driver.connected is True
+
+    async def test_write_recovery_replaces_only_the_write_session(self, monkeypatch):
+        read_driver = FakeLogixDriver()
+        write_driver = FakeLogixDriver(write_error=CommError("socket closed"), dies_on_error=True)
+        replacement = FakeLogixDriver(write_results=[_tag(value=7)])
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: replacement)
+        plc = _allen_bradley(read_driver, write_driver, retry_count=2)
+
+        results = await plc.write_tag([("Tag1", 7)])
+
+        assert results["Tag1"].value == 7
+        assert plc._write_driver is replacement
+        assert write_driver.connected is False
+        assert plc._read_driver is read_driver
+        assert plc.plc is read_driver
+        assert read_driver.connected is True
+
+    async def test_a_session_that_will_not_reopen_still_exhausts_the_budget(self, monkeypatch):
+        read_driver = FakeLogixDriver(read_error=CommError("socket closed"), dies_on_error=True)
+        dead = FakeLogixDriver()
+        dead.open = lambda: False
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: dead)
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), retry_count=2)
+
+        with pytest.raises(PLCCommunicationError, match=r"attempts=2"):
+            await plc.read_tag(["Tag1"])
+
+        # The failed reopen closed the replacement rather than leaking it.
+        assert dead.connected is False
+
+    async def test_an_open_that_raises_does_not_leak_the_driver(self, monkeypatch):
+        """A constructed driver whose open() throws is closed before the raise travels."""
+        read_driver = FakeLogixDriver(read_error=CommError("socket closed"), dies_on_error=True)
+        leaky = FakeLogixDriver()
+
+        def _explode():
+            raise CommError("device refused the session")
+
+        leaky.open = _explode
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: leaky)
+        plc = _allen_bradley(read_driver, FakeLogixDriver(), retry_count=2)
+
+        with pytest.raises(PLCCommunicationError, match=r"attempts=2"):
+            await plc.read_tag(["Tag1"])
+
+        assert leaky.connected is False
+
+
+class TestAllenBradleyAutoDetect:
+    """``plc_type="auto"`` latches a detected type — never the unreachable fallback."""
+
+    @staticmethod
+    def _auto_plc() -> AllenBradleyPLC:
+        return AllenBradleyPLC(
+            plc_name="PLC1", ip_address="192.168.1.100", plc_type="auto", retry_count=1, retry_delay=0.0
+        )
+
+    async def test_an_unreachable_device_does_not_latch_cip(self, monkeypatch):
+        """Nothing answered, so "cip" is a guess for this attempt only."""
+
+        def _dead(ip_address):
+            driver = FakeLogixDriver()
+            driver.open = lambda: False
+            return driver
+
+        monkeypatch.setattr(ab_module, "LogixDriver", _dead)
+        monkeypatch.setattr(ab_module, "SLCDriver", _dead)
+        monkeypatch.setattr(ab_module, "CIPDriver", SimpleNamespace(list_identity=lambda host: None))
+        plc = self._auto_plc()
+
+        assert await plc._detect_plc_type() is None
+        assert await plc._resolve_plc_type() == "cip"
+        assert plc.plc_type == "auto"
+
+    async def test_a_device_that_answers_identity_latches_cip(self, monkeypatch):
+        def _dead(ip_address):
+            driver = FakeLogixDriver()
+            driver.open = lambda: False
+            return driver
+
+        monkeypatch.setattr(ab_module, "LogixDriver", _dead)
+        monkeypatch.setattr(ab_module, "SLCDriver", _dead)
+        monkeypatch.setattr(
+            ab_module, "CIPDriver", SimpleNamespace(list_identity=lambda host: {"product_name": "PowerFlex 525"})
+        )
+        plc = self._auto_plc()
+
+        assert await plc._resolve_plc_type() == "cip"
+        assert plc.plc_type == "cip"

--- a/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
+++ b/tests/unit/mindtrace/hardware/plcs/backends/test_plc_transport_contract.py
@@ -947,6 +947,27 @@ class TestAllenBradleyChannelLifecycle:
         assert plc._write_driver is write_driver
         assert write_driver.connected is True
 
+    async def test_a_reopen_reuses_the_family_connect_resolved(self, monkeypatch):
+        """An entry reopen must not re-detect the PLC family: a failed detection
+        falls back to CIPDriver and would drift ``driver_type`` while the other
+        channel still holds a LogixDriver."""
+        read_driver = FakeLogixDriver(read_error=_socket_death_comm_error())
+        replacement = FakeLogixDriver(read_results=[_tag(value=42)])
+        monkeypatch.setattr(ab_module, "LogixDriver", lambda ip_address: replacement)
+        plc = _allen_bradley(read_driver, FakeLogixDriver())
+
+        async def _no_redetect():
+            raise AssertionError("a reopen must not re-detect the PLC family")
+
+        monkeypatch.setattr(plc, "_resolve_plc_type", _no_redetect)
+
+        with pytest.raises(PLCCommunicationError):
+            await plc.read_tag(["Tag1"])
+        results = await plc.read_tag(["Tag1"])  # reopens without re-detection
+
+        assert results["Tag1"].value == 42
+        assert plc.driver_type == "LogixDriver"
+
     async def test_a_closed_write_channel_reopens_at_entry(self, monkeypatch):
         read_driver = FakeLogixDriver()
         write_driver = FakeLogixDriver(write_error=_socket_death_comm_error())

--- a/tests/unit/mindtrace/hardware/plcs/test_plc_manager.py
+++ b/tests/unit/mindtrace/hardware/plcs/test_plc_manager.py
@@ -485,7 +485,7 @@ class TestPLCManagerTagOperations:
 
         assert result["Tag1"].ok is True
         assert result["Missing"].ok is False
-        assert result["Missing"].value is None
+        assert result["Missing"].value_or(None) is None
         assert result["Missing"].error.kind is TagErrorKind.missing_tag
         assert result["Missing"].error.message == "no such tag"
 
@@ -558,7 +558,7 @@ class TestPLCManagerTagOperations:
 
         assert result["Tag1"].ok is True
         assert result["Tag2"].ok is False
-        assert result["Tag2"].value is None
+        assert result["Tag2"].value_or(None) is None
         assert result["Tag2"].error.kind is TagErrorKind.type_mismatch
 
     @pytest.mark.asyncio

--- a/tests/unit/mindtrace/hardware/plcs/test_plc_manager.py
+++ b/tests/unit/mindtrace/hardware/plcs/test_plc_manager.py
@@ -13,12 +13,14 @@ import pytest
 import pytest_asyncio
 
 from mindtrace.hardware.core.exceptions import (
+    PLCCommunicationError,
     PLCConnectionError,
     PLCNotFoundError,
     PLCTagError,
     PLCTagReadError,
     PLCTagWriteError,
 )
+from mindtrace.hardware.plcs import TagError, TagErrorKind, TagResult
 
 
 @pytest.fixture(scope="session")
@@ -54,8 +56,8 @@ def mock_plc_instance():
     mock_plc.connect = AsyncMock(return_value=True)
     mock_plc.disconnect = AsyncMock(return_value=True)
     mock_plc.is_connected = AsyncMock(return_value=False)
-    mock_plc.read_tag_with_retry = AsyncMock(return_value={"Tag1": 100, "Tag2": 200})
-    mock_plc.write_tag_with_retry = AsyncMock(return_value={"Tag1": True, "Tag2": True})
+    mock_plc.read_tag = AsyncMock(return_value={"Tag1": TagResult(value=100), "Tag2": TagResult(value=200)})
+    mock_plc.write_tag = AsyncMock(return_value={"Tag1": TagResult(value=100), "Tag2": TagResult(value=200)})
     mock_plc.get_all_tags = AsyncMock(return_value=["Tag1", "Tag2", "Tag3"])
     mock_plc.get_plc_info = AsyncMock(return_value={"name": "TestPLC", "connected": True})
     mock_plc.__class__.__name__ = "MockAllenBradleyPLC"
@@ -442,64 +444,100 @@ class TestPLCManagerTagOperations:
     async def test_read_tag_single(self, mock_plc_manager, mock_plc_instance):
         """Test reading a single tag."""
         mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
-        mock_plc_instance.read_tag_with_retry.return_value = {"Tag1": 100}
+        mock_plc_instance.read_tag.return_value = {"Tag1": TagResult(value=100)}
 
         result = await mock_plc_manager.read_tag("TestPLC", "Tag1")
 
         assert "Tag1" in result
-        assert result["Tag1"] == 100
-        mock_plc_instance.read_tag_with_retry.assert_called_once_with("Tag1")
+        assert result["Tag1"].ok is True
+        assert result["Tag1"].value == 100
+        mock_plc_instance.read_tag.assert_called_once_with("Tag1")
 
     @pytest.mark.asyncio
     async def test_read_tag_multiple(self, mock_plc_manager, mock_plc_instance):
         """Test reading multiple tags."""
         mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
-        mock_plc_instance.read_tag_with_retry.return_value = {"Tag1": 100, "Tag2": 200}
+        mock_plc_instance.read_tag.return_value = {"Tag1": TagResult(value=100), "Tag2": TagResult(value=200)}
 
         result = await mock_plc_manager.read_tag("TestPLC", ["Tag1", "Tag2"])
 
         assert len(result) == 2
-        assert result["Tag1"] == 100
-        assert result["Tag2"] == 200
+        assert result["Tag1"].value == 100
+        assert result["Tag2"].value == 200
+        mock_plc_instance.read_tag.assert_called_once_with(["Tag1", "Tag2"])
 
     @pytest.mark.asyncio
     async def test_read_tag_not_registered(self, mock_plc_manager):
         """Test reading tag from non-registered PLC."""
         with pytest.raises(PLCNotFoundError):
-            await mock_plc_manager.read_tag("NonExistentPLC", "Tag1")
+            await mock_plc_manager.read_tag("NonExistentPLC", ["Tag1"])
 
     @pytest.mark.asyncio
-    async def test_read_tag_exception(self, mock_plc_manager, mock_plc_instance):
-        """Test reading tag when exception is raised."""
+    async def test_read_tag_per_tag_error_is_passed_through(self, mock_plc_manager, mock_plc_instance):
+        """A per-tag failure comes back as TagResult.error, not as an exception."""
         mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
-        mock_plc_instance.read_tag_with_retry.side_effect = Exception("Read failed")
+        mock_plc_instance.read_tag.return_value = {
+            "Tag1": TagResult(value=100),
+            "Missing": TagResult(error=TagError(kind=TagErrorKind.missing_tag, message="no such tag")),
+        }
 
-        with pytest.raises(PLCTagReadError):
-            await mock_plc_manager.read_tag("TestPLC", "Tag1")
+        result = await mock_plc_manager.read_tag("TestPLC", ["Tag1", "Missing"])
+
+        assert result["Tag1"].ok is True
+        assert result["Missing"].ok is False
+        assert result["Missing"].value is None
+        assert result["Missing"].error.kind is TagErrorKind.missing_tag
+        assert result["Missing"].error.message == "no such tag"
+
+    @pytest.mark.asyncio
+    async def test_read_tag_backend_exception_propagates_untouched(self, mock_plc_manager, mock_plc_instance):
+        """Whole-call failures keep their type: the manager no longer re-wraps them."""
+        mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
+        original = PLCCommunicationError("socket closed")
+        mock_plc_instance.read_tag.side_effect = original
+
+        with pytest.raises(PLCCommunicationError) as excinfo:
+            await mock_plc_manager.read_tag("TestPLC", ["Tag1"])
+
+        assert excinfo.value is original
+
+    @pytest.mark.asyncio
+    async def test_read_tag_read_error_not_rewrapped(self, mock_plc_manager, mock_plc_instance):
+        """A backend PLCTagReadError reaches the caller as the same instance."""
+        mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
+        original = PLCTagReadError("Read failed")
+        mock_plc_instance.read_tag.side_effect = original
+
+        with pytest.raises(PLCTagReadError) as excinfo:
+            await mock_plc_manager.read_tag("TestPLC", ["Tag1"])
+
+        assert excinfo.value is original
 
     @pytest.mark.asyncio
     async def test_write_tag_single(self, mock_plc_manager, mock_plc_instance):
         """Test writing a single tag."""
         mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
-        mock_plc_instance.write_tag_with_retry.return_value = {"Tag1": True}
+        mock_plc_instance.write_tag.return_value = {"Tag1": TagResult(value=100)}
 
         result = await mock_plc_manager.write_tag("TestPLC", ("Tag1", 100))
 
         assert "Tag1" in result
-        assert result["Tag1"] is True
-        mock_plc_instance.write_tag_with_retry.assert_called_once_with(("Tag1", 100))
+        assert result["Tag1"].ok is True
+        assert result["Tag1"].value == 100
+        mock_plc_instance.write_tag.assert_called_once_with(("Tag1", 100))
 
     @pytest.mark.asyncio
     async def test_write_tag_multiple(self, mock_plc_manager, mock_plc_instance):
         """Test writing multiple tags."""
         mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
-        mock_plc_instance.write_tag_with_retry.return_value = {"Tag1": True, "Tag2": True}
+        mock_plc_instance.write_tag.return_value = {"Tag1": TagResult(value=100), "Tag2": TagResult(value=200)}
 
         result = await mock_plc_manager.write_tag("TestPLC", [("Tag1", 100), ("Tag2", 200)])
 
         assert len(result) == 2
-        assert result["Tag1"] is True
-        assert result["Tag2"] is True
+        assert result["Tag1"].value == 100
+        assert result["Tag2"].value == 200
+        mock_plc_instance.write_tag.assert_called_once_with([("Tag1", 100), ("Tag2", 200)])
 
     @pytest.mark.asyncio
     async def test_write_tag_not_registered(self, mock_plc_manager):
@@ -508,59 +546,94 @@ class TestPLCManagerTagOperations:
             await mock_plc_manager.write_tag("NonExistentPLC", [("Tag1", 100)])
 
     @pytest.mark.asyncio
-    async def test_write_tag_exception(self, mock_plc_manager, mock_plc_instance):
-        """Test writing tag when exception is raised."""
+    async def test_write_tag_per_tag_error_is_passed_through(self, mock_plc_manager, mock_plc_instance):
+        """A rejected value comes back as TagResult.error, not as an exception."""
         mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
-        mock_plc_instance.write_tag_with_retry.side_effect = Exception("Write failed")
+        mock_plc_instance.write_tag.return_value = {
+            "Tag1": TagResult(value=100),
+            "Tag2": TagResult(error=TagError(kind=TagErrorKind.type_mismatch, message="not a DINT")),
+        }
 
-        with pytest.raises(PLCTagWriteError):
+        result = await mock_plc_manager.write_tag("TestPLC", [("Tag1", 100), ("Tag2", "nope")])
+
+        assert result["Tag1"].ok is True
+        assert result["Tag2"].ok is False
+        assert result["Tag2"].value is None
+        assert result["Tag2"].error.kind is TagErrorKind.type_mismatch
+
+    @pytest.mark.asyncio
+    async def test_write_tag_backend_exception_propagates_untouched(self, mock_plc_manager, mock_plc_instance):
+        """Whole-call failures keep their type: the manager no longer re-wraps them."""
+        mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
+        original = PLCCommunicationError("socket closed")
+        mock_plc_instance.write_tag.side_effect = original
+
+        with pytest.raises(PLCCommunicationError) as excinfo:
             await mock_plc_manager.write_tag("TestPLC", [("Tag1", 100)])
+
+        assert excinfo.value is original
+
+    @pytest.mark.asyncio
+    async def test_write_tag_write_error_not_rewrapped(self, mock_plc_manager, mock_plc_instance):
+        """A backend PLCTagWriteError reaches the caller as the same instance."""
+        mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
+        original = PLCTagWriteError("Write failed")
+        mock_plc_instance.write_tag.side_effect = original
+
+        with pytest.raises(PLCTagWriteError) as excinfo:
+            await mock_plc_manager.write_tag("TestPLC", [("Tag1", 100)])
+
+        assert excinfo.value is original
 
     @pytest.mark.asyncio
     async def test_read_tags_batch_success(self, mock_plc_manager):
         """Test batch tag reading successfully."""
         mock_plc1 = MagicMock()
-        mock_plc1.read_tag_with_retry = AsyncMock(return_value={"Tag1": 100})
+        mock_plc1.read_tag = AsyncMock(return_value={"Tag1": TagResult(value=100)})
         mock_plc2 = MagicMock()
-        mock_plc2.read_tag_with_retry = AsyncMock(return_value={"Tag2": 200})
+        mock_plc2.read_tag = AsyncMock(return_value={"Tag2": TagResult(value=200)})
 
         mock_plc_manager.plcs = {"PLC1": mock_plc1, "PLC2": mock_plc2}
 
-        requests = [("PLC1", "Tag1"), ("PLC2", "Tag2")]
+        requests = [("PLC1", ["Tag1"]), ("PLC2", ["Tag2"])]
         results = await mock_plc_manager.read_tags_batch(requests)
 
         assert isinstance(results, dict)
         assert "PLC1" in results
         assert "PLC2" in results
-        assert results["PLC1"]["Tag1"] == 100
-        assert results["PLC2"]["Tag2"] == 200
+        assert results["PLC1"]["Tag1"].value == 100
+        assert results["PLC2"]["Tag2"].value == 200
+        mock_plc1.read_tag.assert_called_once_with(["Tag1"])
+        mock_plc2.read_tag.assert_called_once_with(["Tag2"])
 
     @pytest.mark.asyncio
     async def test_read_tags_batch_with_exception(self, mock_plc_manager):
         """Test batch tag reading with exceptions."""
         mock_plc1 = MagicMock()
-        mock_plc1.read_tag_with_retry = AsyncMock(return_value={"Tag1": 100})
+        mock_plc1.read_tag = AsyncMock(return_value={"Tag1": TagResult(value=100)})
         mock_plc2 = MagicMock()
-        mock_plc2.read_tag_with_retry = AsyncMock(side_effect=Exception("Read failed"))
+        mock_plc2.read_tag = AsyncMock(side_effect=PLCTagReadError("Read failed"))
 
         mock_plc_manager.plcs = {"PLC1": mock_plc1, "PLC2": mock_plc2}
 
-        requests = [("PLC1", "Tag1"), ("PLC2", "Tag2")]
+        requests = [("PLC1", ["Tag1"]), ("PLC2", ["Tag2"])]
         results = await mock_plc_manager.read_tags_batch(requests)
 
         assert "PLC1" in results
         assert "PLC2" in results
+        assert results["PLC1"]["Tag1"].value == 100
         assert "error" in results["PLC2"]
+        assert "Read failed" in results["PLC2"]["error"]
 
     @pytest.mark.asyncio
     async def test_read_tags_batch_not_registered(self, mock_plc_manager):
         """Test batch tag reading with non-registered PLC."""
         mock_plc1 = MagicMock()
-        mock_plc1.read_tag_with_retry = AsyncMock(return_value={"Tag1": 100})
+        mock_plc1.read_tag = AsyncMock(return_value={"Tag1": TagResult(value=100)})
 
         mock_plc_manager.plcs = {"PLC1": mock_plc1}
 
-        requests = [("PLC1", "Tag1"), ("NonExistentPLC", "Tag2")]
+        requests = [("PLC1", ["Tag1"]), ("NonExistentPLC", ["Tag2"])]
         results = await mock_plc_manager.read_tags_batch(requests)
 
         assert "PLC1" in results
@@ -579,9 +652,9 @@ class TestPLCManagerTagOperations:
     async def test_write_tags_batch_success(self, mock_plc_manager):
         """Test batch tag writing successfully."""
         mock_plc1 = MagicMock()
-        mock_plc1.write_tag_with_retry = AsyncMock(return_value={"Tag1": True})
+        mock_plc1.write_tag = AsyncMock(return_value={"Tag1": TagResult(value=100)})
         mock_plc2 = MagicMock()
-        mock_plc2.write_tag_with_retry = AsyncMock(return_value={"Tag2": True})
+        mock_plc2.write_tag = AsyncMock(return_value={"Tag2": TagResult(value=200)})
 
         mock_plc_manager.plcs = {"PLC1": mock_plc1, "PLC2": mock_plc2}
 
@@ -591,16 +664,18 @@ class TestPLCManagerTagOperations:
         assert isinstance(results, dict)
         assert "PLC1" in results
         assert "PLC2" in results
-        assert results["PLC1"]["Tag1"] is True
-        assert results["PLC2"]["Tag2"] is True
+        assert results["PLC1"]["Tag1"].ok is True
+        assert results["PLC2"]["Tag2"].ok is True
+        mock_plc1.write_tag.assert_called_once_with([("Tag1", 100)])
+        mock_plc2.write_tag.assert_called_once_with([("Tag2", 200)])
 
     @pytest.mark.asyncio
     async def test_write_tags_batch_with_exception(self, mock_plc_manager):
         """Test batch tag writing with exceptions."""
         mock_plc1 = MagicMock()
-        mock_plc1.write_tag_with_retry = AsyncMock(return_value={"Tag1": True})
+        mock_plc1.write_tag = AsyncMock(return_value={"Tag1": TagResult(value=100)})
         mock_plc2 = MagicMock()
-        mock_plc2.write_tag_with_retry = AsyncMock(side_effect=Exception("Write failed"))
+        mock_plc2.write_tag = AsyncMock(side_effect=PLCTagWriteError("Write failed"))
 
         mock_plc_manager.plcs = {"PLC1": mock_plc1, "PLC2": mock_plc2}
 
@@ -609,13 +684,15 @@ class TestPLCManagerTagOperations:
 
         assert "PLC1" in results
         assert "PLC2" in results
+        assert results["PLC1"]["Tag1"].ok is True
         assert "error" in results["PLC2"]
+        assert "Write failed" in results["PLC2"]["error"]
 
     @pytest.mark.asyncio
     async def test_write_tags_batch_not_registered(self, mock_plc_manager):
         """Test batch tag writing with non-registered PLC."""
         mock_plc1 = MagicMock()
-        mock_plc1.write_tag_with_retry = AsyncMock(return_value={"Tag1": True})
+        mock_plc1.write_tag = AsyncMock(return_value={"Tag1": TagResult(value=100)})
 
         mock_plc_manager.plcs = {"PLC1": mock_plc1}
 
@@ -878,40 +955,40 @@ class TestPLCManagerEdgeCases:
         """Test that batch tag reading executes concurrently."""
         import time
 
-        async def slow_read(tags):
+        async def slow_read(addresses):
             await asyncio.sleep(0.1)
-            return {"Tag1": 100}
+            return {"Tag1": TagResult(value=100)}
 
         mock_plc1 = MagicMock()
-        mock_plc1.read_tag_with_retry = slow_read
+        mock_plc1.read_tag = slow_read
         mock_plc2 = MagicMock()
-        mock_plc2.read_tag_with_retry = slow_read
+        mock_plc2.read_tag = slow_read
 
         mock_plc_manager.plcs = {"PLC1": mock_plc1, "PLC2": mock_plc2}
 
         start_time = time.time()
-        requests = [("PLC1", "Tag1"), ("PLC2", "Tag1")]
+        requests = [("PLC1", ["Tag1"]), ("PLC2", ["Tag1"])]
         results = await mock_plc_manager.read_tags_batch(requests)
         elapsed_time = time.time() - start_time
 
         # Should take approximately 0.1s (concurrent), not 0.2s (sequential)
         assert elapsed_time < 0.15
-        assert "PLC1" in results
-        assert "PLC2" in results
+        assert results["PLC1"]["Tag1"].value == 100
+        assert results["PLC2"]["Tag1"].value == 100
 
     @pytest.mark.asyncio
     async def test_write_tags_batch_concurrent_execution(self, mock_plc_manager):
         """Test that batch tag writing executes concurrently."""
         import time
 
-        async def slow_write(tags):
+        async def slow_write(writes):
             await asyncio.sleep(0.1)
-            return {"Tag1": True}
+            return {"Tag1": TagResult(value=writes[0][1])}
 
         mock_plc1 = MagicMock()
-        mock_plc1.write_tag_with_retry = slow_write
+        mock_plc1.write_tag = slow_write
         mock_plc2 = MagicMock()
-        mock_plc2.write_tag_with_retry = slow_write
+        mock_plc2.write_tag = slow_write
 
         mock_plc_manager.plcs = {"PLC1": mock_plc1, "PLC2": mock_plc2}
 
@@ -922,8 +999,8 @@ class TestPLCManagerEdgeCases:
 
         # Should take approximately 0.1s (concurrent), not 0.2s (sequential)
         assert elapsed_time < 0.15
-        assert "PLC1" in results
-        assert "PLC2" in results
+        assert results["PLC1"]["Tag1"].value == 100
+        assert results["PLC2"]["Tag1"].value == 200
 
     @pytest.mark.asyncio
     async def test_multiple_operations_on_same_plc(self, mock_plc_manager, mock_plc_instance):
@@ -934,10 +1011,10 @@ class TestPLCManagerEdgeCases:
         await mock_plc_manager.connect_plc("TestPLC")
 
         # Read
-        await mock_plc_manager.read_tag("TestPLC", "Tag1")
+        read = await mock_plc_manager.read_tag("TestPLC", ["Tag1"])
 
         # Write
-        await mock_plc_manager.write_tag("TestPLC", [("Tag1", 100)])
+        written = await mock_plc_manager.write_tag("TestPLC", [("Tag1", 100)])
 
         # Get status
         status = await mock_plc_manager.get_plc_status("TestPLC")
@@ -949,5 +1026,7 @@ class TestPLCManagerEdgeCases:
         await mock_plc_manager.disconnect_plc("TestPLC")
 
         # All operations should succeed
+        assert read["Tag1"].ok is True
+        assert written["Tag1"].ok is True
         assert status["name"] == "TestPLC"
         assert len(tags) > 0

--- a/tests/unit/mindtrace/hardware/plcs/test_plc_manager.py
+++ b/tests/unit/mindtrace/hardware/plcs/test_plc_manager.py
@@ -244,6 +244,17 @@ class TestPLCManagerRegistration:
             assert success is False
 
     @pytest.mark.asyncio
+    async def test_register_plc_lets_a_bad_keyword_escape(self, mock_plc_manager):
+        """A constructor signature mismatch is a programming error, not a failed
+        registration — swallowing it into False points the blame at the registry."""
+        with pytest.raises(TypeError):
+            await mock_plc_manager.register_plc(
+                "TestPLC", "AllenBradley", "192.168.1.100", plc_type="logix", retry_count=3
+            )
+
+        assert "TestPLC" not in mock_plc_manager.plcs
+
+    @pytest.mark.asyncio
     async def test_register_plc_with_kwargs(self, mock_plc_manager, mock_plc_instance):
         """Test registering PLC with additional kwargs."""
         mock_backend_class = MagicMock(return_value=mock_plc_instance)
@@ -268,6 +279,17 @@ class TestPLCManagerRegistration:
 
         assert success is True
         assert "TestPLC" not in mock_plc_manager.plcs
+
+    @pytest.mark.asyncio
+    async def test_unregister_plc_disconnects_a_half_open_plc(self, mock_plc_manager, mock_plc_instance):
+        """A PLC reporting not-connected can still hold a live channel session."""
+        mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
+        mock_plc_instance.is_connected.return_value = False
+
+        success = await mock_plc_manager.unregister_plc("TestPLC")
+
+        assert success is True
+        mock_plc_instance.disconnect.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_unregister_plc_not_found(self, mock_plc_manager):

--- a/tests/unit/mindtrace/hardware/plcs/test_plc_manager.py
+++ b/tests/unit/mindtrace/hardware/plcs/test_plc_manager.py
@@ -16,7 +16,6 @@ from mindtrace.hardware.core.exceptions import (
     PLCCommunicationError,
     PLCConnectionError,
     PLCNotFoundError,
-    PLCTagError,
     PLCTagReadError,
     PLCTagWriteError,
 )
@@ -739,10 +738,9 @@ class TestPLCManagerStatus:
 
     @pytest.mark.asyncio
     async def test_get_plc_status_success(self, mock_plc_manager, mock_plc_instance):
-        """Test getting PLC status successfully."""
+        """Status is the manager's LOCAL knowledge: no wire probe is made."""
         mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
         mock_plc_instance.is_connected.return_value = True
-        mock_plc_instance.get_plc_info.return_value = {"name": "TestPLC", "connected": True, "product_name": "Mock PLC"}
 
         status = await mock_plc_manager.get_plc_status("TestPLC")
 
@@ -751,7 +749,7 @@ class TestPLCManagerStatus:
         assert status["connected"] is True
         assert status["initialized"] is False
         assert status["backend"] == "MockAllenBradleyPLC"
-        assert "product_name" in status
+        mock_plc_instance.get_plc_info.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_plc_status_not_registered(self, mock_plc_manager):
@@ -771,27 +769,28 @@ class TestPLCManagerStatus:
         assert "product_name" not in status
 
     @pytest.mark.asyncio
-    async def test_get_plc_status_get_plc_info_exception(self, mock_plc_manager, mock_plc_instance):
-        """Test getting PLC status when get_plc_info raises exception."""
+    async def test_get_plc_info_is_a_typed_passthrough(self, mock_plc_manager, mock_plc_instance):
+        """Info is the device's testimony: typed failures propagate unwrapped."""
         mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
-        mock_plc_instance.get_plc_info.side_effect = Exception("Info failed")
+        mock_plc_instance.get_plc_info.side_effect = PLCCommunicationError("PLC info read failed")
 
-        status = await mock_plc_manager.get_plc_status("TestPLC")
+        with pytest.raises(PLCCommunicationError, match="PLC info read failed"):
+            await mock_plc_manager.get_plc_info("TestPLC")
 
-        assert status["name"] == "TestPLC"
-        assert "info_error" in status
+        with pytest.raises(PLCNotFoundError):
+            await mock_plc_manager.get_plc_info("Ghost")
 
     @pytest.mark.asyncio
-    async def test_get_plc_status_exception(self, mock_plc_manager, mock_plc_instance):
-        """Test getting PLC status when exception is raised."""
+    async def test_get_all_plc_status_shields_the_fleet_view(self, mock_plc_manager, mock_plc_instance):
+        """One broken backend must not take down the aggregate report; its entry
+        carries only honest fields."""
         mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
         mock_plc_instance.is_connected.side_effect = Exception("Status failed")
 
-        status = await mock_plc_manager.get_plc_status("TestPLC")
+        results = await mock_plc_manager.get_all_plc_status()
 
-        assert "error" in status
-        assert status["connected"] is False
-        assert status["initialized"] is False
+        assert "Status failed" in results["TestPLC"]["error"]
+        assert "connected" not in results["TestPLC"]  # never fabricated
 
     @pytest.mark.asyncio
     async def test_get_all_plc_status_success(self, mock_plc_manager):
@@ -864,12 +863,13 @@ class TestPLCManagerTagListing:
             await mock_plc_manager.get_plc_tags("NonExistentPLC")
 
     @pytest.mark.asyncio
-    async def test_get_plc_tags_exception(self, mock_plc_manager, mock_plc_instance):
-        """Test getting tags when exception is raised."""
+    async def test_get_plc_tags_is_a_typed_passthrough(self, mock_plc_manager, mock_plc_instance):
+        """Backend exceptions propagate unwrapped: link trouble must never be
+        re-labelled as a tag error by the manager."""
         mock_plc_manager.plcs["TestPLC"] = mock_plc_instance
-        mock_plc_instance.get_all_tags.side_effect = Exception("Get tags failed")
+        mock_plc_instance.get_all_tags.side_effect = PLCCommunicationError("Tag discovery failed")
 
-        with pytest.raises(PLCTagError):
+        with pytest.raises(PLCCommunicationError, match="Tag discovery failed"):
             await mock_plc_manager.get_plc_tags("TestPLC")
 
 

--- a/tests/unit/mindtrace/hardware/plcs/test_plcs.py
+++ b/tests/unit/mindtrace/hardware/plcs/test_plcs.py
@@ -11,6 +11,9 @@ import asyncio
 import pytest
 import pytest_asyncio
 
+from mindtrace.hardware.core.exceptions import PLCNotFoundError
+from mindtrace.hardware.plcs import TagErrorKind
+
 
 # Fixtures
 @pytest.fixture(scope="session")
@@ -153,11 +156,12 @@ class TestLogixDriverFunctionality:
         assert "Motor1_Speed" in results
         assert "Conveyor_Status" in results
         assert "Production_Count" in results
+        assert all(result.ok for result in results.values())
 
         # Verify data types
-        assert isinstance(results["Motor1_Speed"], float)
-        assert isinstance(results["Conveyor_Status"], bool)
-        assert isinstance(results["Production_Count"], int)
+        assert isinstance(results["Motor1_Speed"].value, float)
+        assert isinstance(results["Conveyor_Status"].value, bool)
+        assert isinstance(results["Production_Count"].value, int)
 
     @pytest.mark.asyncio
     async def test_logix_tag_writing(self):
@@ -170,11 +174,13 @@ class TestLogixDriverFunctionality:
         # Test writing single tag (use a tag that won't get variation)
         write_result = await plc.write_tag([("Production_Count", 2000)])
         assert isinstance(write_result, dict)
-        assert write_result["Production_Count"] is True
+        assert write_result["Production_Count"].ok is True
+        assert write_result["Production_Count"].value == 2000
 
         # Verify the write by reading back
         read_result = await plc.read_tag("Production_Count")
-        assert read_result["Production_Count"] == 2000
+        assert read_result["Production_Count"].ok is True
+        assert read_result["Production_Count"].value == 2000
 
     @pytest.mark.asyncio
     async def test_logix_tag_discovery(self):
@@ -217,12 +223,13 @@ class TestSLCDriverFunctionality:
         assert "B3:0" in results
         assert "T4:0.PRE" in results
         assert "C5:0.ACC" in results
+        assert all(result.ok for result in results.values())
 
         # Verify SLC data types
-        assert isinstance(results["N7:0"], int)  # Integer file
-        assert isinstance(results["B3:0"], bool)  # Binary file
-        assert isinstance(results["T4:0.PRE"], int)  # Timer preset
-        assert isinstance(results["C5:0.ACC"], int)  # Counter accumulated
+        assert isinstance(results["N7:0"].value, int)  # Integer file
+        assert isinstance(results["B3:0"].value, bool)  # Binary file
+        assert isinstance(results["T4:0.PRE"].value, int)  # Timer preset
+        assert isinstance(results["C5:0.ACC"].value, int)  # Counter accumulated
 
     @pytest.mark.asyncio
     async def test_slc_timer_operations(self):
@@ -237,11 +244,12 @@ class TestSLCDriverFunctionality:
         results = await plc.read_tag(timer_tags)
 
         assert len(results) == 5
-        assert isinstance(results["T4:0.PRE"], int)  # Preset value
-        assert isinstance(results["T4:0.ACC"], int)  # Accumulated value
-        assert isinstance(results["T4:0.EN"], bool)  # Enable bit
-        assert isinstance(results["T4:0.TT"], bool)  # Timer timing bit
-        assert isinstance(results["T4:0.DN"], bool)  # Done bit
+        assert all(result.ok for result in results.values())
+        assert isinstance(results["T4:0.PRE"].value, int)  # Preset value
+        assert isinstance(results["T4:0.ACC"].value, int)  # Accumulated value
+        assert isinstance(results["T4:0.EN"].value, bool)  # Enable bit
+        assert isinstance(results["T4:0.TT"].value, bool)  # Timer timing bit
+        assert isinstance(results["T4:0.DN"].value, bool)  # Done bit
 
     @pytest.mark.asyncio
     async def test_slc_counter_operations(self):
@@ -256,10 +264,11 @@ class TestSLCDriverFunctionality:
         results = await plc.read_tag(counter_tags)
 
         assert len(results) == 4
-        assert isinstance(results["C5:0.PRE"], int)  # Preset value
-        assert isinstance(results["C5:0.ACC"], int)  # Accumulated value
-        assert isinstance(results["C5:0.CU"], bool)  # Count up bit
-        assert isinstance(results["C5:0.DN"], bool)  # Done bit
+        assert all(result.ok for result in results.values())
+        assert isinstance(results["C5:0.PRE"].value, int)  # Preset value
+        assert isinstance(results["C5:0.ACC"].value, int)  # Accumulated value
+        assert isinstance(results["C5:0.CU"].value, bool)  # Count up bit
+        assert isinstance(results["C5:0.DN"].value, bool)  # Done bit
 
     @pytest.mark.asyncio
     async def test_slc_io_operations(self):
@@ -274,10 +283,11 @@ class TestSLCDriverFunctionality:
         results = await plc.read_tag(io_tags)
 
         assert len(results) == 4
-        assert isinstance(results["I:0.0"], int)  # Input word
-        assert isinstance(results["O:0.0"], int)  # Output word
-        assert isinstance(results["I:0.0/0"], bool)  # Input bit
-        assert isinstance(results["O:0.0/1"], bool)  # Output bit
+        assert all(result.ok for result in results.values())
+        assert isinstance(results["I:0.0"].value, int)  # Input word
+        assert isinstance(results["O:0.0"].value, int)  # Output word
+        assert isinstance(results["I:0.0/0"].value, bool)  # Input bit
+        assert isinstance(results["O:0.0/1"].value, bool)  # Output bit
 
 
 class TestCIPDriverFunctionality:
@@ -298,10 +308,11 @@ class TestCIPDriverFunctionality:
         assert isinstance(results, dict)
         assert "Assembly:20" in results
         assert "Assembly:21" in results
+        assert all(result.ok for result in results.values())
 
         # Assembly objects should return lists (I/O data)
-        assert isinstance(results["Assembly:20"], list)
-        assert isinstance(results["Assembly:21"], list)
+        assert isinstance(results["Assembly:20"].value, list)
+        assert isinstance(results["Assembly:21"].value, list)
 
     @pytest.mark.asyncio
     async def test_cip_parameter_operations(self):
@@ -321,8 +332,9 @@ class TestCIPDriverFunctionality:
         assert "Parameter:3" in results  # Torque Reference
 
         # Parameters should be numeric values
-        for param_value in results.values():
-            assert isinstance(param_value, (int, float))
+        for param_result in results.values():
+            assert param_result.ok is True
+            assert isinstance(param_result.value, (int, float))
 
     @pytest.mark.asyncio
     async def test_cip_identity_operations(self):
@@ -338,9 +350,10 @@ class TestCIPDriverFunctionality:
 
         assert "Identity" in results
         assert "DeviceInfo" in results
+        assert all(result.ok for result in results.values())
 
         # Identity should be a dictionary with device information
-        identity = results["Identity"]
+        identity = results["Identity"].value
         assert isinstance(identity, dict)
         assert "vendor_id" in identity
         assert "device_type" in identity
@@ -409,10 +422,42 @@ class TestPLCManager:
             [("BatchTest0", ["Production_Count"]), ("BatchTest1", ["N7:0"]), ("BatchTest2", ["Parameter:1"])]
         )
         assert isinstance(tag_results, dict)
+        assert tag_results["BatchTest0"]["Production_Count"].ok is True
+        assert tag_results["BatchTest1"]["N7:0"].ok is True
+        assert tag_results["BatchTest2"]["Parameter:1"].ok is True
+
+        # Test batch tag writing using correct method
+        write_results = await manager.write_tags_batch(
+            [("BatchTest0", [("Production_Count", 4242)]), ("BatchTest1", [("N7:0", 7)])]
+        )
+        assert isinstance(write_results, dict)
+        assert write_results["BatchTest0"]["Production_Count"].ok is True
+        assert write_results["BatchTest0"]["Production_Count"].value == 4242
+        assert write_results["BatchTest1"]["N7:0"].ok is True
 
         # Test batch disconnection
         results = await manager.disconnect_all_plcs()
         assert isinstance(results, dict)
+
+    @pytest.mark.asyncio
+    async def test_manager_tag_round_trip(self, mock_plc_manager):
+        """Read and write a single PLC's tags through the manager."""
+        manager = mock_plc_manager
+
+        assert await manager.register_plc("RoundTrip", "AllenBradley", "192.168.1.210", plc_type="logix")
+        assert await manager.connect_plc("RoundTrip")
+
+        write_results = await manager.write_tag("RoundTrip", [("Production_Count", 321), ("NoSuchTag", 1)])
+        assert write_results["Production_Count"].ok is True
+        assert write_results["Production_Count"].value == 321
+        assert write_results["NoSuchTag"].ok is False
+        assert write_results["NoSuchTag"].error.kind is TagErrorKind.missing_tag
+
+        read_results = await manager.read_tag("RoundTrip", ["Production_Count", "NoSuchTag"])
+        assert read_results["Production_Count"].ok is True
+        assert read_results["Production_Count"].value == 321
+        assert read_results["NoSuchTag"].ok is False
+        assert read_results["NoSuchTag"].error.kind is TagErrorKind.missing_tag
 
     @pytest.mark.asyncio
     async def test_manager_error_handling(self, mock_plc_manager):
@@ -425,10 +470,15 @@ class TestPLCManager:
         assert len(results) == 0
 
         # Test invalid PLC operations
-        try:
+        with pytest.raises(PLCNotFoundError):
             await manager.read_tag("NonExistentPLC", ["SomeTag"])
-        except Exception:
-            pass
+
+        with pytest.raises(PLCNotFoundError):
+            await manager.write_tag("NonExistentPLC", [("SomeTag", 1)])
+
+        # A batch request naming an unregistered PLC reports it inline instead
+        batch = await manager.read_tags_batch([("NonExistentPLC", ["SomeTag"])])
+        assert "error" in batch["NonExistentPLC"]
 
 
 class TestPLCErrorHandling:
@@ -457,10 +507,11 @@ class TestPLCErrorHandling:
         # Mock should handle reads quickly
         result = await plc.read_tag("Motor1_Speed")
         assert "Motor1_Speed" in result
+        assert result["Motor1_Speed"].ok is True
 
     @pytest.mark.asyncio
     async def test_invalid_tag_operations(self):
-        """Test handling of invalid tag operations."""
+        """An unknown tag is a classified per-tag error on both read and write."""
         from mindtrace.hardware.plcs.backends.allen_bradley.mock_allen_bradley import MockAllenBradleyPLC
 
         plc = MockAllenBradleyPLC("InvalidTagTest", "192.168.1.100", plc_type="logix")
@@ -468,11 +519,13 @@ class TestPLCErrorHandling:
 
         # Test reading non-existent tag
         result = await plc.read_tag("NonExistentTag")
-        assert result["NonExistentTag"] is None
+        assert result["NonExistentTag"].ok is False
+        assert result["NonExistentTag"].error.kind is TagErrorKind.missing_tag
 
         # Test writing to non-existent tag
         write_result = await plc.write_tag([("NonExistentTag", 123)])
-        assert write_result["NonExistentTag"] is False
+        assert write_result["NonExistentTag"].ok is False
+        assert write_result["NonExistentTag"].error.kind is TagErrorKind.missing_tag
 
     @pytest.mark.asyncio
     async def test_connection_recovery(self):
@@ -494,7 +547,7 @@ class TestPLCErrorHandling:
 
         # Should still be able to read tags
         result = await plc.read_tag("Motor1_Speed")
-        assert "Motor1_Speed" in result
+        assert result["Motor1_Speed"].ok is True
 
 
 class TestPLCPerformance:
@@ -527,6 +580,7 @@ class TestPLCPerformance:
             for result in results:
                 assert isinstance(result, dict)
                 assert "Production_Count" in result
+                assert result["Production_Count"].ok is True
 
         finally:
             # Cleanup
@@ -548,11 +602,13 @@ class TestPLCPerformance:
         for i in range(10):
             # Write a value
             write_result = await plc.write_tag([("Production_Count", i * 100)])
-            assert write_result["Production_Count"] is True
+            assert write_result["Production_Count"].ok is True
+            assert write_result["Production_Count"].value == i * 100
 
             # Read it back
             read_result = await plc.read_tag("Production_Count")
-            assert read_result["Production_Count"] == i * 100
+            assert read_result["Production_Count"].ok is True
+            assert read_result["Production_Count"].value == i * 100
 
     @pytest.mark.asyncio
     async def test_plc_resource_cleanup(self):
@@ -568,7 +624,7 @@ class TestPLCPerformance:
 
             # Perform some operations
             result = await plc.read_tag("Motor1_Speed")
-            assert "Motor1_Speed" in result
+            assert result["Motor1_Speed"].ok is True
 
             await plc.disconnect()
             assert not await plc.is_connected()
@@ -630,13 +686,13 @@ class TestPLCConfiguration:
             # Test basic operations for each driver type
             if plc_type == "logix":
                 result = await plc.read_tag("Motor1_Speed")
-                assert "Motor1_Speed" in result
+                assert result["Motor1_Speed"].ok is True
             elif plc_type == "slc":
                 result = await plc.read_tag("N7:0")
-                assert "N7:0" in result
+                assert result["N7:0"].ok is True
             elif plc_type == "cip":
                 result = await plc.read_tag("Parameter:1")
-                assert "Parameter:1" in result
+                assert result["Parameter:1"].ok is True
 
             await plc.disconnect()
 
@@ -669,39 +725,47 @@ async def test_plc_integration_scenario():
         slc_data = await slc_plc.read_tag(["N7:0", "B3:0"])
         cip_data = await cip_plc.read_tag(["Parameter:1", "Parameter:2"])
 
-        assert "Production_Count" in logix_data
-        assert "N7:0" in slc_data
-        assert "Parameter:1" in cip_data
+        assert logix_data["Production_Count"].ok is True
+        assert slc_data["N7:0"].ok is True
+        assert cip_data["Parameter:1"].ok is True
+
+        # "Station_Status" is not configured on this controller — the read reports
+        # it as missing instead of handing back a value that was never read.
+        assert logix_data["Station_Status"].ok is False
+        assert logix_data["Station_Status"].error.kind is TagErrorKind.missing_tag
 
         # Test writing to different PLC types
         logix_write = await logix_plc.write_tag([("Production_Count", 1000)])
         slc_write = await slc_plc.write_tag([("N7:0", 500)])
         cip_write = await cip_plc.write_tag([("Parameter:1", 1500.0)])
 
-        assert logix_write["Production_Count"] is True
-        assert slc_write["N7:0"] is True
-        assert cip_write["Parameter:1"] is True
+        assert logix_write["Production_Count"].ok is True
+        assert slc_write["N7:0"].ok is True
+        assert cip_write["Parameter:1"].ok is True
 
         # Verify writes by reading back
         logix_verify = await logix_plc.read_tag("Production_Count")
         slc_verify = await slc_plc.read_tag("N7:0")
         cip_verify = await cip_plc.read_tag("Parameter:1")
 
-        assert logix_verify["Production_Count"] == 1000
-        assert slc_verify["N7:0"] == 500
-        assert cip_verify["Parameter:1"] == 1500.0
+        assert logix_verify["Production_Count"].value == 1000
+        assert slc_verify["N7:0"].value == 500
+        assert cip_verify["Parameter:1"].value == 1500.0
 
         # Test concurrent operations
         import asyncio
 
         concurrent_reads = await asyncio.gather(
-            logix_plc.read_tag(["Production_Count"]), slc_plc.read_tag(["N7:0"]), cip_plc.read_tag(["Parameter:1"])
+            logix_plc.read_tag(["Production_Count"]),
+            slc_plc.read_tag(["N7:0"]),
+            cip_plc.read_tag(["Parameter:1"]),
         )
 
         assert len(concurrent_reads) == 3
         for result in concurrent_reads:
             assert isinstance(result, dict)
             assert len(result) > 0
+            assert all(tag_result.ok for tag_result in result.values())
 
     finally:
         # Cleanup

--- a/tests/unit/mindtrace/hardware/services/plcs/test_hardware_services_plcs_registration.py
+++ b/tests/unit/mindtrace/hardware/services/plcs/test_hardware_services_plcs_registration.py
@@ -1,0 +1,48 @@
+"""The service's registration kwargs must cross the REAL backend constructor.
+
+The endpoint tests stub the manager, so a kwarg the backend constructor no
+longer accepts would only surface at the first customer connect. This seam
+test registers through a real ``PLCManager`` and a real ``AllenBradleyPLC``
+construction (no network is touched until ``connect``, which is stubbed).
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from mindtrace.hardware.plcs.backends.allen_bradley.allen_bradley_plc import AllenBradleyPLC
+from mindtrace.hardware.plcs.plc_manager import PLCManager
+from mindtrace.hardware.services.plcs.models import PLCConnectRequest
+from mindtrace.hardware.services.plcs.service import PLCManagerService
+
+
+def _service(manager):
+    """A stand-in self for the endpoint methods; the Service base is not exercised."""
+    return SimpleNamespace(
+        _get_plc_manager=lambda: manager,
+        logger=logging.getLogger("test.plc.service"),
+    )
+
+
+async def test_connect_plc_registers_through_the_real_constructor(monkeypatch):
+    manager = PLCManager()
+    # The test env swaps in MockAllenBradleyPLC; the seam under test is the real signature.
+    monkeypatch.setattr(manager, "_get_enabled_backends", lambda: {"AllenBradley": AllenBradleyPLC})
+    monkeypatch.setattr(manager, "connect_plc", AsyncMock(return_value=True))
+
+    request = PLCConnectRequest(
+        plc_name="P1",
+        backend="AllenBradley",
+        ip_address="192.0.2.1",
+        plc_type="logix",
+        connection_timeout=1.0,
+        read_timeout=1.0,
+        write_timeout=1.0,
+        retry_delay=0.0,
+    )
+    response = await PLCManagerService.connect_plc(_service(manager), request)
+
+    assert response.data is True
+    assert isinstance(manager.plcs["P1"], AllenBradleyPLC)

--- a/tests/unit/mindtrace/hardware/services/plcs/test_hardware_services_plcs_tag_mapping.py
+++ b/tests/unit/mindtrace/hardware/services/plcs/test_hardware_services_plcs_tag_mapping.py
@@ -1,0 +1,122 @@
+"""The PLC HTTP surface maps TagResult onto its legacy value/bool wire schemas."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from mindtrace.hardware.plcs.types import TagError, TagErrorKind, TagResult
+from mindtrace.hardware.services.plcs.models import (
+    TagBatchReadRequest,
+    TagBatchWriteRequest,
+    TagReadRequest,
+    TagWriteRequest,
+)
+from mindtrace.hardware.services.plcs.service import (
+    PLCManagerService,
+    _adapt_batch,
+    _read_values,
+    _write_flags,
+)
+
+MISSING = TagResult(error=TagError(kind=TagErrorKind.missing_tag, message="Tag doesn't exist"))
+
+
+def _service(manager):
+    """A stand-in self for the endpoint methods; the Service base is not exercised."""
+    return SimpleNamespace(
+        _get_plc_manager=lambda: manager,
+        _total_tag_reads=0,
+        _total_tag_writes=0,
+        logger=logging.getLogger("test.plc.service"),
+    )
+
+
+class TestAdapters:
+    def test_read_values_flattens_errors_to_none(self):
+        assert _read_values({"A": TagResult(value=5), "B": MISSING}) == {"A": 5, "B": None}
+
+    def test_write_flags_reduce_to_success_booleans(self):
+        assert _write_flags({"A": TagResult(value=5), "B": MISSING}) == {"A": True, "B": False}
+
+    def test_adapt_batch_leaves_error_entries_alone(self):
+        batch = {"PLC1": {"A": TagResult(value=1)}, "PLC2": {"error": "PLC 'PLC2' not registered"}}
+
+        assert _adapt_batch(batch, _read_values) == {
+            "PLC1": {"A": 1},
+            "PLC2": {"error": "PLC 'PLC2' not registered"},
+        }
+
+
+class TestEndpointMapping:
+    async def test_read_endpoint_reports_a_failed_tag_as_none(self):
+        manager = SimpleNamespace(read_tag=AsyncMock(return_value={"A": TagResult(value=5), "B": MISSING}))
+
+        response = await PLCManagerService.read_tags(_service(manager), TagReadRequest(plc="PLC1", tags=["A", "B"]))
+
+        manager.read_tag.assert_awaited_once_with("PLC1", ["A", "B"])
+        assert response.data == {"A": 5, "B": None}
+
+    async def test_write_endpoint_reports_a_failed_tag_as_false(self):
+        manager = SimpleNamespace(write_tag=AsyncMock(return_value={"A": TagResult(value=5), "B": MISSING}))
+
+        response = await PLCManagerService.write_tags(
+            _service(manager), TagWriteRequest(plc="PLC1", tags=[("A", 5), ("B", 1)])
+        )
+
+        manager.write_tag.assert_awaited_once_with("PLC1", [("A", 5), ("B", 1)])
+        assert response.data == {"A": True, "B": False}
+
+    async def test_write_endpoint_hands_the_single_write_form_straight_through(self):
+        """The endpoint does no normalizing of its own; BasePLC.write_tag takes the bare pair."""
+        manager = SimpleNamespace(write_tag=AsyncMock(return_value={"A": TagResult(value=5)}))
+
+        response = await PLCManagerService.write_tags(_service(manager), TagWriteRequest(plc="PLC1", tags=("A", 5)))
+
+        manager.write_tag.assert_awaited_once_with("PLC1", ("A", 5))
+        assert response.data == {"A": True}
+
+    async def test_read_endpoint_hands_the_single_tag_form_straight_through(self):
+        """Same for a bare address: the singular shape survives to the backend."""
+        manager = SimpleNamespace(read_tag=AsyncMock(return_value={"A": TagResult(value=5)}))
+
+        response = await PLCManagerService.read_tags(_service(manager), TagReadRequest(plc="PLC1", tags="A"))
+
+        manager.read_tag.assert_awaited_once_with("PLC1", "A")
+        assert response.data == {"A": 5}
+
+    async def test_batch_read_endpoint_passes_requests_through(self):
+        manager = SimpleNamespace(read_tags_batch=AsyncMock(return_value={"PLC1": {"A": TagResult(value=5)}}))
+
+        response = await PLCManagerService.read_tags_batch(
+            _service(manager), TagBatchReadRequest(requests=[("PLC1", "A")])
+        )
+
+        manager.read_tags_batch.assert_awaited_once_with([("PLC1", "A")])
+        assert response.data == {"PLC1": {"A": 5}}
+
+    async def test_batch_read_endpoint_passes_through_plc_level_errors(self):
+        manager = SimpleNamespace(
+            read_tags_batch=AsyncMock(
+                return_value={"PLC1": {"A": MISSING}, "PLC2": {"error": "PLC 'PLC2' not registered"}}
+            )
+        )
+
+        response = await PLCManagerService.read_tags_batch(
+            _service(manager), TagBatchReadRequest(requests=[("PLC1", "A"), ("PLC2", "A")])
+        )
+
+        assert response.data == {"PLC1": {"A": None}, "PLC2": {"error": "PLC 'PLC2' not registered"}}
+
+    async def test_batch_write_endpoint_maps_results_to_success_flags(self):
+        manager = SimpleNamespace(
+            write_tags_batch=AsyncMock(return_value={"PLC1": {"A": TagResult(value=5), "B": MISSING}})
+        )
+
+        response = await PLCManagerService.write_tags_batch(
+            _service(manager), TagBatchWriteRequest(requests=[("PLC1", [("A", 5), ("B", 1)])])
+        )
+
+        manager.write_tags_batch.assert_awaited_once_with([("PLC1", [("A", 5), ("B", 1)])])
+        assert response.data == {"PLC1": {"A": True, "B": False}}


### PR DESCRIPTION
1- TagResult objects are passed back instead of sentinel values
```
@dataclass(frozen=True)
class TagResult:
    """Outcome of one tag read/write: a value, or an error — never both."""

    value: Any = None
    error: Optional[TagError] = None

    @property
    def ok(self) -> bool:
        return self.error is None
```
2- Read/write sessions and per channel locks: reads/writes get seperate driver sessinos, frames don't interleave. connect closes prior sessions. 

### the error contract:

- The controller returned:
1-  {addr: TagResult(value)} -> worked — .ok true, .value holds value
2- {addr: TagResult(error)} -> .ok false -> missing_tag / type_mismatch / encode / unknown

 - PLCCommunicationError raised : 
the link is sick,  already retried retry_count× with a per-channel reconnect between attempts
- PlcTagError raised: the request is wrong

value and adress verdicts come back, overall connection issues &other request wide issues are thrown back.

### choices:
1- return tag results insetad of sentinel, callers can distinguish & log
2- exceptions split by what retrying can fix: CommError/DataError/ResponseError/OSError → PLCCommunicationError ; retried,  RequestError + other errors -> PLCTagError 
3- Comm trouble doesn't return in a map: pycomm3 stamps a failed packet onto packet's tags instead of raising, these are retried and then raised as a whole call past the retry budget. map errors shows non-retryable errors, so left it out of map errors and opted for whole raise.
4- Per tag issue classification is string based: pycomm3 flattens per tag failures to text, patterns are sourced from pycomm3 source.
5- Logix batches once per call, raised errors are whole call.SLC/CIP exchange per tag, issues are captured per tag. Comm errors still escape whole call.




