### PR TITLE
Add EmbeddingModel Protocol

### DIFF
--- a/mindtrace/models/README.md
+++ b/mindtrace/models/README.md
@@ -176,9 +176,10 @@ See [Architectures Documentation](mindtrace/models/architectures/README.md) for 
 
 ## Inference
 
-The generic `Model[InputT, OutputT]` protocol defines task-level prediction without coupling models to HTTP requests,
-queue payloads, or another transport. Implementations own preprocessing, inference, and postprocessing; serving and
-backend integrations remain responsible for transport, scheduling, and backend-specific behavior.
+The generic `Model[InputT, OutputT]` and `EmbeddingModel[InputT, EmbeddingT]` protocols define task-level prediction
+and embedding without coupling models to HTTP requests, queue payloads, or another transport. Implementations own
+preprocessing, inference, and postprocessing; serving and backend integrations remain responsible for transport,
+scheduling, and backend-specific behavior.
 
 Implementations satisfy `Model` structurally; no Mindtrace base class is required:
 
@@ -197,6 +198,27 @@ class ImageSizeModel:
 
 model: Model[Image.Image, dict[str, Any]] = ImageSizeModel()
 result = model.predict(Image.open("tests/resources/hopper.png"), source="local")
+```
+
+Embedding implementations use the independent `EmbeddingModel` capability and expose `embed()` instead. A concrete
+class may satisfy either protocol or both:
+
+```python
+from typing import Any
+
+from PIL import Image
+
+from mindtrace.models import EmbeddingModel
+
+
+class ImageSizeEmbedder:
+    def embed(self, inputs: Image.Image, **params: Any) -> list[float]:
+        scale = float(params.get("scale", 1.0))
+        return [inputs.width * scale, inputs.height * scale]
+
+
+embedder: EmbeddingModel[Image.Image, list[float]] = ImageSizeEmbedder()
+embedding = embedder.embed(Image.open("tests/resources/hopper.png"), scale=0.5)
 ```
 
 `TorchModel` composes a processor, an `nn.Module`, and a postprocessor:
@@ -556,6 +578,7 @@ Everything below is importable directly from `mindtrace.models`:
 ```python
 from mindtrace.models import (
     # -- Inference --
+    EmbeddingModel,                 # Structural task-level embedding protocol
     Model,                          # Structural task-level prediction protocol
     TorchModel,                     # Composable processor/network/postprocessor
     HuggingFaceImageProcessor,      # Lazy raw-image and tensor preprocessing

--- a/mindtrace/models/mindtrace/models/__init__.py
+++ b/mindtrace/models/mindtrace/models/__init__.py
@@ -37,7 +37,7 @@ from mindtrace.models.inference import (
     HuggingFaceImageProcessor,
     TorchModel,
 )
-from mindtrace.models.protocols import Model
+from mindtrace.models.protocols import EmbeddingModel, Model
 from mindtrace.models.serving import (
     ClassificationResult,
     DetectionResult,
@@ -124,6 +124,7 @@ from mindtrace.models.lifecycle import (
 
 __all__ = [
     # runnable models
+    "EmbeddingModel",
     "Model",
     "TorchModel",
     "HuggingFaceImageProcessor",

--- a/mindtrace/models/mindtrace/models/protocols.py
+++ b/mindtrace/models/mindtrace/models/protocols.py
@@ -4,6 +4,7 @@ from typing import Any, Protocol, TypeVar
 
 InputT = TypeVar("InputT", contravariant=True)
 OutputT = TypeVar("OutputT", covariant=True)
+EmbeddingT = TypeVar("EmbeddingT", covariant=True)
 
 
 class Model(Protocol[InputT, OutputT]):
@@ -19,4 +20,17 @@ class Model(Protocol[InputT, OutputT]):
         ...
 
 
-__all__ = ["Model"]
+class EmbeddingModel(Protocol[InputT, EmbeddingT]):
+    """A model that exposes task-level embedding behavior.
+
+    Implementations own their preprocessing, inference, and postprocessing.
+    Transport concerns such as HTTP requests and queue jobs remain outside
+    this contract.
+    """
+
+    def embed(self, inputs: InputT, **params: Any) -> EmbeddingT:
+        """Return task-level embeddings for ``inputs``."""
+        ...
+
+
+__all__ = ["EmbeddingModel", "Model"]

--- a/tests/integration/mindtrace/models/test_embedding_model_protocol.py
+++ b/tests/integration/mindtrace/models/test_embedding_model_protocol.py
@@ -1,0 +1,34 @@
+"""Integration coverage for the public embedding model protocol."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mindtrace.models import EmbeddingModel, Model
+from mindtrace.models.protocols import EmbeddingModel as ProtocolEmbeddingModel
+
+
+class _DualCapabilityModel:
+    def predict(self, inputs: list[str], **params: Any) -> list[str]:
+        prefix = str(params.get("prefix", ""))
+        return [f"{prefix}{value}" for value in inputs]
+
+    def embed(self, inputs: list[str], **params: Any) -> list[list[float]]:
+        scale = float(params.get("scale", 1.0))
+        return [[float(len(value)) * scale] for value in inputs]
+
+
+def _collect_embeddings(
+    model: EmbeddingModel[list[str], list[list[float]]],
+    inputs: list[str],
+) -> list[list[float]]:
+    return model.embed(inputs, scale=0.5)
+
+
+def test_public_protocol_integrates_with_dual_capability_model() -> None:
+    implementation = _DualCapabilityModel()
+    prediction_model: Model[list[str], list[str]] = implementation
+
+    assert EmbeddingModel is ProtocolEmbeddingModel
+    assert prediction_model.predict(["weld"], prefix="healthy:") == ["healthy:weld"]
+    assert _collect_embeddings(implementation, ["weld", "arc"]) == [[2.0], [1.5]]

--- a/tests/unit/mindtrace/models/test_model_protocol.py
+++ b/tests/unit/mindtrace/models/test_model_protocol.py
@@ -16,11 +16,44 @@ from torch import Tensor, nn
 import mindtrace.models as models_module
 from mindtrace.models import (
     ClassificationPostprocessor,
+    EmbeddingModel,
     HuggingFaceImageProcessor,
+    Model,
     TorchModel,
 )
 
 _MODEL_PROTOCOL_SAMPLE = Path(__file__).resolve().parents[4] / "samples" / "models" / "09_model_protocol.py"
+
+
+class _EmbeddingOnlyModel:
+    def embed(self, inputs: tuple[int, ...], **params: Any) -> tuple[float, ...]:
+        scale = float(params.get("scale", 1.0))
+        return tuple(value * scale for value in inputs)
+
+
+class _PredictingEmbeddingModel:
+    def predict(self, inputs: str, **params: Any) -> str:
+        return f"prediction:{inputs}:{params.get('suffix', '')}"
+
+    def embed(self, inputs: str, **params: Any) -> list[float]:
+        offset = float(params.get("offset", 0.0))
+        return [float(len(inputs)) + offset]
+
+
+def test_embedding_model_is_available_from_public_models_namespace() -> None:
+    model: EmbeddingModel[tuple[int, ...], tuple[float, ...]] = _EmbeddingOnlyModel()
+
+    assert models_module.EmbeddingModel is EmbeddingModel
+    assert model.embed((1, 2), scale=0.5) == (0.5, 1.0)
+
+
+def test_concrete_model_can_support_prediction_and_embedding_protocols() -> None:
+    implementation = _PredictingEmbeddingModel()
+    prediction_model: Model[str, str] = implementation
+    embedding_model: EmbeddingModel[str, list[float]] = implementation
+
+    assert prediction_model.predict("weld", suffix="ok") == "prediction:weld:ok"
+    assert embedding_model.embed("weld", offset=1.0) == [5.0]
 
 
 class _ImageSizeProcessor:


### PR DESCRIPTION
## Summary

Adds a minimal structural `EmbeddingModel` protocol for task-level embedding. Existing `Model`, `TorchModel`, architecture factories, Registry APIs, `ModelCard`, `ModelService`, jobs, and lifecycle behavior remain unchanged.

This PR is stacked directly on #522 and mirrors its task-level protocol boundary:

- `EmbeddingModel` implementations own task-level preprocessing, inference, and postprocessing.
- Serving and backend integrations own transport, scheduling, and backend-specific behavior.

## What this adds

- `EmbeddingModel`: a generic static protocol around `embed(inputs, **params)`.
- Focused unit and integration coverage.
- README documentation and public API reference updates.

## API examples

The core contract intentionally mirrors `Model`, while naming the embedding operation explicitly:

```python
from typing import Any, Protocol, TypeVar

InputT = TypeVar("InputT", contravariant=True)
EmbeddingT = TypeVar("EmbeddingT", covariant=True)


class EmbeddingModel(Protocol[InputT, EmbeddingT]):
    def embed(self, inputs: InputT, **params: Any) -> EmbeddingT:
        ...
```

User-defined embedding models do not need to inherit from a Mindtrace base class or register themselves. Implementing the compatible `embed` method is sufficient:

```python
from typing import Any

from mindtrace.models import EmbeddingModel


class LengthEmbeddingModel:
    def embed(self, inputs: list[str], **params: Any) -> list[list[float]]:
        scale = float(params.get("scale", 1.0))
        return [[float(len(text)) * scale] for text in inputs]


model: EmbeddingModel[list[str], list[list[float]]] = LengthEmbeddingModel()
embeddings = model.embed(
    ["surface defect detected", "sample is healthy"],
    scale=0.5,
)
```

Prediction and embedding remain independent structural capabilities, so one concrete implementation may expose both:

```python
from typing import Any

from mindtrace.models import EmbeddingModel, Model


class DualCapabilityModel:
    def predict(self, inputs: str, **params: Any) -> str:
        return f"prediction:{inputs}"

    def embed(self, inputs: str, **params: Any) -> list[float]:
        return [float(len(inputs))]


implementation = DualCapabilityModel()
prediction_model: Model[str, str] = implementation
embedding_model: EmbeddingModel[str, list[float]] = implementation
```

## Scope

This PR does not add `TorchEmbeddingModel`, embedding result or metadata types, Registry persistence, or embedding serving schemas and endpoints. It also does not change `TorchModel`, `ModelService`, or MIP. Those concrete inference and serving designs remain follow-up work after this minimal capability protocol is agreed.

As with `Model`, `EmbeddingModel` is deliberately structural and is not `runtime_checkable`.

## Validation

Focused unit coverage was added for the public export, embedding-only implementations, and concrete implementations satisfying both `Model` and `EmbeddingModel`. Integration coverage exercises the dual-capability contract through the public package API.

Closes #560
