### PR TITLE
Add TorchEmbeddingModel

### DIFF
--- a/mindtrace/models/README.md
+++ b/mindtrace/models/README.md
@@ -252,18 +252,54 @@ image = Image.open("tests/resources/hopper.png").convert("RGB")
 predictions = model.predict(image, include_probabilities=True)
 ```
 
-`model.predict(input, **params)` runs the complete task-level pipeline and forwards prediction options to the
-postprocessor. Calling `model(tensor)` invokes standard `nn.Module.forward` behavior and accepts only a preprocessed
-Tensor batch. `HuggingFaceImageProcessor` also accepts floating-point CHW or BCHW tensors, treating them as already
-normalized and adding a batch dimension to CHW input.
+`TorchEmbeddingModel` provides the same processor, network, and postprocessor composition for the independent
+embedding capability:
 
-When loading a state dict saved from the bare network, load it through the child module before prediction:
+```python
+import torch
+import torch.nn.functional as F
+from PIL import Image
+from torch import Tensor, nn
+
+from mindtrace.models import TorchEmbeddingModel
+
+
+class ImageSizeProcessor:
+    def __call__(self, image: Image.Image) -> Tensor:
+        return torch.tensor([[image.width, image.height]], dtype=torch.float32)
+
+
+class NormalizedEmbeddingNetwork(nn.Module):
+    def forward(self, inputs: Tensor) -> Tensor:
+        return F.normalize(inputs, p=2, dim=1)
+
+
+embedding_model = TorchEmbeddingModel(
+    network=NormalizedEmbeddingNetwork(),
+    processor=ImageSizeProcessor(),
+    postprocessor=lambda outputs, **params: outputs.cpu().tolist(),
+    device="auto",
+)
+
+image = Image.open("tests/resources/hopper.png").convert("RGB")
+embeddings = embedding_model.embed(image)
+```
+
+`model.predict(input, **params)` and `embedding_model.embed(input, **params)` run their complete task-level pipelines
+and forward task options to their postprocessors. `TorchModel` exposes only `predict()`, while `TorchEmbeddingModel`
+exposes only `embed()`; a higher-level implementation may compose both capabilities explicitly when needed.
+
+Calling either wrapper with `wrapper(tensor)` invokes standard `nn.Module.forward` behavior and accepts only a
+preprocessed Tensor batch. `HuggingFaceImageProcessor` also accepts floating-point CHW or BCHW tensors, treating them
+as already normalized and adding a batch dimension to CHW input.
+
+When loading a state dict saved from the bare network, load it through the child module before task-level inference:
 
 ```python
 model.network.load_state_dict(network_state_dict)
 ```
 
-Complete `TorchModel` Registry persistence is intentionally outside this API. See
+Complete `TorchModel` and `TorchEmbeddingModel` Registry persistence is intentionally outside this API. See
 [the composite archiver design issue](https://github.com/Mindtrace/mindtrace/issues/544).
 
 See [`samples/models/09_model_protocol.py`](../../samples/models/09_model_protocol.py) for a complete local example.
@@ -580,6 +616,7 @@ from mindtrace.models import (
     # -- Inference --
     EmbeddingModel,                 # Structural task-level embedding protocol
     Model,                          # Structural task-level prediction protocol
+    TorchEmbeddingModel,            # Composable PyTorch embedding pipeline
     TorchModel,                     # Composable processor/network/postprocessor
     HuggingFaceImageProcessor,      # Lazy raw-image and tensor preprocessing
     ClassificationPostprocessor,   # Labelled classification result conversion

--- a/mindtrace/models/README.md
+++ b/mindtrace/models/README.md
@@ -28,7 +28,7 @@ The Mindtrace Models module provides a complete ML lifecycle library: assemble m
 The models module consists of eight sub-packages:
 
 - **Architectures**: Backbone + head assembly with factory pattern, 33 registered backbones, 6 head types, LoRA fine-tuning
-- **Inference**: Task-level model contracts and composable local PyTorch prediction
+- **Inference**: Task-level model contracts and composable local PyTorch prediction and embedding
 - **Training**: Supervised training loop with AMP, DDP, gradient accumulation, 7 callbacks, 9 loss functions, optimizer/scheduler factories
 - **Tracking**: Unified experiment tracking with MLflow, WandB, TensorBoard backends and framework bridges
 - **Evaluation**: Framework-agnostic metric computation (pure NumPy) with EvaluationRunner for orchestrated inference
@@ -252,16 +252,20 @@ image = Image.open("tests/resources/hopper.png").convert("RGB")
 predictions = model.predict(image, include_probabilities=True)
 ```
 
