### PR TITLE
[Jobs] Add configurable benchmark suites

### DIFF
--- a/docs/core/benchmarks.md
+++ b/docs/core/benchmarks.md
@@ -128,12 +128,14 @@ Tier 1 smoke suites verify local wiring and one end-to-end operation:
 - **`database.smoke.mongo_crud`** — Mongo ODM insert/get/update/find/delete.
 - **`registry.smoke.local_crud`** — local Registry save/load/delete.
 - **`datalake.smoke.local_object`** — local Datalake put/get/head object with Mongo metadata initialization.
+- **`jobs.smoke.round_trip`** — isolated Local publish/consume round trips for one second.
 
 Tier 2 stress suites are designed for overhead comparisons across layers and parameter sweeps such as concurrency, object size, backend, and local-vs-remote Mongo:
 
 - **Database**: **`database.stress.mongo_insert_ceiling`**, **`database.stress.mongo_read_ceiling`**, **`database.stress.mongo_update_ceiling`**.
 - **Registry**: **`registry.stress.write_ceiling`**, **`registry.stress.read_ceiling`**, **`registry.stress.mixed_rw`**, **`registry.stress.version_churn`**.
 - **Datalake**: **`datalake.stress.payload_write_ceiling`**, **`datalake.stress.payload_read_ceiling`**, **`datalake.stress.payload_mixed_rw`**, **`datalake.stress.mongo_insert_ceiling`**, **`datalake.stress.create_asset_from_object`**, **`datalake.stress.collection_item`**, **`datalake.stress.retention`**.
+- **Jobs**: RabbitMQ publication ceiling; iterative `consume(1)`, steady pull, and broker-push consume ceilings; and one-vs-four-consumer end-to-end pipeline scaling.
 
 Tier 3, intentionally left for a follow-on PR, should cover broader package areas and operational scenarios such as hardware packages, replication, large import sessions, and long-haul soak runs.
 
@@ -148,6 +150,7 @@ Each first-party wheel that ships benchmarks exposes **`mindtrace.<pkg>.testing`
 database = "mindtrace.database.testing:register_benchmark_suites"
 registry = "mindtrace.registry.testing:register_benchmark_suites"
 datalake = "mindtrace.datalake.testing:register_benchmark_suites"
