### PR TITLE
Add a generic grouped-class batch sampler

### DIFF
--- a/mindtrace/datalake/README.md
+++ b/mindtrace/datalake/README.md
@@ -599,6 +599,9 @@ construction fails if fewer than `classes_per_batch` eligible classes remain. Th
 group identities, change dataset splits, integrate with trainer epoch hooks, or shard batches across distributed
 ranks.
 
+See the [grouped class batch sampler sample](../../samples/models/09_grouped_class_batch_sampler.py) for a complete
+standalone example with transforms and returned group metadata.
+
 Detection and instance targets follow torchvision conventions. The detection adapter is source-dataset-generic but
 expects the canonical Mindtrace HF detection schema: embedded image media, absolute pixel-space `xywh` boxes, and
 contiguous category IDs. VOC `difficult` remains available as its own boolean tensor and is also projected into the

--- a/mindtrace/datalake/README.md
+++ b/mindtrace/datalake/README.md
@@ -559,6 +559,46 @@ loaders = build_dataloaders(
 Requested keys must exist in the saved Hugging Face schema. They are read directly from the typed fields without
 reparsing `metadata_json`.
 
+### Grouped class batches
+
+Use `GroupedClassBatchSampler` when a label-based metric-learning batch needs multiple classes and multiple
+distinct groups per class. The sampler is dataset-agnostic: callers define the group identity from typed exported
+columns and pass the resulting batch sampler through the existing per-split DataLoader options.
+
+```python
+from datasets import load_from_disk
+
+from mindtrace.models.training import GroupedClassBatchSampler, build_dataloaders
+
+export_path = export_root / "selected-classification"
+train = load_from_disk(str(export_path))["train"]
+group_ids = list(zip(train["subject_id"], train["session_id"], strict=True))
+batch_sampler = GroupedClassBatchSampler(
+    train["label"],
+    group_ids,
+    classes_per_batch=4,
+    samples_per_class=2,
+    seed=42,
+)
+train_loader = build_dataloaders(
+    export_path,
+    splits=("train",),
+    per_split_dataloader_kwargs={"train": {"batch_sampler": batch_sampler}},
+)["train"]
+
+for epoch in range(10):
+    batch_sampler.set_epoch(epoch)
+    for images, targets in train_loader:
+        # Compute a label-based metric-learning loss.
+        ...
+```
+
+Each class contributes `samples_per_class` observations from distinct groups within a batch. Classes, groups, and
+observations may be selected again in later batches. Classes without enough distinct groups are ineligible; sampler
+construction fails if fewer than `classes_per_batch` eligible classes remain. The initial sampler does not derive
+group identities, change dataset splits, integrate with trainer epoch hooks, or shard batches across distributed
+ranks.
+
 Detection and instance targets follow torchvision conventions. The detection adapter is source-dataset-generic but
 expects the canonical Mindtrace HF detection schema: embedded image media, absolute pixel-space `xywh` boxes, and
 contiguous category IDs. VOC `difficult` remains available as its own boolean tensor and is also projected into the

--- a/mindtrace/models/mindtrace/models/training/README.md
+++ b/mindtrace/models/mindtrace/models/training/README.md
@@ -26,6 +26,7 @@ The training sub-package provides:
 - **Loss Functions**: 9 task-specific losses for classification, detection, segmentation, and composite use
 - **Optimizer Factory**: `build_optimizer` with differential learning rate support
 - **Scheduler Factory**: `build_scheduler` with warmup-cosine, step, plateau, and 1-cycle options
+- **Grouped Sampling**: Class-balanced batches with distinct sample groups per class
 - **Hugging Face Data Adapters**: typed datasets and DataLoaders over exported artifacts
 
 ## Architecture
@@ -36,6 +37,7 @@ training/
 ├── trainer.py               # Trainer class (AMP, DDP, grad accum)
 ├── callbacks.py             # Callback base + 6 built-in callbacks
 ├── optimizers.py            # build_optimizer, build_scheduler, WarmupCosineScheduler
+├── samplers.py              # GroupedClassBatchSampler
 ├── huggingface_dataloaders.py # Exported-artifact datasets and DataLoaders
 └── losses/
     ├── __init__.py          # All loss exports
@@ -354,6 +356,9 @@ from mindtrace.models.training import (
     build_scheduler,            # name -> LRScheduler
 
     # Datalake
+    GroupedClassBatchSampler,    # balanced classes with distinct groups
+    build_datasets,              # exported artifact -> split datasets
+    build_dataloaders,           # exported artifact -> split DataLoaders
 )
 
 from mindtrace.models.training.losses import (

--- a/mindtrace/models/mindtrace/models/training/__init__.py
+++ b/mindtrace/models/mindtrace/models/training/__init__.py
@@ -44,6 +44,7 @@ from mindtrace.models.training.huggingface_dataloaders import (
     build_datasets,
 )
 from mindtrace.models.training.optimizers import build_optimizer, build_scheduler
+from mindtrace.models.training.samplers import GroupedClassBatchSampler
 from mindtrace.models.training.trainer import Trainer
 
 __all__ = [
@@ -62,4 +63,5 @@ __all__ = [
     "build_scheduler",
     "build_datasets",
     "build_dataloaders",
+    "GroupedClassBatchSampler",
 ]

--- a/mindtrace/models/mindtrace/models/training/__init__.py
+++ b/mindtrace/models/mindtrace/models/training/__init__.py
@@ -23,6 +23,11 @@ Optimizers & Schedulers
   differential learning rates (``backbone_lr_multiplier``).
 - ``build_scheduler``: Factory for named PyTorch LR schedulers.
 
+Samplers
+--------
+- ``GroupedClassBatchSampler``: Builds class-balanced batches from distinct
+  sample groups.
+
 Hugging Face Data Adapters
 --------------------------
 - Native Hugging Face datasets with PyTorch transforms and DataLoader builders.

--- a/mindtrace/models/mindtrace/models/training/samplers.py
+++ b/mindtrace/models/mindtrace/models/training/samplers.py
@@ -72,14 +72,10 @@ class GroupedClassBatchSampler(Sampler[list[int]]):
         _require_hashable("group_ids", materialized_group_ids)
 
         index: dict[Hashable, dict[Hashable, list[int]]] = {}
-        for sample_index, (label, group_id) in enumerate(
-            zip(materialized_labels, materialized_group_ids, strict=True)
-        ):
+        for sample_index, (label, group_id) in enumerate(zip(materialized_labels, materialized_group_ids, strict=True)):
             index.setdefault(label, {}).setdefault(group_id, []).append(sample_index)
 
-        eligible_labels = tuple(
-            label for label, groups in index.items() if len(groups) >= samples_per_class
-        )
+        eligible_labels = tuple(label for label, groups in index.items() if len(groups) >= samples_per_class)
         if len(eligible_labels) < classes_per_batch:
             raise ValueError(
                 "Grouped sampling requires "
@@ -92,8 +88,7 @@ class GroupedClassBatchSampler(Sampler[list[int]]):
             batches_per_epoch = len(materialized_labels) // batch_size
             if batches_per_epoch == 0:
                 raise ValueError(
-                    "The default batches_per_epoch is zero; provide enough samples "
-                    "or set batches_per_epoch explicitly."
+                    "The default batches_per_epoch is zero; provide enough samples or set batches_per_epoch explicitly."
                 )
         else:
             _require_positive_int("batches_per_epoch", batches_per_epoch)
@@ -106,9 +101,7 @@ class GroupedClassBatchSampler(Sampler[list[int]]):
         self.batch_size = batch_size
         self.eligible_labels = eligible_labels
         self._index = index
-        self._groups_by_label = {
-            label: tuple(index[label]) for label in eligible_labels
-        }
+        self._groups_by_label = {label: tuple(index[label]) for label in eligible_labels}
 
     def __iter__(self) -> Iterator[list[int]]:
         rng = random.Random(self.seed + self.epoch)

--- a/mindtrace/models/mindtrace/models/training/samplers.py
+++ b/mindtrace/models/mindtrace/models/training/samplers.py
@@ -1,0 +1,141 @@
+"""Sampling policies for model training."""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Hashable, Iterator, Sequence
+
+from torch.utils.data import Sampler
+
+
+def _require_positive_int(name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer")
+    if value <= 0:
+        raise ValueError(f"{name} must be greater than zero")
+
+
+def _require_hashable(name: str, values: Sequence[Hashable]) -> None:
+    for index, value in enumerate(values):
+        try:
+            hash(value)
+        except TypeError as exc:
+            raise TypeError(f"{name}[{index}] must be hashable") from exc
+
+
+class GroupedClassBatchSampler(Sampler[list[int]]):
+    """Build class-balanced batches whose same-class samples use distinct groups.
+
+    Classes, groups, and observations are sampled uniformly. Selection is without
+    replacement within a batch and with replacement between batches. A class is
+    eligible only when it contains at least ``samples_per_class`` distinct groups.
+
+    Args:
+        labels: Class label for each dataset sample.
+        group_ids: Group identifier for each dataset sample. Composite identities
+            may be represented by tuples.
+        classes_per_batch: Number of distinct classes in each batch.
+        samples_per_class: Number of distinct groups sampled for each class.
+        batches_per_epoch: Number of batches yielded per epoch. When omitted, uses
+            ``len(labels) // (classes_per_batch * samples_per_class)``.
+        seed: Base seed for deterministic sampling. The effective seed is
+            ``seed + epoch``.
+
+    Raises:
+        TypeError: If configuration values have invalid types or labels/group IDs
+            are not hashable.
+        ValueError: If the inputs or sampling configuration cannot form batches.
+    """
+
+    def __init__(
+        self,
+        labels: Sequence[Hashable],
+        group_ids: Sequence[Hashable],
+        *,
+        classes_per_batch: int,
+        samples_per_class: int,
+        batches_per_epoch: int | None = None,
+        seed: int = 0,
+    ) -> None:
+        _require_positive_int("classes_per_batch", classes_per_batch)
+        _require_positive_int("samples_per_class", samples_per_class)
+        if isinstance(seed, bool) or not isinstance(seed, int):
+            raise TypeError("seed must be an integer")
+
+        materialized_labels = tuple(labels)
+        materialized_group_ids = tuple(group_ids)
+        if len(materialized_labels) != len(materialized_group_ids):
+            raise ValueError("labels and group_ids must contain the same number of items")
+        if not materialized_labels:
+            raise ValueError("labels and group_ids must not be empty")
+        _require_hashable("labels", materialized_labels)
+        _require_hashable("group_ids", materialized_group_ids)
+
+        index: dict[Hashable, dict[Hashable, list[int]]] = {}
+        for sample_index, (label, group_id) in enumerate(
+            zip(materialized_labels, materialized_group_ids, strict=True)
+        ):
+            index.setdefault(label, {}).setdefault(group_id, []).append(sample_index)
+
+        eligible_labels = tuple(
+            label for label, groups in index.items() if len(groups) >= samples_per_class
+        )
+        if len(eligible_labels) < classes_per_batch:
+            raise ValueError(
+                "Grouped sampling requires "
+                f"{classes_per_batch} eligible classes with at least "
+                f"{samples_per_class} distinct groups each; found {len(eligible_labels)}."
+            )
+
+        batch_size = classes_per_batch * samples_per_class
+        if batches_per_epoch is None:
+            batches_per_epoch = len(materialized_labels) // batch_size
+            if batches_per_epoch == 0:
+                raise ValueError(
+                    "The default batches_per_epoch is zero; provide enough samples "
+                    "or set batches_per_epoch explicitly."
+                )
+        else:
+            _require_positive_int("batches_per_epoch", batches_per_epoch)
+
+        self.classes_per_batch = classes_per_batch
+        self.samples_per_class = samples_per_class
+        self.batches_per_epoch = batches_per_epoch
+        self.seed = seed
+        self.epoch = 0
+        self.batch_size = batch_size
+        self.eligible_labels = eligible_labels
+        self._index = index
+        self._groups_by_label = {
+            label: tuple(index[label]) for label in eligible_labels
+        }
+
+    def __iter__(self) -> Iterator[list[int]]:
+        rng = random.Random(self.seed + self.epoch)
+        for _ in range(self.batches_per_epoch):
+            selected_labels = rng.sample(self.eligible_labels, self.classes_per_batch)
+            batch: list[int] = []
+            for label in selected_labels:
+                selected_groups = rng.sample(
+                    self._groups_by_label[label],
+                    self.samples_per_class,
+                )
+                for group_id in selected_groups:
+                    batch.append(rng.choice(self._index[label][group_id]))
+            rng.shuffle(batch)
+            yield batch
+
+    def __len__(self) -> int:
+        return self.batches_per_epoch
+
+    def set_epoch(self, epoch: int) -> None:
+        """Set the epoch used to derive deterministic sampling order."""
+
+        if isinstance(epoch, bool) or not isinstance(epoch, int):
+            raise TypeError("epoch must be an integer")
+        if epoch < 0:
+            raise ValueError("epoch must be greater than or equal to zero")
+        self.epoch = epoch
+
+
+__all__ = ["GroupedClassBatchSampler"]

--- a/samples/models/09_grouped_class_batch_sampler.py
+++ b/samples/models/09_grouped_class_batch_sampler.py
@@ -1,0 +1,63 @@
+"""Build grouped classification batches from a saved Hugging Face export."""
+
+from pathlib import Path
+
+from datasets import load_from_disk
+from torchvision import transforms
+
+from mindtrace.models.training import GroupedClassBatchSampler, build_dataloaders
+
+
+EXPORT_PATH = Path("exports/grouped-classification")
+SPLIT_NAME = "train"
+
+
+def main() -> None:
+    exported_dataset = load_from_disk(str(EXPORT_PATH))
+    split = exported_dataset[SPLIT_NAME]
+
+    # Callers define which typed fields together identify a logical group.
+    group_ids = list(zip(split["subject_id"], split["session_id"], strict=True))
+
+    batch_sampler = GroupedClassBatchSampler(
+        labels=split["label"],
+        group_ids=group_ids,
+        classes_per_batch=4,
+        samples_per_class=2,
+        batches_per_epoch=10,
+        seed=42,
+    )
+
+    transform = transforms.Compose(
+        [
+            transforms.Resize((224, 224)),
+            transforms.ToTensor(),
+        ]
+    )
+
+    train_loader = build_dataloaders(
+        EXPORT_PATH,
+        task="classification",
+        splits=(SPLIT_NAME,),
+        transforms={SPLIT_NAME: transform},
+        return_metadata=True,
+        metadata_keys=("subject_id", "session_id"),
+        per_split_dataloader_kwargs={
+            SPLIT_NAME: {"batch_sampler": batch_sampler},
+        },
+    )[SPLIT_NAME]
+
+    for epoch in range(2):
+        # Change the sampling order deterministically at each epoch boundary.
+        batch_sampler.set_epoch(epoch)
+
+        for images, labels, metadata in train_loader:
+            print(f"epoch={epoch}")
+            print(f"image batch shape: {images.shape}")
+            print(f"labels: {labels.tolist()}")
+            print(f"first two metadata records: {metadata[:2]}")
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/mindtrace/models/test_huggingface_dataloaders.py
+++ b/tests/integration/mindtrace/models/test_huggingface_dataloaders.py
@@ -1,3 +1,4 @@
+from collections import Counter, defaultdict
 from io import BytesIO
 from pathlib import Path
 
@@ -7,7 +8,7 @@ from PIL import Image
 from mindtrace.datalake.exporters.huggingface import export_dataset_as_huggingface
 from mindtrace.datalake.exporters.types import ExportableDataset, ExportableItem
 from mindtrace.datalake.types import AnnotationRecord, Asset, StorageRef
-from mindtrace.models.training import build_datasets
+from mindtrace.models.training import GroupedClassBatchSampler, build_dataloaders, build_datasets
 
 
 def _png_bytes() -> bytes:
@@ -126,3 +127,56 @@ def test_selected_classification_metadata_keys_round_trip_to_dataset_samples(tmp
     }
     assert dataset.features["subject_id"].dtype == "string"
     assert dataset.info.metadata["mindtrace"]["label_to_id"] == {"healthy": 0, "defective": 1}
+
+
+def test_grouped_class_sampler_drives_saved_artifact_dataloader(tmp_path: Path):
+    features = datasets.Features(
+        {
+            "asset_id": datasets.Value("string"),
+            "image": datasets.Image(),
+            "label": datasets.ClassLabel(names=["negative", "positive"]),
+            "group_id": datasets.Value("string"),
+        }
+    )
+    rows = []
+    for label in range(2):
+        for group in range(2):
+            for observation in range(2):
+                asset_id = f"image-{label}-{group}-{observation}"
+                rows.append(
+                    {
+                        "asset_id": asset_id,
+                        "image": {"bytes": _png_bytes(), "path": f"{asset_id}.png"},
+                        "label": label,
+                        "group_id": f"group-{label}-{group}",
+                    }
+                )
+    split = datasets.Dataset.from_list(rows, features=features)
+    export_path = tmp_path / "grouped-classification"
+    datasets.DatasetDict({"train": split}).save_to_disk(str(export_path))
+    batch_sampler = GroupedClassBatchSampler(
+        split["label"],
+        split["group_id"],
+        classes_per_batch=2,
+        samples_per_class=2,
+        batches_per_epoch=1,
+        seed=11,
+    )
+
+    loader = build_dataloaders(
+        export_path,
+        return_metadata=True,
+        metadata_keys=("group_id",),
+        per_split_dataloader_kwargs={"train": {"batch_sampler": batch_sampler}},
+    )["train"]
+    images, targets, metadata = next(iter(loader))
+
+    assert images.shape[0] == 4
+    assert Counter(targets.tolist()) == {0: 2, 1: 2}
+    groups_by_label: dict[int, set[str]] = defaultdict(set)
+    for label, item_metadata in zip(targets.tolist(), metadata, strict=True):
+        groups_by_label[label].add(item_metadata["group_id"])
+    assert groups_by_label == {
+        0: {"group-0-0", "group-0-1"},
+        1: {"group-1-0", "group-1-1"},
+    }

--- a/tests/unit/mindtrace/datalake/test_dataloaders.py
+++ b/tests/unit/mindtrace/datalake/test_dataloaders.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from mindtrace.models.training import GroupedClassBatchSampler
 from mindtrace.models.training import huggingface_dataloaders as dataloaders
 
 
@@ -883,6 +884,30 @@ def test_build_dataloaders_forwards_native_dataloader_kwargs(monkeypatch):
 
     assert loaders["train"].kwargs["sampler"] is sampler
     assert loaders["train"].kwargs["shuffle"] is False
+
+
+def test_build_dataloaders_forwards_grouped_batch_sampler(monkeypatch):
+    payload = _FakeDatasetDict(train=_FakeSplitDataset([{"image": _FakeImage(), "label": 0}]))
+    monkeypatch.setattr(
+        dataloaders,
+        "_require_huggingface_dataloader_dependencies",
+        lambda: _dependency_bundle(payload),
+    )
+    batch_sampler = GroupedClassBatchSampler(
+        [0, 0, 1, 1],
+        ["a", "b", "c", "d"],
+        classes_per_batch=2,
+        samples_per_class=2,
+    )
+
+    loaders = dataloaders.build_dataloaders(
+        "/export",
+        per_split_dataloader_kwargs={"train": {"batch_sampler": batch_sampler}},
+    )
+
+    assert loaders["train"].kwargs["batch_sampler"] is batch_sampler
+    for incompatible in ("batch_size", "shuffle", "sampler", "drop_last"):
+        assert incompatible not in loaders["train"].kwargs
 
 
 def test_semantic_dataset_reads_constants_without_decoding_first_sample(monkeypatch):

--- a/tests/unit/mindtrace/models/training/test_samplers.py
+++ b/tests/unit/mindtrace/models/training/test_samplers.py
@@ -1,0 +1,168 @@
+"""Unit tests for training samplers."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+
+import pytest
+
+from mindtrace.models.training import GroupedClassBatchSampler
+
+
+def _sampling_data() -> tuple[list[int], list[tuple[str, int]]]:
+    labels: list[int] = []
+    group_ids: list[tuple[str, int]] = []
+    for label in range(3):
+        for group in range(4):
+            observations = 2 if group == 0 else 1
+            for _ in range(observations):
+                labels.append(label)
+                group_ids.append((f"subject-{label}", group))
+    return labels, group_ids
+
+
+def test_batches_contain_configured_classes_and_distinct_groups():
+    labels, group_ids = _sampling_data()
+    sampler = GroupedClassBatchSampler(
+        labels,
+        group_ids,
+        classes_per_batch=2,
+        samples_per_class=3,
+        batches_per_epoch=5,
+        seed=17,
+    )
+
+    assert len(sampler) == 5
+    assert sampler.batch_size == 6
+    for batch in sampler:
+        batch_labels = [labels[index] for index in batch]
+        assert set(Counter(batch_labels).values()) == {3}
+        assert len(set(batch_labels)) == 2
+
+        groups_by_label: dict[int, set[tuple[str, int]]] = defaultdict(set)
+        for index in batch:
+            groups_by_label[labels[index]].add(group_ids[index])
+        assert all(len(groups) == 3 for groups in groups_by_label.values())
+
+
+def test_same_seed_and_epoch_produce_the_same_batches():
+    labels, group_ids = _sampling_data()
+    kwargs = {
+        "classes_per_batch": 2,
+        "samples_per_class": 2,
+        "batches_per_epoch": 8,
+        "seed": 23,
+    }
+    first = GroupedClassBatchSampler(labels, group_ids, **kwargs)
+    second = GroupedClassBatchSampler(labels, group_ids, **kwargs)
+
+    assert list(first) == list(second)
+
+    first.set_epoch(4)
+    second.set_epoch(4)
+    epoch_four_batches = list(first)
+    assert epoch_four_batches == list(second)
+
+    first.set_epoch(5)
+    assert list(first) != epoch_four_batches
+
+
+def test_default_epoch_length_matches_drop_last_pass():
+    labels, group_ids = _sampling_data()
+    sampler = GroupedClassBatchSampler(
+        labels,
+        group_ids,
+        classes_per_batch=2,
+        samples_per_class=2,
+    )
+
+    assert len(sampler) == len(labels) // 4
+
+
+def test_rare_classes_are_excluded_when_enough_classes_remain():
+    labels = [0, 0, 1, 1, 2, 2]
+    group_ids = ["a", "b", "c", "d", "rare", "rare"]
+    sampler = GroupedClassBatchSampler(
+        labels,
+        group_ids,
+        classes_per_batch=2,
+        samples_per_class=2,
+        batches_per_epoch=4,
+    )
+
+    assert sampler.eligible_labels == (0, 1)
+    assert {labels[index] for batch in sampler for index in batch} == {0, 1}
+
+
+@pytest.mark.parametrize(
+    ("labels", "group_ids", "message"),
+    [
+        ([], [], "must not be empty"),
+        ([0], [], "same number"),
+        ([[0]], ["group"], "labels\\[0\\] must be hashable"),
+        ([0], [["group"]], "group_ids\\[0\\] must be hashable"),
+    ],
+)
+def test_rejects_invalid_input_sequences(labels, group_ids, message):
+    with pytest.raises((TypeError, ValueError), match=message):
+        GroupedClassBatchSampler(
+            labels,
+            group_ids,
+            classes_per_batch=1,
+            samples_per_class=1,
+        )
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "error_type", "message"),
+    [
+        ("classes_per_batch", 0, ValueError, "greater than zero"),
+        ("classes_per_batch", True, TypeError, "must be an integer"),
+        ("samples_per_class", -1, ValueError, "greater than zero"),
+        ("samples_per_class", 1.5, TypeError, "must be an integer"),
+        ("batches_per_epoch", 0, ValueError, "greater than zero"),
+        ("batches_per_epoch", False, TypeError, "must be an integer"),
+        ("seed", False, TypeError, "must be an integer"),
+    ],
+)
+def test_rejects_invalid_configuration(name, value, error_type, message):
+    kwargs = {
+        "classes_per_batch": 1,
+        "samples_per_class": 1,
+        "batches_per_epoch": 1,
+        "seed": 0,
+    }
+    kwargs[name] = value
+
+    with pytest.raises(error_type, match=message):
+        GroupedClassBatchSampler([0], ["group"], **kwargs)
+
+
+def test_rejects_too_few_eligible_classes():
+    with pytest.raises(ValueError, match=r"2 eligible classes.*found 1"):
+        GroupedClassBatchSampler(
+            [0, 0, 1, 1],
+            ["a", "b", "rare", "rare"],
+            classes_per_batch=2,
+            samples_per_class=2,
+        )
+
+
+@pytest.mark.parametrize(
+    ("epoch", "error_type", "message"),
+    [
+        (-1, ValueError, "greater than or equal to zero"),
+        (True, TypeError, "must be an integer"),
+        (1.5, TypeError, "must be an integer"),
+    ],
+)
+def test_set_epoch_rejects_invalid_values(epoch, error_type, message):
+    sampler = GroupedClassBatchSampler(
+        [0],
+        ["group"],
+        classes_per_batch=1,
+        samples_per_class=1,
+    )
+
+    with pytest.raises(error_type, match=message):
+        sampler.set_epoch(epoch)


### PR DESCRIPTION
## Summary

This PR adds a generic grouped-class batch sampler for constructing finite, reproducible batches with multiple classes and distinct groups per class. It integrates through the existing Hugging Face DataLoader batch-sampler hook without introducing dataset-specific identity rules.

Closes #555

## Motivation

Label-based metric-learning objectives often require multiple observations of each selected class while avoiding trivial positives drawn from the same subject, session, track, or other logical group. The existing generic DataLoader path supported custom batch samplers, but Mindtrace did not provide a reusable sampler for this grouped-class policy.

This PR adds that policy as a public, dataset-agnostic PyTorch sampler. Callers retain control of group identity, exported metadata fields, transforms, and epoch boundaries.

## Example

```python
"""Build grouped classification batches from a saved Hugging Face export."""

from pathlib import Path

from datasets import load_from_disk
from torchvision import transforms

from mindtrace.models.training import GroupedClassBatchSampler, build_dataloaders


EXPORT_PATH = Path("exports/grouped-classification")
SPLIT_NAME = "train"


exported_dataset = load_from_disk(str(EXPORT_PATH))
split = exported_dataset[SPLIT_NAME]

# Callers define which typed fields together identify a logical group.
group_ids = list(zip(split["subject_id"], split["session_id"], strict=True))

batch_sampler = GroupedClassBatchSampler(
    labels=split["label"],
    group_ids=group_ids,
    classes_per_batch=4,
    samples_per_class=2,
    batches_per_epoch=10,
    seed=42,
)

transform = transforms.Compose(
    [
        transforms.Resize((224, 224)),
        transforms.ToTensor(),
    ]
)

train_loader = build_dataloaders(
    EXPORT_PATH,
    task="classification",
    splits=(SPLIT_NAME,),
    transforms={SPLIT_NAME: transform},
    return_metadata=True,
    metadata_keys=("subject_id", "session_id"),
    per_split_dataloader_kwargs={
        SPLIT_NAME: {"batch_sampler": batch_sampler},
    },
)[SPLIT_NAME]

for epoch in range(2):
    # Change the sampling order deterministically at each epoch boundary.
    batch_sampler.set_epoch(epoch)

    for images, labels, metadata in train_loader:
        print(f"epoch={epoch}")
        print(f"image batch shape: {images.shape}")
        print(f"labels: {labels.tolist()}")
        print(f"first two metadata records: {metadata[:2]}")
        break
```

The same example is available at `samples/models/09_grouped_class_batch_sampler.py`.

## Tests and documentation

- add focused sampler unit coverage for batch invariants, validation, and deterministic epoch behavior
- add DataLoader forwarding coverage and a saved Hugging Face artifact integration case
- document generic grouped sampling with neutral metadata field names
- add a standalone grouped-class sampling example under `samples/models`