-`TorchEmbeddingModel` provides the same processor, network, and postprocessor composition for the independent
-embedding capability:
+`TorchInferencePipeline` owns a processor, network, and device placement. `TorchModel` and `TorchEmbeddingModel`
+apply independent task-level postprocessors to that runtime pipeline. A single-capability model may still pass its
+network and processor directly to either wrapper; use an explicit pipeline when prediction and embedding should share
+one processor and network instance:
 
 ```python
+from typing import Any
+
 import torch
 import torch.nn.functional as F
 from PIL import Image
 from torch import Tensor, nn
 
-from mindtrace.models import TorchEmbeddingModel
+from mindtrace.models import TorchEmbeddingModel, TorchInferencePipeline, TorchModel
 
 
 class ImageSizeProcessor:
@@ -269,25 +273,37 @@ class ImageSizeProcessor:
         return torch.tensor([[image.width, image.height]], dtype=torch.float32)
 
 
-class NormalizedEmbeddingNetwork(nn.Module):
-    def forward(self, inputs: Tensor) -> Tensor:
-        return F.normalize(inputs, p=2, dim=1)
+def classify_orientation(outputs: Tensor, **params: Any) -> list[str]:
+    return ["landscape" if width >= height else "portrait" for width, height in outputs]
 
 
-embedding_model = TorchEmbeddingModel(
-    network=NormalizedEmbeddingNetwork(),
+def normalize_embeddings(outputs: Tensor, **params: Any) -> list[list[float]]:
+    return F.normalize(outputs, p=2, dim=1).cpu().tolist()
+
+
+pipeline = TorchInferencePipeline(
+    network=nn.Identity(),
     processor=ImageSizeProcessor(),
-    postprocessor=lambda outputs, **params: outputs.cpu().tolist(),
     device="auto",
+)
+prediction_model = TorchModel(
+    pipeline=pipeline,
+    postprocessor=classify_orientation,
+)
+embedding_model = TorchEmbeddingModel(
+    pipeline=pipeline,
+    postprocessor=normalize_embeddings,
 )
 
 image = Image.open("tests/resources/hopper.png").convert("RGB")
+predictions = prediction_model.predict(image)
 embeddings = embedding_model.embed(image)
 ```
 
-`model.predict(input, **params)` and `embedding_model.embed(input, **params)` run their complete task-level pipelines
-and forward task options to their postprocessors. `TorchModel` exposes only `predict()`, while `TorchEmbeddingModel`
-exposes only `embed()`; a higher-level implementation may compose both capabilities explicitly when needed.
+`prediction_model` and `embedding_model` above are two capability views over the same runtime pipeline. There is one
+processor, one network, and one device allocation, while each view has its own postprocessor. `predict(input,
+**params)` and `embed(input, **params)` run their complete task-level operation and forward task options to the
+appropriate postprocessor. `TorchModel` exposes only `predict()`, while `TorchEmbeddingModel` exposes only `embed()`.
 
 Calling either wrapper with `wrapper(tensor)` invokes standard `nn.Module.forward` behavior and accepts only a
 preprocessed Tensor batch. `HuggingFaceImageProcessor` also accepts floating-point CHW or BCHW tensors, treating them