+jobs = "mindtrace.jobs.testing:register_benchmark_suites"
 ```
 
 ---

--- a/docs/core/benchmarks.md
+++ b/docs/core/benchmarks.md
@@ -113,6 +113,7 @@ bench_results, exec_rows = runner.run_registered_benches(
     ["registry.stress.write_ceiling"],
     profile="stress",
     run_id="dev-run-1",
+    parameters={},  # optional workload overrides merged over the selected profile
     resources={},  # optional: e.g. mongo_uri, minio_endpoint from your environment
 )
 for row in bench_results:
@@ -135,7 +136,7 @@ Tier 2 stress suites are designed for overhead comparisons across layers and par
 - **Database**: **`database.stress.mongo_insert_ceiling`**, **`database.stress.mongo_read_ceiling`**, **`database.stress.mongo_update_ceiling`**.
 - **Registry**: **`registry.stress.write_ceiling`**, **`registry.stress.read_ceiling`**, **`registry.stress.mixed_rw`**, **`registry.stress.version_churn`**.
 - **Datalake**: **`datalake.stress.payload_write_ceiling`**, **`datalake.stress.payload_read_ceiling`**, **`datalake.stress.payload_mixed_rw`**, **`datalake.stress.mongo_insert_ceiling`**, **`datalake.stress.create_asset_from_object`**, **`datalake.stress.collection_item`**, **`datalake.stress.retention`**.
-- **Jobs**: RabbitMQ publication ceiling; iterative `consume(1)`, steady pull, and broker-push consume ceilings; and one-vs-four-consumer end-to-end pipeline scaling.
+- **Jobs**: configurable Local, Redis, and RabbitMQ round-trip, publication, consumption, and pipeline workloads. RabbitMQ consumption can compare iterative `consume(1)`, steady `basic_get`, and broker-pushed `basic_consume` modes under one stable suite ID.
 
 Tier 3, intentionally left for a follow-on PR, should cover broader package areas and operational scenarios such as hardware packages, replication, large import sessions, and long-haul soak runs.
 
@@ -301,6 +302,7 @@ bench_results, exec_rows = runner.run_registered_benches(
     ["example.echo.loop_throughput"],
     profile="smoke",
     run_id="2026-03-09Tbench-local",
+    parameters={"iter_chunk": 100},
     resources={},  # e.g. merge API base URLs / DB URIs from your config here
 )
 
@@ -331,7 +333,7 @@ Ship a custom CLI only when you need application-specific resource loading, auth
 
 ### Resources and configuration
 
-Pass secrets and service endpoints via your normal config layer; at bench time merge them into **`runner.run_registered_benches(..., resources={...})`** so **`build_bench_suite_config`** can unify Mindtrace defaults with overrides. Document which **`resources`** keys your suites consume.
+Pass workload choices through **`runner.run_registered_benches(..., parameters={...})`** and secrets or service endpoints through **`resources={...}`**. **`build_bench_suite_config`** merges both over the selected profile defaults while keeping workload and environment configuration separate. Document which parameter/resource keys your suites consume.
 
 ### Recommended tagging
 

--- a/mindtrace/core/mindtrace/core/testing/__main__.py
+++ b/mindtrace/core/mindtrace/core/testing/__main__.py
@@ -9,6 +9,23 @@ from mindtrace.core.testing.runner import TestRunner
 from mindtrace.core.utils.time import utcnow
 
 
+def _format_bench_summary(summary: dict) -> str:
+    """Format one benchmark result with its directly comparable throughput."""
+
+    line = (
+        f"{summary['suite_id']}: {summary['status']} "
+        f"ops={summary['operations']} failures={summary['failures']} "
+        f"rate={summary['throughput_ops_per_second']:.2f} ops/s "
+        f"duration={summary['duration_seconds']:.2f}s"
+    )
+    if summary.get("error_counts"):
+        line += f" errors={summary['error_counts']}"
+    metrics = summary.get("metrics") or {}
+    if metrics.get("last_error_type"):
+        line += f" last_error={metrics['last_error_type']}: {metrics.get('last_error_message', '')}"
+    return line
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run installed Mindtrace benchmark suites.")
     parser.add_argument(
@@ -67,14 +84,7 @@ def main(argv: list[str] | None = None) -> int:
 
     suite_failures = sum(1 for row in exec_rows if row.status != "passed")
     for row in bench_results:
-        summary = row.to_dict()
-        line = f"{summary['suite_id']}: {summary['status']} ops={summary['operations']} failures={summary['failures']}"
-        if summary.get("error_counts"):
-            line += f" errors={summary['error_counts']}"
-        metrics = summary.get("metrics") or {}
-        if metrics.get("last_error_type"):
-            line += f" last_error={metrics['last_error_type']}: {metrics.get('last_error_message', '')}"
-        print(line)
+        print(_format_bench_summary(row.to_dict()))
 
     return 1 if suite_failures else 0
 

--- a/mindtrace/core/mindtrace/core/testing/__main__.py
+++ b/mindtrace/core/mindtrace/core/testing/__main__.py
@@ -26,6 +26,18 @@ def _format_bench_summary(summary: dict) -> str:
     return line
 
 
+def _format_progress_event(event: object) -> str:
+    """Format progress and retain setup/runtime failure details."""
+
+    kind = getattr(event, "kind", "?")
+    suite_id = getattr(event, "suite_id", "")
+    line = f"[{kind}] {suite_id}"
+    detail = getattr(event, "detail", None)
+    if detail:
+        line += f": {detail}"
+    return line
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run installed Mindtrace benchmark suites.")
     parser.add_argument(
@@ -70,9 +82,7 @@ def main(argv: list[str] | None = None) -> int:
     run_id = args.run_id or utcnow().strftime("%Y-%m-%dT%H-%M-%SZ")
 
     def _progress(ev: object) -> None:
-        kind = getattr(ev, "kind", "?")
-        sid = getattr(ev, "suite_id", "")
-        print(f"[{kind}] {sid}", flush=True)
+        print(_format_progress_event(ev), flush=True)
 
     bench_results, exec_rows = TestRunner.run_registered_benches(
         matched,

--- a/mindtrace/core/mindtrace/core/testing/runner.py
+++ b/mindtrace/core/mindtrace/core/testing/runner.py
@@ -237,16 +237,18 @@ class TestRunner(Mindtrace):
         *,
         profile: str,
         run_id: str,
+        parameters: Mapping[str, Any] | None = None,
         resources: Mapping[str, Any] | None = None,
         progress: Callable[[ProgressEvent], None] | None = None,
         cancellation_token: Any | None = None,
         output_dir: Path | None = None,
         keep_resources: bool = False,
     ) -> tuple[list[BenchResult], list[SuiteExecutionResult]]:
-        """Run registered benchmark suites with timing/profile resolved from their contributions."""
+        """Run benches with optional parameter/resource overrides merged over the selected profile."""
 
         rows: list[SuiteExecutionResult] = []
         bench_rows: list[BenchResult] = []
+        merged_parameters = dict(parameters or {})
         merged_resources = dict(resources or {})
 
         for sid in suite_ids:
@@ -255,6 +257,7 @@ class TestRunner(Mindtrace):
                 contrib,
                 profile=profile,
                 run_id=run_id,
+                extra_parameters=merged_parameters,
                 resources=merged_resources,
                 output_dir=output_dir,
                 keep_resources=keep_resources,

--- a/mindtrace/jobs/README.md
+++ b/mindtrace/jobs/README.md
@@ -501,6 +501,45 @@ Related examples in the repo:
 
 - [Simple orchestrator example](../../samples/jobs/orchestrator_simple.py)
 
+## Benchmarks
+
+The Jobs package registers benchmark suites with the `mindtrace-bench` CLI.
+The smoke profile runs an isolated Local publish/consume round trip for about
+one second:
+
+```bash
+$ uv run mindtrace-bench jobs --profile smoke
+```
+
+With RabbitMQ available at `localhost:5672` using the README setup credentials
+`user` / `password`, the stress profile runs each workload for about ten
+seconds:
+
+```bash
+$ uv run mindtrace-bench jobs --profile stress
+```
+
+The RabbitMQ stress suites report:
+
+- sustained batch publication throughput;
+- repeated public `consume(num_messages=1)` throughput, including per-call
+  connection and channel lifecycle;
+- steady `basic_get` pull throughput using one long finite consume call;
+- broker-pushed `basic_consume` throughput using bare blocking `consume()`;
+- end-to-end broker-pushed pipeline throughput and latency with one consumer;
+- the same pipeline workload with four independent consumers and connections.
+
+The three consume-ceiling suites use identical payload, backlog, prefetch, and
+ten-second defaults so their `messages_per_second` metrics can be compared
+directly. Each suite creates a uniquely named durable queue and removes it
+after the run unless `--keep-resources` is supplied.
+
+List the registered suite IDs without running them:
+
+```bash
+$ uv run mindtrace-bench jobs --profile stress --list
+```
+
 ## Testing
 
 If you are working in the full Mindtrace repo, run tests for this module specifically:

--- a/mindtrace/jobs/README.md
+++ b/mindtrace/jobs/README.md
@@ -568,9 +568,13 @@ The consume modes report:
 Use identical parameter overrides for payload, backlog, prefetch, and duration
 when comparing these modes. Round-trip and publication support Local, Redis,
 and RabbitMQ. Iterative and steady consumption also support all three backends;
-push is RabbitMQ-only. Pipeline scaling supports Redis and RabbitMQ with
-multiple consumers, while Local is restricted to one producer and one consumer
-until its shared-queue concurrency semantics are established.
+push is RabbitMQ-only. Pipeline scaling supports Redis and RabbitMQ; Local is
+rejected because its registry-backed queues are not safe for concurrent
+producer/consumer access.
+
+Unexpected Redis event-listener failures are included in each Jobs benchmark's
+`background_errors` metric and promoted to validation failures. Normal listener
+shutdown does not count as a failure.
 
 Backend connection settings are resources: Local accepts an optional
 `local_base_dir`; Redis accepts `redis_host`, `redis_port`, and `redis_db`; and

--- a/mindtrace/jobs/README.md
+++ b/mindtrace/jobs/README.md
@@ -503,36 +503,80 @@ Related examples in the repo:
 
 ## Benchmarks
 
-The Jobs package registers benchmark suites with the `mindtrace-bench` CLI.
-The smoke profile runs an isolated Local publish/consume round trip for about
-one second:
+The Jobs package registers four configurable workload suites:
+
+- `jobs.smoke.round_trip`;
+- `jobs.stress.publish_ceiling`;
+- `jobs.stress.consume_ceiling`;
+- `jobs.stress.pipeline_scaling`.
+
+Profiles provide convenient defaults rather than fixing a workload to one
+backend. The CLI smoke default runs an isolated Local publish/consume round
+trip for about one second:
 
 ```bash
 $ uv run mindtrace-bench jobs --profile smoke
 ```
 
 With RabbitMQ available at `localhost:5672` using the README setup credentials
-`user` / `password`, the stress profile runs each workload for about ten
-seconds:
+`user` / `password`, the CLI stress defaults run RabbitMQ publication,
+broker-pushed consumption, and a one-consumer pipeline for about ten seconds
+each:
 
 ```bash
 $ uv run mindtrace-bench jobs --profile stress
 ```
 
-The RabbitMQ stress suites report:
+Python callers can override the selected backend, workload mode, worker counts,
+and connection resources without changing suite IDs. This example runs the
+three directly comparable RabbitMQ consumption modes:
 
-- sustained batch publication throughput;
+```python
+from mindtrace.core import TestRunner
+from mindtrace.jobs.testing import register_benchmark_suites
+
+runner = TestRunner()
+register_benchmark_suites(runner=runner)
+
+resources = {
+    "rabbitmq_host": "localhost",
+    "rabbitmq_port": 5672,
+    "rabbitmq_username": "user",
+    "rabbitmq_password": "password",
+}
+for mode in ("iterative_pull_one", "steady_pull", "push"):
+    results, executions = runner.run_registered_benches(
+        ["jobs.stress.consume_ceiling"],
+        profile="stress",
+        run_id=f"rmq-{mode}",
+        parameters={"backend": "rabbitmq", "consume_mode": mode},
+        resources=resources,
+    )
+    for result in results:
+        print(result.to_dict())
+    if any(execution.status != "passed" for execution in executions):
+        raise RuntimeError(f"RabbitMQ {mode} benchmark failed")
+```
+
+The consume modes report:
+
 - repeated public `consume(num_messages=1)` throughput, including per-call
   connection and channel lifecycle;
 - steady `basic_get` pull throughput using one long finite consume call;
-- broker-pushed `basic_consume` throughput using bare blocking `consume()`;
-- end-to-end broker-pushed pipeline throughput and latency with one consumer;
-- the same pipeline workload with four independent consumers and connections.
+- broker-pushed `basic_consume` throughput using bare blocking `consume()`.
 
-The three consume-ceiling suites use identical payload, backlog, prefetch, and
-ten-second defaults so their `messages_per_second` metrics can be compared
-directly. Each suite creates a uniquely named durable queue and removes it
-after the run unless `--keep-resources` is supplied.
+Use identical parameter overrides for payload, backlog, prefetch, and duration
+when comparing these modes. Round-trip and publication support Local, Redis,
+and RabbitMQ. Iterative and steady consumption also support all three backends;
+push is RabbitMQ-only. Pipeline scaling supports Redis and RabbitMQ with
+multiple consumers, while Local is restricted to one producer and one consumer
+until its shared-queue concurrency semantics are established.
+
+Backend connection settings are resources: Local accepts an optional
+`local_base_dir`; Redis accepts `redis_host`, `redis_port`, and `redis_db`; and
+RabbitMQ accepts its host, port, username, and password. Each invocation creates
+a unique queue and removes only the resources it owns unless resource retention
+is requested.
 
 List the registered suite IDs without running them:
 

--- a/mindtrace/jobs/mindtrace/jobs/redis/connection.py
+++ b/mindtrace/jobs/mindtrace/jobs/redis/connection.py
@@ -54,7 +54,9 @@ class RedisConnection(BrokerConnectionBase):
         self._local_lock = threading.Lock()  # Thread lock for local state modifications
         self._shutdown_event = threading.Event()  # Event to signal shutdown to background thread
         self._pubsub = None  # Store pubsub instance for proper cleanup
+        self._listener_connection: redis.Redis | None = None
         self._event_thread = None  # Store thread reference for cleanup
+        self._event_listener_error: BaseException | None = None
         self._load_queue_metadata()  # Load previously declared queues from metadata.
         self._start_event_listener()  # Start a background thread to listen for queue events.
 
@@ -105,8 +107,15 @@ class RedisConnection(BrokerConnectionBase):
                 try:
                     self._pubsub.close()
                 except Exception as e:
-                    self.logger.error(f"Error closing pubsub connection: {str(e)}")
+                    self.logger.debug(f"Pubsub connection was already closed during shutdown: {str(e)}")
                 self._pubsub = None
+
+            if self._listener_connection is not None:
+                try:
+                    self._listener_connection.close()
+                except Exception as e:
+                    self.logger.debug(f"Event listener connection was already closed during shutdown: {str(e)}")
+                self._listener_connection = None
 
         # Wait for the background thread to finish (with timeout)
         if self._event_thread is not None and self._event_thread.is_alive():
@@ -135,12 +144,39 @@ class RedisConnection(BrokerConnectionBase):
         self._event_thread = threading.Thread(target=self._subscribe_to_events, daemon=True)
         self._event_thread.start()
 
-    def _subscribe_to_events(self):
-        try:
-            self._pubsub = self.connection.pubsub()
-            self._pubsub.subscribe(self.EVENTS_CHANNEL)
+    @property
+    def event_listener_error(self) -> BaseException | None:
+        """Return the unexpected exception that stopped the event listener, if any."""
 
-            for message in self._pubsub.listen():
+        with self._local_lock:
+            return self._event_listener_error
+
+    def _subscribe_to_events(self):
+        listener_connection = None
+        pubsub = None
+        try:
+            if self._shutdown_event.is_set():
+                return
+
+            listener_params = {
+                "host": self.host,
+                "port": self.port,
+                "db": self.db,
+                "socket_timeout": None,
+                "socket_connect_timeout": self.socket_connect_timeout,
+            }
+            if self.password:
+                listener_params["password"] = self.password
+            listener_connection = redis.Redis(**listener_params)
+            pubsub = listener_connection.pubsub()
+            with self._local_lock:
+                if self._shutdown_event.is_set():
+                    return
+                self._listener_connection = listener_connection
+                self._pubsub = pubsub
+            pubsub.subscribe(self.EVENTS_CHANNEL)
+
+            for message in pubsub.listen():
                 if self._shutdown_event.is_set():
                     break
                 if message["type"] != "message":
@@ -183,15 +219,26 @@ class RedisConnection(BrokerConnectionBase):
                 except Exception:
                     pass
         except Exception as e:
-            self.logger.error(f"Event listener thread exception: {str(e)}")
+            if not self._shutdown_event.is_set():
+                with self._local_lock:
+                    self._event_listener_error = e
+                self.logger.error(f"Event listener thread exception: {str(e)}")
         finally:
             with self._local_lock:
-                if self._pubsub is not None:
-                    try:
-                        self._pubsub.close()
-                    except Exception:
-                        pass
+                if self._pubsub is pubsub:
                     self._pubsub = None
+                if self._listener_connection is listener_connection:
+                    self._listener_connection = None
+            if pubsub is not None:
+                try:
+                    pubsub.close()
+                except Exception:
+                    pass
+            if listener_connection is not None:
+                try:
+                    listener_connection.close()
+                except Exception:
+                    pass
 
     def _load_queue_metadata(self):
         """Load all declared queues from the centralized metadata hash."""

--- a/mindtrace/jobs/mindtrace/jobs/testing/__init__.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/__init__.py
@@ -1,0 +1,23 @@
+"""Embedded benchmark suites for ``mindtrace-jobs``.
+
+Use :func:`register_benchmark_suites` directly or discover it through the
+``mindtrace.benchmark_suites`` entry point group.
+"""
+
+from __future__ import annotations
+
+from mindtrace.core import TestRunner
+
+
+def register_benchmark_suites(*, runner: TestRunner | None = None, replace: bool = True) -> None:
+    """Register Jobs benchmark suites on ``runner`` or the default runner."""
+
+    from mindtrace.jobs.testing.suites import JOBS_BENCHMARK_SUITES
+
+    target = runner or TestRunner.default()
+    for suite_cls in JOBS_BENCHMARK_SUITES:
+        if replace or suite_cls.suite_id not in target.registered_suites():
+            target.register_test_suite(suite_cls, replace=replace)
+
+
+__all__ = ["register_benchmark_suites"]

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/__init__.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/__init__.py
@@ -1,0 +1,34 @@
+"""Jobs benchmark suite implementations."""
+
+from mindtrace.jobs.testing.suites.consume import (
+    JobsRabbitMQIterativePullOneSuite,
+    JobsRabbitMQPushSuite,
+    JobsRabbitMQSteadyPullSuite,
+)
+from mindtrace.jobs.testing.suites.pipeline import (
+    JobsRabbitMQPipelineFourConsumersSuite,
+    JobsRabbitMQPipelineOneConsumerSuite,
+)
+from mindtrace.jobs.testing.suites.publish import JobsRabbitMQPublishCeilingSuite
+from mindtrace.jobs.testing.suites.round_trip import JobsRoundTripSmokeSuite
+
+JOBS_BENCHMARK_SUITES = (
+    JobsRoundTripSmokeSuite,
+    JobsRabbitMQPublishCeilingSuite,
+    JobsRabbitMQIterativePullOneSuite,
+    JobsRabbitMQSteadyPullSuite,
+    JobsRabbitMQPushSuite,
+    JobsRabbitMQPipelineOneConsumerSuite,
+    JobsRabbitMQPipelineFourConsumersSuite,
+)
+
+__all__ = [
+    "JOBS_BENCHMARK_SUITES",
+    "JobsRabbitMQIterativePullOneSuite",
+    "JobsRabbitMQPipelineFourConsumersSuite",
+    "JobsRabbitMQPipelineOneConsumerSuite",
+    "JobsRabbitMQPublishCeilingSuite",
+    "JobsRabbitMQPushSuite",
+    "JobsRabbitMQSteadyPullSuite",
+    "JobsRoundTripSmokeSuite",
+]

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/__init__.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/__init__.py
@@ -1,34 +1,21 @@
 """Jobs benchmark suite implementations."""
 
-from mindtrace.jobs.testing.suites.consume import (
-    JobsRabbitMQIterativePullOneSuite,
-    JobsRabbitMQPushSuite,
-    JobsRabbitMQSteadyPullSuite,
-)
-from mindtrace.jobs.testing.suites.pipeline import (
-    JobsRabbitMQPipelineFourConsumersSuite,
-    JobsRabbitMQPipelineOneConsumerSuite,
-)
-from mindtrace.jobs.testing.suites.publish import JobsRabbitMQPublishCeilingSuite
+from mindtrace.jobs.testing.suites.consume import JobsConsumeCeilingSuite
+from mindtrace.jobs.testing.suites.pipeline import JobsPipelineScalingSuite
+from mindtrace.jobs.testing.suites.publish import JobsPublishCeilingSuite
 from mindtrace.jobs.testing.suites.round_trip import JobsRoundTripSmokeSuite
 
 JOBS_BENCHMARK_SUITES = (
     JobsRoundTripSmokeSuite,
-    JobsRabbitMQPublishCeilingSuite,
-    JobsRabbitMQIterativePullOneSuite,
-    JobsRabbitMQSteadyPullSuite,
-    JobsRabbitMQPushSuite,
-    JobsRabbitMQPipelineOneConsumerSuite,
-    JobsRabbitMQPipelineFourConsumersSuite,
+    JobsPublishCeilingSuite,
+    JobsConsumeCeilingSuite,
+    JobsPipelineScalingSuite,
 )
 
 __all__ = [
     "JOBS_BENCHMARK_SUITES",
-    "JobsRabbitMQIterativePullOneSuite",
-    "JobsRabbitMQPipelineFourConsumersSuite",
-    "JobsRabbitMQPipelineOneConsumerSuite",
-    "JobsRabbitMQPublishCeilingSuite",
-    "JobsRabbitMQPushSuite",
-    "JobsRabbitMQSteadyPullSuite",
+    "JobsConsumeCeilingSuite",
+    "JobsPipelineScalingSuite",
+    "JobsPublishCeilingSuite",
     "JobsRoundTripSmokeSuite",
 ]

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/_common.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/_common.py
@@ -19,6 +19,7 @@ from mindtrace.core import BenchResult, BenchSuiteConfig, utcnow_iso
 from mindtrace.core.testing.workloads import deterministic_payload
 from mindtrace.jobs import Job, LocalClient, Orchestrator, RabbitMQClient, RedisClient
 from mindtrace.jobs.base.orchestrator_backend import OrchestratorBackend
+from mindtrace.jobs.redis.connection import RedisConnection
 
 BackendName = Literal["local", "redis", "rabbitmq"]
 _QUEUE_COMPONENT = re.compile(r"[^a-zA-Z0-9_.-]+")
@@ -280,6 +281,25 @@ def close_rabbitmq_client(client: RabbitMQClient) -> None:
     connection = getattr(client, "_connection", None)
     if connection is not None:
         connection.close()
+
+
+def redis_background_errors(*owners: object) -> list[str]:
+    """Return unexpected Redis listener failures owned by benchmark resources."""
+
+    errors: list[str] = []
+    seen_connections: set[int] = set()
+    for owner in owners:
+        connection = owner if isinstance(owner, RedisConnection) else getattr(owner, "connection", None)
+        if not isinstance(connection, RedisConnection) or id(connection) in seen_connections:
+            continue
+        seen_connections.add(id(connection))
+        error = connection.event_listener_error
+        if error is not None:
+            errors.append(
+                f"Redis event listener {connection.host}:{connection.port}/{connection.db} raised "
+                f"{type(error).__name__}: {error}"
+            )
+    return errors
 
 
 def connect_consumer(consumer, runtime: BackendRuntime, *, prefetch_count: int) -> None:

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/_common.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/_common.py
@@ -353,8 +353,7 @@ def make_jobs(queue_name: str, *, start: int, count: int, payload: str) -> list[
 
     sent_at_ns = time.perf_counter_ns()
     return [
-        make_job(queue_name, sequence=start + offset, payload=payload, sent_at_ns=sent_at_ns)
-        for offset in range(count)
+        make_job(queue_name, sequence=start + offset, payload=payload, sent_at_ns=sent_at_ns) for offset in range(count)
     ]
 
 

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/_common.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/_common.py
@@ -10,21 +10,31 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
-from typing import Any, Callable
+from typing import Any, Callable, Literal, TypeVar
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
 
 from mindtrace.core import BenchResult, BenchSuiteConfig, utcnow_iso
 from mindtrace.core.testing.workloads import deterministic_payload
-from mindtrace.jobs import Job, LocalClient, Orchestrator, RabbitMQClient
+from mindtrace.jobs import Job, LocalClient, Orchestrator, RabbitMQClient, RedisClient
+from mindtrace.jobs.base.orchestrator_backend import OrchestratorBackend
 
+BackendName = Literal["local", "redis", "rabbitmq"]
 _QUEUE_COMPONENT = re.compile(r"[^a-zA-Z0-9_.-]+")
+_InputModel = TypeVar("_InputModel", bound=BaseModel)
 
 
-class RabbitMQBenchResources(BaseModel):
-    """Connection settings used by RabbitMQ benchmark suites."""
+class JobsBenchResources(BaseModel):
+    """Optional connection settings for every supported Jobs backend."""
 
+    local_base_dir: Path | None = Field(
+        None,
+        description="Optional parent directory for the isolated Local benchmark directory.",
+    )
+    redis_host: str = Field("localhost", description="Redis server hostname.")
+    redis_port: int = Field(6379, ge=1, le=65535, description="Redis server port.")
+    redis_db: int = Field(0, ge=0, description="Redis database number.")
     rabbitmq_host: str = Field("localhost", description="RabbitMQ server hostname.")
     rabbitmq_port: int = Field(5672, ge=1, le=65535, description="RabbitMQ server port.")
     rabbitmq_username: str = Field("user", description="RabbitMQ username.")
@@ -112,79 +122,153 @@ def merge_worker_stats(stats: list[WorkerStats], *, latency_sample_limit: int) -
 
 
 @dataclass(frozen=True)
-class RabbitMQRuntime:
-    """Owned RabbitMQ resources for one benchmark variant."""
+class BackendRuntime:
+    """Resources owned by one benchmark variant."""
 
-    client: RabbitMQClient
+    backend: BackendName
+    client: OrchestratorBackend
     orchestrator: Orchestrator
     queue_name: str
+    local_root: Path | None = None
 
 
-@dataclass(frozen=True)
-class LocalRuntime:
-    """Owned Local backend resources for one benchmark invocation."""
+def validate_parameters(config: BenchSuiteConfig, model: type[_InputModel]) -> _InputModel:
+    """Validate resolved workload parameters through the declared input model."""
 
-    client: LocalClient
-    orchestrator: Orchestrator
-    queue_name: str
-    root: Path
+    return model.model_validate(config.parameters)
+
+
+def validate_resources(config: BenchSuiteConfig) -> JobsBenchResources:
+    """Validate resolved backend resources."""
+
+    return JobsBenchResources.model_validate(config.resources)
 
 
 def queue_name_for(config: BenchSuiteConfig, suffix: str = "work") -> str:
-    """Return a RabbitMQ-safe queue name unique to a suite invocation."""
+    """Return a backend-safe queue name unique to a suite invocation."""
 
     raw = f"mindtrace.bench.{config.run_id}.{config.suite_id}.{suffix}.{uuid4().hex}"
     return _QUEUE_COMPONENT.sub("-", raw)[:220]
 
 
-def rabbitmq_kwargs(config: BenchSuiteConfig) -> dict[str, Any]:
-    """Resolve RabbitMQ client settings from benchmark resources."""
+def create_backend_client(
+    backend: BackendName,
+    resources: JobsBenchResources,
+    *,
+    local_root: Path | None = None,
+) -> OrchestratorBackend:
+    """Create one client for the selected backend."""
 
-    return {
-        "host": str(config.resources.get("rabbitmq_host", "localhost")),
-        "port": int(config.resources.get("rabbitmq_port", 5672)),
-        "username": str(config.resources.get("rabbitmq_username", "user")),
-        "password": str(config.resources.get("rabbitmq_password", "password")),
-    }
+    if backend == "local":
+        if local_root is None:
+            raise ValueError("local_root is required when creating a Local benchmark client")
+        return LocalClient(client_dir=local_root)
+    if backend == "redis":
+        return RedisClient(host=resources.redis_host, port=resources.redis_port, db=resources.redis_db)
+    return RabbitMQClient(
+        host=resources.rabbitmq_host,
+        port=resources.rabbitmq_port,
+        username=resources.rabbitmq_username,
+        password=resources.rabbitmq_password,
+    )
 
 
-def create_rabbitmq_runtime(config: BenchSuiteConfig, *, suffix: str = "work") -> RabbitMQRuntime:
-    """Create a unique durable RabbitMQ queue and its orchestrator."""
+def create_backend_runtime(
+    config: BenchSuiteConfig,
+    *,
+    backend: BackendName,
+    suffix: str = "work",
+) -> BackendRuntime:
+    """Create an isolated queue and orchestrator for the selected backend."""
 
-    client = RabbitMQClient(**rabbitmq_kwargs(config))
-    queue_name = queue_name_for(config, suffix)
-    declaration = client.declare_queue(queue_name, durable=True, auto_delete=False)
-    if declaration.get("status") != "success":
-        close_rabbitmq_client(client)
-        raise RuntimeError(f"Failed to declare RabbitMQ benchmark queue {queue_name!r}: {declaration}")
-    return RabbitMQRuntime(client=client, orchestrator=Orchestrator(client), queue_name=queue_name)
+    resources = validate_resources(config)
+    local_root: Path | None = None
+    if backend == "local":
+        base_dir = resources.local_base_dir
+        if base_dir is not None:
+            base_dir.mkdir(parents=True, exist_ok=True)
+        local_root = Path(
+            mkdtemp(
+                prefix="mindtrace-jobs-bench-",
+                dir=str(base_dir) if base_dir is not None else None,
+            )
+        )
+
+    client = create_backend_client(backend, resources, local_root=local_root)
+    queue_name = queue_name_for(config, f"{backend}-{suffix}")
+    try:
+        declaration = client.declare_queue(queue_name, queue_type="fifo", durable=True, auto_delete=False)
+        if declaration.get("status") != "success":
+            raise RuntimeError(f"Failed to declare benchmark queue {queue_name!r}: {declaration}")
+    except BaseException:
+        close_backend_client(client)
+        if local_root is not None:
+            rmtree(local_root, ignore_errors=True)
+        raise
+
+    return BackendRuntime(
+        backend=backend,
+        client=client,
+        orchestrator=Orchestrator(client),
+        queue_name=queue_name,
+        local_root=local_root,
+    )
 
 
-def cleanup_rabbitmq_runtime(runtime: RabbitMQRuntime, *, keep_resources: bool) -> None:
-    """Delete the benchmark queue unless the caller asked to retain it."""
+def create_backend_worker_client(
+    runtime: BackendRuntime,
+    resources: JobsBenchResources,
+) -> OrchestratorBackend:
+    """Create a worker client and attach it to the runtime's existing queue."""
+
+    client = create_backend_client(runtime.backend, resources, local_root=runtime.local_root)
+    if runtime.backend == "rabbitmq":
+        # RabbitMQ queues are broker-owned. Batch publication opens and closes
+        # its operation-local connection in the worker thread, so the client's
+        # coordinator-owned bootstrap channel does not need to redeclare it.
+        return client
+    try:
+        declaration = client.declare_queue(
+            runtime.queue_name,
+            queue_type="fifo",
+            durable=True,
+            auto_delete=False,
+        )
+        if declaration.get("status") != "success":
+            raise RuntimeError(
+                f"Failed to attach worker client to benchmark queue {runtime.queue_name!r}: {declaration}"
+            )
+    except BaseException:
+        close_backend_client(client)
+        raise
+    return client
+
+
+def cleanup_backend_runtime(
+    runtime: BackendRuntime,
+    *,
+    keep_resources: bool,
+    close_client: bool = True,
+) -> None:
+    """Delete only resources created by this benchmark invocation."""
 
     try:
         if not keep_resources:
             runtime.client.delete_queue(runtime.queue_name)
     finally:
-        close_rabbitmq_client(runtime.client)
+        if close_client:
+            close_backend_client(runtime.client)
+        if runtime.local_root is not None and not keep_resources:
+            rmtree(runtime.local_root, ignore_errors=True)
 
 
-def create_local_runtime(config: BenchSuiteConfig) -> LocalRuntime:
-    """Create an isolated Local backend for the smoke benchmark."""
+def close_backend_client(client: OrchestratorBackend) -> None:
+    """Close backend-specific resources without assuming a common close API."""
 
-    root = Path(mkdtemp(prefix="mindtrace-jobs-bench-"))
-    client = LocalClient(client_dir=root)
-    queue_name = queue_name_for(config, "local")
-    client.declare_queue(queue_name)
-    return LocalRuntime(client=client, orchestrator=Orchestrator(client), queue_name=queue_name, root=root)
-
-
-def cleanup_local_runtime(runtime: LocalRuntime, *, keep_resources: bool) -> None:
-    """Remove the Local benchmark directory unless retention was requested."""
-
-    if not keep_resources:
-        rmtree(runtime.root, ignore_errors=True)
+    if isinstance(client, RedisClient):
+        client.close()
+    elif isinstance(client, RabbitMQClient):
+        close_rabbitmq_client(client)
 
 
 def close_rabbitmq_client(client: RabbitMQClient) -> None:
@@ -196,6 +280,29 @@ def close_rabbitmq_client(client: RabbitMQClient) -> None:
     connection = getattr(client, "_connection", None)
     if connection is not None:
         connection.close()
+
+
+def connect_consumer(consumer, runtime: BackendRuntime, *, prefetch_count: int) -> None:
+    """Connect a consumer with only backend-supported options."""
+
+    kwargs: dict[str, Any] = {}
+    if runtime.backend == "rabbitmq":
+        kwargs["prefetch_count"] = prefetch_count
+    elif runtime.backend == "redis":
+        kwargs["poll_timeout"] = 1
+    else:
+        kwargs["poll_timeout"] = 0.1
+    consumer.connect_to_orchestrator(runtime.orchestrator, runtime.queue_name, **kwargs)
+
+
+def delivery_transport(backend: BackendName, consume_mode: str) -> str:
+    """Describe the backend mechanism used by a consume workload."""
+
+    if backend == "rabbitmq":
+        return "basic_consume" if consume_mode == "push" else "basic_get"
+    if backend == "redis":
+        return "redis_pop"
+    return "local_pop"
 
 
 def payload_text(size_bytes: int) -> str:

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/_common.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/_common.py
@@ -1,0 +1,279 @@
+"""Shared helpers for Jobs benchmark suites."""
+
+from __future__ import annotations
+
+import random
+import re
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from shutil import rmtree
+from tempfile import mkdtemp
+from typing import Any, Callable
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+from mindtrace.core import BenchResult, BenchSuiteConfig, utcnow_iso
+from mindtrace.core.testing.workloads import deterministic_payload
+from mindtrace.jobs import Job, LocalClient, Orchestrator, RabbitMQClient
+
+_QUEUE_COMPONENT = re.compile(r"[^a-zA-Z0-9_.-]+")
+
+
+class RabbitMQBenchResources(BaseModel):
+    """Connection settings used by RabbitMQ benchmark suites."""
+
+    rabbitmq_host: str = Field("localhost", description="RabbitMQ server hostname.")
+    rabbitmq_port: int = Field(5672, ge=1, le=65535, description="RabbitMQ server port.")
+    rabbitmq_username: str = Field("user", description="RabbitMQ username.")
+    rabbitmq_password: str = Field(
+        "password",
+        description="RabbitMQ password.",
+        json_schema_extra={"secret": True},
+    )
+
+
+@dataclass
+class WorkerStats:
+    """Worker-local counters with bounded reservoir latency sampling."""
+
+    latency_sample_limit: int = 10_000
+    operations: int = 0
+    successes: int = 0
+    failures: int = 0
+    bytes_processed: int = 0
+    latency_seconds: list[float] = field(default_factory=list)
+    error_counts: Counter[str] = field(default_factory=Counter)
+    seen_ids: set[str] = field(default_factory=set)
+    duplicate_ids: int = 0
+    _latencies_seen: int = 0
+    _random: random.Random = field(default_factory=lambda: random.Random(0), repr=False)
+
+    def record(
+        self,
+        *,
+        success: bool,
+        latency_seconds: float,
+        bytes_processed: int = 0,
+        error: BaseException | None = None,
+        item_id: str | None = None,
+        operations: int = 1,
+    ) -> None:
+        """Record one logical operation or a batch of equivalent operations."""
+
+        self.operations += operations
+        self.bytes_processed += bytes_processed
+        if success:
+            self.successes += operations
+        else:
+            self.failures += operations
+            if error is not None:
+                self.error_counts[type(error).__name__] += operations
+        if item_id:
+            if item_id in self.seen_ids:
+                self.duplicate_ids += 1
+            else:
+                self.seen_ids.add(item_id)
+        self._record_latency(latency_seconds)
+
+    def _record_latency(self, latency_seconds: float) -> None:
+        self._latencies_seen += 1
+        if self.latency_sample_limit <= 0:
+            return
+        if len(self.latency_seconds) < self.latency_sample_limit:
+            self.latency_seconds.append(latency_seconds)
+            return
+        replacement = self._random.randrange(self._latencies_seen)
+        if replacement < self.latency_sample_limit:
+            self.latency_seconds[replacement] = latency_seconds
+
+
+def merge_worker_stats(stats: list[WorkerStats], *, latency_sample_limit: int) -> WorkerStats:
+    """Merge worker-local counters and retain a bounded combined sample."""
+
+    merged = WorkerStats(latency_sample_limit=latency_sample_limit)
+    for worker in stats:
+        merged.operations += worker.operations
+        merged.successes += worker.successes
+        merged.failures += worker.failures
+        merged.bytes_processed += worker.bytes_processed
+        merged.error_counts.update(worker.error_counts)
+        merged.duplicate_ids += worker.duplicate_ids
+        for item_id in worker.seen_ids:
+            if item_id in merged.seen_ids:
+                merged.duplicate_ids += 1
+            else:
+                merged.seen_ids.add(item_id)
+        for latency in worker.latency_seconds:
+            merged._record_latency(latency)
+    return merged
+
+
+@dataclass(frozen=True)
+class RabbitMQRuntime:
+    """Owned RabbitMQ resources for one benchmark variant."""
+
+    client: RabbitMQClient
+    orchestrator: Orchestrator
+    queue_name: str
+
+
+@dataclass(frozen=True)
+class LocalRuntime:
+    """Owned Local backend resources for one benchmark invocation."""
+
+    client: LocalClient
+    orchestrator: Orchestrator
+    queue_name: str
+    root: Path
+
+
+def queue_name_for(config: BenchSuiteConfig, suffix: str = "work") -> str:
+    """Return a RabbitMQ-safe queue name unique to a suite invocation."""
+
+    raw = f"mindtrace.bench.{config.run_id}.{config.suite_id}.{suffix}.{uuid4().hex}"
+    return _QUEUE_COMPONENT.sub("-", raw)[:220]
+
+
+def rabbitmq_kwargs(config: BenchSuiteConfig) -> dict[str, Any]:
+    """Resolve RabbitMQ client settings from benchmark resources."""
+
+    return {
+        "host": str(config.resources.get("rabbitmq_host", "localhost")),
+        "port": int(config.resources.get("rabbitmq_port", 5672)),
+        "username": str(config.resources.get("rabbitmq_username", "user")),
+        "password": str(config.resources.get("rabbitmq_password", "password")),
+    }
+
+
+def create_rabbitmq_runtime(config: BenchSuiteConfig, *, suffix: str = "work") -> RabbitMQRuntime:
+    """Create a unique durable RabbitMQ queue and its orchestrator."""
+
+    client = RabbitMQClient(**rabbitmq_kwargs(config))
+    queue_name = queue_name_for(config, suffix)
+    declaration = client.declare_queue(queue_name, durable=True, auto_delete=False)
+    if declaration.get("status") != "success":
+        close_rabbitmq_client(client)
+        raise RuntimeError(f"Failed to declare RabbitMQ benchmark queue {queue_name!r}: {declaration}")
+    return RabbitMQRuntime(client=client, orchestrator=Orchestrator(client), queue_name=queue_name)
+
+
+def cleanup_rabbitmq_runtime(runtime: RabbitMQRuntime, *, keep_resources: bool) -> None:
+    """Delete the benchmark queue unless the caller asked to retain it."""
+
+    try:
+        if not keep_resources:
+            runtime.client.delete_queue(runtime.queue_name)
+    finally:
+        close_rabbitmq_client(runtime.client)
+
+
+def create_local_runtime(config: BenchSuiteConfig) -> LocalRuntime:
+    """Create an isolated Local backend for the smoke benchmark."""
+
+    root = Path(mkdtemp(prefix="mindtrace-jobs-bench-"))
+    client = LocalClient(client_dir=root)
+    queue_name = queue_name_for(config, "local")
+    client.declare_queue(queue_name)
+    return LocalRuntime(client=client, orchestrator=Orchestrator(client), queue_name=queue_name, root=root)
+
+
+def cleanup_local_runtime(runtime: LocalRuntime, *, keep_resources: bool) -> None:
+    """Remove the Local benchmark directory unless retention was requested."""
+
+    if not keep_resources:
+        rmtree(runtime.root, ignore_errors=True)
+
+
+def close_rabbitmq_client(client: RabbitMQClient) -> None:
+    """Close persistent resources retained by a RabbitMQ client."""
+
+    channel = getattr(client, "_channel", None)
+    if channel is not None and getattr(channel, "is_open", False):
+        channel.close()
+    connection = getattr(client, "_connection", None)
+    if connection is not None:
+        connection.close()
+
+
+def payload_text(size_bytes: int) -> str:
+    """Return deterministic JSON-safe text with approximately the requested size."""
+
+    return deterministic_payload(max(0, size_bytes)).decode("ascii")
+
+
+def make_job(queue_name: str, *, sequence: int, payload: str, sent_at_ns: int | None = None) -> Job:
+    """Build a deterministic benchmark job with unique identity and timing metadata."""
+
+    return Job(
+        id=uuid4().hex,
+        name=queue_name,
+        schema_name=queue_name,
+        payload={
+            "sequence": sequence,
+            "sent_at_ns": sent_at_ns if sent_at_ns is not None else time.perf_counter_ns(),
+            "payload_size_bytes": len(payload),
+            "data": payload,
+        },
+        created_at=utcnow_iso(),
+    )
+
+
+def make_jobs(queue_name: str, *, start: int, count: int, payload: str) -> list[Job]:
+    """Build one ordered benchmark batch."""
+
+    sent_at_ns = time.perf_counter_ns()
+    return [
+        make_job(queue_name, sequence=start + offset, payload=payload, sent_at_ns=sent_at_ns)
+        for offset in range(count)
+    ]
+
+
+def wait_for_deadline(deadline: float, *, is_cancelled: Callable[[], bool]) -> None:
+    """Wait cooperatively for a monotonic deadline."""
+
+    import threading
+
+    waiter = threading.Event()
+    while not is_cancelled():
+        remaining = deadline - time.perf_counter()
+        if remaining <= 0:
+            return
+        waiter.wait(min(remaining, 0.05))
+
+
+def bench_result(
+    *,
+    config: BenchSuiteConfig,
+    started_at: str,
+    duration_seconds: float,
+    stats: WorkerStats,
+    metrics: dict[str, Any],
+    validation_errors: list[str] | None = None,
+) -> BenchResult:
+    """Build a standard Jobs benchmark result."""
+
+    errors = list(validation_errors or [])
+    status = "passed" if stats.operations > 0 and stats.failures == 0 and not errors else "failed"
+    return BenchResult(
+        suite_id=config.suite_id,
+        status=status,
+        started_at=started_at,
+        ended_at=utcnow_iso(),
+        duration_seconds=max(duration_seconds, 0.0),
+        operations=stats.operations,
+        successes=stats.successes,
+        failures=stats.failures + len(errors),
+        bytes_processed=stats.bytes_processed,
+        latency_seconds=stats.latency_seconds,
+        error_counts=dict(stats.error_counts),
+        metrics={
+            **metrics,
+            "latency_samples": len(stats.latency_seconds),
+            "latency_sample_limit": stats.latency_sample_limit,
+            "duplicate_ids": stats.duplicate_ids,
+            "validation_errors": errors,
+        },
+    )

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/consume.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/consume.py
@@ -1,4 +1,4 @@
-"""RabbitMQ push and pull consumption ceiling benchmarks."""
+"""Configurable Jobs consumption ceiling benchmark."""
 
 from __future__ import annotations
 
@@ -6,20 +6,25 @@ import threading
 import time
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import ClassVar, Literal
+from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from mindtrace.core import BenchReporter, BenchResult, BenchResultSchema, BenchSuiteConfig, BenchTestSuite, TaskSchema
 from mindtrace.jobs import Consumer
 from mindtrace.jobs.testing.suites._common import (
-    RabbitMQBenchResources,
+    BackendName,
+    BackendRuntime,
+    JobsBenchResources,
     WorkerStats,
     bench_result,
-    cleanup_rabbitmq_runtime,
-    create_rabbitmq_runtime,
+    cleanup_backend_runtime,
+    connect_consumer,
+    create_backend_runtime,
+    delivery_transport,
     make_jobs,
     payload_text,
+    validate_parameters,
     wait_for_deadline,
 )
 
@@ -27,14 +32,22 @@ ConsumeMode = Literal["iterative_pull_one", "steady_pull", "push"]
 
 
 class JobsConsumeCeilingInput(BaseModel):
-    """Parameters shared by RabbitMQ consume ceiling modes."""
+    """Parameters for sustained consumption from a preloaded queue."""
 
+    backend: BackendName = Field("rabbitmq", description="Jobs backend to exercise.")
+    consume_mode: ConsumeMode = Field("push", description="Public consumption pattern to benchmark.")
     payload_size_bytes: int = Field(256, ge=0, description="Deterministic payload size per job.")
     backlog_messages: int = Field(100_000, ge=1, description="Messages preloaded before measurement.")
     preload_batch_size: int = Field(1_000, ge=1, description="Messages per preload publication call.")
-    prefetch_count: int = Field(1, ge=1, description="RabbitMQ consumer prefetch count.")
+    prefetch_count: int = Field(1, ge=1, description="RabbitMQ prefetch count; ignored by other backends.")
     latency_sample_limit: int = Field(10_000, ge=0, description="Maximum retained callback-latency samples.")
     join_timeout_seconds: float = Field(15.0, gt=0, description="Maximum post-deadline consumer join time.")
+
+    @model_validator(mode="after")
+    def validate_backend_mode(self) -> "JobsConsumeCeilingInput":
+        if self.consume_mode == "push" and self.backend != "rabbitmq":
+            raise ValueError("consume_mode='push' requires backend='rabbitmq'")
+        return self
 
 
 class _RecordingConsumer(Consumer):
@@ -78,36 +91,7 @@ def _consume_worker(consumer: _RecordingConsumer, mode: ConsumeMode, outcome: _C
         outcome.error = exc
 
 
-def _profiles() -> MappingProxyType:
-    return MappingProxyType(
-        {
-            "smoke": {
-                "duration_seconds": 1.0,
-                "payload_size_bytes": 128,
-                "backlog_messages": 1_000,
-                "preload_batch_size": 250,
-                "prefetch_count": 1,
-            },
-            "stress": {
-                "duration_seconds": 10.0,
-                "payload_size_bytes": 256,
-                "backlog_messages": 100_000,
-                "preload_batch_size": 1_000,
-                "prefetch_count": 1,
-                "latency_sample_limit": 10_000,
-                "join_timeout_seconds": 15.0,
-                "resources": {
-                    "rabbitmq_host": "localhost",
-                    "rabbitmq_port": 5672,
-                    "rabbitmq_username": "user",
-                    "rabbitmq_password": "password",
-                },
-            },
-        }
-    )
-
-
-def _preload_jobs(*, runtime, message_count: int, batch_size: int, payload: str) -> None:
+def _preload_jobs(*, runtime: BackendRuntime, message_count: int, batch_size: int, payload: str) -> None:
     sequence = 0
     while sequence < message_count:
         count = min(batch_size, message_count - sequence)
@@ -115,55 +99,77 @@ def _preload_jobs(*, runtime, message_count: int, batch_size: int, payload: str)
         result = runtime.orchestrator.publish_batch(runtime.queue_name, jobs)
         if not result.all_succeeded:
             raise RuntimeError(
-                f"RabbitMQ preload failed at sequence {sequence}: "
-                f"successes={result.success_count}, errors={result.errors}, unattempted={result.unattempted_count}"
+                f"Preload failed at sequence {sequence}: successes={result.success_count}, "
+                f"errors={result.errors}, unattempted={result.unattempted_count}"
             )
         sequence += count
 
 
-class _RabbitMQConsumeCeilingSuite(BenchTestSuite):
-    mode: ClassVar[ConsumeMode]
-    tags = frozenset({"stress", "jobs", "rabbitmq", "consume"})
-    requires = ("rabbitmq",)
-    safety = "Creates, fills, and deletes one uniquely named durable RabbitMQ queue."
-    task_schema: ClassVar[TaskSchema]
-    resource_schema = RabbitMQBenchResources
-    profiles = _profiles()
+class JobsConsumeCeilingSuite(BenchTestSuite):
+    """Measure selected pull or push consumption over a preloaded queue."""
+
+    suite_id = "jobs.stress.consume_ceiling"
+    title = "Jobs stress — consume ceiling"
+    description = "Measures iterative, steady, or broker-pushed consumption using a selected Jobs backend."
+    tags = frozenset({"stress", "jobs", "consume"})
+    requires = ()
+    safety = "Creates, fills, and deletes one uniquely named queue on the selected backend."
+    task_schema = TaskSchema(name=suite_id, input_schema=JobsConsumeCeilingInput, output_schema=BenchResultSchema)
+    resource_schema = JobsBenchResources
+    profiles = MappingProxyType(
+        {
+            "smoke": {
+                "duration_seconds": 1.0,
+                "backend": "local",
+                "consume_mode": "steady_pull",
+                "payload_size_bytes": 128,
+                "backlog_messages": 1_000,
+                "preload_batch_size": 250,
+                "prefetch_count": 1,
+            },
+            "stress": {
+                "duration_seconds": 10.0,
+                "backend": "rabbitmq",
+                "consume_mode": "push",
+                "payload_size_bytes": 256,
+                "backlog_messages": 100_000,
+                "preload_batch_size": 1_000,
+                "prefetch_count": 1,
+                "latency_sample_limit": 10_000,
+                "join_timeout_seconds": 15.0,
+            },
+        }
+    )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        payload_size = int(config.parameters.get("payload_size_bytes", 256))
-        backlog_messages = int(config.parameters.get("backlog_messages", 100_000))
-        preload_batch_size = int(config.parameters.get("preload_batch_size", 1_000))
-        prefetch_count = int(config.parameters.get("prefetch_count", 1))
-        sample_limit = int(config.parameters.get("latency_sample_limit", 10_000))
-        join_timeout = float(config.parameters.get("join_timeout_seconds", 15.0))
-        payload = payload_text(payload_size)
-        runtime = create_rabbitmq_runtime(config, suffix=self.mode)
-        stats = WorkerStats(latency_sample_limit=sample_limit)
-        consumer = _RecordingConsumer(stats)
-        consumer.connect_to_orchestrator(
-            runtime.orchestrator,
-            runtime.queue_name,
-            prefetch_count=prefetch_count,
+        parameters = validate_parameters(config, JobsConsumeCeilingInput)
+        payload = payload_text(parameters.payload_size_bytes)
+        runtime = create_backend_runtime(
+            config,
+            backend=parameters.backend,
+            suffix=f"consume-{parameters.consume_mode}",
         )
+        stats = WorkerStats(latency_sample_limit=parameters.latency_sample_limit)
+        consumer = _RecordingConsumer(stats)
         outcome = _ConsumeOutcome()
         thread = threading.Thread(
             target=_consume_worker,
-            args=(consumer, self.mode, outcome),
-            name=f"jobs-consume-{self.mode}",
+            args=(consumer, parameters.consume_mode, outcome),
+            name=f"jobs-consume-{parameters.backend}-{parameters.consume_mode}",
             daemon=True,
         )
         validation_errors: list[str] = []
+        resources_retained = config.keep_resources
         started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         elapsed = 0.0
         remaining_messages: int | None = None
-        resources_retained = config.keep_resources
 
         try:
+            connect_consumer(consumer, runtime, prefetch_count=parameters.prefetch_count)
             _preload_jobs(
                 runtime=runtime,
-                message_count=backlog_messages,
-                batch_size=preload_batch_size,
+                message_count=parameters.backlog_messages,
+                batch_size=parameters.preload_batch_size,
                 payload=payload,
             )
             measurement_start = time.perf_counter()
@@ -171,11 +177,13 @@ class _RabbitMQConsumeCeilingSuite(BenchTestSuite):
             thread.start()
             wait_for_deadline(deadline, is_cancelled=reporter.is_cancelled)
             consumer.stop()
-            thread.join(timeout=join_timeout)
+            thread.join(timeout=parameters.join_timeout_seconds)
             elapsed = time.perf_counter() - measurement_start
 
             if thread.is_alive():
-                validation_errors.append(f"Consumer thread did not stop within {join_timeout}s")
+                validation_errors.append(
+                    f"Consumer thread did not stop within {parameters.join_timeout_seconds}s"
+                )
             if outcome.error is not None:
                 validation_errors.append(f"Consumer raised {type(outcome.error).__name__}: {outcome.error}")
             if outcome.attempted != stats.operations:
@@ -185,26 +193,30 @@ class _RabbitMQConsumeCeilingSuite(BenchTestSuite):
             if stats.duplicate_ids:
                 validation_errors.append(f"Observed {stats.duplicate_ids} duplicate job IDs")
 
-            remaining_messages = runtime.orchestrator.count_queue_messages(runtime.queue_name)
-            expected_remaining = backlog_messages - outcome.attempted
-            if remaining_messages != expected_remaining:
-                validation_errors.append(
-                    f"Queue count mismatch: expected {expected_remaining} remaining, observed {remaining_messages}"
-                )
-            if remaining_messages == 0:
-                validation_errors.append(
-                    "Preloaded backlog was exhausted before the deadline; increase backlog_messages for a ceiling run"
-                )
+            if not thread.is_alive():
+                remaining_messages = runtime.orchestrator.count_queue_messages(runtime.queue_name)
+                expected_remaining = parameters.backlog_messages - outcome.attempted
+                if remaining_messages != expected_remaining:
+                    validation_errors.append(
+                        f"Queue count mismatch: expected {expected_remaining} remaining, "
+                        f"observed {remaining_messages}"
+                    )
+                if remaining_messages == 0:
+                    validation_errors.append(
+                        "Preloaded backlog was exhausted before the deadline; "
+                        "increase backlog_messages for a ceiling run"
+                    )
         finally:
             if thread.is_alive():
                 consumer.stop()
-                thread.join(timeout=join_timeout)
+                thread.join(timeout=parameters.join_timeout_seconds)
             if not thread.is_alive():
                 consumer.close()
             resources_retained = config.keep_resources or thread.is_alive()
-            cleanup_rabbitmq_runtime(
+            cleanup_backend_runtime(
                 runtime,
                 keep_resources=resources_retained,
+                close_client=not thread.is_alive(),
             )
 
         return bench_result(
@@ -214,12 +226,13 @@ class _RabbitMQConsumeCeilingSuite(BenchTestSuite):
             stats=stats,
             validation_errors=validation_errors,
             metrics={
-                "backend": "rabbitmq",
-                "mode": self.mode,
-                "payload_size_bytes": payload_size,
-                "backlog_messages": backlog_messages,
+                "backend": parameters.backend,
+                "consume_mode": parameters.consume_mode,
+                "delivery_transport": delivery_transport(parameters.backend, parameters.consume_mode),
+                "payload_size_bytes": parameters.payload_size_bytes,
+                "backlog_messages": parameters.backlog_messages,
                 "remaining_messages": remaining_messages,
-                "prefetch_count": prefetch_count,
+                "prefetch_count": parameters.prefetch_count if parameters.backend == "rabbitmq" else None,
                 "attempted_deliveries": outcome.attempted,
                 "consume_api_calls": outcome.consume_calls,
                 "messages_per_second": stats.successes / elapsed if elapsed > 0 else 0.0,
@@ -228,27 +241,3 @@ class _RabbitMQConsumeCeilingSuite(BenchTestSuite):
                 "queue_name": runtime.queue_name if resources_retained else None,
             },
         )
-
-
-class JobsRabbitMQIterativePullOneSuite(_RabbitMQConsumeCeilingSuite):
-    suite_id = "jobs.stress.rabbitmq_consume_iterative_pull_one"
-    title = "Jobs stress — RabbitMQ iterative consume(1) ceiling"
-    description = "Measures repeated public consume(num_messages=1) calls, including per-call connection lifecycle."
-    mode = "iterative_pull_one"
-    task_schema = TaskSchema(name=suite_id, input_schema=JobsConsumeCeilingInput, output_schema=BenchResultSchema)
-
-
-class JobsRabbitMQSteadyPullSuite(_RabbitMQConsumeCeilingSuite):
-    suite_id = "jobs.stress.rabbitmq_consume_steady_pull"
-    title = "Jobs stress — RabbitMQ steady basic_get ceiling"
-    description = "Measures one long finite consume operation using basic_get on one connection and channel."
-    mode = "steady_pull"
-    task_schema = TaskSchema(name=suite_id, input_schema=JobsConsumeCeilingInput, output_schema=BenchResultSchema)
-
-
-class JobsRabbitMQPushSuite(_RabbitMQConsumeCeilingSuite):
-    suite_id = "jobs.stress.rabbitmq_consume_push"
-    title = "Jobs stress — RabbitMQ broker-push ceiling"
-    description = "Measures bare blocking consume() using basic_consume and start_consuming."
-    mode = "push"
-    task_schema = TaskSchema(name=suite_id, input_schema=JobsConsumeCeilingInput, output_schema=BenchResultSchema)

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/consume.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/consume.py
@@ -183,9 +183,7 @@ class JobsConsumeCeilingSuite(BenchTestSuite):
             elapsed = time.perf_counter() - measurement_start
 
             if thread.is_alive():
-                validation_errors.append(
-                    f"Consumer thread did not stop within {parameters.join_timeout_seconds}s"
-                )
+                validation_errors.append(f"Consumer thread did not stop within {parameters.join_timeout_seconds}s")
             if outcome.error is not None:
                 validation_errors.append(f"Consumer raised {type(outcome.error).__name__}: {outcome.error}")
             if outcome.attempted != stats.operations:
@@ -200,8 +198,7 @@ class JobsConsumeCeilingSuite(BenchTestSuite):
                 expected_remaining = parameters.backlog_messages - outcome.attempted
                 if remaining_messages != expected_remaining:
                     validation_errors.append(
-                        f"Queue count mismatch: expected {expected_remaining} remaining, "
-                        f"observed {remaining_messages}"
+                        f"Queue count mismatch: expected {expected_remaining} remaining, observed {remaining_messages}"
                     )
                 if remaining_messages == 0:
                     validation_errors.append(

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/consume.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/consume.py
@@ -24,6 +24,7 @@ from mindtrace.jobs.testing.suites._common import (
     delivery_transport,
     make_jobs,
     payload_text,
+    redis_background_errors,
     validate_parameters,
     wait_for_deadline,
 )
@@ -123,7 +124,7 @@ class JobsConsumeCeilingSuite(BenchTestSuite):
                 "backend": "local",
                 "consume_mode": "steady_pull",
                 "payload_size_bytes": 128,
-                "backlog_messages": 1_000,
+                "backlog_messages": 500,
                 "preload_batch_size": 250,
                 "prefetch_count": 1,
             },
@@ -159,6 +160,7 @@ class JobsConsumeCeilingSuite(BenchTestSuite):
             daemon=True,
         )
         validation_errors: list[str] = []
+        background_errors: list[str] = []
         resources_retained = config.keep_resources
         started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         elapsed = 0.0
@@ -210,6 +212,11 @@ class JobsConsumeCeilingSuite(BenchTestSuite):
             if thread.is_alive():
                 consumer.stop()
                 thread.join(timeout=parameters.join_timeout_seconds)
+            background_errors = redis_background_errors(
+                runtime.client,
+                getattr(consumer, "consumer_backend", None),
+            )
+            validation_errors.extend(background_errors)
             if not thread.is_alive():
                 consumer.close()
             resources_retained = config.keep_resources or thread.is_alive()
@@ -237,6 +244,7 @@ class JobsConsumeCeilingSuite(BenchTestSuite):
                 "consume_api_calls": outcome.consume_calls,
                 "messages_per_second": stats.successes / elapsed if elapsed > 0 else 0.0,
                 "latency_kind": "consumer_callback",
+                "background_errors": background_errors,
                 "resources_retained": resources_retained,
                 "queue_name": runtime.queue_name if resources_retained else None,
             },

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/consume.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/consume.py
@@ -1,0 +1,254 @@
+"""RabbitMQ push and pull consumption ceiling benchmarks."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, Field
+
+from mindtrace.core import BenchReporter, BenchResult, BenchResultSchema, BenchSuiteConfig, BenchTestSuite, TaskSchema
+from mindtrace.jobs import Consumer
+from mindtrace.jobs.testing.suites._common import (
+    RabbitMQBenchResources,
+    WorkerStats,
+    bench_result,
+    cleanup_rabbitmq_runtime,
+    create_rabbitmq_runtime,
+    make_jobs,
+    payload_text,
+    wait_for_deadline,
+)
+
+ConsumeMode = Literal["iterative_pull_one", "steady_pull", "push"]
+
+
+class JobsConsumeCeilingInput(BaseModel):
+    """Parameters shared by RabbitMQ consume ceiling modes."""
+
+    payload_size_bytes: int = Field(256, ge=0, description="Deterministic payload size per job.")
+    backlog_messages: int = Field(100_000, ge=1, description="Messages preloaded before measurement.")
+    preload_batch_size: int = Field(1_000, ge=1, description="Messages per preload publication call.")
+    prefetch_count: int = Field(1, ge=1, description="RabbitMQ consumer prefetch count.")
+    latency_sample_limit: int = Field(10_000, ge=0, description="Maximum retained callback-latency samples.")
+    join_timeout_seconds: float = Field(15.0, gt=0, description="Maximum post-deadline consumer join time.")
+
+
+class _RecordingConsumer(Consumer):
+    def __init__(self, stats: WorkerStats) -> None:
+        super().__init__()
+        self.stats = stats
+
+    def run(self, job_dict: dict) -> dict:
+        op_start = time.perf_counter()
+        payload = job_dict.get("payload")
+        payload_size = int(payload.get("payload_size_bytes", 0)) if isinstance(payload, dict) else 0
+        self.stats.record(
+            success=True,
+            latency_seconds=time.perf_counter() - op_start,
+            bytes_processed=payload_size,
+            item_id=str(job_dict.get("id", "")),
+        )
+        return {}
+
+
+@dataclass
+class _ConsumeOutcome:
+    attempted: int = 0
+    consume_calls: int = 0
+    error: BaseException | None = None
+
+
+def _consume_worker(consumer: _RecordingConsumer, mode: ConsumeMode, outcome: _ConsumeOutcome) -> None:
+    try:
+        if mode == "iterative_pull_one":
+            while not consumer.consumer_backend.stopped:
+                outcome.consume_calls += 1
+                outcome.attempted += consumer.consume(num_messages=1, block=True)
+        elif mode == "steady_pull":
+            outcome.consume_calls = 1
+            outcome.attempted = consumer.consume(num_messages=2**63 - 1, block=True)
+        else:
+            outcome.consume_calls = 1
+            outcome.attempted = consumer.consume(num_messages=0, block=True)
+    except BaseException as exc:  # noqa: BLE001 - surfaced in benchmark result.
+        outcome.error = exc
+
+
+def _profiles() -> MappingProxyType:
+    return MappingProxyType(
+        {
+            "smoke": {
+                "duration_seconds": 1.0,
+                "payload_size_bytes": 128,
+                "backlog_messages": 1_000,
+                "preload_batch_size": 250,
+                "prefetch_count": 1,
+            },
+            "stress": {
+                "duration_seconds": 10.0,
+                "payload_size_bytes": 256,
+                "backlog_messages": 100_000,
+                "preload_batch_size": 1_000,
+                "prefetch_count": 1,
+                "latency_sample_limit": 10_000,
+                "join_timeout_seconds": 15.0,
+                "resources": {
+                    "rabbitmq_host": "localhost",
+                    "rabbitmq_port": 5672,
+                    "rabbitmq_username": "user",
+                    "rabbitmq_password": "password",
+                },
+            },
+        }
+    )
+
+
+def _preload_jobs(*, runtime, message_count: int, batch_size: int, payload: str) -> None:
+    sequence = 0
+    while sequence < message_count:
+        count = min(batch_size, message_count - sequence)
+        jobs = make_jobs(runtime.queue_name, start=sequence, count=count, payload=payload)
+        result = runtime.orchestrator.publish_batch(runtime.queue_name, jobs)
+        if not result.all_succeeded:
+            raise RuntimeError(
+                f"RabbitMQ preload failed at sequence {sequence}: "
+                f"successes={result.success_count}, errors={result.errors}, unattempted={result.unattempted_count}"
+            )
+        sequence += count
+
+
+class _RabbitMQConsumeCeilingSuite(BenchTestSuite):
+    mode: ClassVar[ConsumeMode]
+    tags = frozenset({"stress", "jobs", "rabbitmq", "consume"})
+    requires = ("rabbitmq",)
+    safety = "Creates, fills, and deletes one uniquely named durable RabbitMQ queue."
+    task_schema: ClassVar[TaskSchema]
+    resource_schema = RabbitMQBenchResources
+    profiles = _profiles()
+
+    def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
+        payload_size = int(config.parameters.get("payload_size_bytes", 256))
+        backlog_messages = int(config.parameters.get("backlog_messages", 100_000))
+        preload_batch_size = int(config.parameters.get("preload_batch_size", 1_000))
+        prefetch_count = int(config.parameters.get("prefetch_count", 1))
+        sample_limit = int(config.parameters.get("latency_sample_limit", 10_000))
+        join_timeout = float(config.parameters.get("join_timeout_seconds", 15.0))
+        payload = payload_text(payload_size)
+        runtime = create_rabbitmq_runtime(config, suffix=self.mode)
+        stats = WorkerStats(latency_sample_limit=sample_limit)
+        consumer = _RecordingConsumer(stats)
+        consumer.connect_to_orchestrator(
+            runtime.orchestrator,
+            runtime.queue_name,
+            prefetch_count=prefetch_count,
+        )
+        outcome = _ConsumeOutcome()
+        thread = threading.Thread(
+            target=_consume_worker,
+            args=(consumer, self.mode, outcome),
+            name=f"jobs-consume-{self.mode}",
+            daemon=True,
+        )
+        validation_errors: list[str] = []
+        started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        elapsed = 0.0
+        remaining_messages: int | None = None
+        resources_retained = config.keep_resources
+
+        try:
+            _preload_jobs(
+                runtime=runtime,
+                message_count=backlog_messages,
+                batch_size=preload_batch_size,
+                payload=payload,
+            )
+            measurement_start = time.perf_counter()
+            deadline = reporter.deadline(config.duration_seconds)
+            thread.start()
+            wait_for_deadline(deadline, is_cancelled=reporter.is_cancelled)
+            consumer.stop()
+            thread.join(timeout=join_timeout)
+            elapsed = time.perf_counter() - measurement_start
+
+            if thread.is_alive():
+                validation_errors.append(f"Consumer thread did not stop within {join_timeout}s")
+            if outcome.error is not None:
+                validation_errors.append(f"Consumer raised {type(outcome.error).__name__}: {outcome.error}")
+            if outcome.attempted != stats.operations:
+                validation_errors.append(
+                    f"Attempted-delivery count {outcome.attempted} did not match callback count {stats.operations}"
+                )
+            if stats.duplicate_ids:
+                validation_errors.append(f"Observed {stats.duplicate_ids} duplicate job IDs")
+
+            remaining_messages = runtime.orchestrator.count_queue_messages(runtime.queue_name)
+            expected_remaining = backlog_messages - outcome.attempted
+            if remaining_messages != expected_remaining:
+                validation_errors.append(
+                    f"Queue count mismatch: expected {expected_remaining} remaining, observed {remaining_messages}"
+                )
+            if remaining_messages == 0:
+                validation_errors.append(
+                    "Preloaded backlog was exhausted before the deadline; increase backlog_messages for a ceiling run"
+                )
+        finally:
+            if thread.is_alive():
+                consumer.stop()
+                thread.join(timeout=join_timeout)
+            if not thread.is_alive():
+                consumer.close()
+            resources_retained = config.keep_resources or thread.is_alive()
+            cleanup_rabbitmq_runtime(
+                runtime,
+                keep_resources=resources_retained,
+            )
+
+        return bench_result(
+            config=config,
+            started_at=started_at,
+            duration_seconds=elapsed,
+            stats=stats,
+            validation_errors=validation_errors,
+            metrics={
+                "backend": "rabbitmq",
+                "mode": self.mode,
+                "payload_size_bytes": payload_size,
+                "backlog_messages": backlog_messages,
+                "remaining_messages": remaining_messages,
+                "prefetch_count": prefetch_count,
+                "attempted_deliveries": outcome.attempted,
+                "consume_api_calls": outcome.consume_calls,
+                "messages_per_second": stats.successes / elapsed if elapsed > 0 else 0.0,
+                "latency_kind": "consumer_callback",
+                "resources_retained": resources_retained,
+                "queue_name": runtime.queue_name if resources_retained else None,
+            },
+        )
+
+
+class JobsRabbitMQIterativePullOneSuite(_RabbitMQConsumeCeilingSuite):
+    suite_id = "jobs.stress.rabbitmq_consume_iterative_pull_one"
+    title = "Jobs stress — RabbitMQ iterative consume(1) ceiling"
+    description = "Measures repeated public consume(num_messages=1) calls, including per-call connection lifecycle."
+    mode = "iterative_pull_one"
+    task_schema = TaskSchema(name=suite_id, input_schema=JobsConsumeCeilingInput, output_schema=BenchResultSchema)
+
+
+class JobsRabbitMQSteadyPullSuite(_RabbitMQConsumeCeilingSuite):
+    suite_id = "jobs.stress.rabbitmq_consume_steady_pull"
+    title = "Jobs stress — RabbitMQ steady basic_get ceiling"
+    description = "Measures one long finite consume operation using basic_get on one connection and channel."
+    mode = "steady_pull"
+    task_schema = TaskSchema(name=suite_id, input_schema=JobsConsumeCeilingInput, output_schema=BenchResultSchema)
+
+
+class JobsRabbitMQPushSuite(_RabbitMQConsumeCeilingSuite):
+    suite_id = "jobs.stress.rabbitmq_consume_push"
+    title = "Jobs stress — RabbitMQ broker-push ceiling"
+    description = "Measures bare blocking consume() using basic_consume and start_consuming."
+    mode = "push"
+    task_schema = TaskSchema(name=suite_id, input_schema=JobsConsumeCeilingInput, output_schema=BenchResultSchema)

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/pipeline.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/pipeline.py
@@ -1,4 +1,4 @@
-"""RabbitMQ end-to-end producer/consumer scaling benchmarks."""
+"""Configurable Jobs end-to-end pipeline scaling benchmark."""
 
 from __future__ import annotations
 
@@ -6,37 +6,49 @@ import threading
 import time
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import ClassVar
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from mindtrace.core import BenchReporter, BenchResult, BenchResultSchema, BenchSuiteConfig, BenchTestSuite, TaskSchema
-from mindtrace.jobs import Consumer, Orchestrator, RabbitMQClient
+from mindtrace.jobs import Consumer, Orchestrator
 from mindtrace.jobs.testing.suites._common import (
-    RabbitMQBenchResources,
+    BackendName,
+    JobsBenchResources,
     WorkerStats,
     bench_result,
-    cleanup_rabbitmq_runtime,
-    close_rabbitmq_client,
-    create_rabbitmq_runtime,
+    cleanup_backend_runtime,
+    close_backend_client,
+    connect_consumer,
+    create_backend_runtime,
+    create_backend_worker_client,
+    delivery_transport,
     make_jobs,
     merge_worker_stats,
     payload_text,
-    rabbitmq_kwargs,
+    validate_parameters,
+    validate_resources,
     wait_for_deadline,
 )
 
 
 class JobsPipelineScalingInput(BaseModel):
-    """Parameters for concurrent RabbitMQ producer/consumer throughput."""
+    """Parameters for concurrent producer/consumer throughput."""
 
+    backend: BackendName = Field("rabbitmq", description="Jobs backend to exercise.")
     payload_size_bytes: int = Field(256, ge=0, description="Deterministic payload size per job.")
     batch_size: int = Field(250, ge=1, description="Messages submitted by each producer API call.")
-    producer_count: int = Field(1, ge=1, description="Independent producer threads and connections.")
-    prefetch_count: int = Field(1, ge=1, description="RabbitMQ prefetch count per consumer.")
-    consumer_startup_seconds: float = Field(0.5, ge=0, description="Consumer registration time before producers start.")
+    producer_count: int = Field(1, ge=1, description="Independent producer threads and clients.")
+    consumer_count: int = Field(1, ge=1, description="Independent consumer threads.")
+    prefetch_count: int = Field(1, ge=1, description="RabbitMQ prefetch count; ignored by other backends.")
+    consumer_startup_seconds: float = Field(0.5, ge=0, description="Consumer startup time before producers begin.")
     latency_sample_limit: int = Field(10_000, ge=0, description="Maximum retained end-to-end latency samples.")
     join_timeout_seconds: float = Field(15.0, gt=0, description="Maximum post-deadline worker join time.")
+
+    @model_validator(mode="after")
+    def validate_backend_concurrency(self) -> "JobsPipelineScalingInput":
+        if self.backend == "local" and (self.producer_count != 1 or self.consumer_count != 1):
+            raise ValueError("Local pipeline benchmarks require producer_count=1 and consumer_count=1")
+        return self
 
 
 class _PipelineConsumer(Consumer):
@@ -64,7 +76,7 @@ class _PipelineConsumeOutcome:
     error: BaseException | None = None
 
 
-def _run_push_consumer(consumer: _PipelineConsumer, outcome: _PipelineConsumeOutcome) -> None:
+def _run_pipeline_consumer(consumer: _PipelineConsumer, outcome: _PipelineConsumeOutcome) -> None:
     try:
         outcome.attempted = consumer.consume(num_messages=0, block=True)
     except BaseException as exc:  # noqa: BLE001 - surfaced in benchmark result.
@@ -119,7 +131,7 @@ def _run_pipeline_producer(
                 success=False,
                 latency_seconds=latency,
                 error=RuntimeError(
-                    f"RabbitMQ batch published {result.success_count}/{len(jobs)} messages; errors={result.errors}"
+                    f"Batch published {result.success_count}/{len(jobs)} messages; errors={result.errors}"
                 ),
                 operations=rejected,
             )
@@ -127,92 +139,100 @@ def _run_pipeline_producer(
         sequence += batch_size
 
 
-def _profiles(consumer_count: int) -> MappingProxyType:
-    return MappingProxyType(
+class JobsPipelineScalingSuite(BenchTestSuite):
+    """Measure end-to-end pipeline scaling on a selected Jobs backend."""
+
+    suite_id = "jobs.stress.pipeline_scaling"
+    title = "Jobs stress — pipeline scaling"
+    description = "Measures concurrent publication, consumption, and work distribution on a selected backend."
+    tags = frozenset({"stress", "jobs", "pipeline", "scaling"})
+    requires = ()
+    safety = "Creates and deletes one uniquely named queue and generates sustained traffic."
+    task_schema = TaskSchema(name=suite_id, input_schema=JobsPipelineScalingInput, output_schema=BenchResultSchema)
+    resource_schema = JobsBenchResources
+    profiles = MappingProxyType(
         {
             "smoke": {
                 "duration_seconds": 1.0,
+                "backend": "local",
                 "payload_size_bytes": 128,
                 "batch_size": 25,
                 "producer_count": 1,
+                "consumer_count": 1,
                 "prefetch_count": 1,
                 "consumer_startup_seconds": 0.1,
             },
             "stress": {
                 "duration_seconds": 10.0,
+                "backend": "rabbitmq",
                 "payload_size_bytes": 256,
                 "batch_size": 250,
                 "producer_count": 1,
-                "consumer_count": consumer_count,
+                "consumer_count": 1,
                 "prefetch_count": 1,
                 "consumer_startup_seconds": 0.5,
                 "latency_sample_limit": 10_000,
                 "join_timeout_seconds": 15.0,
-                "resources": {
-                    "rabbitmq_host": "localhost",
-                    "rabbitmq_port": 5672,
-                    "rabbitmq_username": "user",
-                    "rabbitmq_password": "password",
-                },
             },
         }
     )
 
-
-class _RabbitMQPipelineScalingSuite(BenchTestSuite):
-    consumer_count: ClassVar[int]
-    tags = frozenset({"stress", "jobs", "rabbitmq", "pipeline", "scaling"})
-    requires = ("rabbitmq",)
-    safety = "Creates and deletes one uniquely named durable RabbitMQ queue and generates sustained traffic."
-    task_schema: ClassVar[TaskSchema]
-    resource_schema = RabbitMQBenchResources
-
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        payload_size = int(config.parameters.get("payload_size_bytes", 256))
-        batch_size = int(config.parameters.get("batch_size", 250))
-        producer_count = int(config.parameters.get("producer_count", 1))
-        consumer_count = int(config.parameters.get("consumer_count", self.consumer_count))
-        prefetch_count = int(config.parameters.get("prefetch_count", 1))
-        startup_seconds = float(config.parameters.get("consumer_startup_seconds", 0.5))
-        sample_limit = int(config.parameters.get("latency_sample_limit", 10_000))
-        join_timeout = float(config.parameters.get("join_timeout_seconds", 15.0))
-        payload = payload_text(payload_size)
-        runtime = create_rabbitmq_runtime(config, suffix=f"pipeline-{consumer_count}")
-        producer_clients = [RabbitMQClient(**rabbitmq_kwargs(config)) for _ in range(producer_count)]
-        producer_orchestrators = [Orchestrator(client) for client in producer_clients]
-        producer_stats = [WorkerStats(latency_sample_limit=sample_limit) for _ in range(producer_count)]
-        api_calls = [0] * producer_count
-        consumer_stats = [WorkerStats(latency_sample_limit=sample_limit) for _ in range(consumer_count)]
-        consumers = [_PipelineConsumer(stats) for stats in consumer_stats]
-        for consumer in consumers:
-            consumer.connect_to_orchestrator(
-                runtime.orchestrator,
-                runtime.queue_name,
-                prefetch_count=prefetch_count,
-            )
-        consume_outcomes = [_PipelineConsumeOutcome() for _ in consumers]
-        consumer_threads = [
-            threading.Thread(
-                target=_run_push_consumer,
-                args=(consumer, consume_outcomes[index]),
-                name=f"jobs-pipeline-consumer-{index}",
-                daemon=True,
-            )
-            for index, consumer in enumerate(consumers)
+        parameters = validate_parameters(config, JobsPipelineScalingInput)
+        resources = validate_resources(config)
+        payload = payload_text(parameters.payload_size_bytes)
+        runtime = create_backend_runtime(config, backend=parameters.backend, suffix="pipeline")
+        producer_clients = [runtime.client] if parameters.backend == "local" else []
+        producer_orchestrators = [runtime.orchestrator] if parameters.backend == "local" else []
+        producer_stats = [
+            WorkerStats(latency_sample_limit=parameters.latency_sample_limit)
+            for _ in range(parameters.producer_count)
         ]
+        consumer_stats = [
+            WorkerStats(latency_sample_limit=parameters.latency_sample_limit)
+            for _ in range(parameters.consumer_count)
+        ]
+        api_calls = [0] * parameters.producer_count
+        consumers: list[_PipelineConsumer] = []
+        consume_outcomes: list[_PipelineConsumeOutcome] = []
+        consumer_threads: list[threading.Thread] = []
+        producer_threads: list[threading.Thread] = []
         producer_start = threading.Event()
         producer_stop = threading.Event()
         validation_errors: list[str] = []
         started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         elapsed = 0.0
         remaining_messages: int | None = None
-        producer_threads: list[threading.Thread] = []
         resources_retained = config.keep_resources
 
         try:
+            for _ in range(len(producer_clients), parameters.producer_count):
+                client = create_backend_worker_client(runtime, resources)
+                producer_clients.append(client)
+                producer_orchestrators.append(Orchestrator(client))
+
+            for index, stats in enumerate(consumer_stats):
+                consumer = _PipelineConsumer(stats)
+                try:
+                    connect_consumer(consumer, runtime, prefetch_count=parameters.prefetch_count)
+                except BaseException:
+                    consumer.close()
+                    raise
+                consumers.append(consumer)
+                outcome = _PipelineConsumeOutcome()
+                consume_outcomes.append(outcome)
+                consumer_threads.append(
+                    threading.Thread(
+                        target=_run_pipeline_consumer,
+                        args=(consumer, outcome),
+                        name=f"jobs-pipeline-{parameters.backend}-consumer-{index}",
+                        daemon=True,
+                    )
+                )
+
             for thread in consumer_threads:
                 thread.start()
-            threading.Event().wait(startup_seconds)
+            threading.Event().wait(parameters.consumer_startup_seconds)
 
             measurement_start = time.perf_counter()
             deadline = reporter.deadline(config.duration_seconds)
@@ -223,8 +243,8 @@ class _RabbitMQPipelineScalingSuite(BenchTestSuite):
                         "orchestrator": producer_orchestrators[index],
                         "queue_name": runtime.queue_name,
                         "payload": payload,
-                        "payload_size": payload_size,
-                        "batch_size": batch_size,
+                        "payload_size": parameters.payload_size_bytes,
+                        "batch_size": parameters.batch_size,
                         "producer_index": index,
                         "deadline": deadline,
                         "start_event": producer_start,
@@ -232,10 +252,10 @@ class _RabbitMQPipelineScalingSuite(BenchTestSuite):
                         "stats": producer_stats[index],
                         "api_calls": api_calls,
                     },
-                    name=f"jobs-pipeline-producer-{index}",
+                    name=f"jobs-pipeline-{parameters.backend}-producer-{index}",
                     daemon=True,
                 )
-                for index in range(producer_count)
+                for index in range(parameters.producer_count)
             ]
             for thread in producer_threads:
                 thread.start()
@@ -243,15 +263,19 @@ class _RabbitMQPipelineScalingSuite(BenchTestSuite):
             wait_for_deadline(deadline, is_cancelled=reporter.is_cancelled)
             producer_stop.set()
             for thread in producer_threads:
-                thread.join(timeout=join_timeout)
+                thread.join(timeout=parameters.join_timeout_seconds)
                 if thread.is_alive():
-                    validation_errors.append(f"Producer thread {thread.name} did not stop within {join_timeout}s")
+                    validation_errors.append(
+                        f"Producer thread {thread.name} did not stop within {parameters.join_timeout_seconds}s"
+                    )
             for consumer in consumers:
                 consumer.stop()
             for thread in consumer_threads:
-                thread.join(timeout=join_timeout)
+                thread.join(timeout=parameters.join_timeout_seconds)
                 if thread.is_alive():
-                    validation_errors.append(f"Consumer thread {thread.name} did not stop within {join_timeout}s")
+                    validation_errors.append(
+                        f"Consumer thread {thread.name} did not stop within {parameters.join_timeout_seconds}s"
+                    )
             elapsed = time.perf_counter() - measurement_start
 
             for index, outcome in enumerate(consume_outcomes):
@@ -265,51 +289,61 @@ class _RabbitMQPipelineScalingSuite(BenchTestSuite):
                         f"{consumer_stats[index].operations} callbacks"
                     )
 
-            published = merge_worker_stats(producer_stats, latency_sample_limit=sample_limit)
-            processed = merge_worker_stats(consumer_stats, latency_sample_limit=sample_limit)
+            published = merge_worker_stats(
+                producer_stats,
+                latency_sample_limit=parameters.latency_sample_limit,
+            )
+            processed = merge_worker_stats(
+                consumer_stats,
+                latency_sample_limit=parameters.latency_sample_limit,
+            )
             unknown_ids = processed.seen_ids.difference(published.seen_ids)
             if unknown_ids:
-                validation_errors.append(f"Consumed {len(unknown_ids)} job IDs that were not published by this run")
+                validation_errors.append(f"Consumed {len(unknown_ids)} job IDs not published by this run")
             if processed.duplicate_ids:
                 validation_errors.append(f"Observed {processed.duplicate_ids} duplicate deliveries")
             if published.failures:
                 validation_errors.append(f"Failed or skipped {published.failures} publication attempts")
 
-            remaining_messages = runtime.orchestrator.count_queue_messages(runtime.queue_name)
-            expected_remaining = published.successes - processed.successes
-            if remaining_messages != expected_remaining:
-                validation_errors.append(
-                    f"Pipeline balance mismatch: published={published.successes}, processed={processed.successes}, "
-                    f"expected_remaining={expected_remaining}, observed_remaining={remaining_messages}"
-                )
+            if not any(thread.is_alive() for thread in [*producer_threads, *consumer_threads]):
+                remaining_messages = runtime.orchestrator.count_queue_messages(runtime.queue_name)
+                expected_remaining = published.successes - processed.successes
+                if remaining_messages != expected_remaining:
+                    validation_errors.append(
+                        f"Pipeline balance mismatch: published={published.successes}, "
+                        f"processed={processed.successes}, expected_remaining={expected_remaining}, "
+                        f"observed_remaining={remaining_messages}"
+                    )
         finally:
             producer_stop.set()
+            producer_start.set()
             for consumer in consumers:
                 if not consumer.consumer_backend.stopped:
                     consumer.stop()
             for thread in producer_threads:
                 if thread.is_alive():
-                    thread.join(timeout=join_timeout)
+                    thread.join(timeout=parameters.join_timeout_seconds)
             for thread in consumer_threads:
                 if thread.is_alive():
-                    thread.join(timeout=join_timeout)
-            for index, client in enumerate(producer_clients):
-                thread = producer_threads[index] if index < len(producer_threads) else None
-                if thread is None or not thread.is_alive():
-                    close_rabbitmq_client(client)
+                    thread.join(timeout=parameters.join_timeout_seconds)
             for consumer, thread in zip(consumers, consumer_threads, strict=True):
                 if not thread.is_alive():
                     consumer.close()
-            all_stopped = not any(thread.is_alive() for thread in [*producer_threads, *consumer_threads])
+            for index, client in enumerate(producer_clients):
+                thread = producer_threads[index] if index < len(producer_threads) else None
+                if client is not runtime.client and (thread is None or not thread.is_alive()):
+                    close_backend_client(client)
+            all_threads = [*producer_threads, *consumer_threads]
+            all_stopped = not any(thread.is_alive() for thread in all_threads)
             resources_retained = config.keep_resources or not all_stopped
-            cleanup_rabbitmq_runtime(
+            cleanup_backend_runtime(
                 runtime,
                 keep_resources=resources_retained,
+                close_client=all_stopped,
             )
 
-        published = merge_worker_stats(producer_stats, latency_sample_limit=sample_limit)
-        processed = merge_worker_stats(consumer_stats, latency_sample_limit=sample_limit)
-        per_consumer = [stats.successes for stats in consumer_stats]
+        published = merge_worker_stats(producer_stats, latency_sample_limit=parameters.latency_sample_limit)
+        processed = merge_worker_stats(consumer_stats, latency_sample_limit=parameters.latency_sample_limit)
         return bench_result(
             config=config,
             started_at=started_at,
@@ -317,39 +351,25 @@ class _RabbitMQPipelineScalingSuite(BenchTestSuite):
             stats=processed,
             validation_errors=validation_errors,
             metrics={
-                "backend": "rabbitmq",
-                "mode": "push_pipeline",
-                "payload_size_bytes": payload_size,
-                "batch_size": batch_size,
-                "producer_count": producer_count,
-                "consumer_count": consumer_count,
-                "prefetch_count": prefetch_count,
+                "backend": parameters.backend,
+                "mode": "pipeline",
+                "delivery_transport": delivery_transport(
+                    parameters.backend,
+                    "push" if parameters.backend == "rabbitmq" else "steady_pull",
+                ),
+                "payload_size_bytes": parameters.payload_size_bytes,
+                "batch_size": parameters.batch_size,
+                "producer_count": parameters.producer_count,
+                "consumer_count": parameters.consumer_count,
+                "prefetch_count": parameters.prefetch_count if parameters.backend == "rabbitmq" else None,
                 "publish_api_calls": sum(api_calls),
                 "messages_published": published.successes,
                 "messages_processed": processed.successes,
                 "remaining_messages": remaining_messages,
-                "per_consumer_messages": per_consumer,
+                "per_consumer_messages": [stats.successes for stats in consumer_stats],
                 "messages_per_second": processed.successes / elapsed if elapsed > 0 else 0.0,
                 "latency_kind": "publish_to_consumer_end_to_end",
                 "resources_retained": resources_retained,
                 "queue_name": runtime.queue_name if resources_retained else None,
             },
         )
-
-
-class JobsRabbitMQPipelineOneConsumerSuite(_RabbitMQPipelineScalingSuite):
-    suite_id = "jobs.stress.rabbitmq_pipeline_one_consumer"
-    title = "Jobs stress — RabbitMQ pipeline with one consumer"
-    description = "Measures broker-pushed end-to-end throughput and latency with one consumer."
-    consumer_count = 1
-    task_schema = TaskSchema(name=suite_id, input_schema=JobsPipelineScalingInput, output_schema=BenchResultSchema)
-    profiles = _profiles(consumer_count)
-
-
-class JobsRabbitMQPipelineFourConsumersSuite(_RabbitMQPipelineScalingSuite):
-    suite_id = "jobs.stress.rabbitmq_pipeline_four_consumers"
-    title = "Jobs stress — RabbitMQ pipeline with four consumers"
-    description = "Measures broker-pushed end-to-end throughput, latency, and distribution across four consumers."
-    consumer_count = 4
-    task_schema = TaskSchema(name=suite_id, input_schema=JobsPipelineScalingInput, output_schema=BenchResultSchema)
-    profiles = _profiles(consumer_count)

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/pipeline.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/pipeline.py
@@ -1,0 +1,355 @@
+"""RabbitMQ end-to-end producer/consumer scaling benchmarks."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import ClassVar
+
+from pydantic import BaseModel, Field
+
+from mindtrace.core import BenchReporter, BenchResult, BenchResultSchema, BenchSuiteConfig, BenchTestSuite, TaskSchema
+from mindtrace.jobs import Consumer, Orchestrator, RabbitMQClient
+from mindtrace.jobs.testing.suites._common import (
+    RabbitMQBenchResources,
+    WorkerStats,
+    bench_result,
+    cleanup_rabbitmq_runtime,
+    close_rabbitmq_client,
+    create_rabbitmq_runtime,
+    make_jobs,
+    merge_worker_stats,
+    payload_text,
+    rabbitmq_kwargs,
+    wait_for_deadline,
+)
+
+
+class JobsPipelineScalingInput(BaseModel):
+    """Parameters for concurrent RabbitMQ producer/consumer throughput."""
+
+    payload_size_bytes: int = Field(256, ge=0, description="Deterministic payload size per job.")
+    batch_size: int = Field(250, ge=1, description="Messages submitted by each producer API call.")
+    producer_count: int = Field(1, ge=1, description="Independent producer threads and connections.")
+    prefetch_count: int = Field(1, ge=1, description="RabbitMQ prefetch count per consumer.")
+    consumer_startup_seconds: float = Field(0.5, ge=0, description="Consumer registration time before producers start.")
+    latency_sample_limit: int = Field(10_000, ge=0, description="Maximum retained end-to-end latency samples.")
+    join_timeout_seconds: float = Field(15.0, gt=0, description="Maximum post-deadline worker join time.")
+
+
+class _PipelineConsumer(Consumer):
+    def __init__(self, stats: WorkerStats) -> None:
+        super().__init__()
+        self.stats = stats
+
+    def run(self, job_dict: dict) -> dict:
+        received_at_ns = time.perf_counter_ns()
+        payload = job_dict.get("payload")
+        payload_size = int(payload.get("payload_size_bytes", 0)) if isinstance(payload, dict) else 0
+        sent_at_ns = int(payload.get("sent_at_ns", received_at_ns)) if isinstance(payload, dict) else received_at_ns
+        self.stats.record(
+            success=True,
+            latency_seconds=max(0, received_at_ns - sent_at_ns) / 1_000_000_000,
+            bytes_processed=payload_size,
+            item_id=str(job_dict.get("id", "")),
+        )
+        return {}
+
+
+@dataclass
+class _PipelineConsumeOutcome:
+    attempted: int = 0
+    error: BaseException | None = None
+
+
+def _run_push_consumer(consumer: _PipelineConsumer, outcome: _PipelineConsumeOutcome) -> None:
+    try:
+        outcome.attempted = consumer.consume(num_messages=0, block=True)
+    except BaseException as exc:  # noqa: BLE001 - surfaced in benchmark result.
+        outcome.error = exc
+
+
+def _run_pipeline_producer(
+    *,
+    orchestrator: Orchestrator,
+    queue_name: str,
+    payload: str,
+    payload_size: int,
+    batch_size: int,
+    producer_index: int,
+    deadline: float,
+    start_event: threading.Event,
+    stop_event: threading.Event,
+    stats: WorkerStats,
+    api_calls: list[int],
+) -> None:
+    sequence = producer_index * 1_000_000_000
+    start_event.wait()
+    while time.perf_counter() < deadline and not stop_event.is_set():
+        jobs = make_jobs(queue_name, start=sequence, count=batch_size, payload=payload)
+        op_start = time.perf_counter()
+        try:
+            result = orchestrator.publish_batch(queue_name, jobs)
+        except Exception as exc:  # noqa: BLE001 - benchmark records backend failures.
+            stats.record(
+                success=False,
+                latency_seconds=time.perf_counter() - op_start,
+                error=exc,
+                operations=batch_size,
+            )
+            api_calls[producer_index] += 1
+            return
+
+        latency = time.perf_counter() - op_start
+        api_calls[producer_index] += 1
+        if result.success_count:
+            stats.record(
+                success=True,
+                latency_seconds=latency,
+                bytes_processed=result.success_count * payload_size,
+                operations=result.success_count,
+            )
+            for index in result.successful_indices:
+                stats.seen_ids.add(jobs[index].id)
+        rejected = result.failure_count + result.unattempted_count
+        if rejected:
+            stats.record(
+                success=False,
+                latency_seconds=latency,
+                error=RuntimeError(
+                    f"RabbitMQ batch published {result.success_count}/{len(jobs)} messages; errors={result.errors}"
+                ),
+                operations=rejected,
+            )
+            return
+        sequence += batch_size
+
+
+def _profiles(consumer_count: int) -> MappingProxyType:
+    return MappingProxyType(
+        {
+            "smoke": {
+                "duration_seconds": 1.0,
+                "payload_size_bytes": 128,
+                "batch_size": 25,
+                "producer_count": 1,
+                "prefetch_count": 1,
+                "consumer_startup_seconds": 0.1,
+            },
+            "stress": {
+                "duration_seconds": 10.0,
+                "payload_size_bytes": 256,
+                "batch_size": 250,
+                "producer_count": 1,
+                "consumer_count": consumer_count,
+                "prefetch_count": 1,
+                "consumer_startup_seconds": 0.5,
+                "latency_sample_limit": 10_000,
+                "join_timeout_seconds": 15.0,
+                "resources": {
+                    "rabbitmq_host": "localhost",
+                    "rabbitmq_port": 5672,
+                    "rabbitmq_username": "user",
+                    "rabbitmq_password": "password",
+                },
+            },
+        }
+    )
+
+
+class _RabbitMQPipelineScalingSuite(BenchTestSuite):
+    consumer_count: ClassVar[int]
+    tags = frozenset({"stress", "jobs", "rabbitmq", "pipeline", "scaling"})
+    requires = ("rabbitmq",)
+    safety = "Creates and deletes one uniquely named durable RabbitMQ queue and generates sustained traffic."
+    task_schema: ClassVar[TaskSchema]
+    resource_schema = RabbitMQBenchResources
+
+    def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
+        payload_size = int(config.parameters.get("payload_size_bytes", 256))
+        batch_size = int(config.parameters.get("batch_size", 250))
+        producer_count = int(config.parameters.get("producer_count", 1))
+        consumer_count = int(config.parameters.get("consumer_count", self.consumer_count))
+        prefetch_count = int(config.parameters.get("prefetch_count", 1))
+        startup_seconds = float(config.parameters.get("consumer_startup_seconds", 0.5))
+        sample_limit = int(config.parameters.get("latency_sample_limit", 10_000))
+        join_timeout = float(config.parameters.get("join_timeout_seconds", 15.0))
+        payload = payload_text(payload_size)
+        runtime = create_rabbitmq_runtime(config, suffix=f"pipeline-{consumer_count}")
+        producer_clients = [RabbitMQClient(**rabbitmq_kwargs(config)) for _ in range(producer_count)]
+        producer_orchestrators = [Orchestrator(client) for client in producer_clients]
+        producer_stats = [WorkerStats(latency_sample_limit=sample_limit) for _ in range(producer_count)]
+        api_calls = [0] * producer_count
+        consumer_stats = [WorkerStats(latency_sample_limit=sample_limit) for _ in range(consumer_count)]
+        consumers = [_PipelineConsumer(stats) for stats in consumer_stats]
+        for consumer in consumers:
+            consumer.connect_to_orchestrator(
+                runtime.orchestrator,
+                runtime.queue_name,
+                prefetch_count=prefetch_count,
+            )
+        consume_outcomes = [_PipelineConsumeOutcome() for _ in consumers]
+        consumer_threads = [
+            threading.Thread(
+                target=_run_push_consumer,
+                args=(consumer, consume_outcomes[index]),
+                name=f"jobs-pipeline-consumer-{index}",
+                daemon=True,
+            )
+            for index, consumer in enumerate(consumers)
+        ]
+        producer_start = threading.Event()
+        producer_stop = threading.Event()
+        validation_errors: list[str] = []
+        started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        elapsed = 0.0
+        remaining_messages: int | None = None
+        producer_threads: list[threading.Thread] = []
+        resources_retained = config.keep_resources
+
+        try:
+            for thread in consumer_threads:
+                thread.start()
+            threading.Event().wait(startup_seconds)
+
+            measurement_start = time.perf_counter()
+            deadline = reporter.deadline(config.duration_seconds)
+            producer_threads = [
+                threading.Thread(
+                    target=_run_pipeline_producer,
+                    kwargs={
+                        "orchestrator": producer_orchestrators[index],
+                        "queue_name": runtime.queue_name,
+                        "payload": payload,
+                        "payload_size": payload_size,
+                        "batch_size": batch_size,
+                        "producer_index": index,
+                        "deadline": deadline,
+                        "start_event": producer_start,
+                        "stop_event": producer_stop,
+                        "stats": producer_stats[index],
+                        "api_calls": api_calls,
+                    },
+                    name=f"jobs-pipeline-producer-{index}",
+                    daemon=True,
+                )
+                for index in range(producer_count)
+            ]
+            for thread in producer_threads:
+                thread.start()
+            producer_start.set()
+            wait_for_deadline(deadline, is_cancelled=reporter.is_cancelled)
+            producer_stop.set()
+            for thread in producer_threads:
+                thread.join(timeout=join_timeout)
+                if thread.is_alive():
+                    validation_errors.append(f"Producer thread {thread.name} did not stop within {join_timeout}s")
+            for consumer in consumers:
+                consumer.stop()
+            for thread in consumer_threads:
+                thread.join(timeout=join_timeout)
+                if thread.is_alive():
+                    validation_errors.append(f"Consumer thread {thread.name} did not stop within {join_timeout}s")
+            elapsed = time.perf_counter() - measurement_start
+
+            for index, outcome in enumerate(consume_outcomes):
+                if outcome.error is not None:
+                    validation_errors.append(
+                        f"Consumer {index} raised {type(outcome.error).__name__}: {outcome.error}"
+                    )
+                if outcome.attempted != consumer_stats[index].operations:
+                    validation_errors.append(
+                        f"Consumer {index} attempted {outcome.attempted} deliveries but recorded "
+                        f"{consumer_stats[index].operations} callbacks"
+                    )
+
+            published = merge_worker_stats(producer_stats, latency_sample_limit=sample_limit)
+            processed = merge_worker_stats(consumer_stats, latency_sample_limit=sample_limit)
+            unknown_ids = processed.seen_ids.difference(published.seen_ids)
+            if unknown_ids:
+                validation_errors.append(f"Consumed {len(unknown_ids)} job IDs that were not published by this run")
+            if processed.duplicate_ids:
+                validation_errors.append(f"Observed {processed.duplicate_ids} duplicate deliveries")
+            if published.failures:
+                validation_errors.append(f"Failed or skipped {published.failures} publication attempts")
+
+            remaining_messages = runtime.orchestrator.count_queue_messages(runtime.queue_name)
+            expected_remaining = published.successes - processed.successes
+            if remaining_messages != expected_remaining:
+                validation_errors.append(
+                    f"Pipeline balance mismatch: published={published.successes}, processed={processed.successes}, "
+                    f"expected_remaining={expected_remaining}, observed_remaining={remaining_messages}"
+                )
+        finally:
+            producer_stop.set()
+            for consumer in consumers:
+                if not consumer.consumer_backend.stopped:
+                    consumer.stop()
+            for thread in producer_threads:
+                if thread.is_alive():
+                    thread.join(timeout=join_timeout)
+            for thread in consumer_threads:
+                if thread.is_alive():
+                    thread.join(timeout=join_timeout)
+            for index, client in enumerate(producer_clients):
+                thread = producer_threads[index] if index < len(producer_threads) else None
+                if thread is None or not thread.is_alive():
+                    close_rabbitmq_client(client)
+            for consumer, thread in zip(consumers, consumer_threads, strict=True):
+                if not thread.is_alive():
+                    consumer.close()
+            all_stopped = not any(thread.is_alive() for thread in [*producer_threads, *consumer_threads])
+            resources_retained = config.keep_resources or not all_stopped
+            cleanup_rabbitmq_runtime(
+                runtime,
+                keep_resources=resources_retained,
+            )
+
+        published = merge_worker_stats(producer_stats, latency_sample_limit=sample_limit)
+        processed = merge_worker_stats(consumer_stats, latency_sample_limit=sample_limit)
+        per_consumer = [stats.successes for stats in consumer_stats]
+        return bench_result(
+            config=config,
+            started_at=started_at,
+            duration_seconds=elapsed,
+            stats=processed,
+            validation_errors=validation_errors,
+            metrics={
+                "backend": "rabbitmq",
+                "mode": "push_pipeline",
+                "payload_size_bytes": payload_size,
+                "batch_size": batch_size,
+                "producer_count": producer_count,
+                "consumer_count": consumer_count,
+                "prefetch_count": prefetch_count,
+                "publish_api_calls": sum(api_calls),
+                "messages_published": published.successes,
+                "messages_processed": processed.successes,
+                "remaining_messages": remaining_messages,
+                "per_consumer_messages": per_consumer,
+                "messages_per_second": processed.successes / elapsed if elapsed > 0 else 0.0,
+                "latency_kind": "publish_to_consumer_end_to_end",
+                "resources_retained": resources_retained,
+                "queue_name": runtime.queue_name if resources_retained else None,
+            },
+        )
+
+
+class JobsRabbitMQPipelineOneConsumerSuite(_RabbitMQPipelineScalingSuite):
+    suite_id = "jobs.stress.rabbitmq_pipeline_one_consumer"
+    title = "Jobs stress — RabbitMQ pipeline with one consumer"
+    description = "Measures broker-pushed end-to-end throughput and latency with one consumer."
+    consumer_count = 1
+    task_schema = TaskSchema(name=suite_id, input_schema=JobsPipelineScalingInput, output_schema=BenchResultSchema)
+    profiles = _profiles(consumer_count)
+
+
+class JobsRabbitMQPipelineFourConsumersSuite(_RabbitMQPipelineScalingSuite):
+    suite_id = "jobs.stress.rabbitmq_pipeline_four_consumers"
+    title = "Jobs stress — RabbitMQ pipeline with four consumers"
+    description = "Measures broker-pushed end-to-end throughput, latency, and distribution across four consumers."
+    consumer_count = 4
+    task_schema = TaskSchema(name=suite_id, input_schema=JobsPipelineScalingInput, output_schema=BenchResultSchema)
+    profiles = _profiles(consumer_count)

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/pipeline.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/pipeline.py
@@ -25,6 +25,7 @@ from mindtrace.jobs.testing.suites._common import (
     make_jobs,
     merge_worker_stats,
     payload_text,
+    redis_background_errors,
     validate_parameters,
     validate_resources,
     wait_for_deadline,
@@ -46,8 +47,11 @@ class JobsPipelineScalingInput(BaseModel):
 
     @model_validator(mode="after")
     def validate_backend_concurrency(self) -> "JobsPipelineScalingInput":
-        if self.backend == "local" and (self.producer_count != 1 or self.consumer_count != 1):
-            raise ValueError("Local pipeline benchmarks require producer_count=1 and consumer_count=1")
+        if self.backend == "local":
+            raise ValueError(
+                "Local pipeline benchmarks are unsupported because registry-backed queues are not safe for "
+                "concurrent producer/consumer access"
+            )
         return self
 
 
@@ -154,7 +158,7 @@ class JobsPipelineScalingSuite(BenchTestSuite):
         {
             "smoke": {
                 "duration_seconds": 1.0,
-                "backend": "local",
+                "backend": "redis",
                 "payload_size_bytes": 128,
                 "batch_size": 25,
                 "producer_count": 1,
@@ -200,6 +204,7 @@ class JobsPipelineScalingSuite(BenchTestSuite):
         producer_start = threading.Event()
         producer_stop = threading.Event()
         validation_errors: list[str] = []
+        background_errors: list[str] = []
         started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         elapsed = 0.0
         remaining_messages: int | None = None
@@ -326,6 +331,12 @@ class JobsPipelineScalingSuite(BenchTestSuite):
             for thread in consumer_threads:
                 if thread.is_alive():
                     thread.join(timeout=parameters.join_timeout_seconds)
+            background_errors = redis_background_errors(
+                runtime.client,
+                *producer_clients,
+                *(getattr(consumer, "consumer_backend", None) for consumer in consumers),
+            )
+            validation_errors.extend(background_errors)
             for consumer, thread in zip(consumers, consumer_threads, strict=True):
                 if not thread.is_alive():
                     consumer.close()
@@ -369,6 +380,7 @@ class JobsPipelineScalingSuite(BenchTestSuite):
                 "per_consumer_messages": [stats.successes for stats in consumer_stats],
                 "messages_per_second": processed.successes / elapsed if elapsed > 0 else 0.0,
                 "latency_kind": "publish_to_consumer_end_to_end",
+                "background_errors": background_errors,
                 "resources_retained": resources_retained,
                 "queue_name": runtime.queue_name if resources_retained else None,
             },

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/pipeline.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/pipeline.py
@@ -189,12 +189,10 @@ class JobsPipelineScalingSuite(BenchTestSuite):
         producer_clients = [runtime.client] if parameters.backend == "local" else []
         producer_orchestrators = [runtime.orchestrator] if parameters.backend == "local" else []
         producer_stats = [
-            WorkerStats(latency_sample_limit=parameters.latency_sample_limit)
-            for _ in range(parameters.producer_count)
+            WorkerStats(latency_sample_limit=parameters.latency_sample_limit) for _ in range(parameters.producer_count)
         ]
         consumer_stats = [
-            WorkerStats(latency_sample_limit=parameters.latency_sample_limit)
-            for _ in range(parameters.consumer_count)
+            WorkerStats(latency_sample_limit=parameters.latency_sample_limit) for _ in range(parameters.consumer_count)
         ]
         api_calls = [0] * parameters.producer_count
         consumers: list[_PipelineConsumer] = []
@@ -285,9 +283,7 @@ class JobsPipelineScalingSuite(BenchTestSuite):
 
             for index, outcome in enumerate(consume_outcomes):
                 if outcome.error is not None:
-                    validation_errors.append(
-                        f"Consumer {index} raised {type(outcome.error).__name__}: {outcome.error}"
-                    )
+                    validation_errors.append(f"Consumer {index} raised {type(outcome.error).__name__}: {outcome.error}")
                 if outcome.attempted != consumer_stats[index].operations:
                     validation_errors.append(
                         f"Consumer {index} attempted {outcome.attempted} deliveries but recorded "

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/publish.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/publish.py
@@ -1,4 +1,4 @@
-"""RabbitMQ Jobs publication throughput benchmark."""
+"""Configurable Jobs publication throughput benchmark."""
 
 from __future__ import annotations
 
@@ -6,33 +6,43 @@ import threading
 import time
 from types import MappingProxyType
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from mindtrace.core import BenchReporter, BenchResult, BenchResultSchema, BenchSuiteConfig, BenchTestSuite, TaskSchema
-from mindtrace.jobs import Orchestrator, RabbitMQClient
+from mindtrace.jobs import Orchestrator
 from mindtrace.jobs.testing.suites._common import (
-    RabbitMQBenchResources,
+    BackendName,
+    JobsBenchResources,
     WorkerStats,
     bench_result,
-    cleanup_rabbitmq_runtime,
-    close_rabbitmq_client,
-    create_rabbitmq_runtime,
+    cleanup_backend_runtime,
+    close_backend_client,
+    create_backend_runtime,
+    create_backend_worker_client,
     make_jobs,
     merge_worker_stats,
     payload_text,
-    rabbitmq_kwargs,
+    validate_parameters,
+    validate_resources,
     wait_for_deadline,
 )
 
 
 class JobsPublishCeilingInput(BaseModel):
-    """Parameters for sustained RabbitMQ batch publication."""
+    """Parameters for sustained batch publication."""
 
+    backend: BackendName = Field("rabbitmq", description="Jobs backend to exercise.")
     payload_size_bytes: int = Field(256, ge=0, description="Deterministic payload size per job.")
     batch_size: int = Field(250, ge=1, description="Messages submitted by each publish API call.")
-    producer_count: int = Field(1, ge=1, description="Independent producer threads and connections.")
+    producer_count: int = Field(1, ge=1, description="Independent producer workers and clients.")
     latency_sample_limit: int = Field(10_000, ge=0, description="Maximum retained batch-latency samples.")
     join_timeout_seconds: float = Field(15.0, gt=0, description="Maximum post-deadline worker join time.")
+
+    @model_validator(mode="after")
+    def validate_backend_concurrency(self) -> "JobsPublishCeilingInput":
+        if self.backend == "local" and self.producer_count != 1:
+            raise ValueError("Local publish benchmarks require producer_count=1")
+        return self
 
 
 def _publish_until_deadline(
@@ -79,65 +89,75 @@ def _publish_until_deadline(
                 success=False,
                 latency_seconds=latency,
                 error=RuntimeError(
-                    f"RabbitMQ batch published {result.success_count}/{len(jobs)} messages; errors={result.errors}"
+                    f"Batch published {result.success_count}/{len(jobs)} messages; errors={result.errors}"
                 ),
                 operations=rejected,
             )
             return
 
 
-class JobsRabbitMQPublishCeilingSuite(BenchTestSuite):
-    """Measure sustained RabbitMQ publication through the public batch API."""
+class JobsPublishCeilingSuite(BenchTestSuite):
+    """Measure sustained publication through the public batch API."""
 
-    suite_id = "jobs.stress.rabbitmq_publish_ceiling"
-    title = "Jobs stress — RabbitMQ publish ceiling"
-    description = "Measures sustained RabbitMQ batch publication using independent producer connections."
-    tags = frozenset({"stress", "jobs", "rabbitmq", "publish"})
-    requires = ("rabbitmq",)
-    safety = "Creates and deletes one uniquely named durable RabbitMQ queue; stress traffic is unbounded by rate."
+    suite_id = "jobs.stress.publish_ceiling"
+    title = "Jobs stress — publish ceiling"
+    description = "Measures sustained batch publication using a selected Jobs backend."
+    tags = frozenset({"stress", "jobs", "publish"})
+    requires = ()
+    safety = "Creates one uniquely named queue and generates sustained traffic for the selected backend."
     task_schema = TaskSchema(name=suite_id, input_schema=JobsPublishCeilingInput, output_schema=BenchResultSchema)
-    resource_schema = RabbitMQBenchResources
+    resource_schema = JobsBenchResources
     profiles = MappingProxyType(
         {
             "smoke": {
                 "duration_seconds": 1.0,
-                "payload_size_bytes": 256,
+                "backend": "local",
+                "payload_size_bytes": 128,
                 "batch_size": 25,
                 "producer_count": 1,
             },
             "stress": {
                 "duration_seconds": 10.0,
+                "backend": "rabbitmq",
                 "payload_size_bytes": 256,
                 "batch_size": 250,
                 "producer_count": 1,
                 "latency_sample_limit": 10_000,
                 "join_timeout_seconds": 15.0,
-                "resources": {
-                    "rabbitmq_host": "localhost",
-                    "rabbitmq_port": 5672,
-                    "rabbitmq_username": "user",
-                    "rabbitmq_password": "password",
-                },
             },
         }
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        payload_size = int(config.parameters.get("payload_size_bytes", 256))
-        batch_size = int(config.parameters.get("batch_size", 250))
-        producer_count = int(config.parameters.get("producer_count", 1))
-        sample_limit = int(config.parameters.get("latency_sample_limit", 10_000))
-        join_timeout = float(config.parameters.get("join_timeout_seconds", 15.0))
-        payload = payload_text(payload_size)
-        runtime = create_rabbitmq_runtime(config, suffix="publish")
-        clients = [RabbitMQClient(**rabbitmq_kwargs(config)) for _ in range(producer_count)]
+        parameters = validate_parameters(config, JobsPublishCeilingInput)
+        resources = validate_resources(config)
+        payload = payload_text(parameters.payload_size_bytes)
+        runtime = create_backend_runtime(config, backend=parameters.backend, suffix="publish")
+        clients = [runtime.client] if parameters.backend == "local" else []
+        try:
+            for _ in range(len(clients), parameters.producer_count):
+                clients.append(create_backend_worker_client(runtime, resources))
+        except BaseException:
+            for client in clients:
+                if client is not runtime.client:
+                    close_backend_client(client)
+            cleanup_backend_runtime(runtime, keep_resources=False)
+            raise
         orchestrators = [Orchestrator(client) for client in clients]
-        worker_stats = [WorkerStats(latency_sample_limit=sample_limit) for _ in range(producer_count)]
-        worker_batches = [
-            make_jobs(runtime.queue_name, start=index * batch_size, count=batch_size, payload=payload)
-            for index in range(producer_count)
+        worker_stats = [
+            WorkerStats(latency_sample_limit=parameters.latency_sample_limit)
+            for _ in range(parameters.producer_count)
         ]
-        api_calls = [0] * producer_count
+        worker_batches = [
+            make_jobs(
+                runtime.queue_name,
+                start=index * parameters.batch_size,
+                count=parameters.batch_size,
+                payload=payload,
+            )
+            for index in range(parameters.producer_count)
+        ]
+        api_calls = [0] * parameters.producer_count
         start_event = threading.Event()
         stop_event = threading.Event()
         validation_errors: list[str] = []
@@ -152,7 +172,7 @@ class JobsRabbitMQPublishCeilingSuite(BenchTestSuite):
                     "orchestrator": orchestrators[index],
                     "queue_name": runtime.queue_name,
                     "jobs": worker_batches[index],
-                    "payload_size": payload_size,
+                    "payload_size": parameters.payload_size_bytes,
                     "deadline": deadline,
                     "start_event": start_event,
                     "stop_event": stop_event,
@@ -161,10 +181,10 @@ class JobsRabbitMQPublishCeilingSuite(BenchTestSuite):
                     "api_calls": api_calls,
                     "worker_index": index,
                 },
-                name=f"jobs-publish-{index}",
+                name=f"jobs-publish-{parameters.backend}-{index}",
                 daemon=True,
             )
-            for index in range(producer_count)
+            for index in range(parameters.producer_count)
         ]
 
         try:
@@ -174,25 +194,28 @@ class JobsRabbitMQPublishCeilingSuite(BenchTestSuite):
             wait_for_deadline(deadline, is_cancelled=reporter.is_cancelled)
             stop_event.set()
             for thread in threads:
-                thread.join(timeout=join_timeout)
+                thread.join(timeout=parameters.join_timeout_seconds)
                 if thread.is_alive():
-                    validation_errors.append(f"Producer thread {thread.name} did not stop within {join_timeout}s")
+                    validation_errors.append(
+                        f"Producer thread {thread.name} did not stop within {parameters.join_timeout_seconds}s"
+                    )
         finally:
             stop_event.set()
             for thread in threads:
                 if thread.is_alive():
-                    thread.join(timeout=join_timeout)
+                    thread.join(timeout=parameters.join_timeout_seconds)
             for client, thread in zip(clients, threads, strict=True):
-                if not thread.is_alive():
-                    close_rabbitmq_client(client)
+                if client is not runtime.client and not thread.is_alive():
+                    close_backend_client(client)
             resources_retained = config.keep_resources or any(thread.is_alive() for thread in threads)
-            cleanup_rabbitmq_runtime(
+            cleanup_backend_runtime(
                 runtime,
                 keep_resources=resources_retained,
+                close_client=not any(thread.is_alive() for thread in threads),
             )
 
         elapsed = time.perf_counter() - measurement_start
-        stats = merge_worker_stats(worker_stats, latency_sample_limit=sample_limit)
+        stats = merge_worker_stats(worker_stats, latency_sample_limit=parameters.latency_sample_limit)
         return bench_result(
             config=config,
             started_at=started_at,
@@ -200,11 +223,11 @@ class JobsRabbitMQPublishCeilingSuite(BenchTestSuite):
             stats=stats,
             validation_errors=validation_errors,
             metrics={
-                "backend": "rabbitmq",
+                "backend": parameters.backend,
                 "mode": "publish_batch",
-                "payload_size_bytes": payload_size,
-                "batch_size": batch_size,
-                "producer_count": producer_count,
+                "payload_size_bytes": parameters.payload_size_bytes,
+                "batch_size": parameters.batch_size,
+                "producer_count": parameters.producer_count,
                 "publish_api_calls": sum(api_calls),
                 "messages_published": stats.successes,
                 "messages_per_second": stats.successes / elapsed if elapsed > 0 else 0.0,

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/publish.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/publish.py
@@ -146,8 +146,7 @@ class JobsPublishCeilingSuite(BenchTestSuite):
             raise
         orchestrators = [Orchestrator(client) for client in clients]
         worker_stats = [
-            WorkerStats(latency_sample_limit=parameters.latency_sample_limit)
-            for _ in range(parameters.producer_count)
+            WorkerStats(latency_sample_limit=parameters.latency_sample_limit) for _ in range(parameters.producer_count)
         ]
         worker_batches = [
             make_jobs(

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/publish.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/publish.py
@@ -22,6 +22,7 @@ from mindtrace.jobs.testing.suites._common import (
     make_jobs,
     merge_worker_stats,
     payload_text,
+    redis_background_errors,
     validate_parameters,
     validate_resources,
     wait_for_deadline,
@@ -161,6 +162,7 @@ class JobsPublishCeilingSuite(BenchTestSuite):
         start_event = threading.Event()
         stop_event = threading.Event()
         validation_errors: list[str] = []
+        background_errors: list[str] = []
         resources_retained = config.keep_resources
         started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         measurement_start = time.perf_counter()
@@ -204,6 +206,8 @@ class JobsPublishCeilingSuite(BenchTestSuite):
             for thread in threads:
                 if thread.is_alive():
                     thread.join(timeout=parameters.join_timeout_seconds)
+            background_errors = redis_background_errors(runtime.client, *clients)
+            validation_errors.extend(background_errors)
             for client, thread in zip(clients, threads, strict=True):
                 if client is not runtime.client and not thread.is_alive():
                     close_backend_client(client)
@@ -232,6 +236,7 @@ class JobsPublishCeilingSuite(BenchTestSuite):
                 "messages_published": stats.successes,
                 "messages_per_second": stats.successes / elapsed if elapsed > 0 else 0.0,
                 "latency_kind": "publish_batch_api_call",
+                "background_errors": background_errors,
                 "resources_retained": resources_retained,
                 "queue_name": runtime.queue_name if resources_retained else None,
             },

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/publish.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/publish.py
@@ -1,0 +1,215 @@
+"""RabbitMQ Jobs publication throughput benchmark."""
+
+from __future__ import annotations
+
+import threading
+import time
+from types import MappingProxyType
+
+from pydantic import BaseModel, Field
+
+from mindtrace.core import BenchReporter, BenchResult, BenchResultSchema, BenchSuiteConfig, BenchTestSuite, TaskSchema
+from mindtrace.jobs import Orchestrator, RabbitMQClient
+from mindtrace.jobs.testing.suites._common import (
+    RabbitMQBenchResources,
+    WorkerStats,
+    bench_result,
+    cleanup_rabbitmq_runtime,
+    close_rabbitmq_client,
+    create_rabbitmq_runtime,
+    make_jobs,
+    merge_worker_stats,
+    payload_text,
+    rabbitmq_kwargs,
+    wait_for_deadline,
+)
+
+
+class JobsPublishCeilingInput(BaseModel):
+    """Parameters for sustained RabbitMQ batch publication."""
+
+    payload_size_bytes: int = Field(256, ge=0, description="Deterministic payload size per job.")
+    batch_size: int = Field(250, ge=1, description="Messages submitted by each publish API call.")
+    producer_count: int = Field(1, ge=1, description="Independent producer threads and connections.")
+    latency_sample_limit: int = Field(10_000, ge=0, description="Maximum retained batch-latency samples.")
+    join_timeout_seconds: float = Field(15.0, gt=0, description="Maximum post-deadline worker join time.")
+
+
+def _publish_until_deadline(
+    *,
+    orchestrator: Orchestrator,
+    queue_name: str,
+    jobs,
+    payload_size: int,
+    deadline: float,
+    start_event: threading.Event,
+    stop_event: threading.Event,
+    is_cancelled,
+    stats: WorkerStats,
+    api_calls: list[int],
+    worker_index: int,
+) -> None:
+    start_event.wait()
+    while time.perf_counter() < deadline and not stop_event.is_set() and not is_cancelled():
+        op_start = time.perf_counter()
+        try:
+            result = orchestrator.publish_batch(queue_name, jobs)
+        except Exception as exc:  # noqa: BLE001 - benchmark records backend failures.
+            stats.record(
+                success=False,
+                latency_seconds=time.perf_counter() - op_start,
+                error=exc,
+                operations=len(jobs),
+            )
+            api_calls[worker_index] += 1
+            return
+
+        latency = time.perf_counter() - op_start
+        api_calls[worker_index] += 1
+        if result.success_count:
+            stats.record(
+                success=True,
+                latency_seconds=latency,
+                bytes_processed=result.success_count * payload_size,
+                operations=result.success_count,
+            )
+        rejected = result.failure_count + result.unattempted_count
+        if rejected:
+            stats.record(
+                success=False,
+                latency_seconds=latency,
+                error=RuntimeError(
+                    f"RabbitMQ batch published {result.success_count}/{len(jobs)} messages; errors={result.errors}"
+                ),
+                operations=rejected,
+            )
+            return
+
+
+class JobsRabbitMQPublishCeilingSuite(BenchTestSuite):
+    """Measure sustained RabbitMQ publication through the public batch API."""
+
+    suite_id = "jobs.stress.rabbitmq_publish_ceiling"
+    title = "Jobs stress — RabbitMQ publish ceiling"
+    description = "Measures sustained RabbitMQ batch publication using independent producer connections."
+    tags = frozenset({"stress", "jobs", "rabbitmq", "publish"})
+    requires = ("rabbitmq",)
+    safety = "Creates and deletes one uniquely named durable RabbitMQ queue; stress traffic is unbounded by rate."
+    task_schema = TaskSchema(name=suite_id, input_schema=JobsPublishCeilingInput, output_schema=BenchResultSchema)
+    resource_schema = RabbitMQBenchResources
+    profiles = MappingProxyType(
+        {
+            "smoke": {
+                "duration_seconds": 1.0,
+                "payload_size_bytes": 256,
+                "batch_size": 25,
+                "producer_count": 1,
+            },
+            "stress": {
+                "duration_seconds": 10.0,
+                "payload_size_bytes": 256,
+                "batch_size": 250,
+                "producer_count": 1,
+                "latency_sample_limit": 10_000,
+                "join_timeout_seconds": 15.0,
+                "resources": {
+                    "rabbitmq_host": "localhost",
+                    "rabbitmq_port": 5672,
+                    "rabbitmq_username": "user",
+                    "rabbitmq_password": "password",
+                },
+            },
+        }
+    )
+
+    def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
+        payload_size = int(config.parameters.get("payload_size_bytes", 256))
+        batch_size = int(config.parameters.get("batch_size", 250))
+        producer_count = int(config.parameters.get("producer_count", 1))
+        sample_limit = int(config.parameters.get("latency_sample_limit", 10_000))
+        join_timeout = float(config.parameters.get("join_timeout_seconds", 15.0))
+        payload = payload_text(payload_size)
+        runtime = create_rabbitmq_runtime(config, suffix="publish")
+        clients = [RabbitMQClient(**rabbitmq_kwargs(config)) for _ in range(producer_count)]
+        orchestrators = [Orchestrator(client) for client in clients]
+        worker_stats = [WorkerStats(latency_sample_limit=sample_limit) for _ in range(producer_count)]
+        worker_batches = [
+            make_jobs(runtime.queue_name, start=index * batch_size, count=batch_size, payload=payload)
+            for index in range(producer_count)
+        ]
+        api_calls = [0] * producer_count
+        start_event = threading.Event()
+        stop_event = threading.Event()
+        validation_errors: list[str] = []
+        resources_retained = config.keep_resources
+        started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        measurement_start = time.perf_counter()
+        deadline = reporter.deadline(config.duration_seconds)
+        threads = [
+            threading.Thread(
+                target=_publish_until_deadline,
+                kwargs={
+                    "orchestrator": orchestrators[index],
+                    "queue_name": runtime.queue_name,
+                    "jobs": worker_batches[index],
+                    "payload_size": payload_size,
+                    "deadline": deadline,
+                    "start_event": start_event,
+                    "stop_event": stop_event,
+                    "is_cancelled": reporter.is_cancelled,
+                    "stats": worker_stats[index],
+                    "api_calls": api_calls,
+                    "worker_index": index,
+                },
+                name=f"jobs-publish-{index}",
+                daemon=True,
+            )
+            for index in range(producer_count)
+        ]
+
+        try:
+            for thread in threads:
+                thread.start()
+            start_event.set()
+            wait_for_deadline(deadline, is_cancelled=reporter.is_cancelled)
+            stop_event.set()
+            for thread in threads:
+                thread.join(timeout=join_timeout)
+                if thread.is_alive():
+                    validation_errors.append(f"Producer thread {thread.name} did not stop within {join_timeout}s")
+        finally:
+            stop_event.set()
+            for thread in threads:
+                if thread.is_alive():
+                    thread.join(timeout=join_timeout)
+            for client, thread in zip(clients, threads, strict=True):
+                if not thread.is_alive():
+                    close_rabbitmq_client(client)
+            resources_retained = config.keep_resources or any(thread.is_alive() for thread in threads)
+            cleanup_rabbitmq_runtime(
+                runtime,
+                keep_resources=resources_retained,
+            )
+
+        elapsed = time.perf_counter() - measurement_start
+        stats = merge_worker_stats(worker_stats, latency_sample_limit=sample_limit)
+        return bench_result(
+            config=config,
+            started_at=started_at,
+            duration_seconds=elapsed,
+            stats=stats,
+            validation_errors=validation_errors,
+            metrics={
+                "backend": "rabbitmq",
+                "mode": "publish_batch",
+                "payload_size_bytes": payload_size,
+                "batch_size": batch_size,
+                "producer_count": producer_count,
+                "publish_api_calls": sum(api_calls),
+                "messages_published": stats.successes,
+                "messages_per_second": stats.successes / elapsed if elapsed > 0 else 0.0,
+                "latency_kind": "publish_batch_api_call",
+                "resources_retained": resources_retained,
+                "queue_name": runtime.queue_name if resources_retained else None,
+            },
+        )

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/round_trip.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/round_trip.py
@@ -19,6 +19,7 @@ from mindtrace.jobs.testing.suites._common import (
     create_backend_runtime,
     make_job,
     payload_text,
+    redis_background_errors,
     validate_parameters,
 )
 
@@ -81,6 +82,8 @@ class JobsRoundTripSmokeSuite(BenchTestSuite):
         started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         measurement_start = 0.0
         sequence = 0
+        validation_errors: list[str] = []
+        background_errors: list[str] = []
 
         try:
             connect_consumer(consumer, runtime, prefetch_count=parameters.prefetch_count)
@@ -114,6 +117,11 @@ class JobsRoundTripSmokeSuite(BenchTestSuite):
                     )
                 sequence += 1
         finally:
+            background_errors = redis_background_errors(
+                runtime.client,
+                getattr(consumer, "consumer_backend", None),
+            )
+            validation_errors.extend(background_errors)
             consumer.close()
             cleanup_backend_runtime(runtime, keep_resources=config.keep_resources)
 
@@ -124,10 +132,12 @@ class JobsRoundTripSmokeSuite(BenchTestSuite):
             started_at=started_at,
             duration_seconds=elapsed,
             stats=stats,
+            validation_errors=validation_errors,
             metrics={
                 "backend": parameters.backend,
                 "mode": "round_trip",
                 "payload_size_bytes": parameters.payload_size_bytes,
+                "background_errors": background_errors,
                 "messages_per_second": stats.successes / elapsed if elapsed > 0 else 0.0,
                 "resources_retained": config.keep_resources,
                 "queue_name": runtime.queue_name if config.keep_resources else None,

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/round_trip.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/round_trip.py
@@ -1,0 +1,121 @@
+"""Local Jobs round-trip smoke benchmark."""
+
+from __future__ import annotations
+
+import time
+from types import MappingProxyType
+
+from pydantic import BaseModel, Field
+
+from mindtrace.core import BenchReporter, BenchResult, BenchResultSchema, BenchSuiteConfig, BenchTestSuite, TaskSchema
+from mindtrace.jobs import Consumer
+from mindtrace.jobs.testing.suites._common import (
+    WorkerStats,
+    bench_result,
+    cleanup_local_runtime,
+    create_local_runtime,
+    make_job,
+    payload_text,
+)
+
+
+class JobsRoundTripSmokeInput(BaseModel):
+    """Parameters for the isolated Local round-trip smoke benchmark."""
+
+    payload_size_bytes: int = Field(256, ge=0, description="Deterministic payload size per job.")
+    latency_sample_limit: int = Field(1_000, ge=0, description="Maximum retained latency samples.")
+
+
+class _RoundTripConsumer(Consumer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.received_ids: list[str] = []
+
+    def run(self, job_dict: dict) -> dict:
+        self.received_ids.append(str(job_dict.get("id", "")))
+        return {}
+
+
+class JobsRoundTripSmokeSuite(BenchTestSuite):
+    """Exercise repeated publish/consume round trips on an isolated Local backend."""
+
+    suite_id = "jobs.smoke.round_trip"
+    title = "Jobs smoke — Local publish/consume round trip"
+    description = "Publishes and consumes deterministic jobs for one second using an isolated Local backend."
+    tags = frozenset({"smoke", "jobs", "local"})
+    requires = ("local_disk",)
+    safety = "Uses a unique temporary Local backend and removes it after the run by default."
+    task_schema = TaskSchema(name=suite_id, input_schema=JobsRoundTripSmokeInput, output_schema=BenchResultSchema)
+    profiles = MappingProxyType(
+        {
+            "smoke": {
+                "duration_seconds": 1.0,
+                "payload_size_bytes": 256,
+                "latency_sample_limit": 1_000,
+            },
+            "stress": {
+                "duration_seconds": 1.0,
+                "payload_size_bytes": 256,
+                "latency_sample_limit": 1_000,
+            },
+        }
+    )
+
+    def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
+        payload_size = int(config.parameters.get("payload_size_bytes", 256))
+        sample_limit = int(config.parameters.get("latency_sample_limit", 1_000))
+        payload = payload_text(payload_size)
+        stats = WorkerStats(latency_sample_limit=sample_limit)
+        runtime = create_local_runtime(config)
+        consumer = _RoundTripConsumer()
+        consumer.connect_to_orchestrator(runtime.orchestrator, runtime.queue_name)
+        started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        measurement_start = time.perf_counter()
+        deadline = reporter.deadline(config.duration_seconds)
+        sequence = 0
+
+        try:
+            while time.perf_counter() < deadline and not reporter.is_cancelled():
+                job = make_job(runtime.queue_name, sequence=sequence, payload=payload)
+                op_start = time.perf_counter()
+                try:
+                    runtime.orchestrator.publish(runtime.queue_name, job)
+                    attempted = consumer.consume(num_messages=1, block=True)
+                    received_id = consumer.received_ids[-1] if consumer.received_ids else None
+                    if attempted != 1 or received_id != job.id:
+                        raise RuntimeError(
+                            f"Round-trip mismatch: attempted={attempted}, "
+                            f"expected_id={job.id}, received_id={received_id}"
+                        )
+                except Exception as exc:  # noqa: BLE001 - benchmark records failures and continues.
+                    stats.record(
+                        success=False,
+                        latency_seconds=time.perf_counter() - op_start,
+                        bytes_processed=payload_size,
+                        error=exc,
+                    )
+                else:
+                    stats.record(
+                        success=True,
+                        latency_seconds=time.perf_counter() - op_start,
+                        bytes_processed=payload_size,
+                        item_id=job.id,
+                    )
+                sequence += 1
+        finally:
+            consumer.close()
+            cleanup_local_runtime(runtime, keep_resources=config.keep_resources)
+
+        return bench_result(
+            config=config,
+            started_at=started_at,
+            duration_seconds=time.perf_counter() - measurement_start,
+            stats=stats,
+            metrics={
+                "backend": "local",
+                "mode": "round_trip",
+                "payload_size_bytes": payload_size,
+                "resources_retained": config.keep_resources,
+                "local_root": str(runtime.root) if config.keep_resources else None,
+            },
+        )

--- a/mindtrace/jobs/mindtrace/jobs/testing/suites/round_trip.py
+++ b/mindtrace/jobs/mindtrace/jobs/testing/suites/round_trip.py
@@ -1,4 +1,4 @@
-"""Local Jobs round-trip smoke benchmark."""
+"""Configurable Jobs round-trip smoke benchmark."""
 
 from __future__ import annotations
 
@@ -10,78 +10,89 @@ from pydantic import BaseModel, Field
 from mindtrace.core import BenchReporter, BenchResult, BenchResultSchema, BenchSuiteConfig, BenchTestSuite, TaskSchema
 from mindtrace.jobs import Consumer
 from mindtrace.jobs.testing.suites._common import (
+    BackendName,
+    JobsBenchResources,
     WorkerStats,
     bench_result,
-    cleanup_local_runtime,
-    create_local_runtime,
+    cleanup_backend_runtime,
+    connect_consumer,
+    create_backend_runtime,
     make_job,
     payload_text,
+    validate_parameters,
 )
 
 
 class JobsRoundTripSmokeInput(BaseModel):
-    """Parameters for the isolated Local round-trip smoke benchmark."""
+    """Parameters for a short publish/consume round-trip benchmark."""
 
+    backend: BackendName = Field("local", description="Jobs backend to exercise.")
     payload_size_bytes: int = Field(256, ge=0, description="Deterministic payload size per job.")
+    prefetch_count: int = Field(1, ge=1, description="RabbitMQ prefetch count; ignored by other backends.")
     latency_sample_limit: int = Field(1_000, ge=0, description="Maximum retained latency samples.")
 
 
 class _RoundTripConsumer(Consumer):
     def __init__(self) -> None:
         super().__init__()
-        self.received_ids: list[str] = []
+        self.last_received_id: str | None = None
 
     def run(self, job_dict: dict) -> dict:
-        self.received_ids.append(str(job_dict.get("id", "")))
+        self.last_received_id = str(job_dict.get("id", ""))
         return {}
 
 
 class JobsRoundTripSmokeSuite(BenchTestSuite):
-    """Exercise repeated publish/consume round trips on an isolated Local backend."""
+    """Exercise repeated publish/consume round trips on a selected backend."""
 
     suite_id = "jobs.smoke.round_trip"
-    title = "Jobs smoke — Local publish/consume round trip"
-    description = "Publishes and consumes deterministic jobs for one second using an isolated Local backend."
-    tags = frozenset({"smoke", "jobs", "local"})
-    requires = ("local_disk",)
-    safety = "Uses a unique temporary Local backend and removes it after the run by default."
+    title = "Jobs smoke — publish/consume round trip"
+    description = "Publishes and consumes deterministic jobs for one second using a selected Jobs backend."
+    tags = frozenset({"smoke", "jobs", "round_trip"})
+    requires = ()
+    safety = "Creates one uniquely named queue and removes only resources owned by the run."
     task_schema = TaskSchema(name=suite_id, input_schema=JobsRoundTripSmokeInput, output_schema=BenchResultSchema)
+    resource_schema = JobsBenchResources
     profiles = MappingProxyType(
         {
             "smoke": {
                 "duration_seconds": 1.0,
+                "backend": "local",
                 "payload_size_bytes": 256,
+                "prefetch_count": 1,
                 "latency_sample_limit": 1_000,
             },
             "stress": {
-                "duration_seconds": 1.0,
+                "duration_seconds": 10.0,
+                "backend": "rabbitmq",
                 "payload_size_bytes": 256,
-                "latency_sample_limit": 1_000,
+                "prefetch_count": 1,
+                "latency_sample_limit": 10_000,
             },
         }
     )
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
-        payload_size = int(config.parameters.get("payload_size_bytes", 256))
-        sample_limit = int(config.parameters.get("latency_sample_limit", 1_000))
-        payload = payload_text(payload_size)
-        stats = WorkerStats(latency_sample_limit=sample_limit)
-        runtime = create_local_runtime(config)
+        parameters = validate_parameters(config, JobsRoundTripSmokeInput)
+        payload = payload_text(parameters.payload_size_bytes)
+        stats = WorkerStats(latency_sample_limit=parameters.latency_sample_limit)
+        runtime = create_backend_runtime(config, backend=parameters.backend, suffix="round-trip")
         consumer = _RoundTripConsumer()
-        consumer.connect_to_orchestrator(runtime.orchestrator, runtime.queue_name)
         started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-        measurement_start = time.perf_counter()
-        deadline = reporter.deadline(config.duration_seconds)
+        measurement_start = 0.0
         sequence = 0
 
         try:
+            connect_consumer(consumer, runtime, prefetch_count=parameters.prefetch_count)
+            measurement_start = time.perf_counter()
+            deadline = reporter.deadline(config.duration_seconds)
             while time.perf_counter() < deadline and not reporter.is_cancelled():
                 job = make_job(runtime.queue_name, sequence=sequence, payload=payload)
                 op_start = time.perf_counter()
                 try:
                     runtime.orchestrator.publish(runtime.queue_name, job)
                     attempted = consumer.consume(num_messages=1, block=True)
-                    received_id = consumer.received_ids[-1] if consumer.received_ids else None
+                    received_id = consumer.last_received_id
                     if attempted != 1 or received_id != job.id:
                         raise RuntimeError(
                             f"Round-trip mismatch: attempted={attempted}, "
@@ -91,31 +102,35 @@ class JobsRoundTripSmokeSuite(BenchTestSuite):
                     stats.record(
                         success=False,
                         latency_seconds=time.perf_counter() - op_start,
-                        bytes_processed=payload_size,
+                        bytes_processed=parameters.payload_size_bytes,
                         error=exc,
                     )
                 else:
                     stats.record(
                         success=True,
                         latency_seconds=time.perf_counter() - op_start,
-                        bytes_processed=payload_size,
+                        bytes_processed=parameters.payload_size_bytes,
                         item_id=job.id,
                     )
                 sequence += 1
         finally:
             consumer.close()
-            cleanup_local_runtime(runtime, keep_resources=config.keep_resources)
+            cleanup_backend_runtime(runtime, keep_resources=config.keep_resources)
 
+        elapsed = time.perf_counter() - measurement_start
+        retained_path = str(runtime.local_root) if config.keep_resources and runtime.local_root is not None else None
         return bench_result(
             config=config,
             started_at=started_at,
-            duration_seconds=time.perf_counter() - measurement_start,
+            duration_seconds=elapsed,
             stats=stats,
             metrics={
-                "backend": "local",
+                "backend": parameters.backend,
                 "mode": "round_trip",
-                "payload_size_bytes": payload_size,
+                "payload_size_bytes": parameters.payload_size_bytes,
+                "messages_per_second": stats.successes / elapsed if elapsed > 0 else 0.0,
                 "resources_retained": config.keep_resources,
-                "local_root": str(runtime.root) if config.keep_resources else None,
+                "queue_name": runtime.queue_name if config.keep_resources else None,
+                "local_root": retained_path,
             },
         )

--- a/mindtrace/jobs/pyproject.toml
+++ b/mindtrace/jobs/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "redis>=5.3.0",
 ]
 
+[project.entry-points."mindtrace.benchmark_suites"]
+jobs = "mindtrace.jobs.testing:register_benchmark_suites"
+
 [project.urls]
 Homepage = "https://mindtrace.ai"
 Repository = "https://github.com/mindtrace/mindtrace/blob/main/mindtrace/jobs"

--- a/tests/unit/mindtrace/core/testing/test_bench_cli.py
+++ b/tests/unit/mindtrace/core/testing/test_bench_cli.py
@@ -1,6 +1,8 @@
 """Unit contracts for benchmark CLI result formatting."""
 
-from mindtrace.core.testing.__main__ import _format_bench_summary
+from types import SimpleNamespace
+
+from mindtrace.core.testing.__main__ import _format_bench_summary, _format_progress_event
 
 
 def test_format_bench_summary_includes_comparable_throughput_and_duration() -> None:
@@ -39,4 +41,16 @@ def test_format_bench_summary_keeps_error_details() -> None:
     assert _format_bench_summary(summary) == (
         "example.stress.failure: failed ops=1 failures=1 rate=0.50 ops/s duration=2.00s "
         "errors={'RuntimeError': 1} last_error=RuntimeError: operation failed"
+    )
+
+
+def test_format_progress_event_includes_failure_detail() -> None:
+    event = SimpleNamespace(
+        kind="suite_failed",
+        suite_id="jobs.stress.consume_ceiling",
+        detail="connection refused",
+    )
+
+    assert _format_progress_event(event) == (
+        "[suite_failed] jobs.stress.consume_ceiling: connection refused"
     )

--- a/tests/unit/mindtrace/core/testing/test_bench_cli.py
+++ b/tests/unit/mindtrace/core/testing/test_bench_cli.py
@@ -18,8 +18,7 @@ def test_format_bench_summary_includes_comparable_throughput_and_duration() -> N
     }
 
     assert _format_bench_summary(summary) == (
-        "example.stress.throughput: passed ops=250 failures=0 "
-        "rate=25.00 ops/s duration=10.00s"
+        "example.stress.throughput: passed ops=250 failures=0 rate=25.00 ops/s duration=10.00s"
     )
 
 
@@ -51,6 +50,4 @@ def test_format_progress_event_includes_failure_detail() -> None:
         detail="connection refused",
     )
 
-    assert _format_progress_event(event) == (
-        "[suite_failed] jobs.stress.consume_ceiling: connection refused"
-    )
+    assert _format_progress_event(event) == ("[suite_failed] jobs.stress.consume_ceiling: connection refused")

--- a/tests/unit/mindtrace/core/testing/test_bench_cli.py
+++ b/tests/unit/mindtrace/core/testing/test_bench_cli.py
@@ -1,0 +1,42 @@
+"""Unit contracts for benchmark CLI result formatting."""
+
+from mindtrace.core.testing.__main__ import _format_bench_summary
+
+
+def test_format_bench_summary_includes_comparable_throughput_and_duration() -> None:
+    summary = {
+        "suite_id": "example.stress.throughput",
+        "status": "passed",
+        "operations": 250,
+        "failures": 0,
+        "throughput_ops_per_second": 25.0,
+        "duration_seconds": 10.0,
+        "error_counts": {},
+        "metrics": {},
+    }
+
+    assert _format_bench_summary(summary) == (
+        "example.stress.throughput: passed ops=250 failures=0 "
+        "rate=25.00 ops/s duration=10.00s"
+    )
+
+
+def test_format_bench_summary_keeps_error_details() -> None:
+    summary = {
+        "suite_id": "example.stress.failure",
+        "status": "failed",
+        "operations": 1,
+        "failures": 1,
+        "throughput_ops_per_second": 0.5,
+        "duration_seconds": 2.0,
+        "error_counts": {"RuntimeError": 1},
+        "metrics": {
+            "last_error_type": "RuntimeError",
+            "last_error_message": "operation failed",
+        },
+    }
+
+    assert _format_bench_summary(summary) == (
+        "example.stress.failure: failed ops=1 failures=1 rate=0.50 ops/s duration=2.00s "
+        "errors={'RuntimeError': 1} last_error=RuntimeError: operation failed"
+    )

--- a/tests/unit/mindtrace/core/testing/test_runner_unit.py
+++ b/tests/unit/mindtrace/core/testing/test_runner_unit.py
@@ -46,7 +46,13 @@ class SampleBenchSuite(BenchTestSuite):
     suite_id = "unit.testing.sample.bench"
     title = "Sample Bench"
     tags = frozenset({"smoke", "unit"})
-    profiles = {"smoke": {"duration_seconds": 0.1, "resources": {"from_profile": True}}}
+    profiles = {
+        "smoke": {
+            "duration_seconds": 0.1,
+            "mode": "profile",
+            "resources": {"from_profile": True},
+        }
+    }
 
     def execute_bench(self, config: BenchSuiteConfig, reporter: BenchReporter) -> BenchResult:
         now = utcnow_iso()
@@ -58,7 +64,11 @@ class SampleBenchSuite(BenchTestSuite):
             duration_seconds=0.1,
             operations=1,
             successes=1,
-            metrics={"from_profile": config.resources["from_profile"], "from_call": config.resources["from_call"]},
+            metrics={
+                "from_profile": config.resources["from_profile"],
+                "from_call": config.resources["from_call"],
+                "mode": config.parameters["mode"],
+            },
         )
 
 
@@ -89,13 +99,14 @@ def test_runner_runs_registered_benches() -> None:
         [SampleBenchSuite.suite_id],
         profile="smoke",
         run_id="unit-run",
+        parameters={"mode": "call"},
         resources={"from_call": True},
     )
 
     assert [row.status for row in exec_rows] == ["passed"]
     assert len(bench_results) == 1
     assert bench_results[0].suite_id == SampleBenchSuite.suite_id
-    assert bench_results[0].metrics == {"from_profile": True, "from_call": True}
+    assert bench_results[0].metrics == {"from_profile": True, "from_call": True, "mode": "call"}
 
 
 def test_runner_discovers_entrypoint_benchmark_suites(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/mindtrace/jobs/redis/test_redis_connection.py
+++ b/tests/unit/mindtrace/jobs/redis/test_redis_connection.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 import redis
@@ -70,9 +70,44 @@ def test_connect_with_password(monkeypatch):
         mock_redis_cls.return_value = instance
         conn = RedisConnection(host="localhost", port=6381, db=0, password="pw")
         assert conn.is_connected()
-        mock_redis_cls.assert_called_with(
-            host="localhost", port=6381, db=0, socket_timeout=5.0, socket_connect_timeout=2.0, password="pw"
+        assert call(
+            host="localhost",
+            port=6381,
+            db=0,
+            socket_timeout=5.0,
+            socket_connect_timeout=2.0,
+            password="pw",
+        ) in mock_redis_cls.call_args_list
+
+
+def test_event_listener_uses_dedicated_connection_without_read_timeout():
+    with (
+        patch("mindtrace.jobs.redis.connection.redis.Redis") as mock_redis_cls,
+        patch("mindtrace.jobs.redis.connection.threading.Thread"),
+    ):
+        main_connection = MagicMock()
+        main_connection.ping.return_value = True
+        main_connection.hgetall.return_value = {}
+        listener_connection = MagicMock()
+        pubsub = MagicMock()
+        pubsub.listen.return_value = iter([])
+        listener_connection.pubsub.return_value = pubsub
+        mock_redis_cls.side_effect = [main_connection, listener_connection]
+
+        conn = RedisConnection(host="localhost", port=6381, db=0, password="pw")
+        conn._subscribe_to_events()
+
+        assert mock_redis_cls.call_args_list[-1] == call(
+            host="localhost",
+            port=6381,
+            db=0,
+            socket_timeout=None,
+            socket_connect_timeout=2.0,
+            password="pw",
         )
+        pubsub.subscribe.assert_called_once_with(conn.EVENTS_CHANNEL)
+        pubsub.close.assert_called_once()
+        listener_connection.close.assert_called_once()
 
 
 def test_connect_retries_exhausted(monkeypatch):
@@ -329,6 +364,28 @@ def test_subscribe_to_events_exception_handling(monkeypatch):
         # This should not raise an exception, just log it
         conn._subscribe_to_events()
 
+        assert isinstance(conn.event_listener_error, Exception)
+        assert str(conn.event_listener_error) == "connection lost"
+
+
+def test_subscribe_to_events_ignores_shutdown_induced_exception(monkeypatch):
+    with patch("mindtrace.jobs.redis.connection.redis.Redis"), patch("threading.Thread"):
+        conn = RedisConnection(host="localhost", port=6381, db=0)
+        conn.logger = MagicMock()
+        pubsub = MagicMock()
+
+        def stop_then_raise():
+            conn._shutdown_event.set()
+            raise redis.ConnectionError("closed for shutdown")
+
+        pubsub.listen.side_effect = stop_then_raise
+        conn.connection.pubsub.return_value = pubsub
+
+        conn._subscribe_to_events()
+
+        assert conn.event_listener_error is None
+        conn.logger.error.assert_not_called()
+
 
 def test_subscribe_to_events_non_message_type(monkeypatch):
     """Test that _subscribe_to_events handles non-message type events."""
@@ -354,7 +411,7 @@ def test_subscribe_to_events_non_message_type(monkeypatch):
 
         def mock_is_set():
             call_count[0] += 1
-            if call_count[0] > 2:  # Allow a few calls then shutdown
+            if call_count[0] > 4:  # Allow listener startup and message processing, then shutdown
                 return True
             return original_is_set()
 
@@ -380,7 +437,7 @@ def test_subscribe_to_events_unknown_queue_type(monkeypatch):
 
         def mock_is_set():
             call_count[0] += 1
-            if call_count[0] > 2:  # Allow a few calls then shutdown
+            if call_count[0] > 4:  # Allow listener startup and message processing, then shutdown
                 return True
             return original_is_set()
 
@@ -408,7 +465,7 @@ def test_subscribe_to_events_delete_nonexistent_queue(monkeypatch):
 
         def mock_is_set():
             call_count[0] += 1
-            if call_count[0] > 2:  # Allow a few calls then shutdown
+            if call_count[0] > 4:  # Allow listener startup and message processing, then shutdown
                 return True
             return original_is_set()
 
@@ -468,7 +525,7 @@ def test_subscribe_to_events_declare_stack_queue(monkeypatch):
 
         def mock_is_set():
             call_count[0] += 1
-            if call_count[0] > 2:  # Allow a few calls then shutdown
+            if call_count[0] > 4:  # Allow listener startup and message processing, then shutdown
                 return True
             return original_is_set()
 
@@ -496,7 +553,7 @@ def test_subscribe_to_events_declare_priority_queue(monkeypatch):
 
         def mock_is_set():
             call_count[0] += 1
-            if call_count[0] > 2:  # Allow a few calls then shutdown
+            if call_count[0] > 4:  # Allow listener startup and message processing, then shutdown
                 return True
             return original_is_set()
 

--- a/tests/unit/mindtrace/jobs/redis/test_redis_connection.py
+++ b/tests/unit/mindtrace/jobs/redis/test_redis_connection.py
@@ -70,14 +70,17 @@ def test_connect_with_password(monkeypatch):
         mock_redis_cls.return_value = instance
         conn = RedisConnection(host="localhost", port=6381, db=0, password="pw")
         assert conn.is_connected()
-        assert call(
-            host="localhost",
-            port=6381,
-            db=0,
-            socket_timeout=5.0,
-            socket_connect_timeout=2.0,
-            password="pw",
-        ) in mock_redis_cls.call_args_list
+        assert (
+            call(
+                host="localhost",
+                port=6381,
+                db=0,
+                socket_timeout=5.0,
+                socket_connect_timeout=2.0,
+                password="pw",
+            )
+            in mock_redis_cls.call_args_list
+        )
 
 
 def test_event_listener_uses_dedicated_connection_without_read_timeout():

--- a/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_helpers.py
+++ b/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_helpers.py
@@ -1,0 +1,96 @@
+"""Focused tests for Jobs benchmark counters and consume-mode dispatch."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mindtrace.jobs.testing.suites._common import WorkerStats, merge_worker_stats
+from mindtrace.jobs.testing.suites.consume import _ConsumeOutcome, _consume_worker
+
+
+def test_worker_stats_bounds_latency_samples_and_detects_duplicates() -> None:
+    stats = WorkerStats(latency_sample_limit=3)
+
+    for index in range(10):
+        stats.record(
+            success=True,
+            latency_seconds=index / 1_000,
+            bytes_processed=10,
+            item_id="duplicate" if index in {0, 1} else f"job-{index}",
+        )
+
+    assert stats.operations == 10
+    assert stats.successes == 10
+    assert stats.bytes_processed == 100
+    assert len(stats.latency_seconds) == 3
+    assert stats.duplicate_ids == 1
+
+
+def test_merge_worker_stats_detects_cross_worker_duplicates() -> None:
+    first = WorkerStats(latency_sample_limit=2)
+    second = WorkerStats(latency_sample_limit=2)
+    first.record(success=True, latency_seconds=0.1, item_id="same")
+    second.record(success=True, latency_seconds=0.2, item_id="same")
+
+    merged = merge_worker_stats([first, second], latency_sample_limit=2)
+
+    assert merged.operations == 2
+    assert merged.successes == 2
+    assert merged.duplicate_ids == 1
+    assert len(merged.latency_seconds) == 2
+
+
+def test_iterative_pull_one_repeats_public_single_message_consume() -> None:
+    consumer = MagicMock()
+    consumer.consumer_backend = SimpleNamespace(stopped=False)
+
+    def consume(*, num_messages, block):
+        assert num_messages == 1
+        assert block is True
+        consumer.consumer_backend.stopped = True
+        return 1
+
+    consumer.consume.side_effect = consume
+    outcome = _ConsumeOutcome()
+
+    _consume_worker(consumer, "iterative_pull_one", outcome)
+
+    assert outcome.attempted == 1
+    assert outcome.consume_calls == 1
+    consumer.consume.assert_called_once_with(num_messages=1, block=True)
+
+
+def test_steady_pull_uses_one_long_finite_consume_call() -> None:
+    consumer = MagicMock()
+    consumer.consume.return_value = 12
+    outcome = _ConsumeOutcome()
+
+    _consume_worker(consumer, "steady_pull", outcome)
+
+    assert outcome.attempted == 12
+    assert outcome.consume_calls == 1
+    consumer.consume.assert_called_once_with(num_messages=2**63 - 1, block=True)
+
+
+def test_push_uses_bare_blocking_unlimited_consume() -> None:
+    consumer = MagicMock()
+    consumer.consume.return_value = 15
+    outcome = _ConsumeOutcome()
+
+    _consume_worker(consumer, "push", outcome)
+
+    assert outcome.attempted == 15
+    assert outcome.consume_calls == 1
+    consumer.consume.assert_called_once_with(num_messages=0, block=True)
+
+
+def test_consume_worker_surfaces_operation_error() -> None:
+    consumer = MagicMock()
+    consumer.consume.side_effect = RuntimeError("broker failed")
+    outcome = _ConsumeOutcome()
+
+    _consume_worker(consumer, "push", outcome)
+
+    assert isinstance(outcome.error, RuntimeError)
+    assert str(outcome.error) == "broker failed"

--- a/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_helpers.py
+++ b/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_helpers.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import mindtrace.jobs.testing.suites._common as common
 from mindtrace.jobs.redis.connection import RedisConnection
 from mindtrace.jobs.testing.suites._common import WorkerStats, merge_worker_stats, redis_background_errors
-from mindtrace.jobs.testing.suites.consume import _ConsumeOutcome, _consume_worker
+from mindtrace.jobs.testing.suites.consume import _consume_worker, _ConsumeOutcome
 
 
 def test_worker_stats_bounds_latency_samples_and_detects_duplicates() -> None:

--- a/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_helpers.py
+++ b/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_helpers.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import mindtrace.jobs.testing.suites._common as common
-from mindtrace.jobs.testing.suites._common import WorkerStats, merge_worker_stats
+from mindtrace.jobs.redis.connection import RedisConnection
+from mindtrace.jobs.testing.suites._common import WorkerStats, merge_worker_stats, redis_background_errors
 from mindtrace.jobs.testing.suites.consume import _ConsumeOutcome, _consume_worker
 
 
@@ -119,3 +121,28 @@ def test_redis_worker_client_attaches_to_existing_queue(monkeypatch) -> None:
         durable=True,
         auto_delete=False,
     )
+
+
+def test_redis_background_errors_are_formatted_and_deduplicated() -> None:
+    connection = RedisConnection.__new__(RedisConnection)
+    connection._local_lock = threading.Lock()
+    connection._event_listener_error = RuntimeError("listener stopped")
+    connection.host = "redis.example"
+    connection.port = 6380
+    connection.db = 2
+    owner = SimpleNamespace(connection=connection)
+
+    assert redis_background_errors(owner, connection, owner) == [
+        "Redis event listener redis.example:6380/2 raised RuntimeError: listener stopped"
+    ]
+
+
+def test_redis_background_errors_ignore_healthy_and_non_redis_resources() -> None:
+    connection = RedisConnection.__new__(RedisConnection)
+    connection._local_lock = threading.Lock()
+    connection._event_listener_error = None
+    connection.host = "localhost"
+    connection.port = 6379
+    connection.db = 0
+
+    assert redis_background_errors(SimpleNamespace(connection=connection), MagicMock()) == []

--- a/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_helpers.py
+++ b/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import mindtrace.jobs.testing.suites._common as common
 from mindtrace.jobs.testing.suites._common import WorkerStats, merge_worker_stats
 from mindtrace.jobs.testing.suites.consume import _ConsumeOutcome, _consume_worker
 
@@ -94,3 +95,27 @@ def test_consume_worker_surfaces_operation_error() -> None:
 
     assert isinstance(outcome.error, RuntimeError)
     assert str(outcome.error) == "broker failed"
+
+
+def test_rabbitmq_worker_client_does_not_redeclare_broker_owned_queue(monkeypatch) -> None:
+    client = MagicMock()
+    monkeypatch.setattr(common, "create_backend_client", MagicMock(return_value=client))
+    runtime = SimpleNamespace(backend="rabbitmq", local_root=None, queue_name="bench-queue")
+
+    assert common.create_backend_worker_client(runtime, MagicMock()) is client
+    client.declare_queue.assert_not_called()
+
+
+def test_redis_worker_client_attaches_to_existing_queue(monkeypatch) -> None:
+    client = MagicMock()
+    client.declare_queue.return_value = {"status": "success"}
+    monkeypatch.setattr(common, "create_backend_client", MagicMock(return_value=client))
+    runtime = SimpleNamespace(backend="redis", local_root=None, queue_name="bench-queue")
+
+    assert common.create_backend_worker_client(runtime, MagicMock()) is client
+    client.declare_queue.assert_called_once_with(
+        "bench-queue",
+        queue_type="fifo",
+        durable=True,
+        auto_delete=False,
+    )

--- a/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_registration.py
+++ b/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_registration.py
@@ -54,7 +54,8 @@ def test_jobs_benchmark_profiles_have_expected_defaults_and_resources() -> None:
     for suite_id in runner.list_suite_ids():
         schema = runner.get_suite_schema(suite_id)
         assert schema.profiles["smoke"]["duration_seconds"] == 1.0
-        assert schema.profiles["smoke"]["backend"] == "local"
+        expected_smoke_backend = "redis" if suite_id == "jobs.stress.pipeline_scaling" else "local"
+        assert schema.profiles["smoke"]["backend"] == expected_smoke_backend
         assert schema.profiles["stress"]["duration_seconds"] == 10.0
         assert schema.profiles["stress"]["backend"] == "rabbitmq"
         assert schema.resource_json_schema is not None
@@ -64,6 +65,10 @@ def test_jobs_benchmark_profiles_have_expected_defaults_and_resources() -> None:
             properties
         )
         assert properties["rabbitmq_password"]["secret"] is True
+
+    consume_schema = runner.get_suite_schema("jobs.stress.consume_ceiling")
+    assert consume_schema.profiles["smoke"]["backlog_messages"] == 500
+    assert consume_schema.profiles["stress"]["backlog_messages"] == 100_000
 
 
 def test_every_jobs_workload_accepts_all_backend_names() -> None:
@@ -83,11 +88,12 @@ def test_consume_mode_compatibility_is_explicit() -> None:
         JobsConsumeCeilingInput(backend="redis", consume_mode="push")
 
 
-def test_local_pipeline_rejects_multi_worker_scaling() -> None:
-    assert JobsPipelineScalingInput(backend="local", producer_count=1, consumer_count=1)
+def test_local_pipeline_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="Local pipeline benchmarks are unsupported"):
+        JobsPipelineScalingInput(backend="local", producer_count=1, consumer_count=1)
 
-    with pytest.raises(ValidationError, match="producer_count=1 and consumer_count=1"):
-        JobsPipelineScalingInput(backend="local", producer_count=1, consumer_count=2)
+    assert JobsPipelineScalingInput(backend="redis", producer_count=1, consumer_count=4)
+    assert JobsPipelineScalingInput(backend="rabbitmq", producer_count=1, consumer_count=4)
 
 
 def test_jobs_benchmark_registration_is_idempotent_when_replace_is_false() -> None:

--- a/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_registration.py
+++ b/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_registration.py
@@ -1,12 +1,24 @@
-"""Registration and metadata contracts for Jobs benchmark suites."""
+"""Registration and configuration contracts for Jobs benchmark suites."""
 
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
 from mindtrace.core import TestRunner
 from mindtrace.jobs.testing.suites import JOBS_BENCHMARK_SUITES
+from mindtrace.jobs.testing.suites.consume import JobsConsumeCeilingInput
+from mindtrace.jobs.testing.suites.pipeline import JobsPipelineScalingInput
 
 
-def test_jobs_testing_registers_expected_suites_and_schemas() -> None:
+def _registered_runner() -> TestRunner:
+    runner = TestRunner()
+    for suite in JOBS_BENCHMARK_SUITES:
+        runner.register_test_suite(suite)
+    return runner
+
+
+def test_jobs_testing_registers_four_workload_suites_and_schemas() -> None:
     import mindtrace.jobs.testing as jobs_testing
 
     runner = TestRunner()
@@ -16,12 +28,9 @@ def test_jobs_testing_registers_expected_suites_and_schemas() -> None:
     assert set(runner.registered_suites()) == expected
     assert expected == {
         "jobs.smoke.round_trip",
-        "jobs.stress.rabbitmq_publish_ceiling",
-        "jobs.stress.rabbitmq_consume_iterative_pull_one",
-        "jobs.stress.rabbitmq_consume_steady_pull",
-        "jobs.stress.rabbitmq_consume_push",
-        "jobs.stress.rabbitmq_pipeline_one_consumer",
-        "jobs.stress.rabbitmq_pipeline_four_consumers",
+        "jobs.stress.publish_ceiling",
+        "jobs.stress.consume_ceiling",
+        "jobs.stress.pipeline_scaling",
     }
 
     for suite_id in expected:
@@ -32,25 +41,53 @@ def test_jobs_testing_registers_expected_suites_and_schemas() -> None:
         assert schema.task_schema["output_json_schema"]["title"] == "BenchResultSchema"
 
 
-def test_jobs_benchmark_profiles_have_expected_durations_and_tags() -> None:
-    runner = TestRunner()
-    for suite in JOBS_BENCHMARK_SUITES:
-        runner.register_test_suite(suite)
+def test_jobs_benchmark_profiles_have_expected_defaults_and_resources() -> None:
+    runner = _registered_runner()
 
-    smoke_ids = set(runner.suite_ids_for_profile("smoke"))
-    stress_ids = set(runner.suite_ids_for_profile("stress"))
-
-    assert smoke_ids == {"jobs.smoke.round_trip"}
-    assert stress_ids == {
-        suite.suite_id for suite in JOBS_BENCHMARK_SUITES if suite.suite_id != "jobs.smoke.round_trip"
+    assert set(runner.suite_ids_for_profile("smoke")) == {"jobs.smoke.round_trip"}
+    assert set(runner.suite_ids_for_profile("stress")) == {
+        "jobs.stress.publish_ceiling",
+        "jobs.stress.consume_ceiling",
+        "jobs.stress.pipeline_scaling",
     }
-    assert runner.get_suite_schema("jobs.smoke.round_trip").profiles["smoke"]["duration_seconds"] == 1.0
-    for suite_id in stress_ids:
+
+    for suite_id in runner.list_suite_ids():
         schema = runner.get_suite_schema(suite_id)
+        assert schema.profiles["smoke"]["duration_seconds"] == 1.0
+        assert schema.profiles["smoke"]["backend"] == "local"
         assert schema.profiles["stress"]["duration_seconds"] == 10.0
+        assert schema.profiles["stress"]["backend"] == "rabbitmq"
         assert schema.resource_json_schema is not None
-        password_schema = schema.resource_json_schema["properties"]["rabbitmq_password"]
-        assert password_schema["secret"] is True
+        properties = schema.resource_json_schema["properties"]
+        assert {"local_base_dir", "redis_host", "redis_port", "redis_db"}.issubset(properties)
+        assert {"rabbitmq_host", "rabbitmq_port", "rabbitmq_username", "rabbitmq_password"}.issubset(
+            properties
+        )
+        assert properties["rabbitmq_password"]["secret"] is True
+
+
+def test_every_jobs_workload_accepts_all_backend_names() -> None:
+    runner = _registered_runner()
+
+    for suite_id in runner.list_suite_ids():
+        input_schema = runner.get_suite_schema(suite_id).task_schema["input_json_schema"]
+        assert set(input_schema["properties"]["backend"]["enum"]) == {"local", "redis", "rabbitmq"}
+
+
+def test_consume_mode_compatibility_is_explicit() -> None:
+    assert JobsConsumeCeilingInput(backend="local", consume_mode="iterative_pull_one")
+    assert JobsConsumeCeilingInput(backend="redis", consume_mode="steady_pull")
+    assert JobsConsumeCeilingInput(backend="rabbitmq", consume_mode="push")
+
+    with pytest.raises(ValidationError, match="requires backend='rabbitmq'"):
+        JobsConsumeCeilingInput(backend="redis", consume_mode="push")
+
+
+def test_local_pipeline_rejects_multi_worker_scaling() -> None:
+    assert JobsPipelineScalingInput(backend="local", producer_count=1, consumer_count=1)
+
+    with pytest.raises(ValidationError, match="producer_count=1 and consumer_count=1"):
+        JobsPipelineScalingInput(backend="local", producer_count=1, consumer_count=2)
 
 
 def test_jobs_benchmark_registration_is_idempotent_when_replace_is_false() -> None:
@@ -61,42 +98,3 @@ def test_jobs_benchmark_registration_is_idempotent_when_replace_is_false() -> No
     jobs_testing.register_benchmark_suites(runner=runner, replace=False)
 
     assert len(runner.registered_suites()) == len(JOBS_BENCHMARK_SUITES)
-
-
-def test_rabbitmq_consume_modes_share_comparable_stress_defaults() -> None:
-    runner = TestRunner()
-    for suite in JOBS_BENCHMARK_SUITES:
-        runner.register_test_suite(suite)
-
-    suite_ids = (
-        "jobs.stress.rabbitmq_consume_iterative_pull_one",
-        "jobs.stress.rabbitmq_consume_steady_pull",
-        "jobs.stress.rabbitmq_consume_push",
-    )
-    comparable_keys = {
-        "duration_seconds",
-        "payload_size_bytes",
-        "backlog_messages",
-        "preload_batch_size",
-        "prefetch_count",
-    }
-    profiles = [runner.get_suite_schema(suite_id).profiles["stress"] for suite_id in suite_ids]
-
-    assert [{key: profile[key] for key in comparable_keys} for profile in profiles] == [
-        {key: profiles[0][key] for key in comparable_keys}
-    ] * len(profiles)
-
-
-def test_pipeline_profiles_compare_one_and_four_consumers() -> None:
-    runner = TestRunner()
-    for suite in JOBS_BENCHMARK_SUITES:
-        runner.register_test_suite(suite)
-
-    one = runner.get_suite_schema("jobs.stress.rabbitmq_pipeline_one_consumer").profiles["stress"]
-    four = runner.get_suite_schema("jobs.stress.rabbitmq_pipeline_four_consumers").profiles["stress"]
-
-    assert one["consumer_count"] == 1
-    assert four["consumer_count"] == 4
-    assert {key: value for key, value in one.items() if key != "consumer_count"} == {
-        key: value for key, value in four.items() if key != "consumer_count"
-    }

--- a/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_registration.py
+++ b/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_registration.py
@@ -61,9 +61,7 @@ def test_jobs_benchmark_profiles_have_expected_defaults_and_resources() -> None:
         assert schema.resource_json_schema is not None
         properties = schema.resource_json_schema["properties"]
         assert {"local_base_dir", "redis_host", "redis_port", "redis_db"}.issubset(properties)
-        assert {"rabbitmq_host", "rabbitmq_port", "rabbitmq_username", "rabbitmq_password"}.issubset(
-            properties
-        )
+        assert {"rabbitmq_host", "rabbitmq_port", "rabbitmq_username", "rabbitmq_password"}.issubset(properties)
         assert properties["rabbitmq_password"]["secret"] is True
 
     consume_schema = runner.get_suite_schema("jobs.stress.consume_ceiling")

--- a/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_registration.py
+++ b/tests/unit/mindtrace/jobs/testing/test_jobs_benchmark_registration.py
@@ -1,0 +1,102 @@
+"""Registration and metadata contracts for Jobs benchmark suites."""
+
+from __future__ import annotations
+
+from mindtrace.core import TestRunner
+from mindtrace.jobs.testing.suites import JOBS_BENCHMARK_SUITES
+
+
+def test_jobs_testing_registers_expected_suites_and_schemas() -> None:
+    import mindtrace.jobs.testing as jobs_testing
+
+    runner = TestRunner()
+    jobs_testing.register_benchmark_suites(runner=runner)
+
+    expected = {suite.suite_id for suite in JOBS_BENCHMARK_SUITES}
+    assert set(runner.registered_suites()) == expected
+    assert expected == {
+        "jobs.smoke.round_trip",
+        "jobs.stress.rabbitmq_publish_ceiling",
+        "jobs.stress.rabbitmq_consume_iterative_pull_one",
+        "jobs.stress.rabbitmq_consume_steady_pull",
+        "jobs.stress.rabbitmq_consume_push",
+        "jobs.stress.rabbitmq_pipeline_one_consumer",
+        "jobs.stress.rabbitmq_pipeline_four_consumers",
+    }
+
+    for suite_id in expected:
+        schema = runner.get_suite_schema(suite_id)
+        assert schema.task_schema is not None
+        assert schema.task_schema["name"] == suite_id
+        assert schema.task_schema["input_json_schema"] is not None
+        assert schema.task_schema["output_json_schema"]["title"] == "BenchResultSchema"
+
+
+def test_jobs_benchmark_profiles_have_expected_durations_and_tags() -> None:
+    runner = TestRunner()
+    for suite in JOBS_BENCHMARK_SUITES:
+        runner.register_test_suite(suite)
+
+    smoke_ids = set(runner.suite_ids_for_profile("smoke"))
+    stress_ids = set(runner.suite_ids_for_profile("stress"))
+
+    assert smoke_ids == {"jobs.smoke.round_trip"}
+    assert stress_ids == {
+        suite.suite_id for suite in JOBS_BENCHMARK_SUITES if suite.suite_id != "jobs.smoke.round_trip"
+    }
+    assert runner.get_suite_schema("jobs.smoke.round_trip").profiles["smoke"]["duration_seconds"] == 1.0
+    for suite_id in stress_ids:
+        schema = runner.get_suite_schema(suite_id)
+        assert schema.profiles["stress"]["duration_seconds"] == 10.0
+        assert schema.resource_json_schema is not None
+        password_schema = schema.resource_json_schema["properties"]["rabbitmq_password"]
+        assert password_schema["secret"] is True
+
+
+def test_jobs_benchmark_registration_is_idempotent_when_replace_is_false() -> None:
+    import mindtrace.jobs.testing as jobs_testing
+
+    runner = TestRunner()
+    jobs_testing.register_benchmark_suites(runner=runner, replace=False)
+    jobs_testing.register_benchmark_suites(runner=runner, replace=False)
+
+    assert len(runner.registered_suites()) == len(JOBS_BENCHMARK_SUITES)
+
+
+def test_rabbitmq_consume_modes_share_comparable_stress_defaults() -> None:
+    runner = TestRunner()
+    for suite in JOBS_BENCHMARK_SUITES:
+        runner.register_test_suite(suite)
+
+    suite_ids = (
+        "jobs.stress.rabbitmq_consume_iterative_pull_one",
+        "jobs.stress.rabbitmq_consume_steady_pull",
+        "jobs.stress.rabbitmq_consume_push",
+    )
+    comparable_keys = {
+        "duration_seconds",
+        "payload_size_bytes",
+        "backlog_messages",
+        "preload_batch_size",
+        "prefetch_count",
+    }
+    profiles = [runner.get_suite_schema(suite_id).profiles["stress"] for suite_id in suite_ids]
+
+    assert [{key: profile[key] for key in comparable_keys} for profile in profiles] == [
+        {key: profiles[0][key] for key in comparable_keys}
+    ] * len(profiles)
+
+
+def test_pipeline_profiles_compare_one_and_four_consumers() -> None:
+    runner = TestRunner()
+    for suite in JOBS_BENCHMARK_SUITES:
+        runner.register_test_suite(suite)
+
+    one = runner.get_suite_schema("jobs.stress.rabbitmq_pipeline_one_consumer").profiles["stress"]
+    four = runner.get_suite_schema("jobs.stress.rabbitmq_pipeline_four_consumers").profiles["stress"]
+
+    assert one["consumer_count"] == 1
+    assert four["consumer_count"] == 4
+    assert {key: value for key, value in one.items() if key != "consumer_count"} == {
+        key: value for key, value in four.items() if key != "consumer_count"
+    }


### PR DESCRIPTION
## Summary

Adds reusable Jobs benchmark suites to the existing `mindtrace.core.testing` framework and registers them through the `jobs` benchmark entry point.

- Adds four configurable workloads:
  - `jobs.smoke.round_trip`
  - `jobs.stress.publish_ceiling`
  - `jobs.stress.consume_ceiling`
  - `jobs.stress.pipeline_scaling`
- Supports Local, Redis, and RabbitMQ through validated suite parameters and resource models.

## Motivation

Mindtrace Jobs needs a reusable way to measure backend throughput and consumer scaling across Local, Redis, and RabbitMQ. These suites provide comparable workload evidence for backend behavior and for the RabbitMQ `basic_consume` change in #537 without baking environment-specific performance thresholds into the library.

Closes #541

## Supported configurations

- Round trip and publication: Local, Redis, or RabbitMQ.
- Iterative `consume(1)` and steady finite pull: Local, Redis, or RabbitMQ.
- Broker push: RabbitMQ only.
- Pipeline scaling: Redis or RabbitMQ; Local is rejected because concurrent producer/consumer access to its registry-backed queue is not safe.
- The Local smoke consume preset preloads 500 messages. Redis and RabbitMQ stress presets retain a 100,000-message backlog.
- Smoke defaults to one second; stress defaults to ten seconds.

## Programmatic matrix runner

Start a non-persistent Redis instance:

```bash
docker run -d --name mindtrace-redis-bench \
  -p 6379:6379 \
  redis:7-alpine \
  redis-server --save "" --appendonly no
