### PR TITLE
Add streaming HuggingFace exports

### DIFF
--- a/mindtrace/datalake/README.md
+++ b/mindtrace/datalake/README.md
@@ -440,6 +440,32 @@ artifact. Supported scalar dtypes are `string`, `bool`, signed and unsigned inte
 and `float16`, `float32`, and `float64`. The resolved selector, class mapping, and metadata-key types are recorded in
 `mindtrace_metadata.json`. Existing exports without these options are unchanged.
 
+Large single-label classification versions can be exported with bounded memory by paging the Datalake view and
+staging media before the final Hugging Face artifact is written. Streaming currently requires an explicit class
+order:
+
+```python
+def report_export(progress):
+    print(f"{progress.stage}: {progress.completed}/{progress.total}")
+
+
+datalake.export_dataset_version_to_format(
+    "multi-field-classification",
+    "1.0.0",
+    format="huggingface",
+    destination=export_root / "selected-classification",
+    streaming=True,
+    page_size=256,
+    progress_callback=report_export,
+    exporter_options={
+        "task": "classification",
+        "class_names": ["negative", "positive"],
+    },
+)
+```
+
+Other task profiles continue to use the existing in-memory export path and reject `streaming=True` explicitly.
+
 #### Build all associated Datasets and DataLoaders
 
 ```python

--- a/mindtrace/datalake/mindtrace/datalake/__init__.py
+++ b/mindtrace/datalake/mindtrace/datalake/__init__.py
@@ -32,7 +32,14 @@ from .data_vault_backends import (
     LocalDataVaultBackend,
 )
 from .datalake import Datalake
-from .exporters import ExportableDataset, ExportableItem, ExportResult, export_dataset_to_format, get_dataset_exporter
+from .exporters import (
+    ExportableDataset,
+    ExportableItem,
+    ExportProgress,
+    ExportResult,
+    export_dataset_to_format,
+    get_dataset_exporter,
+)
 from .pagination_types import (
     CursorEnvelope,
     CursorPage,
@@ -120,6 +127,7 @@ __all__ = [
     "AsyncDataVaultBackend",
     "VaultDataset",
     "ExportResult",
+    "ExportProgress",
     "ExportableDataset",
     "ExportableItem",
     "export_dataset_to_format",

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -2516,7 +2516,22 @@ class AsyncDatalake(Mindtrace):
         from mindtrace.datalake.exporters.base import build_exportable_dataset_from_resolved_version_async
 
         if streaming:
-            raise NotImplementedError("Streaming dataset export is not implemented yet.")
+            if format.strip().lower() != "huggingface":
+                raise ValueError("Streaming dataset export currently supports only format='huggingface'.")
+            from mindtrace.datalake.exporters.huggingface import export_dataset_version_as_huggingface_streaming
+
+            dataset_version = await self.get_dataset_version(dataset_name, version)
+            return await export_dataset_version_as_huggingface_streaming(
+                self,
+                dataset_version,
+                destination=destination,
+                include_media=include_media,
+                overwrite=overwrite,
+                split_map=split_map,
+                options=exporter_options,
+                page_size=page_size,
+                progress_callback=progress_callback,
+            )
 
         resolved_dataset_version = await self.resolve_dataset_version(dataset_name, version)
         exportable_dataset = await build_exportable_dataset_from_resolved_version_async(

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import os
 import warnings
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncIterator, Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from enum import StrEnum
@@ -29,6 +29,7 @@ from mindtrace.datalake.pagination_types import (
     PageInfo,
     StructuredFilter,
 )
+from mindtrace.datalake.exporters import ExportProgress
 from mindtrace.datalake.types import (
     AnnotationLabelDefinition,
     AnnotationRecord,
@@ -2506,10 +2507,16 @@ class AsyncDatalake(Mindtrace):
         overwrite: bool = False,
         split_map: dict[str, str] | None = None,
         exporter_options: dict[str, Any] | None = None,
+        streaming: bool = False,
+        page_size: int = 256,
+        progress_callback: Callable[[ExportProgress], None] | None = None,
     ):
         """Export an immutable dataset version to a named external format."""
         from mindtrace.datalake.exporters import export_dataset_to_format
         from mindtrace.datalake.exporters.base import build_exportable_dataset_from_resolved_version_async
+
+        if streaming:
+            raise NotImplementedError("Streaming dataset export is not implemented yet.")
 
         resolved_dataset_version = await self.resolve_dataset_version(dataset_name, version)
         exportable_dataset = await build_exportable_dataset_from_resolved_version_async(

--- a/mindtrace/datalake/mindtrace/datalake/async_datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/async_datalake.py
@@ -19,6 +19,7 @@ from motor.motor_asyncio import AsyncIOMotorClient
 from mindtrace.core import Mindtrace, as_utc, utcnow
 from mindtrace.database import MongoMindtraceODM
 from mindtrace.database.core.exceptions import DocumentNotFoundError, DuplicateInsertError
+from mindtrace.datalake.exporters import ExportProgress
 from mindtrace.datalake.pagination_types import (
     CursorEnvelope,
     CursorPage,
@@ -29,7 +30,6 @@ from mindtrace.datalake.pagination_types import (
     PageInfo,
     StructuredFilter,
 )
-from mindtrace.datalake.exporters import ExportProgress
 from mindtrace.datalake.types import (
     AnnotationLabelDefinition,
     AnnotationRecord,

--- a/mindtrace/datalake/mindtrace/datalake/datalake.py
+++ b/mindtrace/datalake/mindtrace/datalake/datalake.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from concurrent.futures import Future
 from pathlib import Path
 from typing import Any, Optional
 
 from mindtrace.core import Mindtrace
 from mindtrace.datalake.async_datalake import AsyncDatalake, SlowOpsPolicy
+from mindtrace.datalake.exporters import ExportProgress
 from mindtrace.registry import Mount, Store
 
 
@@ -899,6 +900,9 @@ class Datalake(Mindtrace):
         overwrite: bool = False,
         split_map: dict[str, str] | None = None,
         exporter_options: dict[str, Any] | None = None,
+        streaming: bool = False,
+        page_size: int = 256,
+        progress_callback: Callable[[ExportProgress], None] | None = None,
     ):
         return self._submit_coro(
             self._backend.export_dataset_version_to_format(
@@ -910,6 +914,9 @@ class Datalake(Mindtrace):
                 overwrite=overwrite,
                 split_map=split_map,
                 exporter_options=exporter_options,
+                streaming=streaming,
+                page_size=page_size,
+                progress_callback=progress_callback,
             )
         )
 

--- a/mindtrace/datalake/mindtrace/datalake/exporters/__init__.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 
-from .types import ExportableDataset, ExportableItem, ExportResult
+from .types import ExportableDataset, ExportableItem, ExportProgress, ExportResult
 
 ExporterFunc = Callable[..., ExportResult]
 
@@ -44,6 +44,7 @@ def export_dataset_to_format(
 
 __all__ = [
     "ExportResult",
+    "ExportProgress",
     "ExportableDataset",
     "ExportableItem",
     "export_dataset_to_format",

--- a/mindtrace/datalake/mindtrace/datalake/exporters/base.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/base.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from mindtrace.datalake.types import AnnotationRecord, AnnotationSet, Asset, ResolvedDatasetVersion, ResolvedDatum
+from mindtrace.datalake.pagination_types import DatasetViewRow
 
 from .types import ExportableDataset, ExportableItem
 
@@ -107,6 +108,63 @@ def _build_exportable_item(
             annotations=annotations,
             annotation_sets=annotation_sets,
             payloads=dict(payloads or {}),
+        ),
+        warnings,
+    )
+
+
+def build_exportable_item_from_view_row(
+    row: DatasetViewRow,
+    *,
+    split_map: dict[str, str] | None = None,
+) -> tuple[ExportableItem | None, list[str]]:
+    """Build one export item from a bounded dataset-view row."""
+
+    assets = dict(row.assets or {})
+    primary_entry = None
+    for role in ("image", "asset"):
+        asset = assets.get(role)
+        if asset is not None:
+            primary_entry = (role, asset)
+            break
+    if primary_entry is None:
+        primary_entry = next(iter(assets.items()), None)
+    if primary_entry is None:
+        return None, [f"Skipped datum {row.datum_id} because it does not reference any assets."]
+
+    role, asset = primary_entry
+    annotation_sets: list[AnnotationSet] = []
+    annotations: list[AnnotationRecord] = []
+    warnings: list[str] = []
+    records_by_set = row.annotation_records or {}
+    for annotation_set in row.annotation_sets or []:
+        set_records = list(records_by_set.get(annotation_set.annotation_set_id, []))
+        matching_records = [
+            record for record in set_records if _annotation_subject_asset_id(record) in {None, asset.asset_id}
+        ]
+        if matching_records:
+            annotation_sets.append(annotation_set)
+            annotations.extend(matching_records)
+            skipped_count = len(set_records) - len(matching_records)
+            if skipped_count:
+                warnings.append(
+                    f"Skipped {skipped_count} annotation(s) in set {annotation_set.annotation_set_id} "
+                    "because they target a non-primary asset."
+                )
+        elif set_records:
+            warnings.append(
+                f"Skipped annotation set {annotation_set.annotation_set_id} for datum {row.datum_id} "
+                f"because it has no records for asset {asset.asset_id}."
+            )
+
+    return (
+        ExportableItem(
+            assets=assets,
+            primary_role=role,
+            split=_mapped_split(row.split, split_map),
+            metadata=dict(row.metadata or {}),
+            annotations=annotations,
+            annotation_sets=annotation_sets,
         ),
         warnings,
     )

--- a/mindtrace/datalake/mindtrace/datalake/exporters/base.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/base.py
@@ -4,8 +4,8 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-from mindtrace.datalake.types import AnnotationRecord, AnnotationSet, Asset, ResolvedDatasetVersion, ResolvedDatum
 from mindtrace.datalake.pagination_types import DatasetViewRow
+from mindtrace.datalake.types import AnnotationRecord, AnnotationSet, Asset, ResolvedDatasetVersion, ResolvedDatum
 
 from .types import ExportableDataset, ExportableItem
 

--- a/mindtrace/datalake/mindtrace/datalake/exporters/huggingface.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/huggingface.py
@@ -837,7 +837,8 @@ def _append_staged_rows(path: Path, rows: list[dict[str, Any]]) -> None:
             stream.write("\n")
 
 
-def _iter_staged_rows(path: Path):
+def _iter_staged_rows(path: str | Path):
+    path = Path(path)
     with path.open(encoding="utf-8") as stream:
         for line in stream:
             row = json.loads(line)
@@ -938,6 +939,7 @@ async def export_dataset_version_as_huggingface_streaming(
     asset_count = 0
     warnings: list[str] = []
     split_manifests: dict[str, Path] = {}
+    split_counts: dict[str, int] = defaultdict(int)
     semaphore = asyncio.Semaphore(_STREAMING_MEDIA_CONCURRENCY)
 
     async def stage_row(row: Any, ordinal: int):
@@ -993,6 +995,7 @@ async def export_dataset_version_as_huggingface_streaming(
                     staged_manifests_path / f"split-{len(split_manifests):04d}.jsonl",
                 )
                 await asyncio.to_thread(_append_staged_rows, manifest_path, rows)
+                split_counts[split_name] += len(rows)
 
             completed += len(page.items)
             _report_progress(progress_callback, stage="staging", completed=completed, total=total)
@@ -1009,21 +1012,18 @@ async def export_dataset_version_as_huggingface_streaming(
         finalized = 0
         dataset_payload = {}
         for split_name, manifest_path in split_manifests.items():
-
-            def generate_rows(path: Path = manifest_path):
-                nonlocal finalized
-                for exported_row in _iter_staged_rows(path):
-                    yield exported_row
-                    finalized += 1
-                    if finalized % page_size == 0 or finalized == asset_count:
-                        _report_progress(
-                            progress_callback,
-                            stage="finalizing",
-                            completed=finalized,
-                            total=asset_count,
-                        )
-
-            dataset_payload[split_name] = datasets_module.Dataset.from_generator(generate_rows, features=features)
+            dataset_payload[split_name] = datasets_module.Dataset.from_generator(
+                _iter_staged_rows,
+                features=features,
+                gen_kwargs={"path": str(manifest_path)},
+            )
+            finalized += split_counts[split_name]
+            _report_progress(
+                progress_callback,
+                stage="finalizing",
+                completed=finalized,
+                total=asset_count,
+            )
 
         hf_dataset = (
             dataset_payload["default"]

--- a/mindtrace/datalake/mindtrace/datalake/exporters/huggingface.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/huggingface.py
@@ -20,7 +20,7 @@ from .base import (
     prepare_export_destination,
     write_export_file,
 )
-from .types import ExportableDataset, ExportProgress, ExportResult, ExportableItem
+from .types import ExportableDataset, ExportableItem, ExportProgress, ExportResult
 
 _INTEGER_DTYPES = {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}
 _FLOAT_DTYPES = {"float16", "float32", "float64"}
@@ -926,9 +926,7 @@ async def export_dataset_version_as_huggingface_streaming(
     if destination_path.exists() and not overwrite:
         raise FileExistsError(f"Export destination already exists: {destination_path}")
     destination_path.parent.mkdir(parents=True, exist_ok=True)
-    work_path = Path(
-        tempfile.mkdtemp(prefix=f".{destination_path.name}.streaming-", dir=str(destination_path.parent))
-    )
+    work_path = Path(tempfile.mkdtemp(prefix=f".{destination_path.name}.streaming-", dir=str(destination_path.parent)))
     artifact_path = work_path / "artifact"
     staged_media_path = work_path / "media"
     staged_manifests_path = work_path / "manifests"
@@ -979,9 +977,7 @@ async def export_dataset_version_as_huggingface_streaming(
                 expand=DatasetViewExpand(assets=True, annotation_sets=True, annotation_records=True),
                 include_total=False,
             )
-            staged = await asyncio.gather(
-                *(stage_row(row, completed + index) for index, row in enumerate(page.items))
-            )
+            staged = await asyncio.gather(*(stage_row(row, completed + index) for index, row in enumerate(page.items)))
             rows_by_split: dict[str, list[dict[str, Any]]] = defaultdict(list)
             for staged_row, item_warnings in staged:
                 warnings.extend(item_warnings)

--- a/mindtrace/datalake/mindtrace/datalake/exporters/huggingface.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/huggingface.py
@@ -1,18 +1,31 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import io
 import json
+import shutil
+import tempfile
+from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
-from .base import prepare_export_destination, write_export_file
-from .types import ExportableDataset, ExportResult
+from mindtrace.datalake.pagination_types import DatasetViewExpand
+from mindtrace.datalake.types import DatasetVersion
+
+from .base import (
+    _load_asset_payload_async,
+    build_exportable_item_from_view_row,
+    prepare_export_destination,
+    write_export_file,
+)
+from .types import ExportableDataset, ExportProgress, ExportResult, ExportableItem
 
 _INTEGER_DTYPES = {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}
 _FLOAT_DTYPES = {"float16", "float32", "float64"}
 _METADATA_DTYPES = {"string", "bool", *_INTEGER_DTYPES, *_FLOAT_DTYPES}
+_STREAMING_MEDIA_CONCURRENCY = 8
 
 
 def _configured_class_names(
@@ -281,6 +294,42 @@ def _embedded_role_image(item, role: str, *, include_media: bool, task: str):
     return {"bytes": payload_bytes, "path": f"{asset.asset_id}.png"}
 
 
+def _single_label_classification_row(
+    item: ExportableItem,
+    *,
+    annotation_attributes: Mapping[str, Any],
+    metadata_keys: Mapping[str, str],
+    class_ids: Mapping[str, int],
+    image: Any,
+) -> dict[str, Any]:
+    annotation = _classification_annotation(item, annotation_attributes)
+    if annotation.label not in class_ids:
+        raise ValueError(
+            f"Classification annotation {annotation.annotation_id!r} on asset {item.asset.asset_id!r} "
+            f"uses label {annotation.label!r}, which is not present in class_names."
+        )
+    label_id = class_ids[annotation.label]
+    if annotation.label_id is not None and annotation.label_id != label_id:
+        raise ValueError(
+            f"Classification annotation {annotation.annotation_id!r} maps label {annotation.label!r} "
+            f"to configured id {label_id}, but the annotation uses label_id {annotation.label_id}."
+        )
+    row = {
+        "image": image,
+        "asset_id": item.asset.asset_id,
+        "label": label_id,
+        "label_name": annotation.label,
+        "split": item.split or "",
+        "source_image_asset_id": item.asset.asset_id,
+        "source_annotation_id": annotation.annotation_id,
+        "source_bbox": None,
+        "metadata_json": json.dumps(item.metadata or {}, sort_keys=True, default=str),
+        "asset_metadata_json": json.dumps(item.asset.metadata or {}, sort_keys=True, default=str),
+    }
+    row.update(_project_metadata_keys(item, metadata_keys))
+    return row
+
+
 def _save_huggingface_rows(
     datasets_module: Any,
     dataset: ExportableDataset,
@@ -343,33 +392,14 @@ def _export_single_label_classification_dataset(
     rows_by_split: dict[str, list[dict[str, Any]]] = {}
 
     for item in dataset.items:
-        annotation = _classification_annotation(item, selected_attributes)
-        if annotation.label not in class_ids:
-            raise ValueError(
-                f"Classification annotation {annotation.annotation_id!r} on asset {item.asset.asset_id!r} "
-                f"uses label {annotation.label!r}, which is not present in class_names."
-            )
-        label_id = class_ids[annotation.label]
-        if annotation.label_id is not None and annotation.label_id != label_id:
-            raise ValueError(
-                f"Classification annotation {annotation.annotation_id!r} maps label {annotation.label!r} "
-                f"to configured id {label_id}, but the annotation uses label_id {annotation.label_id}."
-            )
         split_name = item.split or "default"
-        image = _embedded_image(item, include_media=include_media, task="classification")
-        row = {
-            "image": image,
-            "asset_id": item.asset.asset_id,
-            "label": label_id,
-            "label_name": annotation.label,
-            "split": item.split or "",
-            "source_image_asset_id": item.asset.asset_id,
-            "source_annotation_id": annotation.annotation_id,
-            "source_bbox": None,
-            "metadata_json": json.dumps(item.metadata or {}, sort_keys=True, default=str),
-            "asset_metadata_json": json.dumps(item.asset.metadata or {}, sort_keys=True, default=str),
-        }
-        row.update(_project_metadata_keys(item, selected_metadata_keys))
+        row = _single_label_classification_row(
+            item,
+            annotation_attributes=selected_attributes,
+            metadata_keys=selected_metadata_keys,
+            class_ids=class_ids,
+            image=_embedded_image(item, include_media=include_media, task="classification"),
+        )
         rows_by_split.setdefault(split_name, []).append(row)
 
     requested_provenance = bool(
@@ -797,6 +827,244 @@ def _export_instance_segmentation_dataset(
         asset_count=dataset.asset_count,
         annotation_count=annotation_count,
     )
+
+
+def _append_staged_rows(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as stream:
+        for row in rows:
+            stream.write(json.dumps(row, sort_keys=True))
+            stream.write("\n")
+
+
+def _iter_staged_rows(path: Path):
+    with path.open(encoding="utf-8") as stream:
+        for line in stream:
+            row = json.loads(line)
+            staged_image_path = row.pop("_mindtrace_staged_image_path", None)
+            image_name = row.pop("_mindtrace_image_name", None)
+            row["image"] = (
+                {"bytes": Path(staged_image_path).read_bytes(), "path": image_name}
+                if staged_image_path is not None
+                else None
+            )
+            yield row
+
+
+def _report_progress(
+    callback: Callable[[ExportProgress], None] | None,
+    *,
+    stage: str,
+    completed: int,
+    total: int,
+) -> None:
+    if callback is not None:
+        callback(ExportProgress(stage=stage, completed=completed, total=total))
+
+
+def _replace_streaming_destination(artifact_path: Path, destination: Path, *, overwrite: bool) -> None:
+    if destination.exists():
+        if not overwrite:
+            raise FileExistsError(f"Export destination already exists: {destination}")
+        if destination.is_file() or destination.is_symlink():
+            destination.unlink()
+        else:
+            shutil.rmtree(destination)
+    artifact_path.replace(destination)
+
+
+async def export_dataset_version_as_huggingface_streaming(
+    object_loader: Any,
+    dataset_version: DatasetVersion,
+    *,
+    destination: str | Path,
+    include_media: bool = True,
+    overwrite: bool = False,
+    split_map: dict[str, str] | None = None,
+    options: dict[str, Any] | None = None,
+    page_size: int = 256,
+    progress_callback: Callable[[ExportProgress], None] | None = None,
+) -> ExportResult:
+    """Stream a single-label classification DatasetVersion to Hugging Face format."""
+
+    if isinstance(page_size, bool) or not isinstance(page_size, int) or page_size <= 0:
+        raise ValueError("page_size must be a positive integer")
+    try:
+        datasets_module = importlib.import_module("datasets")
+    except ImportError as exc:
+        raise ImportError(
+            "Hugging Face export requires the optional 'datasets' dependency. "
+            "Install mindtrace-datalake[export-huggingface]."
+        ) from exc
+
+    dataset = ExportableDataset(
+        name=dataset_version.dataset_name,
+        description=dataset_version.description,
+        metadata=dict(dataset_version.metadata or {}),
+    )
+    requested_task = (options or {}).get("task") or dataset.metadata.get("task_type")
+    classification_type = (options or {}).get("classification_type") or dataset.metadata.get(
+        "classification_type", "single_label"
+    )
+    classification_source = (options or {}).get("classification_source") or dataset.metadata.get(
+        "classification_source", "annotations"
+    )
+    if requested_task != "classification" or classification_type != "single_label":
+        raise ValueError("Streaming Hugging Face export currently supports only single-label classification.")
+    if classification_source != "annotations":
+        raise ValueError("Streaming Hugging Face classification export currently supports only annotation labels.")
+
+    selected_attributes = _annotation_attributes(options)
+    selected_metadata_keys = _metadata_keys(options)
+    class_names = _configured_class_names(dataset, "classification", options)
+    if class_names is None:
+        raise ValueError("Streaming Hugging Face classification export requires explicit class_names.")
+    class_ids = {name: label_id for label_id, name in enumerate(class_names)}
+    features = _single_label_classification_features(datasets_module, class_names, selected_metadata_keys)
+
+    destination_path = Path(destination)
+    if destination_path.exists() and not overwrite:
+        raise FileExistsError(f"Export destination already exists: {destination_path}")
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    work_path = Path(
+        tempfile.mkdtemp(prefix=f".{destination_path.name}.streaming-", dir=str(destination_path.parent))
+    )
+    artifact_path = work_path / "artifact"
+    staged_media_path = work_path / "media"
+    staged_manifests_path = work_path / "manifests"
+    staged_media_path.mkdir(parents=True)
+    staged_manifests_path.mkdir(parents=True)
+
+    total = len(dataset_version.manifest)
+    completed = 0
+    asset_count = 0
+    warnings: list[str] = []
+    split_manifests: dict[str, Path] = {}
+    semaphore = asyncio.Semaphore(_STREAMING_MEDIA_CONCURRENCY)
+
+    async def stage_row(row: Any, ordinal: int):
+        item, item_warnings = build_exportable_item_from_view_row(row, split_map=split_map)
+        if item is None:
+            return None, item_warnings
+
+        staged_image = None
+        if include_media:
+            async with semaphore:
+                payload = await _load_asset_payload_async(object_loader, item.asset)
+                suffix = Path(item.source_filename).suffix or ".bin"
+                staged_image = staged_media_path / f"{ordinal:012d}{suffix}"
+                await asyncio.to_thread(staged_image.write_bytes, payload)
+
+        exported_row = _single_label_classification_row(
+            item,
+            annotation_attributes=selected_attributes,
+            metadata_keys=selected_metadata_keys,
+            class_ids=class_ids,
+            image=None,
+        )
+        exported_row["_mindtrace_staged_image_path"] = str(staged_image) if staged_image is not None else None
+        exported_row["_mindtrace_image_name"] = item.source_filename if staged_image is not None else None
+        return (item.split or "default", exported_row), item_warnings
+
+    try:
+        _report_progress(progress_callback, stage="staging", completed=0, total=total)
+        cursor: str | None = None
+        while True:
+            page = await object_loader.view_dataset_version_page(
+                dataset_version.dataset_name,
+                dataset_version.version,
+                limit=page_size,
+                cursor=cursor,
+                sort="manifest_order",
+                expand=DatasetViewExpand(assets=True, annotation_sets=True, annotation_records=True),
+                include_total=False,
+            )
+            staged = await asyncio.gather(
+                *(stage_row(row, completed + index) for index, row in enumerate(page.items))
+            )
+            rows_by_split: dict[str, list[dict[str, Any]]] = defaultdict(list)
+            for staged_row, item_warnings in staged:
+                warnings.extend(item_warnings)
+                if staged_row is None:
+                    continue
+                split_name, exported_row = staged_row
+                rows_by_split[split_name].append(exported_row)
+                asset_count += 1
+
+            for split_name, rows in rows_by_split.items():
+                manifest_path = split_manifests.setdefault(
+                    split_name,
+                    staged_manifests_path / f"split-{len(split_manifests):04d}.jsonl",
+                )
+                await asyncio.to_thread(_append_staged_rows, manifest_path, rows)
+
+            completed += len(page.items)
+            _report_progress(progress_callback, stage="staging", completed=completed, total=total)
+            if not page.page.has_more:
+                break
+            if page.page.next_cursor is None:
+                raise RuntimeError("Dataset view reported more rows without a continuation cursor.")
+            cursor = page.page.next_cursor
+
+        if asset_count == 0:
+            raise ValueError("Streaming Hugging Face export produced no classification rows.")
+
+        _report_progress(progress_callback, stage="finalizing", completed=0, total=asset_count)
+        finalized = 0
+        dataset_payload = {}
+        for split_name, manifest_path in split_manifests.items():
+
+            def generate_rows(path: Path = manifest_path):
+                nonlocal finalized
+                for exported_row in _iter_staged_rows(path):
+                    yield exported_row
+                    finalized += 1
+                    if finalized % page_size == 0 or finalized == asset_count:
+                        _report_progress(
+                            progress_callback,
+                            stage="finalizing",
+                            completed=finalized,
+                            total=asset_count,
+                        )
+
+            dataset_payload[split_name] = datasets_module.Dataset.from_generator(generate_rows, features=features)
+
+        hf_dataset = (
+            dataset_payload["default"]
+            if len(dataset_payload) == 1 and "default" in dataset_payload
+            else datasets_module.DatasetDict(dataset_payload)
+        )
+        hf_dataset.save_to_disk(str(artifact_path))
+        metadata_file = write_export_file(
+            artifact_path,
+            "mindtrace_metadata.json",
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "mindtrace": {
+                        "task": "classification",
+                        "annotation_attributes": selected_attributes,
+                        "class_names": class_names,
+                        "label_to_id": class_ids,
+                        "metadata_keys": selected_metadata_keys,
+                    },
+                },
+                sort_keys=True,
+            ).encode("utf-8"),
+        )
+        _replace_streaming_destination(artifact_path, destination_path, overwrite=overwrite)
+        _report_progress(progress_callback, stage="complete", completed=asset_count, total=asset_count)
+        return ExportResult(
+            format="huggingface",
+            destination=destination_path,
+            dataset_name=dataset_version.dataset_name,
+            asset_count=asset_count,
+            annotation_count=asset_count,
+            files_written=[metadata_file, "."],
+            warnings=warnings,
+        )
+    finally:
+        shutil.rmtree(work_path, ignore_errors=True)
 
 
 def export_dataset_as_huggingface(

--- a/mindtrace/datalake/mindtrace/datalake/exporters/types.py
+++ b/mindtrace/datalake/mindtrace/datalake/exporters/types.py
@@ -87,3 +87,11 @@ class ExportResult(BaseModel):
     annotation_count: int
     files_written: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
+
+
+class ExportProgress(BaseModel):
+    """Progress reported while a dataset export is being streamed."""
+
+    stage: str
+    completed: int = Field(ge=0)
+    total: int = Field(ge=0)

--- a/tests/integration/mindtrace/datalake/exporters/test_streaming_huggingface_export.py
+++ b/tests/integration/mindtrace/datalake/exporters/test_streaming_huggingface_export.py
@@ -1,0 +1,106 @@
+"""Synthetic integration coverage for streaming Hugging Face exports."""
+
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from mindtrace.datalake.exporters.huggingface import export_dataset_version_as_huggingface_streaming
+from mindtrace.datalake.pagination_types import DatasetViewInfo, DatasetViewPage, DatasetViewRow, PageInfo
+from mindtrace.datalake.types import AnnotationRecord, AnnotationSet, Asset, DatasetVersion, StorageRef, SubjectRef
+
+
+def _png_bytes() -> bytes:
+    payload = BytesIO()
+    Image.new("RGB", (2, 2), color=(255, 0, 0)).save(payload, format="PNG")
+    return payload.getvalue()
+
+
+class _SyntheticLoader:
+    def __init__(self, rows: list[DatasetViewRow]):
+        self.rows = rows
+
+    async def view_dataset_version_page(self, name, version, **kwargs):
+        return DatasetViewPage(
+            items=self.rows,
+            page=PageInfo(limit=kwargs["limit"], next_cursor=None, has_more=False),
+            view=DatasetViewInfo(dataset_name=name, version=version),
+        )
+
+    async def get_asset_payload(self, _asset_id: str) -> bytes:
+        return _png_bytes()
+
+
+def _row(index: int, split: str, label: str, label_id: int) -> DatasetViewRow:
+    asset_id = f"asset-{index}"
+    annotation_id = f"annotation-{index}"
+    annotation_set_id = f"set-{index}"
+    asset = Asset(
+        asset_id=asset_id,
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="assets", name=f"{asset_id}.png", version="1"),
+    )
+    annotation = AnnotationRecord(
+        annotation_id=annotation_id,
+        kind="classification",
+        label=label,
+        label_id=label_id,
+        subject=SubjectRef(kind="asset", id=asset_id),
+        source={"type": "human", "name": "integration-test"},
+        attributes={"field": "defect_type"},
+    )
+    annotation_set = AnnotationSet(
+        annotation_set_id=annotation_set_id,
+        name="ground-truth",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=[annotation_id],
+    )
+    return DatasetViewRow(
+        datum_id=f"datum-{index}",
+        split=split,
+        metadata={"serialnumber": f"serial-{index}", "weldid": f"weld-{index}"},
+        assets={"image": asset},
+        annotation_sets=[annotation_set],
+        annotation_records={annotation_set_id: [annotation]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_streaming_export_round_trips_as_saved_dataset_dict(tmp_path: Path):
+    datasets = pytest.importorskip("datasets")
+    rows = [
+        _row(1, "train", "healthy", 0),
+        _row(2, "val", "porosity", 1),
+        _row(3, "test", "healthy", 0),
+    ]
+    dataset_version = DatasetVersion(
+        dataset_name="synthetic-classification",
+        version="1.0.0",
+        manifest=[row.datum_id for row in rows],
+    )
+    destination = tmp_path / "export"
+
+    result = await export_dataset_version_as_huggingface_streaming(
+        _SyntheticLoader(rows),
+        dataset_version,
+        destination=destination,
+        page_size=2,
+        options={
+            "task": "classification",
+            "class_names": ["healthy", "porosity"],
+            "annotation_attributes": {"field": "defect_type"},
+            "metadata_keys": {"serialnumber": "string", "weldid": "string"},
+        },
+    )
+
+    exported = datasets.load_from_disk(str(destination))
+    assert result.asset_count == 3
+    assert list(exported) == ["train", "val", "test"]
+    assert exported["train"].features["label"].names == ["healthy", "porosity"]
+    assert exported["val"][0]["label"] == 1
+    assert exported["test"][0]["serialnumber"] == "serial-3"
+    assert exported["train"][0]["image"].size == (2, 2)

--- a/tests/unit/mindtrace/datalake/exporters/test_streaming_huggingface_export.py
+++ b/tests/unit/mindtrace/datalake/exporters/test_streaming_huggingface_export.py
@@ -18,8 +18,8 @@ class _FakeDataset:
         self.features = features
 
     @classmethod
-    def from_generator(cls, generator, features=None):
-        return cls(list(generator()), features=features)
+    def from_generator(cls, generator, features=None, gen_kwargs=None):
+        return cls(list(generator(**(gen_kwargs or {}))), features=features)
 
     def save_to_disk(self, path: str):
         target = Path(path)

--- a/tests/unit/mindtrace/datalake/exporters/test_streaming_huggingface_export.py
+++ b/tests/unit/mindtrace/datalake/exporters/test_streaming_huggingface_export.py
@@ -1,0 +1,227 @@
+"""Tests for bounded-memory Hugging Face DatasetVersion exports."""
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mindtrace.datalake.exporters.huggingface import export_dataset_version_as_huggingface_streaming
+from mindtrace.datalake.pagination_types import DatasetViewInfo, DatasetViewPage, DatasetViewRow, PageInfo
+from mindtrace.datalake.types import AnnotationRecord, AnnotationSet, Asset, DatasetVersion, StorageRef, SubjectRef
+
+
+class _FakeDataset:
+    def __init__(self, rows, features=None):
+        self.rows = rows
+        self.features = features
+
+    @classmethod
+    def from_generator(cls, generator, features=None):
+        return cls(list(generator()), features=features)
+
+    def save_to_disk(self, path: str):
+        target = Path(path)
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "dataset.json").write_text(json.dumps(self.rows, sort_keys=True, default=str))
+
+
+class _FakeDatasetDict(dict):
+    def save_to_disk(self, path: str):
+        target = Path(path)
+        target.mkdir(parents=True, exist_ok=True)
+        payload = {split: dataset.rows for split, dataset in self.items()}
+        (target / "dataset_dict.json").write_text(json.dumps(payload, sort_keys=True, default=str))
+
+
+class _FakeFeature:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+def _fake_datasets_module():
+    return SimpleNamespace(
+        Dataset=_FakeDataset,
+        DatasetDict=_FakeDatasetDict,
+        Features=dict,
+        Image=_FakeFeature,
+        Value=_FakeFeature,
+        ClassLabel=_FakeFeature,
+        Sequence=_FakeFeature,
+    )
+
+
+def _view_row(index: int, *, split: str, label: str, label_id: int) -> DatasetViewRow:
+    asset_id = f"asset-{index}"
+    annotation_id = f"annotation-{index}"
+    annotation_set_id = f"set-{index}"
+    asset = Asset(
+        asset_id=asset_id,
+        kind="image",
+        media_type="image/png",
+        storage_ref=StorageRef(mount="assets", name=f"{asset_id}.png", version="1"),
+        metadata={"source": "unit-test"},
+    )
+    annotation = AnnotationRecord(
+        annotation_id=annotation_id,
+        kind="classification",
+        label=label,
+        label_id=label_id,
+        subject=SubjectRef(kind="asset", id=asset_id),
+        source={"type": "human", "name": "pytest"},
+        attributes={"field": "defect_type"},
+    )
+    annotation_set = AnnotationSet(
+        annotation_set_id=annotation_set_id,
+        name="ground-truth",
+        purpose="ground_truth",
+        source_type="human",
+        status="active",
+        annotation_record_ids=[annotation_id],
+    )
+    return DatasetViewRow(
+        datum_id=f"datum-{index}",
+        split=split,
+        metadata={"serialnumber": f"serial-{index}", "weldid": f"weld-{index}"},
+        assets={"image": asset},
+        annotation_sets=[annotation_set],
+        annotation_records={annotation_set_id: [annotation]},
+    )
+
+
+class _PagedLoader:
+    def __init__(self, rows: list[DatasetViewRow], *, fail_payload: bool = False):
+        self.rows = rows
+        self.fail_payload = fail_payload
+        self.page_calls = []
+        self.active_payload_reads = 0
+        self.max_active_payload_reads = 0
+
+    async def view_dataset_version_page(self, _name, _version, **kwargs):
+        self.page_calls.append(kwargs)
+        cursor = kwargs["cursor"]
+        if cursor is None:
+            items = self.rows[:1]
+            page = PageInfo(limit=kwargs["limit"], next_cursor="next", has_more=True)
+        else:
+            items = self.rows[1:]
+            page = PageInfo(limit=kwargs["limit"], next_cursor=None, has_more=False)
+        return DatasetViewPage(
+            items=items,
+            page=page,
+            view=DatasetViewInfo(dataset_name="dataset-a", version="1.0.0"),
+        )
+
+    async def get_asset_payload(self, asset_id: str) -> bytes:
+        if self.fail_payload:
+            raise RuntimeError("payload failed")
+        self.active_payload_reads += 1
+        self.max_active_payload_reads = max(self.max_active_payload_reads, self.active_payload_reads)
+        await asyncio.sleep(0)
+        self.active_payload_reads -= 1
+        return f"payload:{asset_id}".encode()
+
+
+@pytest.mark.asyncio
+async def test_streaming_classification_export_pages_rows_and_reports_progress(tmp_path: Path, monkeypatch):
+    from mindtrace.datalake.exporters import huggingface as exporter
+
+    monkeypatch.setattr(exporter.importlib, "import_module", lambda _name: _fake_datasets_module())
+    rows = [
+        _view_row(1, split="train", label="healthy", label_id=0),
+        _view_row(2, split="test", label="porosity", label_id=1),
+    ]
+    loader = _PagedLoader(rows)
+    dataset_version = DatasetVersion(
+        dataset_name="dataset-a",
+        version="1.0.0",
+        manifest=[row.datum_id for row in rows],
+    )
+    progress = []
+
+    result = await export_dataset_version_as_huggingface_streaming(
+        loader,
+        dataset_version,
+        destination=tmp_path / "export",
+        page_size=1,
+        options={
+            "task": "classification",
+            "class_names": ["healthy", "porosity"],
+            "annotation_attributes": {"field": "defect_type"},
+            "metadata_keys": {"serialnumber": "string", "weldid": "string"},
+        },
+        progress_callback=progress.append,
+    )
+
+    payload = json.loads((tmp_path / "export" / "dataset_dict.json").read_text())
+    metadata = json.loads((tmp_path / "export" / "mindtrace_metadata.json").read_text())
+    assert result.asset_count == 2
+    assert result.annotation_count == 2
+    assert [row["asset_id"] for row in payload["train"]] == ["asset-1"]
+    assert [row["asset_id"] for row in payload["test"]] == ["asset-2"]
+    assert payload["test"][0]["label"] == 1
+    assert metadata["mindtrace"]["class_names"] == ["healthy", "porosity"]
+    assert [event.stage for event in progress] == [
+        "staging",
+        "staging",
+        "staging",
+        "finalizing",
+        "finalizing",
+        "finalizing",
+        "complete",
+    ]
+    assert progress[-1].completed == progress[-1].total == 2
+    assert len(loader.page_calls) == 2
+    assert loader.max_active_payload_reads <= 8
+    assert not list(tmp_path.glob(".export.streaming-*"))
+
+
+@pytest.mark.asyncio
+async def test_streaming_classification_export_rejects_missing_class_names(tmp_path: Path, monkeypatch):
+    from mindtrace.datalake.exporters import huggingface as exporter
+
+    monkeypatch.setattr(exporter.importlib, "import_module", lambda _name: _fake_datasets_module())
+    dataset_version = DatasetVersion(dataset_name="dataset-a", version="1.0.0", manifest=[])
+
+    with pytest.raises(ValueError, match="explicit class_names"):
+        await export_dataset_version_as_huggingface_streaming(
+            _PagedLoader([]),
+            dataset_version,
+            destination=tmp_path / "export",
+            options={"task": "classification"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_streaming_classification_export_cleans_temporary_output_after_failure(tmp_path: Path, monkeypatch):
+    from mindtrace.datalake.exporters import huggingface as exporter
+
+    monkeypatch.setattr(exporter.importlib, "import_module", lambda _name: _fake_datasets_module())
+    row = _view_row(1, split="train", label="healthy", label_id=0)
+    dataset_version = DatasetVersion(dataset_name="dataset-a", version="1.0.0", manifest=[row.datum_id])
+
+    with pytest.raises(RuntimeError, match="payload failed"):
+        await export_dataset_version_as_huggingface_streaming(
+            _PagedLoader([row], fail_payload=True),
+            dataset_version,
+            destination=tmp_path / "export",
+            options={"task": "classification", "class_names": ["healthy"]},
+        )
+
+    assert not (tmp_path / "export").exists()
+    assert not list(tmp_path.glob(".export.streaming-*"))
+
+
+@pytest.mark.asyncio
+async def test_streaming_classification_export_validates_page_size(tmp_path: Path):
+    dataset_version = DatasetVersion(dataset_name="dataset-a", version="1.0.0", manifest=[])
+
+    with pytest.raises(ValueError, match="positive integer"):
+        await export_dataset_version_as_huggingface_streaming(
+            _PagedLoader([]),
+            dataset_version,
+            destination=tmp_path / "export",
+            page_size=0,
+        )

--- a/tests/unit/mindtrace/datalake/test_async_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_async_datalake.py
@@ -2745,6 +2745,53 @@ class TestAsyncDatalakeUnit:
         assert (tmp_path / "coco" / "annotations" / "train.json").exists()
         fake_datalake.resolve_dataset_version.assert_awaited_once_with("dataset-a", "1.0.0")
 
+    @pytest.mark.asyncio
+    async def test_export_dataset_version_to_format_dispatches_streaming_huggingface(self, tmp_path: Path):
+        dataset_version = DatasetVersion(
+            dataset_name="dataset-a",
+            version="1.0.0",
+            manifest=["datum-1"],
+        )
+        fake_datalake = SimpleNamespace(
+            get_dataset_version=AsyncMock(return_value=dataset_version),
+            resolve_dataset_version=AsyncMock(),
+        )
+
+        with patch(
+            "mindtrace.datalake.exporters.huggingface.export_dataset_version_as_huggingface_streaming",
+            new=AsyncMock(return_value="streamed"),
+        ) as streaming_export:
+            result = await AsyncDatalake.export_dataset_version_to_format(
+                fake_datalake,
+                "dataset-a",
+                "1.0.0",
+                format="huggingface",
+                destination=tmp_path / "huggingface",
+                streaming=True,
+                page_size=32,
+                exporter_options={"task": "classification", "class_names": ["healthy"]},
+            )
+
+        assert result == "streamed"
+        fake_datalake.resolve_dataset_version.assert_not_awaited()
+        streaming_export.assert_awaited_once()
+        _, kwargs = streaming_export.await_args
+        assert kwargs["page_size"] == 32
+
+    @pytest.mark.asyncio
+    async def test_streaming_export_rejects_non_huggingface_format(self, tmp_path: Path):
+        fake_datalake = SimpleNamespace()
+
+        with pytest.raises(ValueError, match="format='huggingface'"):
+            await AsyncDatalake.export_dataset_version_to_format(
+                fake_datalake,
+                "dataset-a",
+                "1.0.0",
+                format="coco",
+                destination=tmp_path / "coco",
+                streaming=True,
+            )
+
 
 def _alias_fixture_make_store():
     store = MagicMock()

--- a/tests/unit/mindtrace/datalake/test_datalake.py
+++ b/tests/unit/mindtrace/datalake/test_datalake.py
@@ -754,14 +754,22 @@ class TestDatalakeSyncFacade:
         datalake._backend = Mock()
         datalake._submit_coro = Mock(return_value="exported")
 
+        progress_callback = Mock()
         result = Datalake.export_dataset_version_to_format(
             datalake,
             "dataset-a",
             "1.0.0",
             format="huggingface",
             destination=tmp_path / "hf",
+            streaming=True,
+            page_size=32,
+            progress_callback=progress_callback,
         )
 
         assert result == "exported"
         datalake._backend.export_dataset_version_to_format.assert_called_once()
+        _, kwargs = datalake._backend.export_dataset_version_to_format.call_args
+        assert kwargs["streaming"] is True
+        assert kwargs["page_size"] == 32
+        assert kwargs["progress_callback"] is progress_callback
         datalake._submit_coro.assert_called_once()


### PR DESCRIPTION
## Summary

This PR adds an opt-in streaming path for large single-label classification exports to Hugging Face format. It pages the Datalake view, stages media and split manifests on disk, reports structured progress, and atomically publishes the completed artifact without materializing the full resolved dataset graph in memory.

This PR is stacked on #553.

Closes #566

## Motivation

Large image DatasetVersions can exceed practical memory limits when the existing exporter resolves the complete datum graph and all media payloads before writing the Hugging Face artifact. Callers also lack progress information during that potentially long export, making it difficult to distinguish useful work from a stalled process.

The streaming path preserves the existing Hugging Face artifact and metadata contract while bounding the amount of resolved Datalake state and media held in memory. It remains explicit and narrowly scoped: unsupported task profiles continue to use the existing in-memory path and reject `streaming=True` clearly.

## Example

Edit the constants at the top to match the source DatasetVersion and export contract:

```python
from pathlib import Path

