### PR TITLE
Add annotation selection and typed export metadata

### DIFF
--- a/mindtrace/datalake/README.md
+++ b/mindtrace/datalake/README.md
@@ -411,6 +411,35 @@ with Datalake.create(
 The exports embed media for relocation, preserve ordered class mappings and source lineage, and normalize task
 records into stable HF schemas.
 
+For a DatasetVersion with multiple logical classification annotations, select one field by its exact annotation
+attributes. When the selected annotations do not have label IDs, provide an explicit class order. Required top-level
+row metadata can be copied into typed fields in the same export pass:
+
+```python
+datalake.export_dataset_version_to_format(
+    "multi-field-classification",
+    "1.0.0",
+    format="huggingface",
+    destination=export_root / "selected-classification",
+    include_media=True,
+    exporter_options={
+        "task": "classification",
+        "annotation_attributes": {"field": "primary_target"},
+        "class_names": ["negative", "positive"],
+        "metadata_keys": {
+            "subject_id": "string",
+            "group_id": "string",
+        },
+    },
+)
+```
+
+The attribute mapping is matched exactly against classification records, and every item must have exactly one
+match. Metadata keys refer to required, top-level Datum metadata; the key name is preserved in the Hugging Face
+artifact. Supported scalar dtypes are `string`, `bool`, signed and unsigned integer widths from 8 through 64 bits,
+and `float16`, `float32`, and `float64`. The resolved selector, class mapping, and metadata-key types are recorded in
+`mindtrace_metadata.json`. Existing exports without these options are unchanged.
+
 #### Build all associated Datasets and DataLoaders
 
 ```python
@@ -511,7 +540,24 @@ training-facing `(images, targets)` batch structure below:
 - Instance segmentation: target mappings containing `boxes`, `labels`, `masks`, `area`, and `iscrowd`.
 
 Pass `return_metadata=True` to include a separate `metadata` mapping in dataset samples and a third metadata
-column in DataLoader batches.
+column in DataLoader batches. By default that mapping contains `asset_id`. Pass `metadata_keys=(...)` to add typed
+top-level fields that were selected during export:
+
+```python
+datasets = build_datasets(
+    export_root / "selected-classification",
+    return_metadata=True,
+    metadata_keys=("subject_id", "group_id"),
+)
+loaders = build_dataloaders(
+    export_root / "selected-classification",
+    return_metadata=True,
+    metadata_keys=("subject_id", "group_id"),
+)
+```
+
+Requested keys must exist in the saved Hugging Face schema. They are read directly from the typed fields without
+reparsing `metadata_json`.
 
 Detection and instance targets follow torchvision conventions. The detection adapter is source-dataset-generic but
 expects the canonical Mindtrace HF detection schema: embedded image media, absolute pixel-space `xywh` boxes, and

--- a/mindtrace/datalake/mindtrace/datalake/exporters/huggingface.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/huggingface.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import io
 import json
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -10,22 +11,110 @@ from .base import prepare_export_destination, write_export_file
 from .types import ExportableDataset, ExportResult
 
 
-def _configured_class_names(dataset: ExportableDataset, task: str) -> list[str] | None:
-    configured = dataset.metadata.get(f"{task}_class_names") or dataset.metadata.get("class_names")
-    if configured:
-        return [str(name) for name in configured]
-    return None
+_INTEGER_DTYPES = {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}
+_FLOAT_DTYPES = {"float16", "float32", "float64"}
+_METADATA_DTYPES = {"string", "bool", *_INTEGER_DTYPES, *_FLOAT_DTYPES}
 
 
-def _classification_class_names(dataset: ExportableDataset) -> list[str]:
-    configured = _configured_class_names(dataset, "classification")
+def _configured_class_names(
+    dataset: ExportableDataset,
+    task: str,
+    options: Mapping[str, Any] | None = None,
+) -> list[str] | None:
+    configured = None
+    if options is not None:
+        configured = options.get(f"{task}_class_names") or options.get("class_names")
+    configured = configured or dataset.metadata.get(f"{task}_class_names") or dataset.metadata.get("class_names")
+    if configured is None:
+        return None
+    if isinstance(configured, (str, bytes)) or not isinstance(configured, Sequence):
+        raise ValueError("Classification class_names must be an ordered sequence of label names.")
+    class_names = [str(name) for name in configured]
+    if not class_names:
+        raise ValueError("Classification class_names cannot be empty.")
+    if len(set(class_names)) != len(class_names):
+        raise ValueError("Classification class_names must not contain duplicate label names.")
+    return class_names
+
+
+def _annotation_attributes(options: Mapping[str, Any] | None) -> dict[str, Any]:
+    configured = (options or {}).get("annotation_attributes")
+    if configured is None:
+        return {}
+    if not isinstance(configured, Mapping) or any(not isinstance(key, str) or not key for key in configured):
+        raise ValueError("annotation_attributes must be a mapping with non-empty string keys.")
+    return dict(configured)
+
+
+def _metadata_keys(options: Mapping[str, Any] | None) -> dict[str, str]:
+    configured = (options or {}).get("metadata_keys")
+    if configured is None:
+        return {}
+    if not isinstance(configured, Mapping):
+        raise ValueError("metadata_keys must map top-level row metadata keys to Hugging Face scalar dtypes.")
+    metadata_keys: dict[str, str] = {}
+    for key, dtype in configured.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError("metadata_keys must contain non-empty string keys.")
+        if not isinstance(dtype, str) or dtype not in _METADATA_DTYPES:
+            raise ValueError(
+                f"metadata_keys[{key!r}] must use a supported scalar dtype; found {dtype!r}. "
+                f"Supported dtypes: {sorted(_METADATA_DTYPES)}."
+            )
+        metadata_keys[key] = dtype
+    return metadata_keys
+
+
+def _annotation_matches_attributes(annotation: Any, attributes: Mapping[str, Any]) -> bool:
+    return annotation.kind == "classification" and all(
+        (annotation.attributes or {}).get(key) == value for key, value in attributes.items()
+    )
+
+
+def _metadata_value_matches_dtype(value: Any, dtype: str) -> bool:
+    if dtype == "string":
+        return isinstance(value, str)
+    if dtype == "bool":
+        return isinstance(value, bool)
+    if dtype in _INTEGER_DTYPES:
+        return isinstance(value, int) and not isinstance(value, bool)
+    if dtype in _FLOAT_DTYPES:
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return False
+
+
+def _project_metadata_keys(item: Any, metadata_keys: Mapping[str, str]) -> dict[str, Any]:
+    projected: dict[str, Any] = {}
+    for key, dtype in metadata_keys.items():
+        if key not in item.metadata or item.metadata[key] is None:
+            raise ValueError(
+                f"Hugging Face export requires row metadata key {key!r}; asset {item.asset.asset_id!r} is missing it."
+            )
+        value = item.metadata[key]
+        if not _metadata_value_matches_dtype(value, dtype):
+            raise ValueError(
+                f"Hugging Face export metadata key {key!r} on asset {item.asset.asset_id!r} "
+                f"must match dtype {dtype!r}; found {type(value).__name__}."
+            )
+        projected[key] = value
+    return projected
+
+
+def _classification_class_names(
+    dataset: ExportableDataset,
+    *,
+    options: Mapping[str, Any] | None = None,
+    annotation_attributes: Mapping[str, Any] | None = None,
+) -> list[str]:
+    configured = _configured_class_names(dataset, "classification", options)
     if configured:
         return configured
 
+    selected_attributes = annotation_attributes or {}
     labels_by_id: dict[int, str] = {}
     for item in dataset.items:
         for annotation in item.annotations:
-            if annotation.kind != "classification" or annotation.label_id is None:
+            if not _annotation_matches_attributes(annotation, selected_attributes) or annotation.label_id is None:
                 continue
             previous = labels_by_id.setdefault(annotation.label_id, annotation.label)
             if previous != annotation.label:
@@ -33,7 +122,9 @@ def _classification_class_names(dataset: ExportableDataset) -> list[str]:
                     f"Classification label id {annotation.label_id} maps to both {previous!r} and {annotation.label!r}."
                 )
     if not labels_by_id:
-        raise ValueError("Classification export requires annotation label IDs or dataset metadata class_names.")
+        raise ValueError(
+            "Classification export requires annotation label IDs or explicit exporter option class_names."
+        )
     expected_ids = list(range(len(labels_by_id)))
     if sorted(labels_by_id) != expected_ids:
         raise ValueError(
@@ -55,36 +146,44 @@ def _detection_class_names(dataset: ExportableDataset) -> list[str]:
     return sorted(labels)
 
 
-def _classification_annotation(item) -> Any:
-    annotations = [annotation for annotation in item.annotations if annotation.kind == "classification"]
+def _classification_annotation(item: Any, annotation_attributes: Mapping[str, Any] | None = None) -> Any:
+    selected_attributes = annotation_attributes or {}
+    annotations = [
+        annotation
+        for annotation in item.annotations
+        if _annotation_matches_attributes(annotation, selected_attributes)
+    ]
     if len(annotations) != 1:
+        selector = f" matching attributes {dict(selected_attributes)!r}" if selected_attributes else ""
         raise ValueError(
-            "Single-label classification export requires exactly one classification annotation per image; "
+            f"Single-label classification export requires exactly one classification annotation{selector} per image; "
             f"asset {item.asset.asset_id!r} has {len(annotations)}."
         )
-    annotation = annotations[0]
-    if annotation.label_id is None:
-        raise ValueError(
-            f"Classification annotation {annotation.annotation_id!r} must define a contiguous zero-based label_id."
-        )
-    return annotation
+    return annotations[0]
 
 
-def _single_label_classification_features(datasets_module: Any, class_names: list[str]):
-    return datasets_module.Features(
-        {
-            "image": datasets_module.Image(),
-            "asset_id": datasets_module.Value("string"),
-            "label": datasets_module.ClassLabel(names=class_names),
-            "label_name": datasets_module.Value("string"),
-            "split": datasets_module.Value("string"),
-            "source_image_asset_id": datasets_module.Value("string"),
-            "source_annotation_id": datasets_module.Value("string"),
-            "source_bbox": datasets_module.Sequence(datasets_module.Value("float32"), length=4),
-            "metadata_json": datasets_module.Value("string"),
-            "asset_metadata_json": datasets_module.Value("string"),
-        }
-    )
+def _single_label_classification_features(
+    datasets_module: Any,
+    class_names: list[str],
+    metadata_keys: Mapping[str, str] | None = None,
+):
+    fields = {
+        "image": datasets_module.Image(),
+        "asset_id": datasets_module.Value("string"),
+        "label": datasets_module.ClassLabel(names=class_names),
+        "label_name": datasets_module.Value("string"),
+        "split": datasets_module.Value("string"),
+        "source_image_asset_id": datasets_module.Value("string"),
+        "source_annotation_id": datasets_module.Value("string"),
+        "source_bbox": datasets_module.Sequence(datasets_module.Value("float32"), length=4),
+        "metadata_json": datasets_module.Value("string"),
+        "asset_metadata_json": datasets_module.Value("string"),
+    }
+    collisions = sorted(set(metadata_keys or {}) & set(fields))
+    if collisions:
+        raise ValueError(f"metadata_keys collide with reserved Hugging Face fields: {collisions}.")
+    fields.update({key: datasets_module.Value(dtype) for key, dtype in (metadata_keys or {}).items()})
+    return datasets_module.Features(fields)
 
 
 def _multi_label_classification_features(datasets_module: Any, class_names: list[str]):
@@ -235,40 +334,64 @@ def _export_single_label_classification_dataset(
     *,
     destination: Path,
     include_media: bool,
+    options: Mapping[str, Any] | None = None,
 ) -> ExportResult:
-    class_names = _classification_class_names(dataset)
-    features = _single_label_classification_features(datasets_module, class_names)
+    selected_attributes = _annotation_attributes(options)
+    selected_metadata_keys = _metadata_keys(options)
+    class_names = _classification_class_names(
+        dataset,
+        options=options,
+        annotation_attributes=selected_attributes,
+    )
+    class_ids = {name: label_id for label_id, name in enumerate(class_names)}
+    features = _single_label_classification_features(datasets_module, class_names, selected_metadata_keys)
     rows_by_split: dict[str, list[dict[str, Any]]] = {}
 
     for item in dataset.items:
-        annotation = _classification_annotation(item)
-        if not 0 <= annotation.label_id < len(class_names):
+        annotation = _classification_annotation(item, selected_attributes)
+        if annotation.label not in class_ids:
             raise ValueError(
-                f"Classification label id {annotation.label_id} is outside the exported class range "
-                f"0..{len(class_names) - 1}."
+                f"Classification annotation {annotation.annotation_id!r} on asset {item.asset.asset_id!r} "
+                f"uses label {annotation.label!r}, which is not present in class_names."
             )
-        expected_label = class_names[annotation.label_id]
-        if annotation.label != expected_label:
+        label_id = class_ids[annotation.label]
+        if annotation.label_id is not None and annotation.label_id != label_id:
             raise ValueError(
-                f"Classification label id {annotation.label_id} maps to {expected_label!r}, "
-                f"but annotation {annotation.annotation_id!r} uses {annotation.label!r}."
+                f"Classification annotation {annotation.annotation_id!r} maps label {annotation.label!r} "
+                f"to configured id {label_id}, but the annotation uses label_id {annotation.label_id}."
             )
         split_name = item.split or "default"
         image = _embedded_image(item, include_media=include_media, task="classification")
-        rows_by_split.setdefault(split_name, []).append(
-            {
-                "image": image,
-                "asset_id": item.asset.asset_id,
-                "label": annotation.label_id,
-                "label_name": annotation.label,
-                "split": item.split or "",
-                "source_image_asset_id": item.asset.asset_id,
-                "source_annotation_id": annotation.annotation_id,
-                "source_bbox": None,
-                "metadata_json": json.dumps(item.metadata or {}, sort_keys=True, default=str),
-                "asset_metadata_json": json.dumps(item.asset.metadata or {}, sort_keys=True, default=str),
-            }
-        )
+        row = {
+            "image": image,
+            "asset_id": item.asset.asset_id,
+            "label": label_id,
+            "label_name": annotation.label,
+            "split": item.split or "",
+            "source_image_asset_id": item.asset.asset_id,
+            "source_annotation_id": annotation.annotation_id,
+            "source_bbox": None,
+            "metadata_json": json.dumps(item.metadata or {}, sort_keys=True, default=str),
+            "asset_metadata_json": json.dumps(item.asset.metadata or {}, sort_keys=True, default=str),
+        }
+        row.update(_project_metadata_keys(item, selected_metadata_keys))
+        rows_by_split.setdefault(split_name, []).append(row)
+
+    requested_provenance = bool(
+        selected_attributes
+        or selected_metadata_keys
+        or (options or {}).get("class_names")
+        or (options or {}).get("classification_class_names")
+    )
+    artifact_metadata = None
+    if requested_provenance:
+        artifact_metadata = {
+            "task": "classification",
+            "annotation_attributes": selected_attributes,
+            "class_names": class_names,
+            "label_to_id": class_ids,
+            "metadata_keys": selected_metadata_keys,
+        }
 
     return _save_huggingface_rows(
         datasets_module,
@@ -278,6 +401,7 @@ def _export_single_label_classification_dataset(
         features=features,
         asset_count=dataset.asset_count,
         annotation_count=dataset.asset_count,
+        artifact_metadata=artifact_metadata,
     )
 
 
@@ -723,6 +847,7 @@ def export_dataset_as_huggingface(
                 dataset,
                 destination=destination_path,
                 include_media=include_media,
+                options=options,
             )
         if classification_type == "multi_label":
             if classification_source != "annotations":

--- a/mindtrace/datalake/mindtrace/datalake/exporters/huggingface.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/huggingface.py
@@ -10,7 +10,6 @@ from typing import Any
 from .base import prepare_export_destination, write_export_file
 from .types import ExportableDataset, ExportResult
 
-
 _INTEGER_DTYPES = {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}
 _FLOAT_DTYPES = {"float16", "float32", "float64"}
 _METADATA_DTYPES = {"string", "bool", *_INTEGER_DTYPES, *_FLOAT_DTYPES}
@@ -122,9 +121,7 @@ def _classification_class_names(
                     f"Classification label id {annotation.label_id} maps to both {previous!r} and {annotation.label!r}."
                 )
     if not labels_by_id:
-        raise ValueError(
-            "Classification export requires annotation label IDs or explicit exporter option class_names."
-        )
+        raise ValueError("Classification export requires annotation label IDs or explicit exporter option class_names.")
     expected_ids = list(range(len(labels_by_id)))
     if sorted(labels_by_id) != expected_ids:
         raise ValueError(
@@ -149,9 +146,7 @@ def _detection_class_names(dataset: ExportableDataset) -> list[str]:
 def _classification_annotation(item: Any, annotation_attributes: Mapping[str, Any] | None = None) -> Any:
     selected_attributes = annotation_attributes or {}
     annotations = [
-        annotation
-        for annotation in item.annotations
-        if _annotation_matches_attributes(annotation, selected_attributes)
+        annotation for annotation in item.annotations if _annotation_matches_attributes(annotation, selected_attributes)
     ]
     if len(annotations) != 1:
         selector = f" matching attributes {dict(selected_attributes)!r}" if selected_attributes else ""

--- a/mindtrace/models/mindtrace/models/training/huggingface_dataloaders.py
+++ b/mindtrace/models/mindtrace/models/training/huggingface_dataloaders.py
@@ -104,9 +104,17 @@ def _rgb_image(image: Any, *, consumer: str) -> Any:
     return image.convert("RGB") if hasattr(image, "convert") else image
 
 
-def _add_metadata(output: dict[str, list[Any]], batch: Mapping[str, list[Any]], return_metadata: bool) -> None:
+def _add_metadata(
+    output: dict[str, list[Any]],
+    batch: Mapping[str, list[Any]],
+    return_metadata: bool,
+    metadata_keys: Sequence[str],
+) -> None:
     if return_metadata:
-        output["metadata"] = [{"asset_id": asset_id} for asset_id in batch["asset_id"]]
+        output["metadata"] = [
+            {"asset_id": asset_id, **{key: batch[key][index] for key in metadata_keys}}
+            for index, asset_id in enumerate(batch["asset_id"])
+        ]
 
 
 def _transform_classification_batch(
@@ -115,6 +123,7 @@ def _transform_classification_batch(
     classification_type: str,
     transform: Callable[[Any], Any] | None,
     return_metadata: bool,
+    metadata_keys: Sequence[str],
 ) -> dict[str, list[Any]]:
     _, torch, _, pil_to_tensor = _require_huggingface_dataloader_dependencies()
     target_column = "labels" if classification_type == "multi_label" else "label"
@@ -127,7 +136,7 @@ def _transform_classification_batch(
         target_value = raw_target if classification_type == "multi_label" else int(raw_target)
         targets.append(torch.tensor(target_value, dtype=target_dtype))
     output = {"image": images, "target": targets}
-    _add_metadata(output, batch, return_metadata)
+    _add_metadata(output, batch, return_metadata, metadata_keys)
     return output
 
 
@@ -136,6 +145,7 @@ def _transform_detection_batch(
     *,
     transform: Callable[[Any, dict[str, Any]], tuple[Any, dict[str, Any]]] | None,
     return_metadata: bool,
+    metadata_keys: Sequence[str],
 ) -> dict[str, list[Any]]:
     _, torch, _, pil_to_tensor = _require_huggingface_dataloader_dependencies()
     images: list[Any] = []
@@ -160,7 +170,7 @@ def _transform_detection_batch(
         images.append(image)
         targets.append(target)
     output = {"image": images, "target": targets}
-    _add_metadata(output, batch, return_metadata)
+    _add_metadata(output, batch, return_metadata, metadata_keys)
     return output
 
 
@@ -169,6 +179,7 @@ def _transform_semantic_segmentation_batch(
     *,
     transform: Callable[[Any, Any], tuple[Any, Any]] | None,
     return_metadata: bool,
+    metadata_keys: Sequence[str],
 ) -> dict[str, list[Any]]:
     _, _, _, pil_to_tensor = _require_huggingface_dataloader_dependencies()
     images: list[Any] = []
@@ -194,7 +205,7 @@ def _transform_semantic_segmentation_batch(
         images.append(image)
         targets.append(mask)
     output = {"image": images, "target": targets}
-    _add_metadata(output, batch, return_metadata)
+    _add_metadata(output, batch, return_metadata, metadata_keys)
     return output
 
 
@@ -203,6 +214,7 @@ def _transform_instance_segmentation_batch(
     *,
     transform: Callable[[Any, dict[str, Any]], tuple[Any, dict[str, Any]]] | None,
     return_metadata: bool,
+    metadata_keys: Sequence[str],
 ) -> dict[str, list[Any]]:
     _, torch, _, pil_to_tensor = _require_huggingface_dataloader_dependencies()
     images: list[Any] = []
@@ -243,7 +255,7 @@ def _transform_instance_segmentation_batch(
         images.append(image)
         targets.append(target)
     output = {"image": images, "target": targets}
-    _add_metadata(output, batch, return_metadata)
+    _add_metadata(output, batch, return_metadata, metadata_keys)
     return output
 
 
@@ -252,12 +264,13 @@ def _build_classification_dataset(
     *,
     transform: Callable[..., Any] | None,
     return_metadata: bool,
+    metadata_keys: Sequence[str],
 ) -> Any:
     classification_type = "multi_label" if "labels" in dataset.column_names else "single_label"
     target_column = "labels" if classification_type == "multi_label" else "label"
     required_columns = {"image", target_column}
     if return_metadata:
-        required_columns.add("asset_id")
+        required_columns.update(("asset_id", *metadata_keys))
     _require_columns(dataset, "classification", required_columns)
     return dataset.with_transform(
         partial(
@@ -265,6 +278,7 @@ def _build_classification_dataset(
             classification_type=classification_type,
             transform=transform,
             return_metadata=return_metadata,
+            metadata_keys=metadata_keys,
         )
     )
 
@@ -274,10 +288,16 @@ def _build_detection_dataset(
     *,
     transform: Callable[..., Any] | None,
     return_metadata: bool,
+    metadata_keys: Sequence[str],
 ) -> Any:
-    _require_columns(dataset, "detection", {"asset_id", "image", "objects"})
+    _require_columns(dataset, "detection", {"asset_id", "image", "objects", *metadata_keys})
     return dataset.with_transform(
-        partial(_transform_detection_batch, transform=transform, return_metadata=return_metadata)
+        partial(
+            _transform_detection_batch,
+            transform=transform,
+            return_metadata=return_metadata,
+            metadata_keys=metadata_keys,
+        )
     )
 
 
@@ -286,10 +306,16 @@ def _build_semantic_segmentation_dataset(
     *,
     transform: Callable[..., Any] | None,
     return_metadata: bool,
+    metadata_keys: Sequence[str],
 ) -> Any:
-    _require_columns(dataset, "semantic segmentation", {"asset_id", "image", "mask"})
+    _require_columns(dataset, "semantic segmentation", {"asset_id", "image", "mask", *metadata_keys})
     return dataset.with_transform(
-        partial(_transform_semantic_segmentation_batch, transform=transform, return_metadata=return_metadata)
+        partial(
+            _transform_semantic_segmentation_batch,
+            transform=transform,
+            return_metadata=return_metadata,
+            metadata_keys=metadata_keys,
+        )
     )
 
 
@@ -298,10 +324,16 @@ def _build_instance_segmentation_dataset(
     *,
     transform: Callable[..., Any] | None,
     return_metadata: bool,
+    metadata_keys: Sequence[str],
 ) -> Any:
-    _require_columns(dataset, "instance segmentation", {"asset_id", "image", "objects"})
+    _require_columns(dataset, "instance segmentation", {"asset_id", "image", "objects", *metadata_keys})
     return dataset.with_transform(
-        partial(_transform_instance_segmentation_batch, transform=transform, return_metadata=return_metadata)
+        partial(
+            _transform_instance_segmentation_batch,
+            transform=transform,
+            return_metadata=return_metadata,
+            metadata_keys=metadata_keys,
+        )
     )
 
 
@@ -394,6 +426,21 @@ def _infer_segmentation_profile(dataset: Any) -> str:
     )
 
 
+def _normalize_metadata_keys(metadata_keys: Sequence[str] | None, *, return_metadata: bool) -> tuple[str, ...]:
+    if metadata_keys is None:
+        return ()
+    if isinstance(metadata_keys, (str, bytes)) or not isinstance(metadata_keys, Sequence):
+        raise ValueError("metadata_keys must be a sequence of exported field names.")
+    normalized = tuple(metadata_keys)
+    if any(not isinstance(key, str) or not key for key in normalized):
+        raise ValueError("metadata_keys must contain non-empty string field names.")
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("metadata_keys must not contain duplicate field names.")
+    if normalized and not return_metadata:
+        raise ValueError("metadata_keys requires return_metadata=True.")
+    return normalized
+
+
 def _build_datasets_and_profiles(
     export_path: str | Path,
     *,
@@ -402,8 +449,9 @@ def _build_datasets_and_profiles(
     transforms: Mapping[str, Callable[..., Any]] | Callable[..., Any] | None = None,
     task_profiles: Mapping[str, Callable[..., Any]] | None = None,
     return_metadata: bool = False,
+    metadata_keys: Sequence[str] | None = None,
 ) -> tuple[dict[str, Any], dict[str, str | None]]:
-
+    selected_metadata_keys = _normalize_metadata_keys(metadata_keys, return_metadata=return_metadata)
     custom_profiles = dict(task_profiles or {})
     normalized_task = task.strip().lower().replace("-", "_")
     if normalized_task not in custom_profiles:
@@ -434,6 +482,7 @@ def _build_datasets_and_profiles(
             selected_dataset,
             transform=transform,
             return_metadata=return_metadata,
+            metadata_keys=selected_metadata_keys,
         )
         built_profiles[split] = profile
     return built, built_profiles
@@ -447,6 +496,7 @@ def build_datasets(
     transforms: Mapping[str, Callable[..., Any]] | Callable[..., Any] | None = None,
     task_profiles: Mapping[str, Callable[..., Any]] | None = None,
     return_metadata: bool = False,
+    metadata_keys: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     """Build split-aware native Hugging Face datasets with on-access PyTorch transforms."""
 
@@ -457,6 +507,7 @@ def build_datasets(
         transforms=transforms,
         task_profiles=task_profiles,
         return_metadata=return_metadata,
+        metadata_keys=metadata_keys,
     )
     return built
 
@@ -469,6 +520,7 @@ def build_dataloaders(
     transforms: Mapping[str, Callable[..., Any]] | Callable[..., Any] | None = None,
     task_profiles: Mapping[str, Callable[..., Any]] | None = None,
     return_metadata: bool = False,
+    metadata_keys: Sequence[str] | None = None,
     batch_size: int = 32,
     num_workers: int = 0,
     pin_memory: bool = False,
@@ -499,6 +551,7 @@ def build_dataloaders(
         transforms=transforms,
         task_profiles=task_profiles,
         return_metadata=return_metadata,
+        metadata_keys=metadata_keys,
     )
     _, torch, DataLoader, _ = _require_huggingface_dataloader_dependencies()
     shuffled = {"train"} if shuffle_splits is None else set(shuffle_splits)

--- a/tests/integration/mindtrace/models/test_huggingface_dataloaders.py
+++ b/tests/integration/mindtrace/models/test_huggingface_dataloaders.py
@@ -4,6 +4,9 @@ from pathlib import Path
 import datasets
 from PIL import Image
 
+from mindtrace.datalake.exporters.huggingface import export_dataset_as_huggingface
+from mindtrace.datalake.exporters.types import ExportableDataset, ExportableItem
+from mindtrace.datalake.types import AnnotationRecord, Asset, StorageRef
 from mindtrace.models.training import build_datasets
 
 
@@ -57,3 +60,69 @@ def test_voc_difficult_is_preserved_and_projected_to_torchvision_ignore_channel(
     assert selected[0]["target"]["iscrowd"].tolist() == [1, 0]
     assert target["difficult"].tolist() == [True, False]
     assert target["iscrowd"].tolist() == [1, 0]
+
+
+def test_selected_classification_metadata_keys_round_trip_to_dataset_samples(tmp_path: Path):
+    asset = Asset(
+        asset_id="image-1",
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="assets", name="image-1", version="1"),
+    )
+    exportable = ExportableDataset(
+        name="multi-field-classification",
+        metadata={"task_type": "classification"},
+        items=[
+            ExportableItem(
+                assets={"image": asset},
+                primary_role="image",
+                split="train",
+                metadata={"subject_id": "subject-1", "group_id": "group-1"},
+                payloads={"image": _png_bytes()},
+                annotations=[
+                    AnnotationRecord(
+                        annotation_id="selected-label",
+                        kind="classification",
+                        label="defective",
+                        attributes={"field": "target"},
+                        source={"type": "human", "name": "pytest"},
+                    ),
+                    AnnotationRecord(
+                        annotation_id="other-label",
+                        kind="classification",
+                        label="positive",
+                        attributes={"field": "other"},
+                        source={"type": "human", "name": "pytest"},
+                    ),
+                ],
+            )
+        ],
+    )
+    export_path = tmp_path / "classification"
+
+    export_dataset_as_huggingface(
+        exportable,
+        destination=export_path,
+        options={
+            "task": "classification",
+            "annotation_attributes": {"field": "target"},
+            "class_names": ["healthy", "defective"],
+            "metadata_keys": {"subject_id": "string", "group_id": "string"},
+        },
+    )
+
+    dataset = build_datasets(
+        export_path,
+        return_metadata=True,
+        metadata_keys=("subject_id", "group_id"),
+    )["train"]
+    sample = dataset[0]
+
+    assert sample["target"].item() == 1
+    assert sample["metadata"] == {
+        "asset_id": "image-1",
+        "subject_id": "subject-1",
+        "group_id": "group-1",
+    }
+    assert dataset.features["subject_id"].dtype == "string"
+    assert dataset.info.metadata["mindtrace"]["label_to_id"] == {"healthy": 0, "defective": 1}

--- a/tests/unit/mindtrace/datalake/exporters/test_datalake_exporters_huggingface.py
+++ b/tests/unit/mindtrace/datalake/exporters/test_datalake_exporters_huggingface.py
@@ -213,8 +213,182 @@ def test_huggingface_classification_export_rejects_label_name_mismatch(tmp_path:
         ],
     )
 
-    with pytest.raises(ValueError, match="maps to 'pink primrose'"):
+    with pytest.raises(ValueError, match="not present in class_names"):
         export_dataset_as_huggingface(dataset, destination=tmp_path / "invalid-label-hf")
+
+
+def test_huggingface_classification_export_selects_idless_annotation_and_metadata_keys(
+    tmp_path: Path,
+    monkeypatch,
+):
+    from mindtrace.datalake.exporters import huggingface as huggingface_exporter
+    from mindtrace.datalake.types import AnnotationRecord
+
+    monkeypatch.setattr(
+        huggingface_exporter.importlib,
+        "import_module",
+        lambda name: _fake_datasets_module(),
+    )
+    dataset = ExportableDataset(
+        name="multi-field-classification",
+        metadata={"task_type": "classification"},
+        items=[
+            ExportableItem(
+                assets={"image": sample_asset()},
+                primary_role="image",
+                split="train",
+                metadata={"subject_id": "subject-1", "group_id": "group-1"},
+                payloads={"image": png_bytes()},
+                annotations=[
+                    AnnotationRecord(
+                        annotation_id="defect-type",
+                        kind="classification",
+                        label="defective",
+                        attributes={"field": "defect_type"},
+                        source={"type": "human", "name": "pytest"},
+                    ),
+                    AnnotationRecord(
+                        annotation_id="binary-health",
+                        kind="classification",
+                        label="defective",
+                        attributes={"field": "healthy_defective"},
+                        source={"type": "human", "name": "pytest"},
+                    ),
+                ],
+            )
+        ],
+    )
+
+    result = export_dataset_as_huggingface(
+        dataset,
+        destination=tmp_path / "selected-hf",
+        options={
+            "task": "classification",
+            "annotation_attributes": {"field": "defect_type"},
+            "class_names": ["healthy", "defective"],
+            "metadata_keys": {"subject_id": "string", "group_id": "string"},
+        },
+    )
+
+    payload = json.loads((tmp_path / "selected-hf" / "dataset_dict.json").read_text())
+    artifact_metadata = json.loads((tmp_path / "selected-hf" / "mindtrace_metadata.json").read_text())
+
+    assert result.files_written == ["mindtrace_metadata.json", "."]
+    assert payload["train"][0]["label"] == 1
+    assert payload["train"][0]["source_annotation_id"] == "defect-type"
+    assert payload["train"][0]["subject_id"] == "subject-1"
+    assert payload["train"][0]["group_id"] == "group-1"
+    assert artifact_metadata["mindtrace"] == {
+        "task": "classification",
+        "annotation_attributes": {"field": "defect_type"},
+        "class_names": ["healthy", "defective"],
+        "label_to_id": {"healthy": 0, "defective": 1},
+        "metadata_keys": {"subject_id": "string", "group_id": "string"},
+    }
+
+
+@pytest.mark.parametrize(
+    ("selected_annotations", "expected_count"),
+    [([], 0), (["first", "second"], 2)],
+)
+def test_huggingface_classification_export_requires_one_selected_annotation(
+    tmp_path: Path,
+    monkeypatch,
+    selected_annotations: list[str],
+    expected_count: int,
+):
+    from mindtrace.datalake.exporters import huggingface as huggingface_exporter
+    from mindtrace.datalake.types import AnnotationRecord
+
+    monkeypatch.setattr(
+        huggingface_exporter.importlib,
+        "import_module",
+        lambda name: _fake_datasets_module(),
+    )
+    annotations = [
+        AnnotationRecord(
+            annotation_id=annotation_id,
+            kind="classification",
+            label="healthy",
+            attributes={"field": "target"},
+            source={"type": "human", "name": "pytest"},
+        )
+        for annotation_id in selected_annotations
+    ]
+    dataset = ExportableDataset(
+        name="selected-classification",
+        metadata={"task_type": "classification"},
+        items=[
+            ExportableItem(
+                assets={"image": sample_asset()},
+                primary_role="image",
+                payloads={"image": png_bytes()},
+                annotations=annotations,
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match=rf"matching attributes .* has {expected_count}"):
+        export_dataset_as_huggingface(
+            dataset,
+            destination=tmp_path / f"selected-{expected_count}",
+            options={
+                "task": "classification",
+                "annotation_attributes": {"field": "target"},
+                "class_names": ["healthy"],
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected_error"),
+    [({}, "is missing it"), ({"subject_id": 123}, "must match dtype 'string'")],
+)
+def test_huggingface_classification_export_validates_required_metadata_keys(
+    tmp_path: Path,
+    monkeypatch,
+    metadata: dict,
+    expected_error: str,
+):
+    from mindtrace.datalake.exporters import huggingface as huggingface_exporter
+    from mindtrace.datalake.types import AnnotationRecord
+
+    monkeypatch.setattr(
+        huggingface_exporter.importlib,
+        "import_module",
+        lambda name: _fake_datasets_module(),
+    )
+    dataset = ExportableDataset(
+        name="metadata-validation",
+        metadata={"task_type": "classification"},
+        items=[
+            ExportableItem(
+                assets={"image": sample_asset()},
+                primary_role="image",
+                metadata=metadata,
+                payloads={"image": png_bytes()},
+                annotations=[
+                    AnnotationRecord(
+                        annotation_id="classification-1",
+                        kind="classification",
+                        label="healthy",
+                        source={"type": "human", "name": "pytest"},
+                    )
+                ],
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match=expected_error):
+        export_dataset_as_huggingface(
+            dataset,
+            destination=tmp_path / "invalid-metadata",
+            options={
+                "task": "classification",
+                "class_names": ["healthy"],
+                "metadata_keys": {"subject_id": "string"},
+            },
+        )
 
 
 def test_huggingface_multi_label_classification_export_writes_multi_hot_targets(tmp_path: Path, monkeypatch):

--- a/tests/unit/mindtrace/datalake/test_dataloaders.py
+++ b/tests/unit/mindtrace/datalake/test_dataloaders.py
@@ -319,6 +319,60 @@ def test_detection_dataset_can_return_provenance_outside_tensor_target(monkeypat
     assert all(callable(getattr(value, "to", None)) for value in sample["target"].values())
 
 
+def test_classification_dataset_returns_requested_metadata_keys(monkeypatch):
+    row = {
+        "asset_id": "asset-1",
+        "image": _FakeImage(),
+        "label": 1,
+        "subject_id": "subject-1",
+        "group_id": "group-1",
+    }
+    payload = _FakeDatasetDict(
+        train=_FakeSplitDataset([row], column_names=list(row)),
+    )
+    monkeypatch.setattr(
+        dataloaders,
+        "_require_huggingface_dataloader_dependencies",
+        lambda: _dependency_bundle(payload),
+    )
+
+    dataset = dataloaders.build_datasets(
+        "/export",
+        return_metadata=True,
+        metadata_keys=("subject_id", "group_id"),
+    )["train"]
+
+    assert dataset[0]["metadata"] == {
+        "asset_id": "asset-1",
+        "subject_id": "subject-1",
+        "group_id": "group-1",
+    }
+
+
+def test_build_datasets_rejects_missing_requested_metadata_key(monkeypatch):
+    row = {"asset_id": "asset-1", "image": _FakeImage(), "label": 1}
+    payload = _FakeDatasetDict(
+        train=_FakeSplitDataset([row], column_names=list(row)),
+    )
+    monkeypatch.setattr(
+        dataloaders,
+        "_require_huggingface_dataloader_dependencies",
+        lambda: _dependency_bundle(payload),
+    )
+
+    with pytest.raises(ValueError, match="missing required column.*group_id"):
+        dataloaders.build_datasets(
+            "/export",
+            return_metadata=True,
+            metadata_keys=("group_id",),
+        )
+
+
+def test_build_datasets_requires_return_metadata_for_metadata_keys():
+    with pytest.raises(ValueError, match="metadata_keys requires return_metadata=True"):
+        dataloaders.build_datasets("/export", metadata_keys=("group_id",))
+
+
 def test_detection_dataloader_uses_variable_target_collator(monkeypatch):
     objects_feature = SimpleNamespace(feature={"category": SimpleNamespace(names=["object"])})
     payload = _FakeDatasetDict(


### PR DESCRIPTION
## Summary

This PR adds configurable classification-target selection and deterministic class mappings to Hugging Face exports. It also exposes selected typed Datum metadata through saved artifacts and the built-in dataset/DataLoader builders.

Closes #551

## Motivation

Some existing downstream datasets store multiple logical classification targets per image as separate annotation records, distinguish those targets through annotation attributes, and omit numeric label IDs. Their training consumers also need stable row-level metadata, such as subject or group identifiers, without parsing metadata JSON for every sample.

Those datasets could not previously use the generic single-label Hugging Face export and DataLoader path. This PR supports that dataset shape through a public, dataset-agnostic API without adding domain-specific fields, identity rules, or sampling behavior.

## Example

Edit the constants at the top to match the source DatasetVersion and export contract:

```python
from pathlib import Path

from mindtrace.datalake import Datalake
from mindtrace.registry import LocalMountConfig, Mount, MountBackendKind


# Dataset and export contract
DATASET_NAME = "classification_dataset"
DATASET_VERSION = "1.0.0"
OUTPUT_PATH = Path("exports/classification-category").resolve()
ANNOTATION_FIELD = "category"
CLASS_NAMES = ("class_a", "class_b", "class_c")
METADATA_KEYS = {
    "subject_id": "string",
    "group_id": "string",
}

# Local Datalake connection
MONGO_DB_URI = "mongodb://localhost:27018"
MONGO_DB_NAME = "mindtrace"
MOUNT_NAME = "local"
MOUNT_URI = Path("~/.cache/mindtrace/datalake-v2").expanduser().resolve()


mount = Mount(
    name=MOUNT_NAME,
    backend=MountBackendKind.LOCAL,
    config=LocalMountConfig(uri=MOUNT_URI),
    is_default=True,
    registry_options={"mutable": True},
)

with Datalake.create(
    mongo_db_uri=MONGO_DB_URI,
    mongo_db_name=MONGO_DB_NAME,
    mounts=[mount],
    default_mount=MOUNT_NAME,
) as lake:
    result = lake.export_dataset_version_to_format(
        DATASET_NAME,
        DATASET_VERSION,
        format="huggingface",
        destination=OUTPUT_PATH,
        include_media=True,
        exporter_options={
            "task": "classification",
            "annotation_attributes": {"field": ANNOTATION_FIELD},
            "class_names": CLASS_NAMES,
            "metadata_keys": METADATA_KEYS,
        },
    )

print(result)
print(f"Exported to {OUTPUT_PATH}")
```

The ordered `CLASS_NAMES` sequence fixes the numeric label mapping across exports. Each requested metadata key is projected as a typed top-level field in the saved Hugging Face artifact.

## Tests and documentation

- add focused exporter and DataLoader unit coverage
- add an end-to-end Hugging Face export/load integration case
- document the generic options using neutral metadata field names