```

Start RabbitMQ with the credentials used by the runner:

```bash
docker run -d --name mindtrace-rabbitmq-bench \
  -p 5672:5672 \
  -p 15672:15672 \
  -e RABBITMQ_DEFAULT_USER=user \
  -e RABBITMQ_DEFAULT_PASS=password \
  rabbitmq:3-management
```

The runner below connects to Redis on `localhost:6379` and RabbitMQ on `localhost:5672` with `user/password`.

```python
#!/usr/bin/env python3
"""Run the configurable Mindtrace Jobs benchmarks across all supported backends."""

from mindtrace.core import TestRunner
from mindtrace.jobs.testing import register_benchmark_suites


def main() -> int:
    runner = TestRunner()
    register_benchmark_suites(runner=runner)

    resources_by_backend = {
        "local": {},
        "redis": {
            "redis_host": "localhost",
            "redis_port": 6379,
            "redis_db": 0,
        },
        "rabbitmq": {
            "rabbitmq_host": "localhost",
            "rabbitmq_port": 5672,
            "rabbitmq_username": "user",
            "rabbitmq_password": "password",
        },
    }

    variants = []
    for backend in ("local", "redis", "rabbitmq"):
        # Local remains a short correctness/single-consumer baseline. Redis and
        # RabbitMQ use the ten-second stress profile.
        stress_profile = "smoke" if backend == "local" else "stress"

        variants.append(
            (
                f"{backend}_round_trip",
                "jobs.smoke.round_trip",
                "smoke",
                {"backend": backend},
            )
        )
        variants.append(
            (
                f"{backend}_publish",
                "jobs.stress.publish_ceiling",
                stress_profile,
                {"backend": backend},
            )
        )

        for mode in ("iterative_pull_one", "steady_pull"):
            parameters = {
                "backend": backend,
                "consume_mode": mode,
            }
            if backend == "local":
                # Give the one-second Local run enough work without creating the
                # full 100,000-message stress backlog.
                parameters.update(
                    backlog_messages=500,
                    preload_batch_size=250,
                )
            variants.append(
                (
                    f"{backend}_consume_{mode}",
                    "jobs.stress.consume_ceiling",
                    stress_profile,
                    parameters,
                )
            )

        if backend == "rabbitmq":
            variants.append(
                (
                    "rabbitmq_consume_push",
                    "jobs.stress.consume_ceiling",
                    "stress",
                    {
                        "backend": "rabbitmq",
                        "consume_mode": "push",
                    },
                )
            )

        consumer_counts = () if backend == "local" else (1, 4)
        for consumer_count in consumer_counts:
            variants.append(
                (
                    f"{backend}_pipeline_{consumer_count}_consumer",
                    "jobs.stress.pipeline_scaling",
                    stress_profile,
                    {
                        "backend": backend,
                        "consumer_count": consumer_count,
                    },
                )
            )

    failed = False
    for name, suite_id, profile, parameters in variants:
        results, executions = runner.run_registered_benches(
            [suite_id],
            profile=profile,
            run_id=f"jobs-{name}",
            parameters=parameters,
            resources=resources_by_backend[parameters["backend"]],
        )

        for result in results:
            summary = result.to_dict()
            print(
                f"{name}: {summary['status']} "
                f"ops={summary['operations']} "
                f"failures={summary['failures']} "
                f"rate={summary['throughput_ops_per_second']:.2f} ops/s "
                f"duration={summary['duration_seconds']:.2f}s"
            )
            validation_errors = summary.get("metrics", {}).get("validation_errors", [])
            for error in validation_errors:
                print(f"{name}: VALIDATION {error}")

        for execution in executions:
            if execution.status != "passed":
                failed = True
                if execution.error is not None:
                    print(f"{name}: ERROR {execution.error!r}")

    return 1 if failed else 0