from mindtrace.datalake import Datalake, ExportProgress


# Dataset and export contract
DATASET_NAME = "classification_dataset"
DATASET_VERSION = "1.0.0"
OUTPUT_PATH = Path("exports/classification-category").resolve()
CLASS_NAMES = ("class_a", "class_b", "class_c")
PAGE_SIZE = 256

# Local Datalake connection
MONGO_DB_URI = "mongodb://localhost:27018"
MONGO_DB_NAME = "mindtrace"


def report_export(progress: ExportProgress) -> None:
    print(f"{progress.stage}: {progress.completed}/{progress.total}")


with Datalake.create(
    mongo_db_uri=MONGO_DB_URI,
    mongo_db_name=MONGO_DB_NAME,
) as lake:
    result = lake.export_dataset_version_to_format(
        DATASET_NAME,
        DATASET_VERSION,
        format="huggingface",
        destination=OUTPUT_PATH,
        include_media=True,
        streaming=True,
        page_size=PAGE_SIZE,
        progress_callback=report_export,
        exporter_options={
            "task": "classification",
            "class_names": CLASS_NAMES,
        },
    )

print(result)
print(f"Exported to {OUTPUT_PATH}")
```

Streaming exports currently require single-label annotation-based classification and an explicit ordered class mapping. Progress events cover staging, finalization, and completion; partial work is cleaned up on failure, and an existing destination is replaced only after the new artifact is complete.

## Tests and documentation

- add focused unit coverage for paging, progress, validation, cleanup, and sync/async API forwarding
- add a synthetic integration comparison between legacy and streaming Hugging Face artifacts
- document streaming controls, progress callbacks, supported scope, and failure behavior