@@ -616,8 +632,9 @@ from mindtrace.models import (
     # -- Inference --
     EmbeddingModel,                 # Structural task-level embedding protocol
     Model,                          # Structural task-level prediction protocol
-    TorchEmbeddingModel,            # Composable PyTorch embedding pipeline
-    TorchModel,                     # Composable processor/network/postprocessor
+    TorchInferencePipeline,         # Shareable processor/network/device runtime
+    TorchEmbeddingModel,            # Embedding view over a PyTorch pipeline
+    TorchModel,                     # Prediction view over a PyTorch pipeline
     HuggingFaceImageProcessor,      # Lazy raw-image and tensor preprocessing
     ClassificationPostprocessor,   # Labelled classification result conversion
 

--- a/mindtrace/models/mindtrace/models/__init__.py
+++ b/mindtrace/models/mindtrace/models/__init__.py
@@ -36,6 +36,7 @@ from mindtrace.models.inference import (
     ClassificationPostprocessor,
     HuggingFaceImageProcessor,
     TorchEmbeddingModel,
+    TorchInferencePipeline,
     TorchModel,
 )
 from mindtrace.models.protocols import EmbeddingModel, Model
@@ -128,6 +129,7 @@ __all__ = [
     "EmbeddingModel",
     "Model",
     "TorchEmbeddingModel",
+    "TorchInferencePipeline",
     "TorchModel",
     "HuggingFaceImageProcessor",
     "ClassificationPostprocessor",

--- a/mindtrace/models/mindtrace/models/__init__.py
+++ b/mindtrace/models/mindtrace/models/__init__.py
@@ -35,6 +35,7 @@ from mindtrace.models.architectures.backbones import (
 from mindtrace.models.inference import (
     ClassificationPostprocessor,
     HuggingFaceImageProcessor,
+    TorchEmbeddingModel,
     TorchModel,
 )
 from mindtrace.models.protocols import EmbeddingModel, Model
@@ -126,6 +127,7 @@ __all__ = [
     # runnable models
     "EmbeddingModel",
     "Model",
+    "TorchEmbeddingModel",
     "TorchModel",
     "HuggingFaceImageProcessor",
     "ClassificationPostprocessor",

--- a/mindtrace/models/mindtrace/models/inference/__init__.py
+++ b/mindtrace/models/mindtrace/models/inference/__init__.py
@@ -2,11 +2,12 @@
 
 from mindtrace.models.inference.postprocessors import ClassificationPostprocessor
 from mindtrace.models.inference.processors import HuggingFaceImageProcessor
-from mindtrace.models.inference.torch import TorchEmbeddingModel, TorchModel
+from mindtrace.models.inference.torch import TorchEmbeddingModel, TorchInferencePipeline, TorchModel
 
 __all__ = [
     "ClassificationPostprocessor",
     "HuggingFaceImageProcessor",
     "TorchEmbeddingModel",
+    "TorchInferencePipeline",
     "TorchModel",
 ]

--- a/mindtrace/models/mindtrace/models/inference/__init__.py
+++ b/mindtrace/models/mindtrace/models/inference/__init__.py
@@ -2,10 +2,11 @@
 
 from mindtrace.models.inference.postprocessors import ClassificationPostprocessor
 from mindtrace.models.inference.processors import HuggingFaceImageProcessor
-from mindtrace.models.inference.torch import TorchModel
+from mindtrace.models.inference.torch import TorchEmbeddingModel, TorchModel
 
 __all__ = [
     "ClassificationPostprocessor",
     "HuggingFaceImageProcessor",
+    "TorchEmbeddingModel",
     "TorchModel",
 ]

--- a/mindtrace/models/mindtrace/models/inference/processors.py
+++ b/mindtrace/models/mindtrace/models/inference/processors.py
@@ -18,9 +18,16 @@ else:
 class HuggingFaceImageProcessor:
     """Lazily reconstruct a Hugging Face image processor from its model ID."""
 
-    def __init__(self, model_id: str, *, cache_dir: str | None = None) -> None:
+    def __init__(
+        self,
+        model_id: str,
+        *,
+        cache_dir: str | None = None,
+        use_fast: bool = True,
+    ) -> None:
         self.model_id = model_id
         self.cache_dir = cache_dir
+        self.use_fast = use_fast
         self._processor: Any = None
 
     def __call__(self, inputs: _ImageInput) -> Tensor:
@@ -53,6 +60,7 @@ class HuggingFaceImageProcessor:
             self._processor = AutoImageProcessor.from_pretrained(
                 self.model_id,
                 cache_dir=self.cache_dir,
+                use_fast=self.use_fast,
             )
 
         encoded = self._processor(images=images, return_tensors="pt")

--- a/mindtrace/models/mindtrace/models/inference/torch.py
+++ b/mindtrace/models/mindtrace/models/inference/torch.py
@@ -1,4 +1,4 @@
-"""Composable PyTorch model with task-level prediction behavior."""
+"""Composable PyTorch models with task-level inference behavior."""
 
 from __future__ import annotations
 
@@ -11,20 +11,18 @@ from torch import Tensor, nn
 
 InputT = TypeVar("InputT", contravariant=True)
 OutputT = TypeVar("OutputT", covariant=True)
+EmbeddingT = TypeVar("EmbeddingT", covariant=True)
+ResultT = TypeVar("ResultT", covariant=True)
 
 
-class TorchModel(nn.Module, Generic[InputT, OutputT]):
-    """Compose preprocessing, a PyTorch network, and postprocessing.
-
-    ``forward`` preserves normal ``nn.Module`` tensor semantics, while
-    ``predict`` provides the higher-level Mindtrace model contract.
-    """
+class _TorchInferencePipeline(nn.Module, Generic[InputT, ResultT]):
+    """Share tensor and task-level execution mechanics across PyTorch models."""
 
     def __init__(
         self,
         network: nn.Module,
         processor: Callable[[InputT], Tensor],
-        postprocessor: Callable[..., OutputT],
+        postprocessor: Callable[..., ResultT],
         *,
         device: str | torch.device | None = None,
     ) -> None:
@@ -45,17 +43,14 @@ class TorchModel(nn.Module, Generic[InputT, OutputT]):
     def forward(self, inputs: Tensor) -> Any:
         """Run the wrapped network on a preprocessed tensor batch.
 
-        Use :meth:`predict` for task-level inputs that still require processing.
+        Use the public task-level method for inputs that still require
+        processing.
         """
         if not isinstance(inputs, Tensor):
             raise TypeError(f"forward inputs must be torch.Tensor, got {type(inputs).__name__}")
         return self.network(inputs)
 
-    def predict(self, inputs: InputT, **params: Any) -> OutputT:
-        """Run the full prediction pipeline.
-
-        ``params`` are task-specific options forwarded to the postprocessor.
-        """
+    def _run(self, inputs: InputT, **params: Any) -> ResultT:
         training_states = [(module, module.training) for module in self.modules()]
 
         self.eval()
@@ -79,4 +74,34 @@ class TorchModel(nn.Module, Generic[InputT, OutputT]):
         return next(network_state, self._device_anchor).device
 
 
-__all__ = ["TorchModel"]
+class TorchModel(_TorchInferencePipeline[InputT, OutputT]):
+    """Compose a PyTorch network into a task-level prediction model.
+
+    ``forward`` preserves normal ``nn.Module`` tensor semantics, while
+    ``predict`` provides the higher-level Mindtrace model contract.
+    """
+
+    def predict(self, inputs: InputT, **params: Any) -> OutputT:
+        """Run the full prediction pipeline.
+
+        ``params`` are task-specific options forwarded to the postprocessor.
+        """
+        return self._run(inputs, **params)
+
+
+class TorchEmbeddingModel(_TorchInferencePipeline[InputT, EmbeddingT]):
+    """Compose a PyTorch network into a task-level embedding model.
+
+    ``forward`` preserves normal ``nn.Module`` tensor semantics, while
+    ``embed`` provides the higher-level Mindtrace embedding model contract.
+    """
+
+    def embed(self, inputs: InputT, **params: Any) -> EmbeddingT:
+        """Run the full embedding pipeline.
+
+        ``params`` are task-specific options forwarded to the postprocessor.
+        """
+        return self._run(inputs, **params)
+
+
+__all__ = ["TorchEmbeddingModel", "TorchModel"]

--- a/mindtrace/models/mindtrace/models/inference/torch.py
+++ b/mindtrace/models/mindtrace/models/inference/torch.py
@@ -15,21 +15,23 @@ EmbeddingT = TypeVar("EmbeddingT", covariant=True)
 ResultT = TypeVar("ResultT", covariant=True)
 
 
-class _TorchInferencePipeline(nn.Module, Generic[InputT, ResultT]):
-    """Share tensor and task-level execution mechanics across PyTorch models."""
+class TorchInferencePipeline(nn.Module, Generic[InputT]):
+    """Own a shareable PyTorch processor, network, and device placement.
+
+    Prediction and embedding wrappers may reference the same pipeline while
+    applying different task-level postprocessors to its raw network outputs.
+    """
 
     def __init__(
         self,
         network: nn.Module,
         processor: Callable[[InputT], Tensor],
-        postprocessor: Callable[..., ResultT],
         *,
         device: str | torch.device | None = None,
     ) -> None:
         super().__init__()
         self.network = network
         self.processor = processor
-        self.postprocessor = postprocessor
         self.register_buffer("_device_anchor", torch.empty(0), persistent=False)
 
         if device is not None:
@@ -41,14 +43,64 @@ class _TorchInferencePipeline(nn.Module, Generic[InputT, ResultT]):
             self.to(resolved_device)
 
     def forward(self, inputs: Tensor) -> Any:
-        """Run the wrapped network on a preprocessed tensor batch.
+        """Run the wrapped network on a preprocessed tensor batch."""
+        if not isinstance(inputs, Tensor):
+            raise TypeError(f"forward inputs must be torch.Tensor, got {type(inputs).__name__}")
+        return self.network(inputs)
+
+    def _process(self, inputs: InputT) -> Tensor:
+        batch = self.processor(inputs)
+        if not isinstance(batch, Tensor):
+            raise TypeError(f"processor must return torch.Tensor, got {type(batch).__name__}")
+        return batch.to(self.device)
+
+    @property
+    def device(self) -> torch.device:
+        """Return the network device, or the pipeline device for stateless networks."""
+        network_state = chain(self.network.parameters(), self.network.buffers())
+        return next(network_state, self._device_anchor).device
+
+
+class _TorchCapabilityModel(nn.Module, Generic[InputT, ResultT]):
+    """Apply one task-level postprocessor to a shared inference pipeline."""
+
+    def __init__(
+        self,
+        network: nn.Module | None = None,
+        processor: Callable[[InputT], Tensor] | None = None,
+        postprocessor: Callable[..., ResultT] | None = None,
+        *,
+        device: str | torch.device | None = None,
+        pipeline: TorchInferencePipeline[InputT] | None = None,
+    ) -> None:
+        super().__init__()
+
+        if postprocessor is None:
+            raise TypeError("postprocessor is required")
+
+        if pipeline is not None:
+            if network is not None or processor is not None or device is not None:
+                raise ValueError("pipeline cannot be combined with network, processor, or device")
+            self.pipeline = pipeline
+        else:
+            if network is None or processor is None:
+                raise TypeError("network and processor are required when pipeline is not provided")
+            self.pipeline = TorchInferencePipeline(
+                network=network,
+                processor=processor,
+                device=device,
+            )
+
+        self.postprocessor = postprocessor
+        self.to(self.pipeline.device)
+
+    def forward(self, inputs: Tensor) -> Any:
+        """Run the shared network on a preprocessed tensor batch.
 
         Use the public task-level method for inputs that still require
         processing.
         """
-        if not isinstance(inputs, Tensor):
-            raise TypeError(f"forward inputs must be torch.Tensor, got {type(inputs).__name__}")
-        return self.network(inputs)
+        return self.pipeline(inputs)
 
     def _run(self, inputs: InputT, **params: Any) -> ResultT:
         training_states = [(module, module.training) for module in self.modules()]
@@ -56,11 +108,7 @@ class _TorchInferencePipeline(nn.Module, Generic[InputT, ResultT]):
         self.eval()
         try:
             with torch.inference_mode():
-                batch = self.processor(inputs)
-                if not isinstance(batch, Tensor):
-                    raise TypeError(f"processor must return torch.Tensor, got {type(batch).__name__}")
-
-                batch = batch.to(self.device)
+                batch = self.pipeline._process(inputs)
                 outputs = self(batch)
                 return self.postprocessor(outputs, **params)
         finally:
@@ -68,14 +116,23 @@ class _TorchInferencePipeline(nn.Module, Generic[InputT, ResultT]):
                 module.training = training
 
     @property
+    def network(self) -> nn.Module:
+        """Return the network owned by the shared pipeline."""
+        return self.pipeline.network
+
+    @property
+    def processor(self) -> Callable[[InputT], Tensor]:
+        """Return the processor owned by the shared pipeline."""
+        return self.pipeline.processor
+
+    @property
     def device(self) -> torch.device:
-        """Return the network device, or the wrapper device for stateless networks."""
-        network_state = chain(self.network.parameters(), self.network.buffers())
-        return next(network_state, self._device_anchor).device
+        """Return the device owned by the shared pipeline."""
+        return self.pipeline.device
 
 
-class TorchModel(_TorchInferencePipeline[InputT, OutputT]):
-    """Compose a PyTorch network into a task-level prediction model.
+class TorchModel(_TorchCapabilityModel[InputT, OutputT]):
+    """Compose a PyTorch pipeline into a task-level prediction model.
 
     ``forward`` preserves normal ``nn.Module`` tensor semantics, while
     ``predict`` provides the higher-level Mindtrace model contract.
@@ -89,8 +146,8 @@ class TorchModel(_TorchInferencePipeline[InputT, OutputT]):
         return self._run(inputs, **params)
 
 
-class TorchEmbeddingModel(_TorchInferencePipeline[InputT, EmbeddingT]):
-    """Compose a PyTorch network into a task-level embedding model.
+class TorchEmbeddingModel(_TorchCapabilityModel[InputT, EmbeddingT]):
+    """Compose a PyTorch pipeline into a task-level embedding model.
 
     ``forward`` preserves normal ``nn.Module`` tensor semantics, while
     ``embed`` provides the higher-level Mindtrace embedding model contract.
@@ -104,4 +161,4 @@ class TorchEmbeddingModel(_TorchInferencePipeline[InputT, EmbeddingT]):
         return self._run(inputs, **params)
 
 
-__all__ = ["TorchEmbeddingModel", "TorchModel"]
+__all__ = ["TorchEmbeddingModel", "TorchInferencePipeline", "TorchModel"]

--- a/tests/integration/mindtrace/models/test_model_protocol_devices.py
+++ b/tests/integration/mindtrace/models/test_model_protocol_devices.py
@@ -1,4 +1,4 @@
-"""Accelerator integration coverage for the Model protocol sample."""
+"""Accelerator integration coverage for task-level PyTorch models."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from PIL import Image
 from torch import Tensor, nn
 
 import mindtrace.models as models_module
-from mindtrace.models import TorchModel
+from mindtrace.models import TorchEmbeddingModel, TorchModel
 
 _MODEL_PROTOCOL_SAMPLE = Path(__file__).resolve().parents[4] / "samples" / "models" / "09_model_protocol.py"
 _MPS_AVAILABLE = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
@@ -50,6 +50,11 @@ class _CpuProcessor:
 class _EmptyPostprocessor:
     def __call__(self, outputs: Tensor, **params: Any) -> list[Any]:
         return []
+
+
+class _EmbeddingPostprocessor:
+    def __call__(self, outputs: Tensor, **params: Any) -> list[list[float]]:
+        return outputs.detach().cpu().tolist()
 
 
 class _DeviceCheckingNetwork(nn.Module):
@@ -92,3 +97,18 @@ def test_model_protocol_sample_runs_on_available_accelerators(
     monkeypatch.setattr(Image, "open", lambda path: _FakeImage())
 
     runpy.run_path(str(_MODEL_PROTOCOL_SAMPLE), run_name="__main__")
+
+
+@pytest.mark.parametrize("device", _ACCELERATOR_CASES)
+def test_torch_embedding_model_moves_processed_batches_to_available_accelerators(device: str) -> None:
+    model = TorchEmbeddingModel(
+        network=_DeviceCheckingNetwork(expected_device=device),
+        processor=_CpuProcessor(),
+        postprocessor=_EmbeddingPostprocessor(),
+        device=device,
+    )
+
+    embeddings = model.embed(object())
+
+    assert len(embeddings) == 1
+    assert len(embeddings[0]) == 2

--- a/tests/integration/mindtrace/models/test_model_protocol_devices.py
+++ b/tests/integration/mindtrace/models/test_model_protocol_devices.py
@@ -12,7 +12,7 @@ from PIL import Image
 from torch import Tensor, nn
 
 import mindtrace.models as models_module
-from mindtrace.models import TorchEmbeddingModel, TorchModel
+from mindtrace.models import TorchEmbeddingModel, TorchInferencePipeline, TorchModel
 
 _MODEL_PROTOCOL_SAMPLE = Path(__file__).resolve().parents[4] / "samples" / "models" / "09_model_protocol.py"
 _MPS_AVAILABLE = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
@@ -100,15 +100,26 @@ def test_model_protocol_sample_runs_on_available_accelerators(
 
 
 @pytest.mark.parametrize("device", _ACCELERATOR_CASES)
-def test_torch_embedding_model_moves_processed_batches_to_available_accelerators(device: str) -> None:
-    model = TorchEmbeddingModel(
+def test_shared_pipeline_moves_prediction_and_embedding_batches_to_available_accelerators(device: str) -> None:
+    pipeline = TorchInferencePipeline(
         network=_DeviceCheckingNetwork(expected_device=device),
         processor=_CpuProcessor(),
-        postprocessor=_EmbeddingPostprocessor(),
         device=device,
     )
+    prediction_model = TorchModel(
+        pipeline=pipeline,
+        postprocessor=_EmbeddingPostprocessor(),
+    )
+    embedding_model = TorchEmbeddingModel(
+        pipeline=pipeline,
+        postprocessor=_EmbeddingPostprocessor(),
+    )
 
-    embeddings = model.embed(object())
+    predictions = prediction_model.predict(object())
+    embeddings = embedding_model.embed(object())
 
+    assert prediction_model.pipeline is embedding_model.pipeline is pipeline
+    assert len(predictions) == 1
+    assert len(predictions[0]) == 2
     assert len(embeddings) == 1
     assert len(embeddings[0]) == 2

--- a/tests/unit/mindtrace/models/test_model_protocol.py
+++ b/tests/unit/mindtrace/models/test_model_protocol.py
@@ -20,6 +20,7 @@ from mindtrace.models import (
     HuggingFaceImageProcessor,
     Model,
     TorchEmbeddingModel,
+    TorchInferencePipeline,
     TorchModel,
 )
 
@@ -131,6 +132,89 @@ def _build_test_embedding_model() -> TorchEmbeddingModel[Any, dict[str, Any]]:
         processor=_ImageSizeProcessor(),
         postprocessor=_PassthroughPostprocessor(),
     )
+
+
+def test_torch_inference_pipeline_is_available_from_public_models_namespace() -> None:
+    pipeline = TorchInferencePipeline(
+        network=_RecordingNetwork(),
+        processor=_ImageSizeProcessor(),
+    )
+
+    assert models_module.TorchInferencePipeline is TorchInferencePipeline
+    assert pipeline.network is not None
+
+
+def test_prediction_and_embedding_models_can_share_one_runtime_pipeline() -> None:
+    class TaggedPostprocessor:
+        def __init__(self, capability: str) -> None:
+            self.capability = capability
+
+        def __call__(self, outputs: Tensor, **params: Any) -> dict[str, Any]:
+            return {
+                "capability": self.capability,
+                "outputs": outputs.cpu().tolist(),
+                "params": params,
+            }
+
+    network = _RecordingNetwork()
+    processor = _ImageSizeProcessor()
+    pipeline = TorchInferencePipeline(network=network, processor=processor)
+    prediction_model = TorchModel(
+        pipeline=pipeline,
+        postprocessor=TaggedPostprocessor("prediction"),
+    )
+    embedding_model = TorchEmbeddingModel(
+        pipeline=pipeline,
+        postprocessor=TaggedPostprocessor("embedding"),
+    )
+
+    prediction = prediction_model.predict(Image.new("RGB", (4, 6)), threshold=0.5)
+    embedding = embedding_model.embed(Image.new("RGB", (4, 6)), normalize=True)
+
+    assert prediction_model.pipeline is embedding_model.pipeline is pipeline
+    assert prediction_model.network is embedding_model.network is network
+    assert prediction_model.processor is embedding_model.processor is processor
+    assert prediction == {
+        "capability": "prediction",
+        "outputs": [[5.0, 5.0]],
+        "params": {"threshold": 0.5},
+    }
+    assert embedding == {
+        "capability": "embedding",
+        "outputs": [[5.0, 5.0]],
+        "params": {"normalize": True},
+    }
+    assert not hasattr(prediction_model, "embed")
+    assert not hasattr(embedding_model, "predict")
+
+
+def test_direct_torch_model_construction_exposes_its_created_pipeline() -> None:
+    network = _RecordingNetwork()
+    processor = _ImageSizeProcessor()
+    model = TorchModel(
+        network=network,
+        processor=processor,
+        postprocessor=_PassthroughPostprocessor(),
+    )
+
+    assert isinstance(model.pipeline, TorchInferencePipeline)
+    assert model.network is network
+    assert model.processor is processor
+
+
+def test_shared_pipeline_cannot_be_combined_with_pipeline_components() -> None:
+    pipeline = TorchInferencePipeline(
+        network=_RecordingNetwork(),
+        processor=_ImageSizeProcessor(),
+    )
+
+    with pytest.raises(ValueError, match="pipeline cannot be combined"):
+        TorchModel(
+            network=_RecordingNetwork(),
+            processor=_ImageSizeProcessor(),
+            postprocessor=_PassthroughPostprocessor(),
+            pipeline=pipeline,
+        )
 
 
 def test_torch_embedding_model_is_available_from_public_models_namespace() -> None:

--- a/tests/unit/mindtrace/models/test_model_protocol.py
+++ b/tests/unit/mindtrace/models/test_model_protocol.py
@@ -19,6 +19,7 @@ from mindtrace.models import (
     EmbeddingModel,
     HuggingFaceImageProcessor,
     Model,
+    TorchEmbeddingModel,
     TorchModel,
 )
 
@@ -122,6 +123,111 @@ def _build_test_model() -> TorchModel[Any, dict[str, Any]]:
         processor=_ImageSizeProcessor(),
         postprocessor=_PassthroughPostprocessor(),
     )
+
+
+def _build_test_embedding_model() -> TorchEmbeddingModel[Any, dict[str, Any]]:
+    return TorchEmbeddingModel(
+        network=_RecordingNetwork(),
+        processor=_ImageSizeProcessor(),
+        postprocessor=_PassthroughPostprocessor(),
+    )
+
+
+def test_torch_embedding_model_is_available_from_public_models_namespace() -> None:
+    model = _build_test_embedding_model()
+    embedding_model: EmbeddingModel[Any, dict[str, Any]] = model
+
+    assert models_module.TorchEmbeddingModel is TorchEmbeddingModel
+    assert embedding_model is model
+    assert not hasattr(model, "predict")
+
+
+def test_embedding_forward_delegates_to_wrapped_network() -> None:
+    model = _build_test_embedding_model()
+    inputs = torch.tensor([[2.0, 3.0]])
+
+    outputs = model(inputs)
+
+    assert torch.equal(outputs, torch.tensor([[3.0, 2.0]]))
+
+
+def test_embed_composes_processor_network_and_postprocessor() -> None:
+    model = _build_test_embedding_model()
+    model.train()
+    image = Image.new("RGB", (4, 6))
+
+    result = model.embed(image, normalize=True)
+
+    assert result == {
+        "outputs": [[5.0, 5.0]],
+        "params": {"normalize": True},
+    }
+    assert model.network.training_during_forward is False
+    assert model.network.grad_enabled_during_forward is False
+    assert model.training is True
+    assert model.network.training is True
+
+
+def test_embed_runs_the_complete_pipeline_in_eval_and_inference_mode() -> None:
+    processor = _RecordingProcessor()
+    postprocessor = _RecordingParameterizedPostprocessor()
+    model = TorchEmbeddingModel(
+        network=_RecordingNetwork(),
+        processor=processor,
+        postprocessor=postprocessor,
+    )
+    model.train()
+
+    result = model.embed(torch.ones((1, 2)))
+
+    assert result.shape == (1, 2)
+    assert processor.training_during_call is False
+    assert processor.grad_enabled_during_call is False
+    assert processor.inference_mode_during_call is True
+    assert model.network.training_during_forward is False
+    assert model.network.grad_enabled_during_forward is False
+    assert model.network.inference_mode_during_forward is True
+    assert postprocessor.training_during_call is False
+    assert postprocessor.grad_enabled_during_call is False
+    assert postprocessor.inference_mode_during_call is True
+    assert model.training is True
+    assert processor.training is True
+    assert model.network.training is True
+    assert postprocessor.training is True
+
+
+def test_embed_restores_training_state_after_inference_error() -> None:
+    class RaisingNetwork(nn.Module):
+        def forward(self, inputs: Tensor) -> Tensor:
+            raise RuntimeError("embedding failed")
+
+    model = TorchEmbeddingModel(
+        network=RaisingNetwork(),
+        processor=lambda inputs: inputs,
+        postprocessor=_PassthroughPostprocessor(),
+    )
+    model.train()
+
+    with pytest.raises(RuntimeError, match="embedding failed"):
+        model.embed(torch.ones((1, 2)))
+
+    assert model.training is True
+    assert model.network.training is True
+
+
+def test_embed_rejects_non_tensor_processor_output() -> None:
+    class InvalidProcessor:
+        def __call__(self, inputs: Any) -> list[Any]:
+            return [inputs]
+
+    model = TorchEmbeddingModel(
+        network=nn.Identity(),
+        processor=InvalidProcessor(),
+        postprocessor=_PassthroughPostprocessor(),
+    )
+
+    with pytest.raises(TypeError, match="processor must return torch.Tensor"):
+        model.embed(Image.new("RGB", (1, 1)))
 
 
 def test_forward_delegates_to_wrapped_network() -> None:

--- a/tests/unit/mindtrace/models/test_model_protocol.py
+++ b/tests/unit/mindtrace/models/test_model_protocol.py
@@ -553,11 +553,17 @@ def test_hugging_face_processor_rejects_integer_tensor() -> None:
         processor(torch.ones((1, 3, 8, 8), dtype=torch.uint8))
 
 
+@pytest.mark.parametrize(
+    ("processor_kwargs", "expected_use_fast"),
+    [({}, True), ({"use_fast": False}, False)],
+)
 def test_hugging_face_processor_lazily_processes_single_and_multiple_pil_images(
     monkeypatch: pytest.MonkeyPatch,
+    processor_kwargs: dict[str, bool],
+    expected_use_fast: bool,
 ) -> None:
     pixel_values = torch.ones((2, 3, 8, 8))
-    factory_calls: list[tuple[str, str | None]] = []
+    factory_calls: list[tuple[str, str | None, bool]] = []
     processor_calls: list[tuple[list[Image.Image], str]] = []
 
     class FakeProcessor:
@@ -567,8 +573,14 @@ def test_hugging_face_processor_lazily_processes_single_and_multiple_pil_images(
 
     class FakeAutoImageProcessor:
         @classmethod
-        def from_pretrained(cls, model_id: str, *, cache_dir: str | None = None) -> FakeProcessor:
-            factory_calls.append((model_id, cache_dir))
+        def from_pretrained(
+            cls,
+            model_id: str,
+            *,
+            cache_dir: str | None = None,
+            use_fast: bool,
+        ) -> FakeProcessor:
+            factory_calls.append((model_id, cache_dir, use_fast))
             return FakeProcessor()
 
     monkeypatch.setitem(
@@ -576,13 +588,17 @@ def test_hugging_face_processor_lazily_processes_single_and_multiple_pil_images(
         "transformers",
         SimpleNamespace(AutoImageProcessor=FakeAutoImageProcessor),
     )
-    processor = HuggingFaceImageProcessor("example/model", cache_dir="/tmp/model-cache")
+    processor = HuggingFaceImageProcessor(
+        "example/model",
+        cache_dir="/tmp/model-cache",
+        **processor_kwargs,
+    )
     first_image = Image.new("RGB", (8, 8))
     second_image = Image.new("RGB", (8, 8))
 
     assert processor(first_image) is pixel_values
     assert processor([first_image, second_image]) is pixel_values
-    assert factory_calls == [("example/model", "/tmp/model-cache")]
+    assert factory_calls == [("example/model", "/tmp/model-cache", expected_use_fast)]
     assert processor_calls == [
         ([first_image], "pt"),
         ([first_image, second_image], "pt"),


### PR DESCRIPTION
## Summary

Adds a shareable `TorchInferencePipeline` and a composable `TorchEmbeddingModel` for task-level PyTorch embedding inference. Existing `EmbeddingModel`, `Model`, architecture factories, Registry APIs, `ModelCard`, `ModelService`, jobs, and lifecycle behavior remain unchanged.

This PR is stacked directly on #561 and extends the existing `TorchModel` inference boundary:

- One `TorchInferencePipeline` may own the processor, network, device placement, and raw tensor execution for multiple capabilities.
- `TorchModel.predict()` and `TorchEmbeddingModel.embed()` remain independent public capabilities with separate postprocessors.
- Existing `TorchModel(network=..., processor=..., postprocessor=...)` construction remains supported.
- Serving and backend integrations continue to own transport, scheduling, and backend-specific behavior.

Closes #565

## Motivation

`EmbeddingModel` defines what an embedding-capable model does, but intentionally leaves framework-specific execution to concrete implementations. PyTorch embedding models need the same processing, device, inference-mode, and state-management behavior as prediction models, while a model that supports both tasks should not duplicate its processor or network. The shared runtime pipeline provides that common execution layer while preserving `predict()` and `embed()` as independent capabilities.

## API examples

A single-capability model may construct `TorchEmbeddingModel` directly. When prediction and embedding share one processor and network, both capability views can reference the same runtime pipeline and provide their own postprocessors:

```python
from typing import Any

import torch
import torch.nn.functional as F
from PIL import Image
from torch import Tensor, nn

from mindtrace.models import TorchEmbeddingModel, TorchInferencePipeline, TorchModel


class ImageSizeProcessor:
    def __call__(self, image: Image.Image) -> Tensor:
        return torch.tensor([[image.width, image.height]], dtype=torch.float32)


def classify_orientation(outputs: Tensor, **params: Any) -> list[str]:
    return ["landscape" if width >= height else "portrait" for width, height in outputs]


def normalize_embeddings(outputs: Tensor, **params: Any) -> list[list[float]]:
    return F.normalize(outputs, p=2, dim=1).cpu().tolist()


pipeline = TorchInferencePipeline(
    network=nn.Identity(),
    processor=ImageSizeProcessor(),
    device="auto",
)
prediction_model = TorchModel(
    pipeline=pipeline,
    postprocessor=classify_orientation,
)
embedding_model = TorchEmbeddingModel(
    pipeline=pipeline,
    postprocessor=normalize_embeddings,
)

image = Image.new("RGB", (640, 480))
predictions = prediction_model.predict(image)
embeddings = embedding_model.embed(image)
```

Both views retain normal tensor-level module invocation:

```python
raw_outputs = prediction_model(torch.tensor([[640.0, 480.0]]))
```

## Implementation details

`TorchInferencePipeline` owns the processor, network, device anchor, processed-batch device movement, and raw tensor `forward()`. A private capability wrapper owns one postprocessor and the inference-mode and training-state boundary. `TorchModel` and `TorchEmbeddingModel` then expose only their relevant task-level method:

```python
class TorchInferencePipeline(nn.Module):
    def forward(self, tensor): ...
    def _process(self, inputs): ...


class _TorchCapabilityModel(nn.Module):
    def __init__(self, *, pipeline, postprocessor): ...
    def _run(self, inputs, **params): ...


class TorchModel(_TorchCapabilityModel):
    def predict(self, inputs, **params):
        return self._run(inputs, **params)


class TorchEmbeddingModel(_TorchCapabilityModel):
    def embed(self, inputs, **params):
        return self._run(inputs, **params)
```

This makes runtime sharing explicit: two capability views may reference the identical pipeline object, so there is one processor, one network instance, and one device allocation while their postprocessors remain independent. It also avoids making every `TorchEmbeddingModel` structurally satisfy `Model` or routing embeddings through an ambiguous prediction option.

For backward compatibility, either wrapper may still receive `network`, `processor`, `postprocessor`, and `device` directly; it creates and exposes its own `TorchInferencePipeline` internally.

## Scope

This PR does not add embedding result or metadata types, a dual-capability facade, Registry persistence for composite inference pipelines, embedding serving schemas or endpoints, or MIP integration. It also does not change the `EmbeddingModel` protocol or make `TorchEmbeddingModel` satisfy `Model`.

Hermetic composite persistence and local serving remain separate follow-up work tracked by #544 and #548.

## Validation

Focused unit coverage was added for public exports, structural `EmbeddingModel` compatibility, backward-compatible direct construction, shared runtime identity, independent capability postprocessors and parameters, raw tensor `forward()`, inference state, state restoration after failures, invalid processor outputs, and invalid mixed construction. Integration coverage exercises one shared prediction and embedding pipeline with processed-batch device movement on CUDA and MPS.

Depends on #561