if __name__ == "__main__":
    raise SystemExit(main())
```

Run from the repository root:

```bash
uv run python jobs_benchmark_all_backends.py
```

## Benchmark results

| Backend | Workload | Variant | Status | Ops | Failures | Rate (ops/s) | Duration (s) |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: |
| Local | Round trip | — | Passed | 127 | 0 | 126.88 | 1.00 |
| Local | Publish | — | Passed | 225 | 0 | 222.26 | 1.01 |
| Local | Consume | Iterative pull (1) | Passed | 162 | 0 | 160.71 | 1.01 |
| Local | Consume | Steady pull | Passed | 157 | 0 | 156.20 | 1.01 |
| Redis | Round trip | — | Passed | 3,550 | 0 | 1,176.89 | 3.02 |
| Redis | Publish | — | Passed | 93,250 | 0 | 7,745.37 | 12.04 |
| Redis | Consume | Iterative pull (1) | Passed | 70,084 | 0 | 7,008.26 | 10.00 |
| Redis | Consume | Steady pull | Passed | 76,448 | 0 | 7,644.67 | 10.00 |
| Redis | Pipeline | 1 consumer | Passed | 60,050 | 0 | 5,998.21 | 10.01 |
| Redis | Pipeline | 4 consumers | Passed | 61,061 | 0 | 6,105.55 | 10.00 |
| RabbitMQ | Round trip | — | Passed | 165 | 0 | 163.13 | 1.01 |
| RabbitMQ | Publish | — | Passed | 188,750 | 0 | 17,554.19 | 10.75 |
| RabbitMQ | Consume | Iterative pull (1) | Passed | 3,680 | 0 | 367.94 | 10.00 |
| RabbitMQ | Consume | Steady pull | Passed | 43,204 | 0 | 4,320.09 | 10.00 |
| RabbitMQ | Consume | Push | Passed | 54,743 | 0 | 5,473.74 | 10.00 |
| RabbitMQ | Pipeline | 1 consumer | Passed | 18,329 | 0 | 1,827.97 | 10.03 |
| RabbitMQ | Pipeline | 4 consumers | Passed | 34,250 | 0 | 3,399.12 | 10.08 |


## Interpretation

### Correctness and lifecycle

Every variant passed with zero workload, integrity, lifecycle, validation, or background-listener failures. No Redis listener timeout/error messages appeared. Unexpected Redis listener errors are now promoted into Jobs validation failures, so `failures=0` also confirms listener health for this run.

### Local

The 500-message consume backlog keeps the one-second smoke run bounded. Iterative and steady consumption are within 2.9% because Local has no broker push/pull distinction or repeated connection setup to optimize. Local rewrites its registry-backed queue on each operation, so its absolute rate depends strongly on queue depth and is intended only as a single-process correctness baseline.

### Redis

Steady pull reached 7,645 ops/s, 9.1% above iterative `consume(1)` at 7,008 ops/s. Four pipeline consumers reached 6,106 ops/s versus 5,998 ops/s with one, a 1.8% gain; consumer count is therefore not the limiting factor in this configuration.

The timing boundary is intentionally unchanged in this PR. Redis round-trip and publish summaries include approximately two seconds of client cleanup, so their displayed rates understate throughput inside the one- and ten-second workload windows. The consume and pipeline comparisons use consistent ten-second reported durations.

### RabbitMQ and #537

- Iterative `consume(1)`: 368 ops/s.
- Steady `basic_get`: 4,320 ops/s, 11.7× iterative consumption.
- Push `basic_consume`: 5,474 ops/s, 26.7% above steady pull and 14.9× iterative consumption.

Push versus steady pull is the relevant comparison for #537 because both retain one connection/channel for the measured operation. Across three supplied localhost runs, push exceeded steady pull by approximately 21%, 29%, and 27%, supporting a repeatable 20–30% maximum-throughput improvement from restoring `basic_consume`.

RabbitMQ publication reached 17,554 messages/s, over 3× the isolated push-consume ceiling, so isolated publication is not the bottleneck.

Four RabbitMQ pipeline consumers reached 3,399 ops/s versus 1,828 ops/s for one, an 86% improvement (1.86× scaling). The absolute pipeline rates were more variable than the isolated publish/consume ceilings, so repeated-run medians should be used before treating them as stable capacity figures.

### Cross-backend observations

- Redis produced the highest steady-consume result at 7,645 ops/s.
- RabbitMQ produced the highest publication result at 17,554 messages/s.
- Redis gained little from four consumers; RabbitMQ gained substantially, though not linearly.
- Local results should not be compared directly with broker-backed results because registry queue depth dominates its cost.



